### PR TITLE
chore(deps): pin reth transaction manager instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11283,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
+source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3806,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,18 +11255,15 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
  "crossbeam-utils",
- "derive_more",
- "itertools 0.14.0",
  "metrics",
  "rand 0.9.4",
- "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -11283,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=66ee34cb530e9099b225cb338e72c023e2e452db#66ee34cb530e9099b225cb338e72c023e2e452db"
+source = "git+https://github.com/paradigmxyz/reth?rev=a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e#a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11283,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
+source = "git+https://github.com/paradigmxyz/reth?rev=4ecfe2de4222fef4c2167f99269b2b4136dd585b#4ecfe2de4222fef4c2167f99269b2b4136dd585b"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8615,7 +8615,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8642,7 +8642,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8695,7 +8695,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8708,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8791,7 +8791,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8801,7 +8801,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8854,7 +8854,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8870,7 +8870,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8884,7 +8884,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8897,7 +8897,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8922,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8951,7 +8951,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8977,7 +8977,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9007,7 +9007,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9022,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9047,7 +9047,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9071,7 +9071,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9095,7 +9095,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9130,7 +9130,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9187,7 +9187,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9215,7 +9215,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9238,7 +9238,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9263,7 +9263,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9319,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9349,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9367,7 +9367,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9383,7 +9383,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9445,7 +9445,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9467,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9508,7 +9508,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "clap",
  "eyre",
@@ -9531,7 +9531,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9563,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9576,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9606,7 +9606,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9630,7 +9630,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9675,7 +9675,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9706,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9763,7 +9763,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "serde",
  "serde_json",
@@ -9787,7 +9787,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "bytes",
  "futures",
@@ -9833,7 +9833,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9850,7 +9850,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "bindgen",
  "cc",
@@ -9859,7 +9859,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "futures",
  "metrics",
@@ -9872,7 +9872,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9895,7 +9895,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9978,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10002,7 +10002,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10031,7 +10031,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10048,7 +10048,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10266,7 +10266,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10290,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "bytes",
  "eyre",
@@ -10319,7 +10319,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10331,7 +10331,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10367,7 +10367,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10390,7 +10390,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10433,7 +10433,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10481,7 +10481,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10509,7 +10509,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10525,7 +10525,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10540,7 +10540,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10617,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10647,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10741,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10788,7 +10788,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10839,7 +10839,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10853,7 +10853,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10884,7 +10884,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10935,7 +10935,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10963,7 +10963,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11076,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11092,7 +11092,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "clap",
  "eyre",
@@ -11122,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11141,7 +11141,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11184,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11209,7 +11209,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11255,7 +11255,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11283,7 +11283,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bbc5e6#8bbc5e6b7fd92988e47aa52f4d8064c71c744409"
+source = "git+https://github.com/paradigmxyz/reth?rev=1a5fb6a4b73da10dc1256ba4de8d86e076fca47f#1a5fb6a4b73da10dc1256ba4de8d86e076fca47f"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1a5fb6a4b73da10dc1256ba4de8d86e076fca47f", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4ecfe2de4222fef4c2167f99269b2b4136dd585b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "66ee34cb530e9099b225cb338e72c023e2e452db", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "a5ab3b47645677d6cfbf5e3b0754f62cf3ead02e", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -370,7 +370,7 @@ where
         let BuildArguments {
             cached_reads,
             execution_cache,
-            mut trie_handle,
+            state_root_handle: mut trie_handle,
             config,
             cancel,
             best_payload,
@@ -1021,7 +1021,8 @@ where
 
         let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
             .as_mut()
-            .map(|handle| handle.take_hashed_state_rx().recv())
+            .and_then(|handle| handle.try_take_hashed_state_rx())
+            .map(|rx| rx.recv())
         {
             hashed_state
         } else {


### PR DESCRIPTION
Pins Reth dependencies to `paradigmxyz/reth@1a5fb6a4b73da10dc1256ba4de8d86e076fca47f`, built from `mattsse/tx-manager-instrumentation`.

That branch adds transaction gossip instrumentation for outgoing and incoming transaction counts, plus drop logs around the NetworkManager/TransactionsManager and SessionManager/ActiveSession handoffs.