### PR TITLE
fix(payload): use non-deprecated atomic update

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -239,7 +239,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         let Some(observed) = observed_build_time_multiplier(total_work, work_at_tx_cutoff) else {
             return;
         };
-        let _ = self.build_time_multiplier.fetch_update(
+        let _ = self.build_time_multiplier.try_update(
             Ordering::Relaxed,
             Ordering::Relaxed,
             |current| Some(decay_build_time_multiplier(current, observed)),

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -45,7 +45,7 @@ pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
     let observed = observed.min(u128::from(u64::MAX)) as u64;
 
     let _ =
-        MARSHAL_PERSIST_NS_PER_BYTE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        MARSHAL_PERSIST_NS_PER_BYTE.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(if current == 0 || observed >= current {
                 observed
             } else {


### PR DESCRIPTION
Replaces the deprecated `AtomicU64::fetch_update` call with `try_update` so clippy passes when CI promotes warnings to errors.

Prompted by: @grandizzy