### PR TITLE
docs(tip-1087): clarify upgraded flip book index

### DIFF
--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -163,7 +163,7 @@ TIP-1056 rewrites fully filled flip orders in place under the same mapping key. 
 
 A `V2Order` flip rewrite MUST encode the post-flip order state as follows:
 
-- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, preserved `bookIndex`, zeroed unused bytes, and `version = 2`
+- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, the correct `bookIndex`, zeroed unused bytes, and `version = 2`. For a version `2` flip rewrite, `bookIndex` MUST be preserved from the existing order. For a version `0` or version `1` flip rewrite upgraded to version `2`, `bookIndex` MUST be set from the target orderbook's persisted `id` after asserting that `book_keys[id] == bookKey`.
 - slot `1`: preserved `amount` and `remaining = amount`
 - slot `2`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
 - slots used only by the previous version MUST be cleared when upgrading from version `0` or `1`


### PR DESCRIPTION
## Summary
- Clarify that V2 flip rewrites preserve the existing bookIndex
- Clarify that v0/v1 flip rewrites upgraded to V2 must derive bookIndex from the target orderbook persisted id and assert book_keys[id] == bookKey

## Testing
- Not run; docs-only change

Prompted by: @0xrusowsky