### PR TITLE
docs: rename TIP-1087 index fields

### DIFF
--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -107,9 +107,9 @@ slot 6:
   askBitmap   mapping(int16 => uint256)
 ```
 
-`id` is the `book_keys` vector index for this orderbook. `idFlag` indicates whether `id` is active, distinguishing an active index `0` from the pre-activation default value. These fields are packed after `bestBidTick` and `bestAskTick` in slot `4`, so this TIP does not increase the orderbook slot count or move any existing orderbook fields.
+`bookKeyIdx` is the `book_keys` vector index for this orderbook. `isIndexSet` indicates whether `bookKeyIdx` is active, distinguishing an active index `0` from the pre-activation default value. These fields are packed after `bestBidTick` and `bestAskTick` in slot `4`, so this TIP does not increase the orderbook slot count or move any existing orderbook fields.
 
-Starting at activation, newly created orderbooks MUST store `id = book_keys.length` and `idFlag = true` in slot `4` on the orderbook record before appending the key to `book_keys`. Orderbooks created before activation have `idFlag = false` and no active stored index.
+Starting at activation, newly created orderbooks MUST store `bookKeyIdx = book_keys.length` and `isIndexSet = true` in slot `4` on the orderbook record before appending the key to `book_keys`. Orderbooks created before activation have `isIndexSet = false` and no active stored index.
 
 Pre-activation orderbooks MUST NOT be migrated by linearly scanning `book_keys` onchain. The DEX already has hundreds of thousands of orderbooks on testnet, so an onchain full-array scan cannot fit within the transaction execution budget. Instead, migration tooling MUST derive the index offchain and submit it to the DEX for verification and persistence.
 
@@ -121,9 +121,9 @@ function bookIndexForKey(bytes32 bookKey) external view returns (bool isSet, uin
 function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
 ```
 
-`setIndexForKey` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `id = index` and `idFlag = true` on the orderbook record. If the orderbook already has `idFlag = true`, `setIndexForKey` MUST be idempotent when the supplied `index` matches the existing value and MUST NOT rewrite `id`. If the supplied `index` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `id`.
+`setIndexForKey` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index` and `isIndexSet = true` on the orderbook record. If the orderbook already has `isIndexSet = true`, `setIndexForKey` MUST be idempotent when the supplied `index` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
 
-`bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It returns whether `idFlag` is true and the persisted `id`. `bookKeyForIndex` MUST fail if the requested index is not present in `book_keys`.
+`bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It returns whether `isIndexSet` is true and the persisted `bookKeyIdx`. `bookKeyForIndex` MUST fail if the requested index is not present in `book_keys`.
 
 ## Read behavior
 
@@ -143,12 +143,12 @@ All order reads MUST use the order storage abstraction. Starting at activation, 
 
 Before activation, new orders MUST be written using the latest already-active layout. Starting at activation, new orders MUST use the best available layout for the target orderbook:
 
-- if the orderbook has `idFlag = true`, write `V2Order` using the persisted `id` as `bookIndex`
-- if the orderbook has `idFlag = false`, fall back to writing `V1Order`
+- if the orderbook has `isIndexSet = true`, write `V2Order` using the persisted `bookKeyIdx` as `bookIndex`
+- if the orderbook has `isIndexSet = false`, fall back to writing `V1Order`
 
 Mutations to active order fields (`remaining`, `prev`, `next`) MUST go through version-aware order storage methods.
 
-Once an orderbook's `idFlag` becomes true, all later orders for that orderbook MUST use `V2Order`. Existing version `0` and version `1` orders are not migrated in place.
+Once an orderbook's `isIndexSet` becomes true, all later orders for that orderbook MUST use `V2Order`. Existing version `0` and version `1` orders are not migrated in place.
 
 Mixed-version linked lists are valid. Updating a neighbor's `prev` or `next` pointer MUST use the neighbor order's version, not the current order's version.
 
@@ -156,14 +156,14 @@ Mixed-version linked lists are valid. Updating a neighbor's `prev` or `next` poi
 
 TIP-1056 rewrites fully filled flip orders in place under the same mapping key. Starting at activation:
 
-- user-submitted orders, including `placeFlip` orders, MUST be written as version `2` when the orderbook has `idFlag = true`
-- user-submitted orders, including `placeFlip` orders, MUST fall back to version `1` when the orderbook has `idFlag = false`
-- a version `0` or version `1` flip order that flips after activation MUST be rewritten under the same `orderId` as version `2` when the orderbook has `idFlag = true`, or version `1` otherwise
+- user-submitted orders, including `placeFlip` orders, MUST be written as version `2` when the orderbook has `isIndexSet = true`
+- user-submitted orders, including `placeFlip` orders, MUST fall back to version `1` when the orderbook has `isIndexSet = false`
+- a version `0` or version `1` flip order that flips after activation MUST be rewritten under the same `orderId` as version `2` when the orderbook has `isIndexSet = true`, or version `1` otherwise
 - a version `2` flip order that flips MUST remain version `2`
 
 A `V2Order` flip rewrite MUST encode the post-flip order state as follows:
 
-- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, the correct `bookIndex`, zeroed unused bytes, and `version = 2`. For a version `2` flip rewrite, `bookIndex` MUST be preserved from the existing order. For a version `0` or version `1` flip rewrite upgraded to version `2`, `bookIndex` MUST be set from the target orderbook's persisted `id` after asserting that `book_keys[id] == bookKey`.
+- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, the correct `bookIndex`, zeroed unused bytes, and `version = 2`. For a version `2` flip rewrite, `bookIndex` MUST be preserved from the existing order. For a version `0` or version `1` flip rewrite upgraded to version `2`, `bookIndex` MUST be set from the target orderbook's persisted `bookKeyIdx` after asserting that `book_keys[bookKeyIdx] == bookKey`.
 - slot `1`: preserved `amount` and `remaining = amount`
 - slot `2`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
 - slots used only by the previous version MUST be cleared when upgrading from version `0` or `1`
@@ -176,9 +176,9 @@ Deleting an order clears the storage slots used by that order's versioned layout
 
 # Tooling
 
-Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setIndexForKey(bookKey, index)`, and verifies that each corresponding orderbook has `idFlag = true` and the expected `id`. The workflow MUST avoid onchain linear scans over `book_keys`.
+Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setIndexForKey(bookKey, index)`, and verifies that each corresponding orderbook has `isIndexSet = true` and the expected `bookKeyIdx`. The workflow MUST avoid onchain linear scans over `book_keys`.
 
-Tools that decode raw DEX storage MUST add support for the orderbook `id` / `idFlag` fields packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
+Tools that decode raw DEX storage MUST add support for the orderbook `bookKeyIdx` / `isIndexSet` fields packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
 
 # Observability
 
@@ -190,8 +190,8 @@ The migration workflow MUST produce an operator-verifiable report with the total
 
 - Order identity is stable: the `orders` mapping slot and key type are unchanged, and the mapping key remains the canonical `orderId` for every order layout.
 - Versioned decoding is stable: existing version `0` and version `1` bytes keep their existing meaning, and a stored order's version discriminator is the only source of truth for its layout.
-- Book indexes are stable references: `book_keys` is append-only, and any persisted orderbook `id` or `V2Order.bookIndex` MUST resolve to the orderbook's canonical `bookKey`.
-- Index association is monotonic: an orderbook may move from `idFlag = false` to `idFlag = true`, but once indexed its `id` MUST NOT change to a different value.
+- Book indexes are stable references: `book_keys` is append-only, and any persisted orderbook `bookKeyIdx` or `V2Order.bookIndex` MUST resolve to the orderbook's canonical `bookKey`.
+- Index association is monotonic: an orderbook may move from `isIndexSet = false` to `isIndexSet = true`, but once indexed its `bookKeyIdx` MUST NOT change to a different value.
 - V2 writes are gated by index availability: an orderbook without an active index MUST continue to use the latest non-indexed order layout for new writes.
 - Mixed-version linked lists remain valid: `prev` and `next` pointers always reference canonical order IDs, and pointer updates are encoded according to the target order's own storage version.
 - External order reads remain logically stable: `getOrder(uint128)` returns the same ABI shape and logical fields regardless of whether the underlying order is version `0`, `1`, or `2`.


### PR DESCRIPTION
## Summary
- update TIP-1087 prose to use `bookKeyIdx` and `isIndexSet` instead of `id` and `idFlag`
- keep the existing TIP frontmatter `id` key unchanged

## Testing
- `git diff --check`

Prompted by: @0xrusowsky