### PR TITLE
docs: make TIP-1087 bookKeyIdx one-based

### DIFF
--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -96,9 +96,8 @@ slot 3:
 slot 4:
   offset 0   bestBidTick  int16     2 bytes
   offset 2   bestAskTick  int16     2 bytes
-  offset 4   isIndexSet   bool      1 byte
-  offset 5   bookKeyIdx   uint32    4 bytes
-  offset 9   unused                 23 bytes
+  offset 4   bookKeyIdx   uint32    4 bytes
+  offset 8   unused                 24 bytes
 
 slot 5:
   bidBitmap   mapping(int16 => uint256)
@@ -107,9 +106,9 @@ slot 6:
   askBitmap   mapping(int16 => uint256)
 ```
 
-`bookKeyIdx` is the `book_keys` vector index for this orderbook. `isIndexSet` indicates whether `bookKeyIdx` is active, distinguishing an active index `0` from the pre-activation default value. These fields are packed after `bestBidTick` and `bestAskTick` in slot `4`, so this TIP does not increase the orderbook slot count or move any existing orderbook fields.
+`bookKeyIdx` is the 1-based `book_keys` vector index for this orderbook. A value of `0` means no active index is set, distinguishing the unset state from the active `book_keys[0]` index. This field is packed after `bestBidTick` and `bestAskTick` in slot `4`, so this TIP does not increase the orderbook slot count or move any existing orderbook fields.
 
-Starting at activation, newly created orderbooks MUST store `bookKeyIdx = book_keys.length` and `isIndexSet = true` in slot `4` on the orderbook record before appending the key to `book_keys`. Orderbooks created before activation have `isIndexSet = false` and no active stored index.
+Starting at activation, newly created orderbooks MUST store `bookKeyIdx = book_keys.length + 1` in slot `4` on the orderbook record before appending the key to `book_keys`. Orderbooks created before activation have `bookKeyIdx = 0` and no active stored index.
 
 Pre-activation orderbooks MUST NOT be migrated by linearly scanning `book_keys` onchain. The DEX already has hundreds of thousands of orderbooks on testnet, so an onchain full-array scan cannot fit within the transaction execution budget. Instead, migration tooling MUST derive the index offchain and submit it to the DEX for verification and persistence.
 
@@ -121,9 +120,9 @@ function bookIndexForKey(bytes32 bookKey) external view returns (bool isSet, uin
 function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
 ```
 
-`setIndexForKey` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index` and `isIndexSet = true` on the orderbook record. If the orderbook already has `isIndexSet = true`, `setIndexForKey` MUST be idempotent when the supplied `index` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
+`setIndexForKey` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index + 1` on the orderbook record. If the orderbook already has `bookKeyIdx != 0`, `setIndexForKey` MUST be idempotent when the supplied `index + 1` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index + 1` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
 
-`bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It returns whether `isIndexSet` is true and the persisted `bookKeyIdx`. `bookKeyForIndex` MUST fail if the requested index is not present in `book_keys`.
+`bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It returns whether `bookKeyIdx != 0` and the 0-based index `bookKeyIdx - 1` when set. `bookKeyForIndex` MUST fail if the requested index is not present in `book_keys`.
 
 ## Read behavior
 
@@ -143,12 +142,12 @@ All order reads MUST use the order storage abstraction. Starting at activation, 
 
 Before activation, new orders MUST be written using the latest already-active layout. Starting at activation, new orders MUST use the best available layout for the target orderbook:
 
-- if the orderbook has `isIndexSet = true`, write `V2Order` using the persisted `bookKeyIdx` as `bookIndex`
-- if the orderbook has `isIndexSet = false`, fall back to writing `V1Order`
+- if the orderbook has `bookKeyIdx != 0`, write `V2Order` using `bookKeyIdx - 1` as `bookIndex`
+- if the orderbook has `bookKeyIdx == 0`, fall back to writing `V1Order`
 
 Mutations to active order fields (`remaining`, `prev`, `next`) MUST go through version-aware order storage methods.
 
-Once an orderbook's `isIndexSet` becomes true, all later orders for that orderbook MUST use `V2Order`. Existing version `0` and version `1` orders are not migrated in place.
+Once an orderbook's `bookKeyIdx` becomes nonzero, all later orders for that orderbook MUST use `V2Order`. Existing version `0` and version `1` orders are not migrated in place.
 
 Mixed-version linked lists are valid. Updating a neighbor's `prev` or `next` pointer MUST use the neighbor order's version, not the current order's version.
 
@@ -156,14 +155,14 @@ Mixed-version linked lists are valid. Updating a neighbor's `prev` or `next` poi
 
 TIP-1056 rewrites fully filled flip orders in place under the same mapping key. Starting at activation:
 
-- user-submitted orders, including `placeFlip` orders, MUST be written as version `2` when the orderbook has `isIndexSet = true`
-- user-submitted orders, including `placeFlip` orders, MUST fall back to version `1` when the orderbook has `isIndexSet = false`
-- a version `0` or version `1` flip order that flips after activation MUST be rewritten under the same `orderId` as version `2` when the orderbook has `isIndexSet = true`, or version `1` otherwise
+- user-submitted orders, including `placeFlip` orders, MUST be written as version `2` when the orderbook has `bookKeyIdx != 0`
+- user-submitted orders, including `placeFlip` orders, MUST fall back to version `1` when the orderbook has `bookKeyIdx == 0`
+- a version `0` or version `1` flip order that flips after activation MUST be rewritten under the same `orderId` as version `2` when the orderbook has `bookKeyIdx != 0`, or version `1` otherwise
 - a version `2` flip order that flips MUST remain version `2`
 
 A `V2Order` flip rewrite MUST encode the post-flip order state as follows:
 
-- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, the correct `bookIndex`, zeroed unused bytes, and `version = 2`. For a version `2` flip rewrite, `bookIndex` MUST be preserved from the existing order. For a version `0` or version `1` flip rewrite upgraded to version `2`, `bookIndex` MUST be set from the target orderbook's persisted `bookKeyIdx` after asserting that `book_keys[bookKeyIdx] == bookKey`.
+- slot `0`: preserved `maker`, `metadata` encoding inverted `isBid` and `isFlip = true`, swapped `tick` / `flipTick`, the correct `bookIndex`, zeroed unused bytes, and `version = 2`. For a version `2` flip rewrite, `bookIndex` MUST be preserved from the existing order. For a version `0` or version `1` flip rewrite upgraded to version `2`, `bookIndex` MUST be set from the target orderbook's persisted `bookKeyIdx - 1` after asserting that `bookKeyIdx != 0` and `book_keys[bookKeyIdx - 1] == bookKey`.
 - slot `1`: preserved `amount` and `remaining = amount`
 - slot `2`: post-reinsertion `prev` / `next` pointers, after resetting them before insertion
 - slots used only by the previous version MUST be cleared when upgrading from version `0` or `1`
@@ -176,9 +175,9 @@ Deleting an order clears the storage slots used by that order's versioned layout
 
 # Tooling
 
-Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setIndexForKey(bookKey, index)`, and verifies that each corresponding orderbook has `isIndexSet = true` and the expected `bookKeyIdx`. The workflow MUST avoid onchain linear scans over `book_keys`.
+Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setIndexForKey(bookKey, index)`, and verifies that each corresponding orderbook has the expected 1-based `bookKeyIdx = index + 1`. The workflow MUST avoid onchain linear scans over `book_keys`.
 
-Tools that decode raw DEX storage MUST add support for the orderbook `bookKeyIdx` / `isIndexSet` fields packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
+Tools that decode raw DEX storage MUST add support for the 1-based orderbook `bookKeyIdx` field packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
 
 # Observability
 
@@ -190,8 +189,8 @@ The migration workflow MUST produce an operator-verifiable report with the total
 
 - Order identity is stable: the `orders` mapping slot and key type are unchanged, and the mapping key remains the canonical `orderId` for every order layout.
 - Versioned decoding is stable: existing version `0` and version `1` bytes keep their existing meaning, and a stored order's version discriminator is the only source of truth for its layout.
-- Book indexes are stable references: `book_keys` is append-only, and any persisted orderbook `bookKeyIdx` or `V2Order.bookIndex` MUST resolve to the orderbook's canonical `bookKey`.
-- Index association is monotonic: an orderbook may move from `isIndexSet = false` to `isIndexSet = true`, but once indexed its `bookKeyIdx` MUST NOT change to a different value.
+- Book indexes are stable references: `book_keys` is append-only, and any nonzero persisted orderbook `bookKeyIdx` or `V2Order.bookIndex` MUST resolve to the orderbook's canonical `bookKey`.
+- Index association is monotonic: an orderbook may move from `bookKeyIdx == 0` to `bookKeyIdx != 0`, but once indexed its `bookKeyIdx` MUST NOT change to a different value.
 - V2 writes are gated by index availability: an orderbook without an active index MUST continue to use the latest non-indexed order layout for new writes.
 - Mixed-version linked lists remain valid: `prev` and `next` pointers always reference canonical order IDs, and pointer updates are encoded according to the target order's own storage version.
 - External order reads remain logically stable: `getOrder(uint128)` returns the same ABI shape and logical fields regardless of whether the underlying order is version `0`, `1`, or `2`.


### PR DESCRIPTION
## Summary
- collapse `isIndexSet` into a single 1-based `bookKeyIdx` field
- define `bookKeyIdx == 0` as the unset state and `bookKeyIdx - 1` as the 0-based `book_keys` / `V2Order.bookIndex` value
- update migration, write, flip rewrite, tooling, and invariant prose accordingly

## Testing
- `git diff --check`

Prompted by: @0xrusowsky