### PR TITLE
feat(evm): report FeeAMM liquidity pair when available

### DIFF
--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -424,6 +424,8 @@ impl<DBError> From<FeePaymentError> for EVMError<DBError, TempoInvalidTransactio
 fn liquidity_pair_msg(user_token: &Option<Address>, validator_token: &Option<Address>) -> String {
     if let (Some(user_token), Some(validator_token)) = (user_token, validator_token) {
         return format!(" for pair {user_token} -> {validator_token}");
+    } else if let Some(user_token) = user_token {
+        return format!(" for user token {user_token}");
     }
     String::new()
 }

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -374,12 +374,22 @@ impl From<KeychainVersionError> for TempoInvalidTransaction {
 pub enum FeePaymentError {
     /// Insufficient liquidity in the FeeAMM pool to perform fee token swap.
     ///
+    /// This indicates the user's fee token cannot be swapped to at least one recent
+    /// validator token because there's insufficient liquidity in the relevant AMM pool.
+    #[error("insufficient liquidity in FeeAMM pool to swap fee tokens (required: {fee})")]
+    InsufficientAmmLiquidity {
+        /// The required fee amount that couldn't be swapped.
+        fee: U256,
+    },
+
+    /// Insufficient liquidity in the FeeAMM pool for a specific swap pair.
+    ///
     /// This indicates the user's fee token cannot be swapped for the validator's
     /// token because there's insufficient liquidity in the AMM pool for that pair.
     #[error(
         "insufficient liquidity in FeeAMM pool to swap fee tokens for pair {user_token} -> {validator_token} (required: {fee})"
     )]
-    InsufficientAmmLiquidity {
+    InsufficientAmmLiquidityForPair {
         /// The fee payer's fee token (the token being swapped from).
         user_token: Address,
         /// The validator's preferred token (the token being swapped to).
@@ -457,9 +467,16 @@ mod tests {
             "system transaction must be a call, not a create"
         );
 
+        let err = FeePaymentError::InsufficientAmmLiquidity {
+            fee: U256::from(1000),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("insufficient liquidity in FeeAMM pool"));
+        assert!(msg.contains("required: 1000"));
+
         let user_token = Address::with_last_byte(0x11);
         let validator_token = Address::with_last_byte(0x22);
-        let err = FeePaymentError::InsufficientAmmLiquidity {
+        let err = FeePaymentError::InsufficientAmmLiquidityForPair {
             user_token,
             validator_token,
             fee: U256::from(1000),
@@ -529,8 +546,6 @@ mod tests {
     #[test]
     fn test_fee_payment_error() {
         let _: EVMError<(), TempoInvalidTransaction> = FeePaymentError::InsufficientAmmLiquidity {
-            user_token: Address::ZERO,
-            validator_token: Address::ZERO,
             fee: U256::from(1000),
         }
         .into();

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -374,10 +374,16 @@ impl From<KeychainVersionError> for TempoInvalidTransaction {
 pub enum FeePaymentError {
     /// Insufficient liquidity in the FeeAMM pool to perform fee token swap.
     ///
-    /// This indicates the user's fee token cannot be swapped for the native token
-    /// because there's insufficient liquidity in the AMM pool.
-    #[error("insufficient liquidity in FeeAMM pool to swap fee tokens (required: {fee})")]
+    /// This indicates the user's fee token cannot be swapped for the validator's
+    /// token because there's insufficient liquidity in the AMM pool for that pair.
+    #[error(
+        "insufficient liquidity in FeeAMM pool to swap fee tokens for pair {user_token} -> {validator_token} (required: {fee})"
+    )]
     InsufficientAmmLiquidity {
+        /// The fee payer's fee token (the token being swapped from).
+        user_token: Address,
+        /// The validator's preferred token (the token being swapped to).
+        validator_token: Address,
         /// The required fee amount that couldn't be swapped.
         fee: U256,
     },
@@ -451,13 +457,21 @@ mod tests {
             "system transaction must be a call, not a create"
         );
 
+        let user_token = Address::with_last_byte(0x11);
+        let validator_token = Address::with_last_byte(0x22);
         let err = FeePaymentError::InsufficientAmmLiquidity {
+            user_token,
+            validator_token,
             fee: U256::from(1000),
         };
-        assert!(
-            err.to_string()
-                .contains("insufficient liquidity in FeeAMM pool")
-        );
+        let msg = err.to_string();
+        assert!(msg.contains("insufficient liquidity in FeeAMM pool"));
+        // The swap pair and required amount must be surfaced so callers can
+        // diagnose which fee-token route is under-provisioned.
+        assert!(msg.contains(&user_token.to_string()));
+        assert!(msg.contains(&validator_token.to_string()));
+        assert!(msg.contains(&format!("{user_token} -> {validator_token}")));
+        assert!(msg.contains("required: 1000"));
 
         let err = FeePaymentError::InsufficientFeeTokenBalance {
             fee: U256::from(1000),
@@ -515,6 +529,8 @@ mod tests {
     #[test]
     fn test_fee_payment_error() {
         let _: EVMError<(), TempoInvalidTransaction> = FeePaymentError::InsufficientAmmLiquidity {
+            user_token: Address::ZERO,
+            validator_token: Address::ZERO,
             fee: U256::from(1000),
         }
         .into();

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -376,24 +376,15 @@ pub enum FeePaymentError {
     ///
     /// This indicates the user's fee token cannot be swapped to at least one recent
     /// validator token because there's insufficient liquidity in the relevant AMM pool.
-    #[error("insufficient liquidity in FeeAMM pool to swap fee tokens (required: {fee})")]
-    InsufficientAmmLiquidity {
-        /// The required fee amount that couldn't be swapped.
-        fee: U256,
-    },
-
-    /// Insufficient liquidity in the FeeAMM pool for a specific swap pair.
-    ///
-    /// This indicates the user's fee token cannot be swapped for the validator's
-    /// token because there's insufficient liquidity in the AMM pool for that pair.
     #[error(
-        "insufficient liquidity in FeeAMM pool to swap fee tokens for pair {user_token} -> {validator_token} (required: {fee})"
+        "insufficient liquidity in FeeAMM pool to swap fee tokens{pair} (required: {fee})",
+        pair = liquidity_pair_msg(.user_token, .validator_token)
     )]
-    InsufficientAmmLiquidityForPair {
-        /// The fee payer's fee token (the token being swapped from).
-        user_token: Address,
-        /// The validator's preferred token (the token being swapped to).
-        validator_token: Address,
+    InsufficientAmmLiquidity {
+        /// The fee payer's fee token (the token being swapped from), when known.
+        user_token: Option<Address>,
+        /// The validator's preferred token (the token being swapped to), when known.
+        validator_token: Option<Address>,
         /// The required fee amount that couldn't be swapped.
         fee: U256,
     },
@@ -430,6 +421,13 @@ impl<DBError> From<FeePaymentError> for EVMError<DBError, TempoInvalidTransactio
     }
 }
 
+fn liquidity_pair_msg(user_token: &Option<Address>, validator_token: &Option<Address>) -> String {
+    if let (Some(user_token), Some(validator_token)) = (user_token, validator_token) {
+        return format!(" for pair {user_token} -> {validator_token}");
+    }
+    String::new()
+}
+
 /// Tempo-specific halt reason.
 ///
 /// Used to extend basic [`HaltReason`] with an edge case of a subblock transaction fee payment error.
@@ -455,6 +453,7 @@ impl reth_rpc_eth_types::error::api::FromEvmHalt<TempoHaltReason>
         }
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -468,25 +467,21 @@ mod tests {
         );
 
         let err = FeePaymentError::InsufficientAmmLiquidity {
+            user_token: None,
+            validator_token: None,
             fee: U256::from(1000),
         };
-        let msg = err.to_string();
-        assert!(msg.contains("insufficient liquidity in FeeAMM pool"));
-        assert!(msg.contains("required: 1000"));
+        assert!(err.to_string().contains("required: 1000"));
 
         let user_token = Address::with_last_byte(0x11);
         let validator_token = Address::with_last_byte(0x22);
-        let err = FeePaymentError::InsufficientAmmLiquidityForPair {
-            user_token,
-            validator_token,
+        let err = FeePaymentError::InsufficientAmmLiquidity {
+            user_token: Some(user_token),
+            validator_token: Some(validator_token),
             fee: U256::from(1000),
         };
         let msg = err.to_string();
         assert!(msg.contains("insufficient liquidity in FeeAMM pool"));
-        // The swap pair and required amount must be surfaced so callers can
-        // diagnose which fee-token route is under-provisioned.
-        assert!(msg.contains(&user_token.to_string()));
-        assert!(msg.contains(&validator_token.to_string()));
         assert!(msg.contains(&format!("{user_token} -> {validator_token}")));
         assert!(msg.contains("required: 1000"));
 
@@ -546,6 +541,8 @@ mod tests {
     #[test]
     fn test_fee_payment_error() {
         let _: EVMError<(), TempoInvalidTransaction> = FeePaymentError::InsufficientAmmLiquidity {
+            user_token: None,
+            validator_token: None,
             fee: U256::from(1000),
         }
         .into();

--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -21,6 +21,19 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
         journal.get_fee_token(tx, fee_payer, spec, actions)
     }
 
+    /// Resolves the validator token used to receive protocol fees.
+    fn get_validator_token(
+        &self,
+        journal: &mut Journal<DB>,
+        beneficiary: Address,
+        spec: TempoHardfork,
+        actions: StorageActions,
+    ) -> TempoResult<Address> {
+        journal.with_read_only_storage_ctx(spec, actions, || {
+            TipFeeManager::new().get_validator_token(beneficiary)
+        })
+    }
+
     /// Collects the maximum possible fee before transaction execution.
     fn collect_fee_pre_tx(
         &self,

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -37,7 +37,6 @@ use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_contracts::precompiles::{
     IAccountKeychain::SignatureType as PrecompileSignatureType, TIPFeeAMMError,
 };
-use tempo_precompiles::tip_fee_manager::TipFeeManager;
 use tempo_precompiles::{
     ECRECOVER_GAS,
     account_keychain::{
@@ -1382,8 +1381,6 @@ where
             let checkpoint = journal.checkpoint();
 
             let skip_liquidity_check = evm.skip_liquidity_check;
-            // Capture validator token to report the swap pair on liquidity errors.
-            let mut validator_token = Address::default();
             let result = StorageCtx::enter_evm_without_tip1060_accounting(
                 journal,
                 block,
@@ -1391,8 +1388,6 @@ where
                 tx,
                 actions.clone(),
                 || {
-                    validator_token =
-                        TipFeeManager::new().get_validator_token(block.beneficiary())?;
                     fee_manager.collect_fee_pre_tx(
                         fee_payer,
                         fee_token,
@@ -1413,12 +1408,23 @@ where
                 return Err(match err {
                     TempoPrecompileError::TIPFeeAMMError(
                         TIPFeeAMMError::InsufficientLiquidity(_),
-                    ) => FeePaymentError::InsufficientAmmLiquidity {
-                        user_token: fee_token,
-                        validator_token,
-                        fee: gas_balance_spending,
-                    }
-                    .into(),
+                    ) => match fee_manager.get_validator_token(
+                        journal,
+                        block.beneficiary(),
+                        cfg.spec,
+                        StorageActions::disabled(),
+                    ) {
+                        Ok(validator_token) => FeePaymentError::InsufficientAmmLiquidityForPair {
+                            user_token: fee_token,
+                            validator_token,
+                            fee: gas_balance_spending,
+                        }
+                        .into(),
+                        Err(_) => FeePaymentError::InsufficientAmmLiquidity {
+                            fee: gas_balance_spending,
+                        }
+                        .into(),
+                    },
 
                     TempoPrecompileError::TIP20(TIP20Error::InsufficientBalance(
                         InsufficientBalance { available, .. },
@@ -2534,7 +2540,7 @@ pub fn validate_time_window(
 mod tests {
     use super::*;
     use crate::{
-        TempoBlockEnv, TempoTxEnv, evm::TempoEvm, gas_params::tempo_gas_params,
+        ProtocolFeeManager, TempoBlockEnv, TempoTxEnv, evm::TempoEvm, gas_params::tempo_gas_params,
         tx::TempoBatchCallEnv,
     };
     use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
@@ -2551,9 +2557,10 @@ mod tests {
         primitives::hardfork::SpecId,
     };
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
+    use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIPFeeAMM};
     use tempo_precompiles::{
         PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, storage::ContractStorage, test_util::TIP20Setup,
+        tip_fee_manager::TipFeeManager,
     };
     use tempo_primitives::transaction::{
         Call, RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
@@ -2643,10 +2650,73 @@ mod tests {
                 .validate_against_state_and_deduct_caller(&mut self.evm, &mut Default::default())
         }
 
+        fn with_fee_manager<F>(self, fee_manager: F) -> Self
+        where
+            F: ProtocolFeeManager<CacheDB<EmptyDB>> + 'static,
+        {
+            let Self { evm, handler } = self;
+            Self {
+                evm: evm.with_fee_manager(fee_manager),
+                handler,
+            }
+        }
+
         fn execute(&mut self, init_gas: &InitialAndFloorGas) -> FrameResult {
             self.handler
                 .execution(&mut self.evm, init_gas)
                 .expect("execution should return a frame result")
+        }
+    }
+
+    #[derive(Debug)]
+    struct ValidatorTokenLookupFailsFeeManager;
+
+    impl<DB: Database> ProtocolFeeManager<DB> for ValidatorTokenLookupFailsFeeManager {
+        fn get_fee_token(
+            &self,
+            _journal: &mut Journal<DB>,
+            tx: &TempoTxEnv,
+            _fee_payer: Address,
+            _spec: TempoHardfork,
+            _actions: StorageActions,
+        ) -> tempo_precompiles::error::Result<Address> {
+            Ok(tx.fee_token.unwrap_or(DEFAULT_FEE_TOKEN))
+        }
+
+        fn get_validator_token(
+            &self,
+            _journal: &mut Journal<DB>,
+            _beneficiary: Address,
+            _spec: TempoHardfork,
+            _actions: StorageActions,
+        ) -> tempo_precompiles::error::Result<Address> {
+            Err(TempoPrecompileError::Fatal(
+                "injected validator token lookup failure".to_string(),
+            ))
+        }
+
+        fn collect_fee_pre_tx(
+            &self,
+            _fee_payer: Address,
+            _user_token: Address,
+            _max_amount: U256,
+            _beneficiary: Address,
+            _skip_liquidity_check: bool,
+        ) -> tempo_precompiles::error::Result<Address> {
+            Err(TempoPrecompileError::TIPFeeAMMError(
+                TIPFeeAMMError::InsufficientLiquidity(ITIPFeeAMM::InsufficientLiquidity {}),
+            ))
+        }
+
+        fn collect_fee_post_tx(
+            &self,
+            _fee_payer: Address,
+            _actual_spending: U256,
+            _refund_amount: U256,
+            _fee_token: Address,
+            _beneficiary: Address,
+        ) -> tempo_precompiles::error::Result<U256> {
+            Ok(U256::ZERO)
         }
     }
 
@@ -2745,6 +2815,115 @@ mod tests {
             ),
             "Should reject paused fee token with FeeTokenPaused error"
         );
+    }
+
+    #[test]
+    fn test_collect_fee_pre_tx_insufficient_liquidity_reports_pair_from_handler() -> eyre::Result<()>
+    {
+        use tempo_contracts::precompiles::IFeeManager;
+
+        let admin = Address::random();
+        let fee_payer = Address::random();
+        let validator = Address::random();
+        let gas_limit = 1_000;
+        let gas_price = 1_000_000_000_000_u128;
+        let fee = calc_gas_balance_spending(gas_limit, gas_price);
+
+        let mut test = TestHandlerEvm::tx(TempoHardfork::T5, |tx_env| {
+            tx_env.inner.caller = fee_payer;
+            tx_env.inner.gas_limit = gas_limit;
+            tx_env.inner.gas_price = gas_price;
+            tx_env.inner.gas_priority_fee = Some(gas_price);
+        });
+        test.evm.inner.ctx.block.beneficiary = validator;
+
+        let (user_token, validator_token) =
+            StorageCtx::enter_ctx(&mut test.evm.inner.ctx, StorageActions::disabled(), || {
+                let user_token = TIP20Setup::create("UserToken", "UTK", admin)
+                    .with_issuer(admin)
+                    .with_mint(fee_payer, fee)
+                    .with_approval(fee_payer, TIP_FEE_MANAGER_ADDRESS, U256::MAX)
+                    .apply()?;
+
+                let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                    .with_issuer(admin)
+                    .apply()?;
+
+                TipFeeManager::new().set_validator_token(
+                    validator,
+                    IFeeManager::setValidatorTokenCall {
+                        token: validator_token.address(),
+                    },
+                    Address::random(),
+                )?;
+
+                Ok::<_, TempoPrecompileError>((user_token.address(), validator_token.address()))
+            })?;
+
+        test.evm.inner.ctx.tx.fee_token = Some(user_token);
+
+        let result = test.validate_against_state_and_deduct_caller();
+
+        assert!(
+            matches!(
+                result,
+                Err(EVMError::Transaction(TempoInvalidTransaction::CollectFeePreTx(
+                    FeePaymentError::InsufficientAmmLiquidityForPair {
+                        user_token: reported_user_token,
+                        validator_token: reported_validator_token,
+                        fee: reported_fee,
+                    }
+                ))) if reported_user_token == user_token
+                    && reported_validator_token == validator_token
+                    && reported_fee == fee
+            ),
+            "expected pair-aware insufficient liquidity error, got: {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_collect_fee_pre_tx_insufficient_liquidity_falls_back_when_pair_lookup_fails()
+    -> eyre::Result<()> {
+        let admin = Address::random();
+        let fee_payer = Address::random();
+        let gas_limit = 1_000;
+        let gas_price = 1_000_000_000_000_u128;
+        let fee = calc_gas_balance_spending(gas_limit, gas_price);
+
+        let mut test = TestHandlerEvm::tx(TempoHardfork::T5, |tx_env| {
+            tx_env.inner.caller = fee_payer;
+            tx_env.inner.gas_limit = gas_limit;
+            tx_env.inner.gas_price = gas_price;
+            tx_env.inner.gas_priority_fee = Some(gas_price);
+        })
+        .with_fee_manager(ValidatorTokenLookupFailsFeeManager);
+
+        let user_token =
+            StorageCtx::enter_ctx(&mut test.evm.inner.ctx, StorageActions::disabled(), || {
+                TIP20Setup::create("UserToken", "UTK", admin)
+                    .with_issuer(admin)
+                    .with_mint(fee_payer, fee)
+                    .apply()
+                    .map(|token| token.address())
+            })?;
+
+        test.evm.inner.ctx.tx.fee_token = Some(user_token);
+
+        let result = test.validate_against_state_and_deduct_caller();
+
+        assert!(
+            matches!(
+                result,
+                Err(EVMError::Transaction(TempoInvalidTransaction::CollectFeePreTx(
+                    FeePaymentError::InsufficientAmmLiquidity { fee: reported_fee }
+                ))) if reported_fee == fee
+            ),
+            "expected generic insufficient liquidity error when pair lookup fails, got: {result:?}"
+        );
+
+        Ok(())
     }
 
     #[test]
@@ -2889,68 +3068,6 @@ mod tests {
         assert_eq!(tx_fee_token, fee_token);
 
         Ok(())
-    }
-
-    /// A cross-token fee swap with no pool must fail with `InsufficientLiquidity`,
-    /// and the validator token captured for the error must match what was set.
-    #[test]
-    fn test_collect_fee_pre_tx_insufficient_liquidity_reports_pair() -> eyre::Result<()> {
-        use tempo_contracts::precompiles::IFeeManager;
-        use tempo_precompiles::storage::{StorageCtx, hashmap::HashMapStorageProvider};
-
-        let mut storage = HashMapStorageProvider::new(1);
-        let admin = Address::random();
-        let user = Address::random();
-        let validator = Address::random();
-
-        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
-            // Minted + approved so the pre-tx transfer reaches the route check.
-            let user_token = TIP20Setup::create("UserToken", "UTK", admin)
-                .with_issuer(admin)
-                .with_mint(user, U256::from(10_000))
-                .with_approval(user, TIP_FEE_MANAGER_ADDRESS, U256::MAX)
-                .apply()?;
-
-            // Different token with no pool: no route can be planned.
-            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
-                .with_issuer(admin)
-                .apply()?;
-
-            // Stored under `sender`; `beneficiary` must differ (same-block guard).
-            TipFeeManager::new().set_validator_token(
-                validator,
-                IFeeManager::setValidatorTokenCall {
-                    token: validator_token.address(),
-                },
-                Address::random(),
-            )?;
-
-            // The token the handler captures for the error.
-            let captured_validator_token = TipFeeManager::new().get_validator_token(validator)?;
-            assert_eq!(captured_validator_token, validator_token.address());
-
-            let err = TipFeeManager::new()
-                .collect_fee_pre_tx(user, user_token.address(), U256::from(1_000), validator, false)
-                .expect_err("fee swap must fail with insufficient liquidity");
-            assert!(matches!(
-                err,
-                TempoPrecompileError::TIPFeeAMMError(TIPFeeAMMError::InsufficientLiquidity(_))
-            ));
-
-            // The message built from the captured pair must name it.
-            let msg = FeePaymentError::InsufficientAmmLiquidity {
-                user_token: user_token.address(),
-                validator_token: captured_validator_token,
-                fee: U256::from(1_000),
-            }
-            .to_string();
-            assert!(
-                msg.contains(&format!("{} -> {}", user_token.address(), validator_token.address())),
-                "error message must name the swap pair, got: {msg}"
-            );
-
-            Ok(())
-        })
     }
 
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -37,7 +37,6 @@ use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_contracts::precompiles::{
     IAccountKeychain::SignatureType as PrecompileSignatureType, TIPFeeAMMError,
 };
-#[cfg(test)]
 use tempo_precompiles::tip_fee_manager::TipFeeManager;
 use tempo_precompiles::{
     ECRECOVER_GAS,
@@ -1383,6 +1382,8 @@ where
             let checkpoint = journal.checkpoint();
 
             let skip_liquidity_check = evm.skip_liquidity_check;
+            // Capture validator token to report the swap pair on liquidity errors.
+            let mut validator_token = Address::default();
             let result = StorageCtx::enter_evm_without_tip1060_accounting(
                 journal,
                 block,
@@ -1390,6 +1391,8 @@ where
                 tx,
                 actions.clone(),
                 || {
+                    validator_token =
+                        TipFeeManager::new().get_validator_token(block.beneficiary())?;
                     fee_manager.collect_fee_pre_tx(
                         fee_payer,
                         fee_token,
@@ -1411,6 +1414,8 @@ where
                     TempoPrecompileError::TIPFeeAMMError(
                         TIPFeeAMMError::InsufficientLiquidity(_),
                     ) => FeePaymentError::InsufficientAmmLiquidity {
+                        user_token: fee_token,
+                        validator_token,
                         fee: gas_balance_spending,
                     }
                     .into(),
@@ -2884,6 +2889,68 @@ mod tests {
         assert_eq!(tx_fee_token, fee_token);
 
         Ok(())
+    }
+
+    /// A cross-token fee swap with no pool must fail with `InsufficientLiquidity`,
+    /// and the validator token captured for the error must match what was set.
+    #[test]
+    fn test_collect_fee_pre_tx_insufficient_liquidity_reports_pair() -> eyre::Result<()> {
+        use tempo_contracts::precompiles::IFeeManager;
+        use tempo_precompiles::storage::{StorageCtx, hashmap::HashMapStorageProvider};
+
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let user = Address::random();
+        let validator = Address::random();
+
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            // Minted + approved so the pre-tx transfer reaches the route check.
+            let user_token = TIP20Setup::create("UserToken", "UTK", admin)
+                .with_issuer(admin)
+                .with_mint(user, U256::from(10_000))
+                .with_approval(user, TIP_FEE_MANAGER_ADDRESS, U256::MAX)
+                .apply()?;
+
+            // Different token with no pool: no route can be planned.
+            let validator_token = TIP20Setup::create("ValidatorToken", "VTK", admin)
+                .with_issuer(admin)
+                .apply()?;
+
+            // Stored under `sender`; `beneficiary` must differ (same-block guard).
+            TipFeeManager::new().set_validator_token(
+                validator,
+                IFeeManager::setValidatorTokenCall {
+                    token: validator_token.address(),
+                },
+                Address::random(),
+            )?;
+
+            // The token the handler captures for the error.
+            let captured_validator_token = TipFeeManager::new().get_validator_token(validator)?;
+            assert_eq!(captured_validator_token, validator_token.address());
+
+            let err = TipFeeManager::new()
+                .collect_fee_pre_tx(user, user_token.address(), U256::from(1_000), validator, false)
+                .expect_err("fee swap must fail with insufficient liquidity");
+            assert!(matches!(
+                err,
+                TempoPrecompileError::TIPFeeAMMError(TIPFeeAMMError::InsufficientLiquidity(_))
+            ));
+
+            // The message built from the captured pair must name it.
+            let msg = FeePaymentError::InsufficientAmmLiquidity {
+                user_token: user_token.address(),
+                validator_token: captured_validator_token,
+                fee: U256::from(1_000),
+            }
+            .to_string();
+            assert!(
+                msg.contains(&format!("{} -> {}", user_token.address(), validator_token.address())),
+                "error message must name the swap pair, got: {msg}"
+            );
+
+            Ok(())
+        })
     }
 
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1408,23 +1408,23 @@ where
                 return Err(match err {
                     TempoPrecompileError::TIPFeeAMMError(
                         TIPFeeAMMError::InsufficientLiquidity(_),
-                    ) => match fee_manager.get_validator_token(
-                        journal,
-                        block.beneficiary(),
-                        cfg.spec,
-                        StorageActions::disabled(),
-                    ) {
-                        Ok(validator_token) => FeePaymentError::InsufficientAmmLiquidityForPair {
-                            user_token: fee_token,
+                    ) => {
+                        let validator_token = fee_manager
+                            .get_validator_token(
+                                journal,
+                                block.beneficiary(),
+                                cfg.spec,
+                                StorageActions::disabled(),
+                            )
+                            .ok();
+
+                        FeePaymentError::InsufficientAmmLiquidity {
+                            user_token: validator_token.map(|_| fee_token),
                             validator_token,
                             fee: gas_balance_spending,
                         }
-                        .into(),
-                        Err(_) => FeePaymentError::InsufficientAmmLiquidity {
-                            fee: gas_balance_spending,
-                        }
-                        .into(),
-                    },
+                        .into()
+                    }
 
                     TempoPrecompileError::TIP20(TIP20Error::InsufficientBalance(
                         InsufficientBalance { available, .. },
@@ -2867,15 +2867,12 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(EVMError::Transaction(TempoInvalidTransaction::CollectFeePreTx(
-                    FeePaymentError::InsufficientAmmLiquidityForPair {
-                        user_token: reported_user_token,
-                        validator_token: reported_validator_token,
-                        fee: reported_fee,
+                Err(EVMError::Transaction(TempoInvalidTransaction::CollectFeePreTx(ref err)))
+                    if *err == FeePaymentError::InsufficientAmmLiquidity {
+                        user_token: Some(user_token),
+                        validator_token: Some(validator_token),
+                        fee,
                     }
-                ))) if reported_user_token == user_token
-                    && reported_validator_token == validator_token
-                    && reported_fee == fee
             ),
             "expected pair-aware insufficient liquidity error, got: {result:?}"
         );
@@ -2916,9 +2913,12 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(EVMError::Transaction(TempoInvalidTransaction::CollectFeePreTx(
-                    FeePaymentError::InsufficientAmmLiquidity { fee: reported_fee }
-                ))) if reported_fee == fee
+                Err(EVMError::Transaction(TempoInvalidTransaction::CollectFeePreTx(ref err)))
+                    if *err == FeePaymentError::InsufficientAmmLiquidity {
+                        user_token: None,
+                        validator_token: None,
+                        fee,
+                    }
             ),
             "expected generic insufficient liquidity error when pair lookup fails, got: {result:?}"
         );

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -537,7 +537,7 @@ where
                     InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(
                         TempoInvalidTransaction::CollectFeePreTx(
                             FeePaymentError::InsufficientAmmLiquidity {
-                                user_token: None,
+                                user_token: Some(validation_ctx.fee_token),
                                 validator_token: None,
                                 fee,
                             },

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -536,7 +536,11 @@ where
                     transaction,
                     InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(
                         TempoInvalidTransaction::CollectFeePreTx(
-                            FeePaymentError::InsufficientAmmLiquidity { fee },
+                            FeePaymentError::InsufficientAmmLiquidity {
+                                user_token: None,
+                                validator_token: None,
+                                fee,
+                            },
                         ),
                     )),
                 );


### PR DESCRIPTION
## Summary

- add `FeePaymentError::InsufficientAmmLiquidityForPair { user_token, validator_token, fee }` for handler validation failures that can identify the exact FeeAMM swap pair
- keep `FeePaymentError::InsufficientAmmLiquidity { fee }` for pool-side checks and fallback cases where no specific pair should be reported
- add `ProtocolFeeManager::get_validator_token` so the handler can resolve validator-token context through the fee-manager abstraction
- map FeeAMM `InsufficientLiquidity` from `collect_fee_pre_tx` to the pair-aware error after reverting the failed fee-collection checkpoint, with storage-action recording disabled for the diagnostic lookup
- fall back to the generic insufficient-liquidity error if validator-token lookup fails during enrichment
- update handler and error-display tests for the pair-aware message and fallback behavior
- replace deprecated atomic `fetch_update` calls with `try_update` to unblock latest-nightly clippy

## Why

FeeAMM liquidity failures are more actionable when callers can see the exact `user_token -> validator_token` route that lacks liquidity. The handler already knows the user fee token and can resolve the validator token after the FeeAMM failure, so it can report that pair without changing the normal fee-collection path.

The validator-token lookup is best-effort diagnostic enrichment. If it fails, the handler preserves the original insufficient-liquidity classification instead of replacing it with a secondary lookup error.

The lint-only payload change addresses a repo-wide latest-nightly deprecation warning that CI treats as an error via `RUSTFLAGS=-D warnings`.

## Validation

- cargo +nightly fmt --check -- crates/revm/src/error.rs crates/revm/src/handler.rs crates/revm/src/fee_manager.rs
- cargo +nightly fmt --check -- crates/payload/types/src/budget.rs crates/payload/builder/src/lib.rs
- cargo +nightly test -p tempo-revm test_collect_fee_pre_tx_insufficient_liquidity
- cargo +nightly check -p tempo-revm
- cargo +nightly check -p tempo-transaction-pool
- cargo +nightly test -p tempo-evm test_tip20_full_evm_storage_actions
- RUSTFLAGS="-D warnings" cargo +nightly clippy -p tempo-payload-types -p tempo-payload-builder --all-targets --all-features --locked
- git diff --check origin/main...HEAD
