### PR TITLE
fix(multisig): address native multisig review comments

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -126,11 +126,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         &mut self.inner
     }
 
-    /// Clears block-scoped execution caches on the inner EVM.
-    pub fn clear_block_caches(&mut self) {
-        self.inner.clear_block_caches();
-    }
-
     /// Returns the validator-credited fee amount (post-feeAMM haircut) recorded by the most
     /// recent `collectFeePostTx`. Reset per-tx in the handler's `validate_env`.
     pub fn validator_fee(&self) -> alloy_primitives::U256 {

--- a/crates/precompiles/src/native_multisig/auth.rs
+++ b/crates/precompiles/src/native_multisig/auth.rs
@@ -130,13 +130,7 @@ impl NativeMultisig {
         let digest = signature.digest(inner_digest);
         let mut weight_accumulator = MultisigWeightAccumulator::new(config.threshold());
 
-        for (signature_index, signature_bytes) in signature.signatures().iter().enumerate() {
-            let owner_approval = TempoSignature::from_bytes(signature_bytes).map_err(|reason| {
-                NativeMultisigAuthError::invalid_transaction(format!(
-                    "invalid multisig owner signature: {reason}"
-                ))
-            })?;
-
+        for (signature_index, owner_approval) in signature.signatures().iter().enumerate() {
             let (owner, nested_signature) = match owner_approval {
                 TempoSignature::Primitive(primitive) => {
                     let owner = primitive.recover_signer(&digest).map_err(|_| {
@@ -184,7 +178,7 @@ impl NativeMultisig {
                 account_path.push(owner);
                 self.verify_authorization_inner(
                     digest,
-                    &nested_signature,
+                    nested_signature,
                     NativeMultisigAuthConfig::Registered {
                         account: owner,
                         threshold,

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -1,4 +1,4 @@
-use super::{PrimitiveSignature, tempo_transaction::MAX_WEBAUTHN_SIGNATURE_LENGTH};
+use super::{tempo_transaction::MAX_WEBAUTHN_SIGNATURE_LENGTH, tt_signature::TempoSignature};
 use crate::TempoAddressExt;
 use alloc::{
     string::{String, ToString},
@@ -344,7 +344,12 @@ impl InitMultisig {
         signatures: &[Bytes],
     ) -> Result<u8, &'static str> {
         self.validate().map_err(MultisigConfigError::as_str)?;
-        let owners = recover_multisig_owner_addresses(digest, signatures)?;
+        let signatures = signatures
+            .iter()
+            .cloned()
+            .map(decode_multisig_owner_signature)
+            .collect::<Result<Vec<_>, _>>()?;
+        let owners = recover_multisig_owner_addresses(digest, &signatures)?;
         verify_recovered_multisig_owners(&owners, self)
     }
 
@@ -362,10 +367,10 @@ impl InitMultisig {
 pub struct MultisigSignature {
     /// Native multisig account address.
     account: Address,
-    /// Encoded owner approvals over the multisig digest.
+    /// Owner approvals over the multisig digest.
     ///
     /// Each approval is either a primitive signature or a nested native multisig signature.
-    signatures: Vec<Bytes>,
+    signatures: Vec<TempoSignature>,
     /// Initial native multisig config for bootstrapping this account.
     init: Option<InitMultisig>,
     /// Cached multisig digest for the transaction hash this signature approved.
@@ -378,13 +383,35 @@ pub struct MultisigSignature {
 
 impl MultisigSignature {
     pub fn new(account: Address, signatures: Vec<Bytes>, init: Option<InitMultisig>) -> Self {
-        Self {
+        Self::try_new(account, signatures, init).expect("valid multisig owner signatures")
+    }
+
+    pub fn try_new(
+        account: Address,
+        signatures: Vec<Bytes>,
+        init: Option<InitMultisig>,
+    ) -> Result<Self, &'static str> {
+        let signatures = signatures
+            .into_iter()
+            .map(decode_multisig_owner_signature)
+            .collect::<Result<Vec<_>, _>>()?;
+        Self::from_decoded(account, signatures, init)
+    }
+
+    pub fn from_decoded(
+        account: Address,
+        signatures: Vec<TempoSignature>,
+        init: Option<InitMultisig>,
+    ) -> Result<Self, &'static str> {
+        let signature = Self {
             account,
             signatures,
             init,
             cached_digest: OnceLock::new(),
             cached_recovered_owners: OnceLock::new(),
-        }
+        };
+        signature.validate_shape()?;
+        Ok(signature)
     }
 
     /// Returns the native multisig account address.
@@ -393,7 +420,7 @@ impl MultisigSignature {
     }
 
     /// Returns encoded owner approvals.
-    pub fn signatures(&self) -> &[Bytes] {
+    pub fn signatures(&self) -> &[TempoSignature] {
         &self.signatures
     }
 
@@ -430,13 +457,10 @@ impl MultisigSignature {
         if self.signatures.len() > MAX_MULTISIG_SIGNATURES {
             return Err("too many multisig signatures");
         }
-        if self.signatures.iter().any(|sig| sig.is_empty()) {
-            return Err("multisig owner signature cannot be empty");
-        }
         if self
             .signatures
             .iter()
-            .any(|sig| sig.len() > MAX_MULTISIG_OWNER_SIGNATURE_BYTES)
+            .any(|sig| sig.encoded_length() > MAX_MULTISIG_OWNER_SIGNATURE_BYTES)
         {
             return Err("multisig owner signature too large");
         }
@@ -530,8 +554,12 @@ impl MultisigSignature {
     /// Returns a heuristic for the in-memory size of the signature.
     pub fn size(&self) -> usize {
         size_of::<Self>()
-            + self.signatures.capacity() * size_of::<Bytes>()
-            + self.signatures.iter().map(|sig| sig.len()).sum::<usize>()
+            + self.signatures.capacity() * size_of::<TempoSignature>()
+            + self
+                .signatures
+                .iter()
+                .map(TempoSignature::size)
+                .sum::<usize>()
             + self.init.as_ref().map_or(0, InitMultisig::size)
     }
 }
@@ -566,7 +594,11 @@ impl From<&MultisigSignature> for MultisigSignatureWire {
     fn from(value: &MultisigSignature) -> Self {
         Self {
             account: value.account,
-            signatures: value.signatures.clone(),
+            signatures: value
+                .signatures
+                .iter()
+                .map(TempoSignature::to_bytes)
+                .collect(),
             init: value.init.clone(),
         }
     }
@@ -576,11 +608,7 @@ impl TryFrom<MultisigSignatureWire> for MultisigSignature {
     type Error = alloy_rlp::Error;
 
     fn try_from(value: MultisigSignatureWire) -> alloy_rlp::Result<Self> {
-        let signature = Self::new(value.account, value.signatures, value.init);
-        signature
-            .validate_shape()
-            .map_err(alloy_rlp::Error::Custom)?;
-        Ok(signature)
+        Self::try_new(value.account, value.signatures, value.init).map_err(alloy_rlp::Error::Custom)
     }
 }
 
@@ -666,7 +694,7 @@ pub fn verify_ordered_owner_weights(
 
 fn recover_multisig_owner_addresses(
     digest: B256,
-    signatures: &[Bytes],
+    signatures: &[TempoSignature],
 ) -> Result<Vec<Address>, &'static str> {
     if signatures.is_empty() {
         return Err("multisig signatures cannot be empty");
@@ -676,19 +704,26 @@ fn recover_multisig_owner_addresses(
     }
 
     let mut owners = Vec::with_capacity(signatures.len());
-    for signature_bytes in signatures {
-        if signature_bytes.len() > MAX_MULTISIG_OWNER_SIGNATURE_BYTES {
-            return Err("multisig owner signature too large");
-        }
-
-        let signature = PrimitiveSignature::from_bytes(signature_bytes)
-            .map_err(|_| "invalid multisig owner signature")?;
+    for signature in signatures {
+        let TempoSignature::Primitive(signature) = signature else {
+            return Err("invalid multisig owner signature");
+        };
         let owner = signature
             .recover_signer(&digest)
             .map_err(|_| "invalid multisig owner signature")?;
         owners.push(owner);
     }
     Ok(owners)
+}
+
+fn decode_multisig_owner_signature(signature: Bytes) -> Result<TempoSignature, &'static str> {
+    if signature.is_empty() {
+        return Err("multisig owner signature cannot be empty");
+    }
+    if signature.len() > MAX_MULTISIG_OWNER_SIGNATURE_BYTES {
+        return Err("multisig owner signature too large");
+    }
+    TempoSignature::from_bytes(&signature).map_err(|_| "invalid multisig owner signature")
 }
 
 fn verify_recovered_multisig_owners(
@@ -704,12 +739,7 @@ impl<'a> arbitrary::Arbitrary<'a> for MultisigSignature {
         let len = u.int_in_range(1..=MAX_MULTISIG_SIGNATURES)?;
         let mut signatures = Vec::new();
         for _ in 0..len {
-            let mut signature = Vec::<u8>::arbitrary(u)?;
-            if signature.is_empty() {
-                signature.push(0);
-            }
-            signature.truncate(MAX_MULTISIG_OWNER_SIGNATURE_BYTES);
-            signatures.push(Bytes::from(signature));
+            signatures.push(TempoSignature::Primitive(u.arbitrary()?));
         }
 
         let mut account = Address::arbitrary(u)?;
@@ -717,7 +747,8 @@ impl<'a> arbitrary::Arbitrary<'a> for MultisigSignature {
             account = Address::repeat_byte(1);
         }
 
-        Ok(Self::new(account, signatures, u.arbitrary()?))
+        Self::from_decoded(account, signatures, u.arbitrary()?)
+            .map_err(|_| arbitrary::Error::IncorrectFormat)
     }
 }
 
@@ -760,6 +791,10 @@ mod tests {
         let mut bytes = [0u8; 20];
         bytes[18..].copy_from_slice(&index.to_be_bytes());
         Address::from(bytes)
+    }
+
+    fn valid_owner_signature_bytes() -> Bytes {
+        PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()).to_bytes()
     }
 
     fn generate_p256_keypair() -> (P256SigningKey, B256, B256, Address) {
@@ -1066,7 +1101,7 @@ mod tests {
     #[test]
     fn multisig_signature_without_init_omits_trailing_slot() {
         let account = Address::repeat_byte(0x11);
-        let signatures = vec![Bytes::from(vec![0x03, 0x04])];
+        let signatures = vec![valid_owner_signature_bytes()];
         let signature = MultisigSignature::new(account, signatures.clone(), None);
 
         let mut encoded = Vec::new();
@@ -1101,7 +1136,7 @@ mod tests {
 
     #[test]
     fn multisig_signature_shape_rejects_oversized_owner_signature() {
-        let signature = MultisigSignature::new(
+        let signature = MultisigSignature::try_new(
             Address::repeat_byte(0x11),
             vec![Bytes::from(vec![
                 0xaa;
@@ -1110,24 +1145,15 @@ mod tests {
             None,
         );
 
-        assert_eq!(
-            signature.validate_shape(),
-            Err("multisig owner signature too large")
-        );
+        assert_eq!(signature, Err("multisig owner signature too large"));
     }
 
     #[test]
     fn multisig_signature_decode_rejects_oversized_owner_signature() {
-        let signature = MultisigSignature::new(
+        let encoded = encoded_multisig_without_init_slot(
             Address::repeat_byte(0x11),
-            vec![Bytes::from(vec![
-                0xaa;
-                MAX_MULTISIG_OWNER_SIGNATURE_BYTES + 1
-            ])],
-            None,
+            vec![vec![0xaa; MAX_MULTISIG_OWNER_SIGNATURE_BYTES + 1]],
         );
-        let mut encoded = Vec::new();
-        signature.encode(&mut encoded);
         let mut input = encoded.as_slice();
 
         assert!(
@@ -1138,17 +1164,14 @@ mod tests {
 
     #[test]
     fn tempo_signature_decode_rejects_oversized_multisig_owner_signature() {
-        let signature = TempoSignature::Multisig(MultisigSignature::new(
+        let mut encoded = vec![SIGNATURE_TYPE_MULTISIG];
+        encoded.extend(encoded_multisig_without_init_slot(
             Address::repeat_byte(0x11),
-            vec![Bytes::from(vec![
-                0xaa;
-                MAX_MULTISIG_OWNER_SIGNATURE_BYTES + 1
-            ])],
-            None,
+            vec![vec![0xaa; MAX_MULTISIG_OWNER_SIGNATURE_BYTES + 1]],
         ));
 
         assert!(
-            TempoSignature::from_bytes(&signature.to_bytes()).is_err(),
+            TempoSignature::from_bytes(&encoded).is_err(),
             "TempoSignature decode should reject multisig payloads with oversized owner approvals"
         );
     }

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -327,28 +327,6 @@ impl InitMultisig {
         Ok(account)
     }
 
-    /// Validates RPC simulation mock multisig signatures by treating the first
-    /// `signature_count` configured owners as signers.
-    pub fn validate_rpc_mock_signatures(&self, signature_count: usize) -> Result<(), &'static str> {
-        self.validate().map_err(MultisigConfigError::as_str)?;
-        if signature_count == 0 {
-            return Err("multisig signatures cannot be empty");
-        }
-        if signature_count > MAX_MULTISIG_SIGNATURES || signature_count > self.owners.len() {
-            return Err("too many multisig signatures");
-        }
-
-        multisig_signature_count_for_threshold(
-            self.owners
-                .iter()
-                .take(signature_count)
-                .map(|owner| owner.weight),
-            self.threshold,
-        )
-        .map(|_| ())
-        .map_err(MultisigQuorumError::as_str)
-    }
-
     /// Returns the configured weight for an owner, if present.
     pub fn owner_weight(&self, owner: Address) -> Option<u8> {
         self.owners
@@ -356,7 +334,6 @@ impl InitMultisig {
             .ok()
             .map(|idx| self.owners[idx].weight)
     }
-
     /// Decodes, verifies, and weight-accounts primitive owner approvals.
     ///
     /// This helper does not validate nested multisig owner approvals because that requires state

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -1082,6 +1082,10 @@ mod tests {
         (signing_key, pub_key_x, pub_key_y)
     }
 
+    fn valid_multisig_owner_signature_bytes() -> Bytes {
+        PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()).to_bytes()
+    }
+
     /// Sign a message hash with P256, normalize s, return (r, s)
     fn sign_p256_normalized(signing_key: &P256SigningKey, message_hash: &B256) -> (B256, B256) {
         let signature: p256::ecdsa::Signature =
@@ -1974,8 +1978,8 @@ mod tests {
     #[test]
     fn test_signature_type_is_none_for_multisig() {
         let signature = TempoSignature::Multisig(MultisigSignature::new(
-            Address::ZERO,
-            vec![Bytes::from(vec![0xff])],
+            Address::repeat_byte(0x11),
+            vec![valid_multisig_owner_signature_bytes()],
             None,
         ));
 
@@ -1998,7 +2002,7 @@ mod tests {
         let inner_hash = B256::repeat_byte(0x24);
         let signature = TempoSignature::Multisig(MultisigSignature::new(
             account,
-            vec![Bytes::from(vec![0xff])],
+            vec![valid_multisig_owner_signature_bytes()],
             Some(config.clone()),
         ));
 
@@ -2010,7 +2014,7 @@ mod tests {
             multisig_signature
                 .verify_with_trusted_config(digest, &config)
                 .is_err(),
-            "stateful multisig authorization should still reject the invalid owner signature"
+            "stateful multisig authorization should still reject a non-owner signature"
         );
     }
 

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -613,7 +613,6 @@ impl TempoSignature {
         // PrimitiveSignature. The exact 65-byte secp256k1 path remains untyped for
         // backwards compatibility.
         if data.len() > 1
-            && data.len() != SECP256K1_SIGNATURE_LENGTH
             && (data[0] == SIGNATURE_TYPE_KEYCHAIN || data[0] == SIGNATURE_TYPE_KEYCHAIN_V2)
         {
             let version = if data[0] == SIGNATURE_TYPE_KEYCHAIN {

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -10,14 +10,9 @@ use revm::{
     inspector::InspectorEvmTr,
     interpreter::{InitialAndFloorGas, interpreter::EthInterpreter},
 };
-use std::{cell::RefCell, collections::HashMap, rc::Rc, sync::Arc};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_precompiles::{
-    native_multisig::{NativeMultisig, NativeMultisigAuthError},
-    storage::StorageActions,
-    storage_credits::NonCreditableSlots,
-};
-use tempo_primitives::transaction::InitMultisig;
+use tempo_precompiles::{storage::StorageActions, storage_credits::NonCreditableSlots};
 
 /// The Tempo EVM context type.
 pub type TempoContext<DB> = Context<TempoBlockEnv, TempoTxEnv, CfgEnv<TempoHardfork>, DB>;
@@ -64,13 +59,6 @@ pub struct TempoEvm<DB: Database, I> {
     pub(crate) non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
     /// Internal protocol fee hooks.
     pub(crate) fee_manager: Arc<dyn ProtocolFeeManager<DB>>,
-    /// Block-scoped cache for native multisig account markers and validated configs.
-    ///
-    /// Markers are cached so repeated transactions from the same accounts do not repeatedly read
-    /// the native multisig marker storage slot. Config values are inserted only after the native
-    /// multisig storage path has loaded and validated them. Configs are cleared when a transaction
-    /// directly touches the native multisig precompile because updates mutate account-scoped config.
-    pub(crate) native_multisig_cache: NativeMultisigCache,
 }
 
 impl<DB: Database, I> TempoEvm<DB, I> {
@@ -120,7 +108,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             skip_liquidity_check,
             actions,
             non_creditable_slots,
-            native_multisig_cache,
             ..
         } = self;
 
@@ -135,7 +122,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             actions,
             non_creditable_slots,
             fee_manager,
-            native_multisig_cache,
         }
     }
 
@@ -165,7 +151,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             actions,
             non_creditable_slots,
             fee_manager,
-            native_multisig_cache: NativeMultisigCache::default(),
         }
     }
 
@@ -236,11 +221,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
         self.fee_token = None;
         self.key_expiry = None;
         self.non_creditable_slots.borrow_mut().clear();
-    }
-
-    /// Clears block-scoped execution caches.
-    pub fn clear_block_caches(&mut self) {
-        self.native_multisig_cache.clear();
     }
 }
 
@@ -330,110 +310,6 @@ where
         &mut Self::Inspector,
     ) {
         self.inner.all_mut_inspector()
-    }
-}
-
-/// Block-scoped native multisig lookup cache.
-///
-/// Account markers, thresholds, and validated configs are cached separately so config invalidation
-/// can clear threshold/config data while retaining marker hits. This avoids repeatedly reading
-/// marker storage after a transaction touches the native multisig precompile, while also avoiding a
-/// full marker-cache scan when configs must be invalidated.
-///
-/// The whole cache is cleared when the EVM moves to a new block. Thresholds/configs are cleared,
-/// while marker bits are retained, after transactions that call the native multisig precompile
-/// because config updates can mutate account-scoped configs but do not clear the multisig account
-/// marker.
-#[derive(Debug, Clone, Default)]
-pub(crate) struct NativeMultisigCache {
-    markers: HashMap<Address, bool>,
-    thresholds: HashMap<Address, u8>,
-    configs: HashMap<Address, InitMultisig>,
-}
-
-impl NativeMultisigCache {
-    /// Clears all cached markers and configs.
-    pub(crate) fn clear(&mut self) {
-        self.markers.clear();
-        self.thresholds.clear();
-        self.configs.clear();
-    }
-
-    /// Clears cached configs while preserving cached account markers.
-    pub(crate) fn clear_configs(&mut self) {
-        self.thresholds.clear();
-        self.configs.clear();
-    }
-
-    /// Inserts a validated native multisig config and marks the account as multisig.
-    pub(crate) fn insert_config(&mut self, account: Address, config: InitMultisig) {
-        self.markers.insert(account, true);
-        self.thresholds.insert(account, config.threshold);
-        self.configs.insert(account, config);
-    }
-
-    /// Returns whether `account` is marked as a native multisig account, loading on cache miss.
-    pub(crate) fn is_multisig_account(
-        &mut self,
-        multisig: &NativeMultisig,
-        account: Address,
-    ) -> Result<bool, NativeMultisigAuthError> {
-        if let Some(is_multisig) = self.markers.get(&account) {
-            return Ok(*is_multisig);
-        }
-
-        let threshold = multisig.load_registered_threshold_if_present(account)?;
-        let is_multisig = threshold.is_some();
-        self.markers.insert(account, is_multisig);
-        if let Some(threshold) = threshold {
-            self.thresholds.insert(account, threshold);
-        }
-        Ok(is_multisig)
-    }
-
-    /// Loads and caches the validated registered native multisig config for `account`.
-    pub(crate) fn load_registered_config(
-        &mut self,
-        multisig: &NativeMultisig,
-        account: Address,
-    ) -> Result<InitMultisig, NativeMultisigAuthError> {
-        if let Some(config) = self.configs.get(&account) {
-            return Ok(config.clone());
-        }
-
-        let config = multisig.load_registered_config(account)?;
-        self.insert_config(account, config.clone());
-        Ok(config)
-    }
-
-    /// Loads and caches the registered native multisig threshold for `account`.
-    pub(crate) fn load_registered_threshold(
-        &mut self,
-        multisig: &NativeMultisig,
-        account: Address,
-    ) -> Result<u8, NativeMultisigAuthError> {
-        if let Some(threshold) = self.thresholds.get(&account) {
-            return Ok(*threshold);
-        }
-        if let Some(config) = self.configs.get(&account) {
-            self.thresholds.insert(account, config.threshold);
-            return Ok(config.threshold);
-        }
-
-        let threshold = multisig.load_registered_threshold(account)?;
-        self.markers.insert(account, true);
-        self.thresholds.insert(account, threshold);
-        Ok(threshold)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn get_config(&self, account: &Address) -> Option<&InitMultisig> {
-        self.configs.get(account)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn is_empty(&self) -> bool {
-        self.markers.is_empty() && self.thresholds.is_empty() && self.configs.is_empty()
     }
 }
 

--- a/crates/revm/src/exec.rs
+++ b/crates/revm/src/exec.rs
@@ -32,7 +32,6 @@ where
     type ExecutionResult = ExecutionResult<TempoHaltReason>;
 
     fn set_block(&mut self, block: Self::Block) {
-        self.clear_block_caches();
         self.inner.ctx.set_block(block);
     }
 
@@ -131,7 +130,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use revm::{Context, ExecuteEvm, MainContext, database::EmptyDB, primitives::B256};
+    use revm::{Context, ExecuteEvm, MainContext, database::EmptyDB};
 
     /// Test set_block and replay with default TempoEvm.
     #[test]
@@ -143,18 +142,8 @@ mod tests {
             .with_cfg(Default::default())
             .with_tx(TempoTxEnv::default());
         let mut evm = TempoEvm::new(ctx, ());
-        evm.native_multisig_cache.insert_config(
-            Address::repeat_byte(0x42),
-            tempo_primitives::transaction::InitMultisig {
-                salt: B256::ZERO,
-                threshold: 1,
-                owners: Vec::new(),
-            },
-        );
-
         // Set block with default fields
         evm.set_block(TempoBlockEnv::default());
-        assert!(evm.native_multisig_cache.is_empty());
 
         // Replay executes the current transaction and returns result with state.
         // With default tx (no calls, system tx), it should succeed.

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1248,23 +1248,11 @@ where
                     }
 
                     if caller_is_multisig {
-                        let threshold = multisig_precompile
-                            .load_registered_threshold(multisig_signature.account())
-                            .map_err(NativeMultisigAuthError::from)
-                            .map_err(map_native_multisig_error::<DB>)?;
-                        if is_rpc_simulation {
-                            let config = multisig_precompile
-                                .load_registered_config(multisig_signature.account())
+                        if !is_rpc_simulation {
+                            let threshold = multisig_precompile
+                                .load_registered_threshold(multisig_signature.account())
                                 .map_err(NativeMultisigAuthError::from)
                                 .map_err(map_native_multisig_error::<DB>)?;
-                            config
-                                .validate_rpc_mock_signatures(multisig_signature.signature_count())
-                                .map_err(|reason| {
-                                TempoInvalidTransaction::NativeMultisigValidationFailed {
-                                    reason: reason.to_string(),
-                                }
-                            })?;
-                        } else {
                             multisig_precompile
                                 .verify_authorization(
                                     tempo_tx_env.signature_hash,
@@ -1310,15 +1298,7 @@ where
                             }
                             .into());
                         }
-                        if is_rpc_simulation {
-                            init_config
-                                .validate_rpc_mock_signatures(multisig_signature.signature_count())
-                            .map_err(|reason| {
-                                TempoInvalidTransaction::NativeMultisigValidationFailed {
-                                    reason: reason.to_string(),
-                                }
-                            })?;
-                        } else {
+                        if !is_rpc_simulation {
                             multisig_precompile
                                 .verify_authorization(
                                     tempo_tx_env.signature_hash,
@@ -3476,7 +3456,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t8_rpc_simulation_accepts_mock_registered_multisig_signature() {
+    fn test_t8_rpc_simulation_skips_registered_multisig_owner_verification() {
         let config = native_multisig_config();
         let account = config.account().unwrap();
         let aa_env = TempoBatchCallEnv {
@@ -3500,7 +3480,7 @@ mod tests {
         store_native_multisig_account(&mut test, &config);
 
         test.validate_against_state_and_deduct_caller()
-            .expect("RPC simulation should accept mock native multisig signatures");
+            .expect("RPC simulation should skip native multisig owner-signature verification");
     }
 
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -162,16 +162,20 @@ fn native_multisig_primitive_owner_signature_verification_gas(
     ECRECOVER_GAS + primitive_signature_verification_gas(signature)
 }
 
-fn native_multisig_owner_approval_verification_gas(signature: &[u8], depth: usize) -> u64 {
-    match TempoSignature::from_bytes(signature) {
-        Ok(TempoSignature::Primitive(primitive)) => {
-            native_multisig_primitive_owner_signature_verification_gas(&primitive)
+fn native_multisig_owner_approval_verification_gas(
+    signature: &TempoSignature,
+    depth: usize,
+) -> u64 {
+    match signature {
+        TempoSignature::Primitive(primitive) => {
+            native_multisig_primitive_owner_signature_verification_gas(primitive)
         }
-        Ok(TempoSignature::Multisig(multisig_signature)) if depth < MAX_MULTISIG_NESTING_DEPTH => {
-            native_multisig_signature_verification_gas(&multisig_signature, false, depth + 1)
+        TempoSignature::Multisig(multisig_signature) if depth < MAX_MULTISIG_NESTING_DEPTH => {
+            native_multisig_signature_verification_gas(multisig_signature, false, depth + 1)
         }
-        Ok(TempoSignature::Keychain(_)) | Err(_) => ECRECOVER_GAS + P256_VERIFY_GAS,
-        Ok(TempoSignature::Multisig(_)) => ECRECOVER_GAS + P256_VERIFY_GAS,
+        TempoSignature::Keychain(_) | TempoSignature::Multisig(_) => {
+            ECRECOVER_GAS + P256_VERIFY_GAS
+        }
     }
 }
 
@@ -1149,11 +1153,13 @@ where
                 > {
                     let caller_is_multisig = multisig_precompile
                         .is_multisig_account(tx.caller())
+                        .map_err(NativeMultisigAuthError::from)
                         .map_err(map_native_multisig_error::<DB>)?;
 
                     if tx.has_fee_payer_signature()
                         && multisig_precompile
                             .is_multisig_account(fee_payer)
+                            .map_err(NativeMultisigAuthError::from)
                             .map_err(map_native_multisig_error::<DB>)?
                     {
                         return Err(TempoInvalidTransaction::NativeMultisigFeePayerNotAllowed {
@@ -1162,10 +1168,11 @@ where
                         .into());
                     }
 
-                    let mut validate_authorization_authority =
+                    let validate_authorization_authority =
                         |authority| -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
                             if multisig_precompile
                                 .is_multisig_account(authority)
+                                .map_err(NativeMultisigAuthError::from)
                                 .map_err(map_native_multisig_error::<DB>)?
                             {
                                 return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
@@ -2976,8 +2983,8 @@ mod tests {
         storage::ContractStorage, test_util::TIP20Setup, tip_fee_manager::TipFeeManager,
     };
     use tempo_primitives::transaction::{
-        Call, InitMultisig, MAX_MULTISIG_OWNER_SIGNATURE_BYTES, MultisigOwner, MultisigSignature,
-        RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
+        Call, InitMultisig, KeychainSignature, MAX_MULTISIG_OWNER_SIGNATURE_BYTES, MultisigOwner,
+        MultisigSignature, RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
         tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
     };
 
@@ -3148,7 +3155,7 @@ mod tests {
             tx_env.fee_token = Some(invalid_token);
         });
 
-        let result = test.validate_against_state_and_deduct_caller();
+        let result = test.validate_env();
 
         assert!(
             matches!(
@@ -3179,7 +3186,7 @@ mod tests {
 
         test.evm.inner.ctx.tx.fee_token = Some(fee_token);
 
-        let result = test.validate_against_state_and_deduct_caller();
+        let result = test.validate_env();
 
         assert!(
             matches!(
@@ -3284,7 +3291,7 @@ mod tests {
         });
         store_native_multisig_account(&mut test, &config);
 
-        let result = test.validate_env();
+        let result = test.validate_against_state_and_deduct_caller();
         assert!(
             matches!(
                 result,
@@ -3342,7 +3349,7 @@ mod tests {
             tx_env.inner.caller = account;
         });
 
-        let result = test.validate_against_state_and_deduct_caller();
+        let result = test.validate_env();
         assert!(
             matches!(
                 result,
@@ -3694,13 +3701,18 @@ mod tests {
     }
 
     #[test]
-    fn test_t8_registered_native_multisig_rejects_malformed_owner_approval_as_bad_transaction() {
+    fn test_t8_registered_native_multisig_rejects_keychain_owner_approval_as_bad_transaction() {
         let config = single_owner_native_multisig_config(0x42, Address::repeat_byte(0x11));
         let account = config.account().unwrap();
+        let owner_approval = TempoSignature::Keychain(KeychainSignature::new(
+            Address::random(),
+            PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature()),
+        ))
+        .to_bytes();
         let aa_env = TempoBatchCallEnv {
             signature: TempoSignature::Multisig(MultisigSignature::new(
                 account,
-                vec![Bytes::from_static(&[0xff, 0x00])],
+                vec![owner_approval],
                 None,
             )),
             aa_calls: vec![Call {
@@ -3718,15 +3730,15 @@ mod tests {
 
         let result = test.validate_against_state_and_deduct_caller();
         let Err(EVMError::Transaction(err)) = result else {
-            panic!("malformed owner approval should fail validation");
+            panic!("keychain owner approval should fail validation");
         };
         assert!(
             matches!(
                 &err,
                 TempoInvalidTransaction::NativeMultisigInvalidTransaction { reason }
-                    if reason.contains("invalid multisig owner signature")
+                    if reason.contains("keychain signatures cannot authorize")
             ),
-            "malformed owner approval should be classified as invalid transaction, got {err:?}"
+            "keychain owner approval should be classified as invalid transaction, got {err:?}"
         );
         assert!(err.is_bad_transaction());
     }
@@ -3896,32 +3908,18 @@ mod tests {
 
     #[test]
     fn native_multisig_authorization_rejects_oversized_owner_approval_before_decode() {
-        let config = single_owner_native_multisig_config(0x42, Address::repeat_byte(0x11));
-        let account = config.account().unwrap();
-        let signature = MultisigSignature::new(
-            account,
+        let signature = MultisigSignature::try_new(
+            Address::repeat_byte(0x11),
             vec![Bytes::from(vec![
                 0xaa;
                 MAX_MULTISIG_OWNER_SIGNATURE_BYTES + 1
             ])],
             None,
         );
-        let multisig = NativeMultisig::new();
-
-        let result = multisig.verify_authorization(
-            B256::repeat_byte(0x42),
-            &signature,
-            NativeMultisigAuthConfig::Inline(&config),
-            |_| unreachable!("oversized owner approval should fail before nested config lookup"),
-            |_, _| unreachable!("oversized owner approval should fail before owner weight lookup"),
-        );
 
         assert!(
-            matches!(
-                result,
-                Err(NativeMultisigAuthError::InvalidTransaction(reason)) if reason.contains("too large")
-            ),
-            "oversized owner approval should be rejected before owner approval decode"
+            matches!(signature, Err("multisig owner signature too large")),
+            "oversized owner approval should be rejected before constructing a multisig signature"
         );
     }
 
@@ -6433,9 +6431,7 @@ mod tests {
         use super::*;
         use alloy_signer::SignerSync;
         use alloy_signer_local::PrivateKeySigner;
-        use tempo_precompiles::{
-            ACCOUNT_KEYCHAIN_ADDRESS, account_keychain::getTransactionKeyCall,
-        };
+        use tempo_precompiles::ACCOUNT_KEYCHAIN_ADDRESS;
         use tempo_primitives::transaction::{
             KeychainSignature, KeychainVersion, SignatureType,
             key_authorization::{KeyAuthorization, TokenLimit as PrimTokenLimit},

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1128,8 +1128,6 @@ where
             let is_rpc_simulation =
                 tx.unique_tx_identifier() == Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
             let caller_account_info = if multisig_signature.is_some() {
-                // Native multisig validation needs code/delegation and nonce facts, but K1 and
-                // keychain transactions only need the account marker check below.
                 Some(
                     journal
                         .load_account_with_code(tx.caller())?
@@ -1140,7 +1138,6 @@ where
             } else {
                 None
             };
-
             StorageCtx::enter_precompile(
                 journal,
                 block,
@@ -1226,11 +1223,13 @@ where
                     let caller_account_info = caller_account_info
                         .as_ref()
                         .expect("loaded for native multisig signatures");
-                    let account_has_code_or_delegation = !caller_account_info.is_empty_code_hash()
-                        || caller_account_info
-                            .code
-                            .as_ref()
-                            .is_some_and(|code| code.eip7702_address().is_some());
+                    if !caller_account_info.is_empty_code_hash() {
+                        return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
+                            reason: "native multisig account cannot have code or EIP-7702 delegation"
+                                .to_string(),
+                        }
+                        .into());
+                    }
 
                     if caller_is_multisig {
                         multisig_signature.validate_registered_shape().map_err(|reason| {
@@ -1238,13 +1237,6 @@ where
                                 reason: reason.to_string(),
                             }
                         })?;
-                    }
-                    if account_has_code_or_delegation {
-                        return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
-                            reason: "native multisig account cannot have code or EIP-7702 delegation"
-                                .to_string(),
-                        }
-                        .into());
                     }
 
                     if caller_is_multisig {

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1239,13 +1239,6 @@ where
                             }
                         })?;
                     }
-                    if tempo_tx_env.key_authorization.is_some() {
-                        return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                            reason: "native multisig transactions cannot carry key_authorization"
-                                .to_string(),
-                        }
-                        .into());
-                    }
                     if account_has_code_or_delegation {
                         return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
                             reason: "native multisig account cannot have code or EIP-7702 delegation"

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -35,8 +35,7 @@ use revm::{
 };
 use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_contracts::precompiles::{
-    IAccountKeychain::SignatureType as PrecompileSignatureType, NATIVE_MULTISIG_ADDRESS,
-    TIPFeeAMMError,
+    IAccountKeychain::SignatureType as PrecompileSignatureType, TIPFeeAMMError,
 };
 use tempo_precompiles::{
     ECRECOVER_GAS,
@@ -1013,11 +1012,7 @@ where
         result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
         result_gas: ResultGas,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        let clear_native_multisig_config_cache = evm.tx().targets_address(NATIVE_MULTISIG_ADDRESS);
         evm.clear();
-        if clear_native_multisig_config_cache {
-            evm.native_multisig_cache.clear_configs();
-        }
 
         MainnetHandler::default()
             .execution_result(evm, result, result_gas)
@@ -1091,7 +1086,6 @@ where
         let tx = &evm.inner.ctx.tx;
         let cfg = &evm.inner.ctx.cfg;
         let journal = &mut evm.inner.ctx.journaled_state;
-        let multisig_cache = &mut evm.native_multisig_cache;
 
         let fee_payer = tx.fee_payer().expect("pre-validated in `validate_env`");
         let fee_token = fee_manager
@@ -1129,12 +1123,6 @@ where
             let multisig_signature = tempo_tx_env.and_then(|aa| aa.signature.as_multisig());
             let is_rpc_simulation =
                 tx.unique_tx_identifier() == Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
-            // RPC simulations (e.g. `eth_estimateGas` retries) reuse one EVM and discard
-            // journal state between transacts, so markers/configs seeded by a discarded
-            // execution must not leak into this validation. Re-read from state instead.
-            if is_rpc_simulation {
-                multisig_cache.clear();
-            }
             let caller_account_info = if multisig_signature.is_some() {
                 // Native multisig validation needs code/delegation and nonce facts, but K1 and
                 // keychain transactions only need the account marker check below.
@@ -1159,13 +1147,13 @@ where
                     (),
                     EVMError<DB::Error, TempoInvalidTransaction>,
                 > {
-                    let caller_is_multisig = multisig_cache
-                        .is_multisig_account(&multisig_precompile, tx.caller())
+                    let caller_is_multisig = multisig_precompile
+                        .is_multisig_account(tx.caller())
                         .map_err(map_native_multisig_error::<DB>)?;
 
                     if tx.has_fee_payer_signature()
-                        && multisig_cache
-                            .is_multisig_account(&multisig_precompile, fee_payer)
+                        && multisig_precompile
+                            .is_multisig_account(fee_payer)
                             .map_err(map_native_multisig_error::<DB>)?
                     {
                         return Err(TempoInvalidTransaction::NativeMultisigFeePayerNotAllowed {
@@ -1176,8 +1164,8 @@ where
 
                     let mut validate_authorization_authority =
                         |authority| -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
-                            if multisig_cache
-                                .is_multisig_account(&multisig_precompile, authority)
+                            if multisig_precompile
+                                .is_multisig_account(authority)
                                 .map_err(map_native_multisig_error::<DB>)?
                             {
                                 return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
@@ -1260,18 +1248,14 @@ where
                     }
 
                     if caller_is_multisig {
-                        let threshold = multisig_cache
-                            .load_registered_threshold(
-                                &multisig_precompile,
-                                multisig_signature.account(),
-                            )
+                        let threshold = multisig_precompile
+                            .load_registered_threshold(multisig_signature.account())
+                            .map_err(NativeMultisigAuthError::from)
                             .map_err(map_native_multisig_error::<DB>)?;
                         if is_rpc_simulation {
-                            let config = multisig_cache
-                                .load_registered_config(
-                                    &multisig_precompile,
-                                    multisig_signature.account(),
-                                )
+                            let config = multisig_precompile
+                                .load_registered_config(multisig_signature.account())
+                                .map_err(NativeMultisigAuthError::from)
                                 .map_err(map_native_multisig_error::<DB>)?;
                             config
                                 .validate_rpc_mock_signatures(multisig_signature.signature_count())
@@ -1290,8 +1274,9 @@ where
                                         threshold,
                                     },
                                     |acc| {
-                                        multisig_cache
-                                            .load_registered_threshold(&multisig_precompile, acc)
+                                        multisig_precompile
+                                            .load_registered_threshold(acc)
+                                            .map_err(NativeMultisigAuthError::from)
                                     },
                                     |account, owner| {
                                         multisig_precompile
@@ -1340,8 +1325,9 @@ where
                                     multisig_signature,
                                     NativeMultisigAuthConfig::Inline(init_config),
                                     |acc| {
-                                        multisig_cache
-                                            .load_registered_threshold(&multisig_precompile, acc)
+                                        multisig_precompile
+                                            .load_registered_threshold(acc)
+                                            .map_err(NativeMultisigAuthError::from)
                                     },
                                     |account, owner| {
                                         multisig_precompile
@@ -1824,7 +1810,6 @@ where
                         .map_err(map_native_multisig_error::<DB>)
                 },
             )?;
-            multisig_cache.insert_config(account, config);
         }
 
         // If the transaction includes a KeyAuthorization, validate and authorize the key
@@ -3516,50 +3501,6 @@ mod tests {
 
         test.validate_against_state_and_deduct_caller()
             .expect("RPC simulation should accept mock native multisig signatures");
-        assert_eq!(
-            test.evm.native_multisig_cache.get_config(&account),
-            Some(&config),
-            "registered multisig validation should cache the validated config"
-        );
-    }
-
-    #[test]
-    fn test_t8_rpc_simulation_bootstrap_ignores_stale_marker_cache() {
-        let config = native_multisig_config();
-        let account = config.account().unwrap();
-        let aa_env = TempoBatchCallEnv {
-            signature: TempoSignature::Multisig(MultisigSignature::new(
-                account,
-                vec![Bytes::from_static(&[0xaa; 65])],
-                Some(config.clone()),
-            )),
-            aa_calls: vec![Call {
-                to: TxKind::Call(Address::random()),
-                value: U256::ZERO,
-                input: Bytes::new(),
-            }],
-            ..Default::default()
-        };
-        let mut test = TestHandlerEvm::aa(TempoHardfork::T8, aa_env, |tx_env| {
-            tx_env.inner.caller = account;
-            tx_env.inner.kind = TxKind::Call(Address::random());
-            tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
-        });
-        // A discarded estimate iteration executed this bootstrap and seeded the
-        // cache via `insert_config`; canonical state has no registered account.
-        test.evm
-            .native_multisig_cache
-            .insert_config(account, config.clone());
-
-        test.validate_against_state_and_deduct_caller()
-            .expect("bootstrap simulation must not trust markers from discarded executions");
-        // The stale entry is cleared on entry; this pass then re-seeds the
-        // transient bootstrapped-account guard for its own user calls.
-        assert_eq!(
-            test.evm.native_multisig_cache.get_config(&account),
-            Some(&config),
-            "bootstrap pre-execution should re-seed the guard"
-        );
     }
 
     #[test]

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1174,31 +1174,21 @@ where
                         .into());
                     }
 
-                    let mut validate_authorization_authority = |authority| -> Result<
-                        (),
-                        EVMError<DB::Error, TempoInvalidTransaction>,
-                    > {
-                        if multisig_signature.map(|sig| sig.account()) == Some(authority) {
-                            return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                                reason: format!(
-                                    "native multisig account {authority} cannot be used as an authorization-list authority"
-                                ),
+                    let mut validate_authorization_authority =
+                        |authority| -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
+                            if multisig_cache
+                                .is_multisig_account(&multisig_precompile, authority)
+                                .map_err(map_native_multisig_error::<DB>)?
+                            {
+                                return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                                    reason: format!(
+                                        "native multisig account {authority} cannot be used as an authorization-list authority"
+                                    ),
+                                }
+                                .into());
                             }
-                            .into());
-                        }
-
-                        if multisig_cache
-                            .is_multisig_account(&multisig_precompile, authority)
-                            .map_err(map_native_multisig_error::<DB>)? {
-                            return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                                reason: format!(
-                                    "native multisig account {authority} cannot be used as an authorization-list authority"
-                                ),
-                            }
-                            .into());
-                        }
-                        Ok(())
-                    };
+                            Ok(())
+                        };
 
                     if let Some(tempo_tx_env) = tempo_tx_env {
                         for auth in &tempo_tx_env.tempo_authorization_list {
@@ -1247,21 +1237,8 @@ where
                             .as_ref()
                             .is_some_and(|code| code.eip7702_address().is_some());
 
-                    if multisig_signature.account() != tx.caller() {
-                        return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                            reason: "multisig signature account does not match transaction caller"
-                                .to_string(),
-                        }
-                        .into());
-                    }
                     if caller_is_multisig {
                         multisig_signature.validate_registered_shape().map_err(|reason| {
-                            TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                                reason: reason.to_string(),
-                            }
-                        })?;
-                    } else {
-                        multisig_signature.recover_account().map_err(|reason| {
                             TempoInvalidTransaction::NativeMultisigInvalidTransaction {
                                 reason: reason.to_string(),
                             }
@@ -1348,17 +1325,6 @@ where
                             }
                             .into());
                         }
-                        if init_config
-                            .account()
-                            .map_err(native_multisig_transaction_error::<DB>)?
-                            != tx.caller()
-                        {
-                            return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                                reason: "multisig_init does not derive transaction caller".to_string(),
-                            }
-                            .into());
-                        }
-
                         if is_rpc_simulation {
                             init_config
                                 .validate_rpc_mock_signatures(multisig_signature.signature_count())
@@ -2217,6 +2183,33 @@ where
                 return Err(TempoInvalidTransaction::NativeMultisigNotActive.into());
             }
 
+            if let Some(multisig_signature) = aa_env.signature.as_multisig() {
+                let account = multisig_signature.recover_account().map_err(|reason| {
+                    TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                        reason: reason.to_string(),
+                    }
+                })?;
+                if account != tx.caller {
+                    return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                        reason: "multisig signature account does not match transaction caller"
+                            .to_string(),
+                    }
+                    .into());
+                }
+                if aa_env
+                    .tempo_authorization_list
+                    .iter()
+                    .any(|auth| auth.authority() == Some(account))
+                {
+                    return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                        reason: format!(
+                            "native multisig account {account} cannot be used as an authorization-list authority"
+                        ),
+                    }
+                    .into());
+                }
+            }
+
             if aa_env.signature.is_multisig() && aa_env.key_authorization.is_some() {
                 return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
                     reason: "native multisig transactions cannot carry key_authorization"
@@ -2990,12 +2983,6 @@ fn map_native_multisig_error<DB: Database>(
     }
 }
 
-fn native_multisig_transaction_error<DB: Database>(
-    err: impl Into<TempoInvalidTransaction>,
-) -> EVMError<DB::Error, TempoInvalidTransaction> {
-    err.into().into()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3020,8 +3007,8 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
     use tempo_precompiles::{
-        PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, storage::ContractStorage, test_util::TIP20Setup,
-        tip_fee_manager::TipFeeManager,
+        PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, account_keychain::getTransactionKeyCall,
+        storage::ContractStorage, test_util::TIP20Setup, tip_fee_manager::TipFeeManager,
     };
     use tempo_primitives::transaction::{
         Call, InitMultisig, MAX_MULTISIG_OWNER_SIGNATURE_BYTES, MultisigOwner, MultisigSignature,
@@ -3332,7 +3319,7 @@ mod tests {
         });
         store_native_multisig_account(&mut test, &config);
 
-        let result = test.validate_against_state_and_deduct_caller();
+        let result = test.validate_env();
         assert!(
             matches!(
                 result,
@@ -3399,6 +3386,39 @@ mod tests {
                 )) if reason.contains("authorization-list authority")
             ),
             "bootstrap multisig account cannot be an authorization-list authority"
+        );
+    }
+
+    #[test]
+    fn test_t8_multisig_signature_rejects_caller_mismatch_in_env_validation() {
+        let config = native_multisig_config();
+        let account = config.account().unwrap();
+        let aa_env = TempoBatchCallEnv {
+            signature: TempoSignature::Multisig(MultisigSignature::new(
+                account,
+                vec![Bytes::from_static(&[0xaa; 65])],
+                Some(config),
+            )),
+            aa_calls: vec![Call {
+                to: TxKind::Call(Address::random()),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }],
+            ..Default::default()
+        };
+        let mut test = TestHandlerEvm::aa(TempoHardfork::T8, aa_env, |tx_env| {
+            tx_env.inner.caller = Address::repeat_byte(0x99);
+        });
+
+        let result = test.validate_env();
+        assert!(
+            matches!(
+                result,
+                Err(EVMError::Transaction(
+                    TempoInvalidTransaction::NativeMultisigInvalidTransaction { reason }
+                )) if reason.contains("account does not match transaction caller")
+            ),
+            "native multisig caller mismatch should be rejected statically"
         );
     }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1283,21 +1283,6 @@ where
                             }
                         })?;
 
-                        if !tempo_tx_env.nonce_key.is_zero() || tx.nonce() != 0 {
-                            return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
-                                reason:
-                                    "first native multisig transaction must use protocol nonce 0"
-                                        .to_string(),
-                            }
-                            .into());
-                        }
-                        if caller_account_info.nonce != 0 {
-                            return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
-                                reason: "native multisig account nonce is already used"
-                                    .to_string(),
-                            }
-                            .into());
-                        }
                         if !is_rpc_simulation {
                             multisig_precompile
                                 .verify_authorization(

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -25,10 +25,7 @@ use revm::{
     inspector::{Inspector, InspectorHandler},
     interpreter::{
         CallOutcome, CreateOutcome, Gas, InitialAndFloorGas,
-        gas::{
-            COLD_SLOAD_COST, STANDARD_TOKEN_COST, WARM_SSTORE_RESET,
-            get_tokens_in_calldata_istanbul,
-        },
+        gas::{COLD_SLOAD_COST, WARM_SSTORE_RESET, get_tokens_in_calldata_istanbul},
         interpreter::EthInterpreter,
     },
     precompile::PrecompileError,
@@ -62,8 +59,7 @@ use tempo_precompiles::{
 use tempo_primitives::{
     TempoAddressExt,
     transaction::{
-        InitMultisig, MAX_MULTISIG_NESTING_DEPTH, MultisigSignature, PrimitiveSignature,
-        SignatureType, TEMPO_EXPIRING_NONCE_KEY, TempoSignature, calc_gas_balance_spending,
+        InitMultisig, SignatureType, TEMPO_EXPIRING_NONCE_KEY, calc_gas_balance_spending,
         validate_calls,
     },
 };
@@ -75,30 +71,17 @@ use crate::{
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
     gas_credits,
+    signature_gas::{
+        calculate_native_multisig_bootstrap_storage_gas, primitive_signature_verification_gas,
+        tempo_signature_verification_gas,
+    },
 };
 
-/// Additional gas for P256 signature verification
-/// P256 precompile cost (6900 from EIP-7951) + 1100 for 129 bytes extra signature size - ecrecover savings (3000)
-const P256_VERIFY_GAS: u64 = 5_000;
-
-/// Additional gas for Keychain signatures (key validation overhead: COLD_SLOAD_COST + 900 processing)
-const KEYCHAIN_VALIDATION_GAS: u64 = COLD_SLOAD_COST + 900;
-
-/// Additional gas for each native multisig config/header validation.
-///
-/// Owner signature verification and owner-weight lookups are charged separately, relative to the
-/// secp256k1 verification already covered by the base transaction stipend.
-const NATIVE_MULTISIG_VALIDATION_GAS: u64 = COLD_SLOAD_COST;
-
-/// Additional gas for each native multisig owner-weight lookup.
-const NATIVE_MULTISIG_OWNER_WEIGHT_GAS: u64 = COLD_SLOAD_COST;
-
-/// Persistent storage rows created by native multisig bootstrap before owner rows:
-/// the packed `{ threshold, owner_count }` account header.
-const NATIVE_MULTISIG_BOOTSTRAP_FIXED_STORAGE_SLOTS: u64 = 1;
-
-/// Approximate buffer for the LOG3/no-data `MultisigInitialized` event emitted during bootstrap.
-const NATIVE_MULTISIG_BOOTSTRAP_EVENT_BUFFER: u64 = 1_500;
+#[cfg(test)]
+use crate::signature_gas::{
+    NATIVE_MULTISIG_BOOTSTRAP_EVENT_BUFFER, NATIVE_MULTISIG_OWNER_WEIGHT_GAS,
+    NATIVE_MULTISIG_VALIDATION_GAS, P256_VERIFY_GAS, native_multisig_bootstrap_storage_slots,
+};
 
 /// Base gas for KeyAuthorization (22k storage + 5k buffer), signature gas added at runtime
 const KEY_AUTH_BASE_GAS: u64 = 27_000;
@@ -131,132 +114,6 @@ const KEY_AUTH_EXTRA_EVENT_BUFFER: u64 = 1_500;
 ///
 /// Total: 2*2100 + 100 + 3*2900 = 13,000 gas
 pub const EXPIRING_NONCE_GAS: u64 = 2 * COLD_SLOAD_COST + 100 + 3 * WARM_SSTORE_RESET;
-
-/// Calculates the gas cost for verifying a primitive signature.
-///
-/// Returns the additional gas required beyond the base transaction cost:
-/// - Secp256k1: 0 (already included in base 21k)
-/// - P256: 5000 gas
-/// - WebAuthn: 5000 gas + calldata cost for webauthn_data
-#[inline]
-fn primitive_signature_verification_gas(signature: &PrimitiveSignature) -> u64 {
-    match signature {
-        PrimitiveSignature::Secp256k1(_) => 0,
-        PrimitiveSignature::P256(_) => P256_VERIFY_GAS,
-        PrimitiveSignature::WebAuthn(webauthn_sig) => {
-            let tokens = get_tokens_in_calldata_istanbul(&webauthn_sig.webauthn_data);
-            P256_VERIFY_GAS + tokens * STANDARD_TOKEN_COST
-        }
-    }
-}
-
-/// Calculates full primitive owner-signature verification gas.
-///
-/// Unlike transaction signatures, owner approvals are nested inside the multisig signature, so this
-/// returns the full verification cost before the top-level native multisig schedule subtracts the
-/// one traditional secp256k1 verification already included in base transaction gas.
-#[inline]
-fn native_multisig_primitive_owner_signature_verification_gas(
-    signature: &PrimitiveSignature,
-) -> u64 {
-    ECRECOVER_GAS + primitive_signature_verification_gas(signature)
-}
-
-fn native_multisig_owner_approval_verification_gas(
-    signature: &TempoSignature,
-    depth: usize,
-) -> u64 {
-    match signature {
-        TempoSignature::Primitive(primitive) => {
-            native_multisig_primitive_owner_signature_verification_gas(primitive)
-        }
-        TempoSignature::Multisig(multisig_signature) if depth < MAX_MULTISIG_NESTING_DEPTH => {
-            native_multisig_signature_verification_gas(multisig_signature, false, depth + 1)
-        }
-        TempoSignature::Keychain(_) | TempoSignature::Multisig(_) => {
-            ECRECOVER_GAS + P256_VERIFY_GAS
-        }
-    }
-}
-
-fn native_multisig_signature_verification_gas(
-    signature: &MultisigSignature,
-    subtract_base_secp256k1: bool,
-    depth: usize,
-) -> u64 {
-    let owner_signature_gas = signature
-        .signatures()
-        .iter()
-        .map(|sig| native_multisig_owner_approval_verification_gas(sig, depth))
-        .fold(0u64, u64::saturating_add);
-    let owner_weight_gas =
-        NATIVE_MULTISIG_OWNER_WEIGHT_GAS.saturating_mul(signature.signatures().len() as u64);
-
-    let gas = NATIVE_MULTISIG_VALIDATION_GAS
-        .saturating_add(owner_weight_gas)
-        .saturating_add(owner_signature_gas);
-    if subtract_base_secp256k1 {
-        gas.saturating_sub(ECRECOVER_GAS)
-    } else {
-        gas
-    }
-}
-
-/// Calculates the gas cost for verifying an AA signature.
-///
-/// For Keychain signatures, adds key validation overhead to the inner signature cost
-/// Returns the additional gas required beyond the base transaction cost.
-#[inline]
-fn tempo_signature_verification_gas(signature: &TempoSignature) -> u64 {
-    match signature {
-        TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
-        TempoSignature::Keychain(keychain_sig) => {
-            // Keychain = inner signature + key validation overhead (SLOAD + processing)
-            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
-        }
-        TempoSignature::Multisig(multisig_sig) => {
-            native_multisig_signature_verification_gas(multisig_sig, true, 1)
-        }
-    }
-}
-
-#[inline]
-fn native_multisig_bootstrap_storage_slots(init: &InitMultisig) -> u64 {
-    let owner_slots = u64::try_from(init.owners.len()).unwrap_or(u64::MAX);
-    NATIVE_MULTISIG_BOOTSTRAP_FIXED_STORAGE_SLOTS.saturating_add(owner_slots.saturating_mul(2))
-}
-
-/// Calculates persistent storage gas for native multisig bootstrap.
-///
-/// The committed bootstrap write is a protocol pre-execution write. It runs without TIP-1060
-/// storage-credit accounting because this intrinsic charge includes the creditable portion.
-/// The packed native multisig layout creates exactly:
-/// - one packed account header slot containing threshold and owner count
-/// - one packed owner slot per owner
-#[inline]
-fn calculate_native_multisig_bootstrap_storage_gas(
-    init: &InitMultisig,
-    gas_params: &GasParams,
-    spec: tempo_chainspec::hardfork::TempoHardfork,
-) -> (u64, u64) {
-    let num_sstores = native_multisig_bootstrap_storage_slots(init);
-
-    let mut sstore_cost = gas_params.get(GasId::sstore_set_without_load_cost());
-    if spec.is_t7() {
-        // T7 exposes only the SSTORE residual in the gas table. Since bootstrap storage is
-        // intrinsic-only, also charge the TIP-1060 creditable portion here.
-        sstore_cost = sstore_cost.saturating_add(STORAGE_CREDIT_VALUE);
-    }
-
-    let regular_gas = sstore_cost
-        .saturating_mul(num_sstores)
-        .saturating_add(NATIVE_MULTISIG_BOOTSTRAP_EVENT_BUFFER);
-    let state_gas = gas_params
-        .get(GasId::sstore_set_state_gas())
-        .saturating_mul(num_sstores);
-
-    (regular_gas, state_gas)
-}
 
 #[derive(Debug, Clone)]
 struct LoadedTxAccessKey {
@@ -2954,7 +2811,8 @@ mod tests {
     };
     use tempo_primitives::transaction::{
         Call, InitMultisig, KeychainSignature, MAX_MULTISIG_OWNER_SIGNATURE_BYTES, MultisigOwner,
-        MultisigSignature, RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
+        MultisigSignature, PrimitiveSignature, RecoveredTempoAuthorization, TempoSignature,
+        TempoSignedAuthorization,
         tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
     };
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -17,6 +17,7 @@ pub mod gas_credits;
 pub mod gas_params;
 pub mod handler;
 mod instructions;
+mod signature_gas;
 mod tx;
 
 pub use error::{TempoHaltReason, TempoInvalidTransaction};

--- a/crates/revm/src/signature_gas.rs
+++ b/crates/revm/src/signature_gas.rs
@@ -1,0 +1,158 @@
+use revm::{
+    context_interface::cfg::{GasId, GasParams},
+    interpreter::gas::{COLD_SLOAD_COST, STANDARD_TOKEN_COST, get_tokens_in_calldata_istanbul},
+};
+use tempo_chainspec::{constants::gas::STORAGE_CREDIT_VALUE, hardfork::TempoHardfork};
+use tempo_precompiles::ECRECOVER_GAS;
+use tempo_primitives::transaction::{
+    InitMultisig, MAX_MULTISIG_NESTING_DEPTH, MultisigSignature, PrimitiveSignature, TempoSignature,
+};
+
+/// Additional gas for P256 signature verification
+/// P256 precompile cost (6900 from EIP-7951) + 1100 for 129 bytes extra signature size - ecrecover savings (3000)
+pub(crate) const P256_VERIFY_GAS: u64 = 5_000;
+
+/// Additional gas for Keychain signatures (key validation overhead: COLD_SLOAD_COST + 900 processing)
+const KEYCHAIN_VALIDATION_GAS: u64 = COLD_SLOAD_COST + 900;
+
+/// Additional gas for each native multisig config/header validation.
+///
+/// Owner signature verification and owner-weight lookups are charged separately, relative to the
+/// secp256k1 verification already covered by the base transaction stipend.
+pub(crate) const NATIVE_MULTISIG_VALIDATION_GAS: u64 = COLD_SLOAD_COST;
+
+/// Additional gas for each native multisig owner-weight lookup.
+pub(crate) const NATIVE_MULTISIG_OWNER_WEIGHT_GAS: u64 = COLD_SLOAD_COST;
+
+/// Persistent storage rows created by native multisig bootstrap before owner rows:
+/// the packed `{ threshold, owner_count }` account header.
+const NATIVE_MULTISIG_BOOTSTRAP_FIXED_STORAGE_SLOTS: u64 = 1;
+
+/// Approximate buffer for the LOG3/no-data `MultisigInitialized` event emitted during bootstrap.
+pub(crate) const NATIVE_MULTISIG_BOOTSTRAP_EVENT_BUFFER: u64 = 1_500;
+
+/// Calculates the gas cost for verifying a primitive signature.
+///
+/// Returns the additional gas required beyond the base transaction cost:
+/// - Secp256k1: 0 (already included in base 21k)
+/// - P256: 5000 gas
+/// - WebAuthn: 5000 gas + calldata cost for webauthn_data
+#[inline]
+pub(crate) fn primitive_signature_verification_gas(signature: &PrimitiveSignature) -> u64 {
+    match signature {
+        PrimitiveSignature::Secp256k1(_) => 0,
+        PrimitiveSignature::P256(_) => P256_VERIFY_GAS,
+        PrimitiveSignature::WebAuthn(webauthn_sig) => {
+            let tokens = get_tokens_in_calldata_istanbul(&webauthn_sig.webauthn_data);
+            P256_VERIFY_GAS + tokens * STANDARD_TOKEN_COST
+        }
+    }
+}
+
+/// Calculates full primitive owner-signature verification gas.
+///
+/// Unlike transaction signatures, owner approvals are nested inside the multisig signature, so this
+/// returns the full verification cost before the top-level native multisig schedule subtracts the
+/// one traditional secp256k1 verification already included in base transaction gas.
+#[inline]
+fn native_multisig_primitive_owner_signature_verification_gas(
+    signature: &PrimitiveSignature,
+) -> u64 {
+    ECRECOVER_GAS + primitive_signature_verification_gas(signature)
+}
+
+fn native_multisig_owner_approval_verification_gas(
+    signature: &TempoSignature,
+    depth: usize,
+) -> u64 {
+    match signature {
+        TempoSignature::Primitive(primitive) => {
+            native_multisig_primitive_owner_signature_verification_gas(primitive)
+        }
+        TempoSignature::Multisig(multisig_signature) if depth < MAX_MULTISIG_NESTING_DEPTH => {
+            native_multisig_signature_verification_gas(multisig_signature, false, depth + 1)
+        }
+        TempoSignature::Keychain(_) | TempoSignature::Multisig(_) => {
+            ECRECOVER_GAS + P256_VERIFY_GAS
+        }
+    }
+}
+
+fn native_multisig_signature_verification_gas(
+    signature: &MultisigSignature,
+    subtract_base_secp256k1: bool,
+    depth: usize,
+) -> u64 {
+    let owner_signature_gas = signature
+        .signatures()
+        .iter()
+        .map(|sig| native_multisig_owner_approval_verification_gas(sig, depth))
+        .fold(0u64, u64::saturating_add);
+    let owner_weight_gas =
+        NATIVE_MULTISIG_OWNER_WEIGHT_GAS.saturating_mul(signature.signatures().len() as u64);
+
+    let gas = NATIVE_MULTISIG_VALIDATION_GAS
+        .saturating_add(owner_weight_gas)
+        .saturating_add(owner_signature_gas);
+    if subtract_base_secp256k1 {
+        gas.saturating_sub(ECRECOVER_GAS)
+    } else {
+        gas
+    }
+}
+
+/// Calculates the gas cost for verifying an AA signature.
+///
+/// For Keychain signatures, adds key validation overhead to the inner signature cost
+/// Returns the additional gas required beyond the base transaction cost.
+#[inline]
+pub(crate) fn tempo_signature_verification_gas(signature: &TempoSignature) -> u64 {
+    match signature {
+        TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
+        TempoSignature::Keychain(keychain_sig) => {
+            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
+        }
+        TempoSignature::Multisig(multisig_sig) => {
+            native_multisig_signature_verification_gas(multisig_sig, true, 1)
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn native_multisig_bootstrap_storage_slots(init: &InitMultisig) -> u64 {
+    let owner_slots = u64::try_from(init.owners.len()).unwrap_or(u64::MAX);
+    NATIVE_MULTISIG_BOOTSTRAP_FIXED_STORAGE_SLOTS.saturating_add(owner_slots.saturating_mul(2))
+}
+
+/// Calculates persistent storage gas for native multisig bootstrap.
+///
+/// The committed bootstrap write is a protocol pre-execution write. It runs without TIP-1060
+/// storage-credit accounting because this intrinsic charge includes the creditable portion.
+/// The packed native multisig layout creates exactly:
+/// - one packed account header slot containing threshold and owner count
+/// - one packed owner slot per owner
+/// - one direct owner-weight lookup slot per owner
+#[inline]
+pub(crate) fn calculate_native_multisig_bootstrap_storage_gas(
+    init: &InitMultisig,
+    gas_params: &GasParams,
+    spec: TempoHardfork,
+) -> (u64, u64) {
+    let num_sstores = native_multisig_bootstrap_storage_slots(init);
+
+    let mut sstore_cost = gas_params.get(GasId::sstore_set_without_load_cost());
+    if spec.is_t7() {
+        // T7 exposes only the SSTORE residual in the gas table. Since bootstrap storage is
+        // intrinsic-only, also charge the TIP-1060 creditable portion here.
+        sstore_cost = sstore_cost.saturating_add(STORAGE_CREDIT_VALUE);
+    }
+
+    let regular_gas = sstore_cost
+        .saturating_mul(num_sstores)
+        .saturating_add(NATIVE_MULTISIG_BOOTSTRAP_EVENT_BUFFER);
+    let state_gas = gas_params
+        .get(GasId::sstore_set_state_gas())
+        .saturating_mul(num_sstores);
+
+    (regular_gas, state_gas)
+}

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -369,9 +369,6 @@ where
                 // key authorisation) while keeping loaded accounts and storage warm for the
                 // rest of the batch.
                 evm.ctx_mut().journal_mut().discard_tx();
-                // Native multisig caches may include speculative bootstrap entries written by
-                // the rolled-back transaction, so clear them before validating the next one.
-                evm.clear_block_caches();
                 outcome
             })
             .collect()

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -261,11 +261,11 @@ Derived account rules:
 - The derived account MUST NOT be a TIP-20 token address.
 - The derived account MUST NOT be a virtual address.
 
-Bootstrap claims unused derived account state. The derived account MAY have a nonzero balance before bootstrap, but it MUST otherwise be empty.
+Bootstrap initializes native multisig state for the derived account. The derived account MAY have a nonzero balance or existing transaction nonce state before bootstrap, but it MUST NOT have code or EIP-7702 delegation code.
 
 Bootstrap account-state rules:
 
-- `nonce` MUST be zero.
+- Existing protocol, 2D, or expiring nonce state does not by itself prevent bootstrap.
 - code MUST be empty.
 - EIP-7702 delegation code MUST be absent.
 - balance MAY be nonzero.
@@ -422,50 +422,47 @@ Validation rules:
 
 1. require `signature.init` is present
 2. require `tx.key_authorization` is absent
-3. require `tx.nonce_key == 0`
-4. require `tx.nonce == 0`
-5. validate `signature.signatures.len()` is between `1` and `MAX_MULTISIG_SIGNATURES`
-6. validate `signature.init.owners` is non-empty
-7. validate `signature.init.owners.len() <= MAX_MULTISIG_OWNERS`
-8. validate `signature.init.threshold >= 1`
-9. validate `signature.init.threshold <= MAX_MULTISIG_THRESHOLD`
-10. validate every owner address is nonzero
-11. validate every owner weight is nonzero
-12. compute `total_weight = sum(signature.init.owners.weight)`
-13. validate `total_weight <= u8::MAX`
-14. validate `signature.init.threshold <= total_weight`
-15. validate `signature.init.owners` is strictly ascending by `owner`
-16. derive `expected_account` from `signature.init`
-17. validate `expected_account` satisfies the derived account rules
-18. require `expected_account.nonce == 0`
-19. require `expected_account` code is empty
-20. require `expected_account` has no EIP-7702 delegation code
-21. require `signature.account == expected_account`
-22. require no config exists for `signature.account`
-23. recursively validate owner approvals using `tx.signature_hash()` as the top-level inner digest and `signature.account` as the top-level multisig account
-24. for primitive owner approvals, verify the primitive signature over the current `multisig_digest` and recover the owner address
-25. for nested multisig owner approvals, require `init` is absent, require the nested account is already initialized, and recursively validate the nested signature using the parent `multisig_digest` as the nested inner digest
-26. reject recursive validation if any multisig account appears twice in the same nested validation path or if the path exceeds `MAX_MULTISIG_NESTING_DEPTH`
-27. require owner addresses are strictly ascending
-28. require every owner address is in `signature.init.owners`
-29. accumulate the configured weight for each validated owner
-30. reject trailing owner approvals after accumulated weight first reaches `signature.init.threshold`
-31. require the recovered owner weight sum is at least `signature.init.threshold`
-32. store `signature.init` as the current config for `signature.account`
-33. emit `MultisigInitialized(signature.account)`
-34. consume the protocol nonce for `signature.account`
-35. commit the initial config, account marker, and protocol nonce consumption as transaction-level state
-36. execute the transaction from `signature.account`
+3. validate `signature.signatures.len()` is between `1` and `MAX_MULTISIG_SIGNATURES`
+4. validate `signature.init.owners` is non-empty
+5. validate `signature.init.owners.len() <= MAX_MULTISIG_OWNERS`
+6. validate `signature.init.threshold >= 1`
+7. validate `signature.init.threshold <= MAX_MULTISIG_THRESHOLD`
+8. validate every owner address is nonzero
+9. validate every owner weight is nonzero
+10. compute `total_weight = sum(signature.init.owners.weight)`
+11. validate `total_weight <= u8::MAX`
+12. validate `signature.init.threshold <= total_weight`
+13. validate `signature.init.owners` is strictly ascending by `owner`
+14. derive `expected_account` from `signature.init`
+15. validate `expected_account` satisfies the derived account rules
+16. require `expected_account` code is empty
+17. require `expected_account` has no EIP-7702 delegation code
+18. require `signature.account == expected_account`
+19. require no config exists for `signature.account`
+20. recursively validate owner approvals using `tx.signature_hash()` as the top-level inner digest and `signature.account` as the top-level multisig account
+21. for primitive owner approvals, verify the primitive signature over the current `multisig_digest` and recover the owner address
+22. for nested multisig owner approvals, require `init` is absent, require the nested account is already initialized, and recursively validate the nested signature using the parent `multisig_digest` as the nested inner digest
+23. reject recursive validation if any multisig account appears twice in the same nested validation path or if the path exceeds `MAX_MULTISIG_NESTING_DEPTH`
+24. require owner addresses are strictly ascending
+25. require every owner address is in `signature.init.owners`
+26. accumulate the configured weight for each validated owner
+27. reject trailing owner approvals after accumulated weight first reaches `signature.init.threshold`
+28. require the recovered owner weight sum is at least `signature.init.threshold`
+29. store `signature.init` as the current config for `signature.account`
+30. emit `MultisigInitialized(signature.account)`
+31. consume nonce state according to the transaction's normal Tempo nonce mode
+32. commit the initial config, account marker, and nonce consumption as transaction-level state
+33. execute the transaction from `signature.account`
 
 Bootstrap state effects:
 
 - A prefunded derived account balance does not prevent bootstrap.
 - The initial config write is a transaction-level effect, not part of the EVM call frame.
 - The account marker write and nonce consumption are transaction-level effects.
-- Bootstrap consumes only the protocol nonce for `signature.account`.
+- Bootstrap does not impose a special nonce mode. A protocol-nonce bootstrap consumes the protocol nonce, a 2D-nonce bootstrap consumes the selected nonce key, and an expiring-nonce bootstrap consumes its expiring replay marker under existing Tempo nonce rules.
 - Once bootstrap validation succeeds and the transaction is included, these effects remain even if the subsequent EVM call execution reverts.
 - If bootstrap validation fails, the transaction is invalid.
-- Failed bootstrap validation MUST NOT consume a nonce or write config state.
+- Failed bootstrap validation MUST NOT consume transaction nonce state or write config state.
 - If `multisig_accounts[signature.account] == true`, bootstrap MUST be rejected.
 - If bootstrap execution calls `updateMultisigConfig`, that call MUST revert.
 - A reverted `updateMultisigConfig` call during bootstrap execution MUST NOT revert bootstrap validation state.
@@ -962,8 +959,7 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Existing EOAs cannot be upgraded in place to native multisig accounts under this TIP.
 - Pre-funding a derived multisig account address before bootstrap remains valid.
 - Any migration from an EOA to a multisig account requires moving assets or account-level state through existing application flows.
-- Bootstrap transactions must use protocol nonce `0` with `nonce_key == 0`.
-- Normal post-bootstrap multisig transactions use existing Tempo nonce modes.
+- Bootstrap and normal post-bootstrap multisig transactions use existing Tempo nonce modes.
 - This TIP rejects multisig key authorization in the current protocol.
 
 ## Test Cases
@@ -985,12 +981,12 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Accept bootstrap with `salt == bytes32(0)`.
 - Reject bootstrap when `signature.account` does not match the derived account.
 - Reject bootstrap when the derived account is not a valid Tempo primary account address.
-- Reject bootstrap when `tx.nonce_key != 0`.
-- Reject bootstrap when `tx.nonce != 0`.
+- Accept bootstrap with any supported nonce mode whose normal transaction nonce validation succeeds.
+- Reject bootstrap when the selected nonce mode's normal transaction nonce validation fails.
 - Accept bootstrap for an empty derived account with a nonzero balance.
 - Reject bootstrap when the derived account has non-empty code.
 - Reject bootstrap when the derived account has EIP-7702 delegation code.
-- Reject bootstrap when the derived account has consumed transaction nonce state.
+- Accept bootstrap when the derived account has existing transaction nonce state and the submitted transaction satisfies the selected nonce mode.
 - Reject bootstrap when `multisig_accounts[signature.account] == true`.
 - Reject bootstrap when a config already exists for `signature.account`.
 - Reject bootstrap with empty owners.
@@ -1012,7 +1008,7 @@ This TIP does not define any single-key path that executes with the multisig acc
 - Reject bootstrap owner signatures that verify against the wrong inner digest or account.
 - Preserve the stored initial config, native multisig account marker, and nonce consumption when bootstrap validation succeeds but the subsequent EVM call reverts.
 - Do not write the initial config or native multisig account marker when bootstrap validation fails.
-- Do not consume the nonce when bootstrap validation fails.
+- Do not consume transaction nonce state when bootstrap validation fails.
 - Reject replaying a bootstrap transaction after successful bootstrap validation with reverted EVM execution.
 - Reject a second bootstrap for the same account after successful bootstrap validation with reverted EVM execution.
 - Revert `updateMultisigConfig` when it is called during bootstrap execution.
@@ -1179,7 +1175,7 @@ TBD.
 
 2. **Bootstrap exclusivity.** An account without a native multisig marker MUST require `signature.init`, and an account with a native multisig marker MUST reject `signature.init`.
 
-3. **Unused bootstrap account.** Bootstrap MUST be accepted only when the derived account has zero nonce, empty code, and no delegation code. A nonzero balance alone MUST NOT prevent bootstrap. This TIP does not check derived-account storage at bootstrap.
+3. **Bootstrap account shape.** Bootstrap MUST be accepted independent of existing nonce state when the submitted transaction satisfies its selected nonce mode, but only when the derived account has empty code and no delegation code. A nonzero balance alone MUST NOT prevent bootstrap. This TIP does not check derived-account storage at bootstrap.
 
 4. **Config validity.** Every stored config MUST have `1 <= owners.len() <= MAX_MULTISIG_OWNERS`, strictly ascending unique nonzero owners, nonzero owner weights, `sum(owners.weight) <= u8::MAX`, and `1 <= threshold <= MAX_MULTISIG_THRESHOLD` and `threshold <= sum(owners.weight)`.
 


### PR DESCRIPTION
Addresses native multisig review feedback from #5178 by tightening validation, removing redundant state-time checks/cache paths, charging dynamic config-read gas, and splitting follow-up tests/refactors into one commit per comment.

Stacked on tanishk/native-multisig.