### PR TITLE
fix(dex): make TIP-1087 book index state one-based

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -82,7 +82,7 @@ impl Precompile for StablecoinDEX {
                     storageCredits(call) => view(call, |c| self.storage_credits(c.user)),
 
                     #[schedule(since = T8)]
-                    bookIndexForKey(call) => view(call, |c| self.book_state(c.bookKey).map(|data| (data.is_index_set, data.index).into())),
+                    bookIndexForKey(call) => view(call, |c| Ok(self.book_key_index(c.bookKey)?.into())),
                     #[schedule(since = T8)]
                     bookKeyForIndex(call) => view(call, |c| self.book_key_for_index(c.index)),
                     #[schedule(since = T8)]

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -22,7 +22,7 @@ pub use tempo_contracts::precompiles::{IStablecoinDEX, StablecoinDEXError, Stabl
 use crate::{
     STABLECOIN_DEX_ADDRESS,
     error::{Result, TempoPrecompileError},
-    stablecoin_dex::orderbook::{MAX_PRICE, MIN_PRICE, OrderbookState, compute_book_key},
+    stablecoin_dex::orderbook::{MAX_PRICE, MIN_PRICE, compute_book_key},
     storage::{Handler, Mapping},
     storage_credits::{StorageCreditDeltas, StorageCredits},
     tip20::{ITIP20, TIP20Token, validate_usd_currency},
@@ -511,9 +511,10 @@ impl StablecoinDEX {
         self.book_keys.read()
     }
 
-    /// Returns the packed state for `book_key`.
-    pub(crate) fn book_state(&self, book_key: B256) -> Result<OrderbookState> {
-        self.books[book_key].state.read()
+    /// Returns whether `book_key` has a persisted index and its zero-based `book_keys` index.
+    pub(crate) fn book_key_index(&self, book_key: B256) -> Result<(bool, u32)> {
+        let book_key_index = self.books[book_key].book_key_index.read()?;
+        Ok((book_key_index != 0, book_key_index.saturating_sub(1)))
     }
 
     /// Resolves a book key by index from the append-only `book_keys` vector.
@@ -527,17 +528,15 @@ impl StablecoinDEX {
     /// Persists the `book_keys` vector index for an existing orderbook.
     pub fn set_book_index(&mut self, index: u32) -> Result<()> {
         let book_key = self.book_key_for_index(index)?;
-        let mut state = self.book_state(book_key)?;
-        if state.is_index_set {
-            if index == state.index {
+        let (is_index_set, current_index) = self.book_key_index(book_key)?;
+        if is_index_set {
+            if index == current_index {
                 return Ok(());
             }
             return Err(StablecoinDEXError::index_already_set().into());
         }
 
-        state.index = index;
-        state.is_index_set = true;
-        self.books[book_key].state.write(state)
+        self.books[book_key].book_key_index.write(index + 1)
     }
 
     /// Converts a relative tick to a scaled price. On T2+ validates [`TICK_SPACING`] alignment.
@@ -712,14 +711,14 @@ impl StablecoinDEX {
             self.books[order.book_key()].set_tick_bit(order.tick(), order.is_bid())?;
 
             if order.is_bid() {
-                if order.tick() > orderbook.best_bid_tick() {
+                if order.tick() > orderbook.best_bid_tick {
                     self.books[order.book_key()]
-                        .best_bid_tick()
+                        .best_bid_tick
                         .write(order.tick())?;
                 }
-            } else if order.tick() < orderbook.best_ask_tick() {
+            } else if order.tick() < orderbook.best_ask_tick {
                 self.books[order.book_key()]
-                    .best_ask_tick()
+                    .best_ask_tick
                     .write(order.tick())?;
             }
         } else {
@@ -1140,10 +1139,10 @@ impl StablecoinDEX {
             // Update best_tick when tick is exhausted
             if order.is_bid() {
                 let new_best = if has_liquidity { tick } else { i16::MIN };
-                self.books[book_key].best_bid_tick().write(new_best)?;
+                self.books[book_key].best_bid_tick.write(new_best)?;
             } else {
                 let new_best = if has_liquidity { tick } else { i16::MAX };
-                self.books[book_key].best_ask_tick().write(new_best)?;
+                self.books[book_key].best_ask_tick.write(new_best)?;
             }
 
             if !has_liquidity {
@@ -1352,15 +1351,15 @@ impl StablecoinDEX {
         let orderbook = self.books[book_key].read()?;
 
         let current_tick = if is_bid {
-            if orderbook.best_bid_tick() == i16::MIN {
+            if orderbook.best_bid_tick == i16::MIN {
                 return Err(StablecoinDEXError::insufficient_liquidity().into());
             }
-            orderbook.best_bid_tick()
+            orderbook.best_bid_tick
         } else {
-            if orderbook.best_ask_tick() == i16::MAX {
+            if orderbook.best_ask_tick == i16::MAX {
                 return Err(StablecoinDEXError::insufficient_liquidity().into());
             }
-            orderbook.best_ask_tick()
+            orderbook.best_ask_tick
         };
 
         self.books[book_key]
@@ -1429,9 +1428,9 @@ impl StablecoinDEX {
             // If this was the best tick, update it
             let orderbook = self.books[order.book_key()].read()?;
             let best_tick = if order.is_bid() {
-                orderbook.best_bid_tick()
+                orderbook.best_bid_tick
             } else {
-                orderbook.best_ask_tick()
+                orderbook.best_ask_tick
             };
 
             if best_tick == order.tick() {
@@ -1440,14 +1439,10 @@ impl StablecoinDEX {
 
                 if order.is_bid() {
                     let new_best = if has_liquidity { next_tick } else { i16::MIN };
-                    self.books[order.book_key()]
-                        .best_bid_tick()
-                        .write(new_best)?;
+                    self.books[order.book_key()].best_bid_tick.write(new_best)?;
                 } else {
                     let new_best = if has_liquidity { next_tick } else { i16::MAX };
-                    self.books[order.book_key()]
-                        .best_ask_tick()
-                        .write(new_best)?;
+                    self.books[order.book_key()].best_ask_tick.write(new_best)?;
                 }
             }
         }
@@ -1551,9 +1546,9 @@ impl StablecoinDEX {
         let orderbook = self.books[book_key].read()?;
 
         let mut current_tick = if is_bid {
-            orderbook.best_bid_tick()
+            orderbook.best_bid_tick
         } else {
-            orderbook.best_ask_tick()
+            orderbook.best_ask_tick
         };
         // Check for no liquidity: i16::MIN means no bids, i16::MAX means no asks
         if current_tick == i16::MIN || current_tick == i16::MAX {
@@ -1772,9 +1767,9 @@ impl StablecoinDEX {
         let orderbook = self.books[book_key].read()?;
 
         let mut current_tick = if is_bid {
-            orderbook.best_bid_tick()
+            orderbook.best_bid_tick
         } else {
-            orderbook.best_ask_tick()
+            orderbook.best_ask_tick
         };
 
         // Check for no liquidity: i16::MIN means no bids, i16::MAX means no asks
@@ -1897,6 +1892,30 @@ mod tests {
             .apply()?;
 
         Ok((base.address(), quote.address()))
+    }
+
+    #[test]
+    fn test_t8_book_index_state_is_one_based() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let admin = Address::random();
+            let user = Address::random();
+            let (base, quote) = setup_test_tokens(admin, user, exchange.address, 0)?;
+            let book_key = compute_book_key(base, quote);
+
+            exchange.create_pair(base)?;
+
+            assert_eq!(exchange.book_key_index(book_key)?, (true, 0));
+            assert_eq!(exchange.book_key_for_index(0)?, book_key);
+
+            exchange.set_book_index(0)?;
+            assert_eq!(exchange.book_key_index(book_key)?, (true, 0));
+
+            Ok(())
+        })
     }
 
     #[test]
@@ -2845,8 +2864,8 @@ mod tests {
 
             let book = exchange.books[book_key].read()?;
             // TIP-1030 "locked book": best bid and best ask both at `tick`.
-            assert_eq!(book.best_bid_tick(), tick, "best bid should remain at tick");
-            assert_eq!(book.best_ask_tick(), tick, "best ask can't equal best bid");
+            assert_eq!(book.best_bid_tick, tick, "best bid should remain at tick");
+            assert_eq!(book.best_ask_tick, tick, "best ask can't equal best bid");
 
             // Follow-up swap-buy at the locked tick consumes only the new ask
             // (not the resting bid on the other side) and the ask flips back
@@ -2876,8 +2895,8 @@ mod tests {
             // Ask level is empty (best_ask_tick reset), bid level holds both
             // the resting bid and the freshly flipped-back bid.
             let book_after = exchange.books[book_key].read()?;
-            assert_eq!(book_after.best_bid_tick(), tick);
-            assert_eq!(book_after.best_ask_tick(), i16::MAX);
+            assert_eq!(book_after.best_bid_tick, tick);
+            assert_eq!(book_after.best_ask_tick, i16::MAX);
 
             let bid_level_after = exchange.books[book_key]
                 .tick_level_handler(tick, true)
@@ -3339,8 +3358,8 @@ mod tests {
             // Best ask collapses to `tick` (no asks before, now one at tick).
             let book_key = compute_book_key(base_token, quote_token);
             let book = exchange.books[book_key].read()?;
-            assert_eq!(book.best_ask_tick(), tick);
-            assert_eq!(book.best_bid_tick(), i16::MIN);
+            assert_eq!(book.best_ask_tick, tick);
+            assert_eq!(book.best_bid_tick, i16::MIN);
 
             Ok(())
         })
@@ -4326,24 +4345,24 @@ mod tests {
 
             // Verify initial best ticks
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), bid_tick_1);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_1);
+            assert_eq!(orderbook.best_bid_tick, bid_tick_1);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_1);
 
             // Fill all bids at tick 100 (bob sells base)
             exchange.set_balance(bob, base_token, amount)?;
             exchange.swap_exact_amount_in(bob, base_token, quote_token, amount, 0)?;
             // Verify best_bid_tick moved to tick 90, best_ask_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), bid_tick_2);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_1);
+            assert_eq!(orderbook.best_bid_tick, bid_tick_2);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_1);
 
             // Fill remaining bid at tick 90
             exchange.set_balance(bob, base_token, amount)?;
             exchange.swap_exact_amount_in(bob, base_token, quote_token, amount, 0)?;
             // Verify best_bid_tick is now i16::MIN, best_ask_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), i16::MIN);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_1);
+            assert_eq!(orderbook.best_bid_tick, i16::MIN);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_1);
 
             // Fill all asks at tick 50 (bob buys base)
             let ask_price_1 = orderbook::tick_to_price(ask_tick_1);
@@ -4353,8 +4372,8 @@ mod tests {
             exchange.swap_exact_amount_in(bob, quote_token, base_token, quote_needed, 0)?;
             // Verify best_ask_tick moved to tick 60, best_bid_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_2);
-            assert_eq!(orderbook.best_bid_tick(), i16::MIN);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_2);
+            assert_eq!(orderbook.best_bid_tick, i16::MIN);
 
             Ok(())
         })
@@ -4401,43 +4420,43 @@ mod tests {
 
             // Verify initial best ticks
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), bid_tick_1);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_1);
+            assert_eq!(orderbook.best_bid_tick, bid_tick_1);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_1);
 
             // Cancel one bid at tick 100
             exchange.cancel(alice, bid_order_1)?;
             // Verify best_bid_tick remains 100, best_ask_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), bid_tick_1);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_1);
+            assert_eq!(orderbook.best_bid_tick, bid_tick_1);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_1);
 
             // Cancel remaining bid at tick 100
             exchange.cancel(alice, bid_order_2)?;
             // Verify best_bid_tick moved to 90, best_ask_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), bid_tick_2);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_1);
+            assert_eq!(orderbook.best_bid_tick, bid_tick_2);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_1);
 
             // Cancel ask at tick 50
             exchange.cancel(alice, ask_order_1)?;
             // Verify best_ask_tick moved to 60, best_bid_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), bid_tick_2);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_2);
+            assert_eq!(orderbook.best_bid_tick, bid_tick_2);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_2);
 
             // Cancel bid at tick 90
             exchange.cancel(alice, bid_order_3)?;
             // Verify best_bid_tick is now i16::MIN, best_ask_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), i16::MIN);
-            assert_eq!(orderbook.best_ask_tick(), ask_tick_2);
+            assert_eq!(orderbook.best_bid_tick, i16::MIN);
+            assert_eq!(orderbook.best_ask_tick, ask_tick_2);
 
             // Cancel ask at tick 60
             exchange.cancel(alice, ask_order_2)?;
             // Verify best_ask_tick is now i16::MAX, best_bid_tick unchanged
             let orderbook = exchange.books[book_key].read()?;
-            assert_eq!(orderbook.best_bid_tick(), i16::MIN);
-            assert_eq!(orderbook.best_ask_tick(), i16::MAX);
+            assert_eq!(orderbook.best_bid_tick, i16::MIN);
+            assert_eq!(orderbook.best_ask_tick, i16::MAX);
 
             Ok(())
         })
@@ -4771,8 +4790,7 @@ mod tests {
 
             let orderbook = book_handler.read()?;
             assert_eq!(
-                orderbook.best_bid_tick(),
-                tick,
+                orderbook.best_bid_tick, tick,
                 "Best bid tick should be updated"
             );
 
@@ -4833,8 +4851,7 @@ mod tests {
 
             let orderbook = book_handler.read()?;
             assert_eq!(
-                orderbook.best_bid_tick(),
-                tick,
+                orderbook.best_bid_tick, tick,
                 "Best bid tick should be updated"
             );
 
@@ -4895,7 +4912,7 @@ mod tests {
             assert_eq!(level.total_liquidity, min_order_amount);
 
             let book = exchange.books[book_key].read()?;
-            assert_eq!(book.best_bid_tick(), tick);
+            assert_eq!(book.best_bid_tick, tick);
 
             assert_eq!(exchange.next_order_id()?, 2);
 
@@ -5827,8 +5844,8 @@ mod tests {
 
             // Verify book has liquidity
             let book = exchange.books[book_key].read()?;
-            assert_eq!(book.best_bid_tick(), tick);
-            assert_eq!(book.best_ask_tick(), tick);
+            assert_eq!(book.best_bid_tick, tick);
+            assert_eq!(book.best_ask_tick, tick);
 
             // Fill the bid by selling base into it
             exchange.swap_exact_amount_in(bob, base_token, quote_token, amount, 0)?;
@@ -5839,12 +5856,12 @@ mod tests {
             // Verify sentinel values are restored
             let book = exchange.books[book_key].read()?;
             assert_eq!(
-                book.best_bid_tick(),
+                book.best_bid_tick,
                 i16::MIN,
                 "best_bid_tick must be sentinel after all bids filled"
             );
             assert_eq!(
-                book.best_ask_tick(),
+                book.best_ask_tick,
                 i16::MAX,
                 "best_ask_tick must be sentinel after all asks filled"
             );
@@ -5941,12 +5958,12 @@ mod tests {
             // Verify sentinel values are restored
             let book = exchange.books[book_key].read()?;
             assert_eq!(
-                book.best_bid_tick(),
+                book.best_bid_tick,
                 i16::MIN,
                 "best_bid_tick must be sentinel after all bids cancelled"
             );
             assert_eq!(
-                book.best_ask_tick(),
+                book.best_ask_tick,
                 i16::MAX,
                 "best_ask_tick must be sentinel after all asks cancelled"
             );

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -333,9 +333,9 @@ impl Handler<Order> for OrderHandler {
             OrderVersion::V2 => V2Order::SLOTS,
         };
 
-        let state = StablecoinDEX::new().book_state(value.book_key)?;
-        let new_slots = if state.is_index_set {
-            V2Order::new(value, state.index).store(self, self.base_slot, LayoutCtx::FULL)?;
+        let (is_index_set, book_key_index) = StablecoinDEX::new().book_key_index(value.book_key)?;
+        let new_slots = if is_index_set {
+            V2Order::new(value, book_key_index).store(self, self.base_slot, LayoutCtx::FULL)?;
             V2Order::SLOTS
         } else {
             V1Order::new(value).store(self, self.base_slot, LayoutCtx::FULL)?;
@@ -942,8 +942,7 @@ mod tests {
             }
             OrderVersion::V2 => {
                 ensure_book_index(exchange, order.book_key)?;
-                let state = exchange.book_state(order.book_key)?;
-                let book_index = state.index;
+                let (_, book_index) = exchange.book_key_index(order.book_key)?;
                 let handler = &exchange.orders[order.order_id()];
                 let mut storage = handler.clone();
                 V2Order::new(order, book_index).store(
@@ -1700,8 +1699,8 @@ mod tests {
                 active_orders,
                 bid_level,
                 ask_level,
-                best_bid_tick: book.best_bid_tick(),
-                best_ask_tick: book.best_ask_tick(),
+                best_bid_tick: book.best_bid_tick,
+                best_ask_tick: book.best_ask_tick,
                 alice_internal_base: exchange.balance_of(test.alice, base_token)?,
                 alice_internal_quote: exchange.balance_of(test.alice, quote_token)?,
                 bob_internal_base: exchange.balance_of(test.bob, base_token)?,
@@ -1912,7 +1911,7 @@ mod tests {
     }
 
     fn ensure_book_index(exchange: &mut StablecoinDEX, book_key: B256) -> StorageResult<()> {
-        if exchange.book_state(book_key)?.is_index_set {
+        if exchange.book_key_index(book_key)?.0 {
             return Ok(());
         }
 

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::Result,
     stablecoin_dex::{IStablecoinDEX, TICK_SPACING},
-    storage::{Handler, Mapping, StorableType},
+    storage::{Handler, Mapping},
 };
 use alloy::primitives::{Address, B256, U256, keccak256};
 use tempo_contracts::precompiles::StablecoinDEXError;
@@ -142,36 +142,9 @@ impl From<TickLevel> for IStablecoinDEX::PriceLevel {
     }
 }
 
-/// Per-book state stored in the slot that originally held only the best bid/ask ticks.
-///
-/// T8 adds an orderbook identifier for V2 orders, which maps to the book index in `book_keys`.
-/// Tick fields left enough unused bytes in the slot to pack the index without shifting the layout.
-#[derive(Storable, Clone, Copy)]
-pub(crate) struct OrderbookState {
-    /// Best bid tick for highest bid price.
-    pub best_bid_tick: i16,
-    /// Best ask tick for lowest ask price.
-    pub best_ask_tick: i16,
-    /// (+T8) Distinguishes indexed books, including index zero, from unmigrated books.
-    pub is_index_set: bool,
-    /// (+T8) Index into `book_keys`.
-    pub index: u32,
-}
-
-impl Default for OrderbookState {
-    fn default() -> Self {
-        Self {
-            best_bid_tick: i16::MIN,
-            best_ask_tick: i16::MAX,
-            is_index_set: false,
-            index: 0,
-        }
-    }
-}
-
 /// Orderbook for token pair with price-time priority
 /// Uses tick-based pricing with bitmaps for price discovery
-#[derive(Storable, Default)]
+#[derive(Storable)]
 pub struct Orderbook {
     /// Base token address
     pub base: Address,
@@ -183,8 +156,12 @@ pub struct Orderbook {
     /// Ask orders by tick
     #[allow(dead_code)]
     asks: Mapping<i16, TickLevel>,
-    /// Best bid/ask tick cache with (T8+) packed book index.
-    pub(crate) state: OrderbookState,
+    /// Best bid tick for highest bid price.
+    pub(crate) best_bid_tick: i16,
+    /// Best ask tick for lowest ask price.
+    pub(crate) best_ask_tick: i16,
+    /// (+T8) 1-based index into `book_keys`; zero means unset.
+    pub(crate) book_key_index: u32,
     #[allow(dead_code)]
     /// Mapping of tick index to bid bitmap for price discovery
     bid_bitmap: Mapping<i16, U256>,
@@ -199,19 +176,20 @@ impl Orderbook {
         Self {
             base,
             quote,
-            ..Default::default()
+            best_bid_tick: i16::MIN,
+            best_ask_tick: i16::MAX,
+            book_key_index: 0,
+            bids: Mapping::default(),
+            asks: Mapping::default(),
+            bid_bitmap: Mapping::default(),
+            ask_bitmap: Mapping::default(),
         }
     }
 
-    /// Creates a new orderbook with its persisted `book_keys` index
+    /// Creates a new orderbook with its persisted `book_keys` index.
     pub fn new_with_id(base: Address, quote: Address, id: u32) -> Self {
         Self {
-            state: OrderbookState {
-                best_bid_tick: i16::MIN,
-                best_ask_tick: i16::MAX,
-                is_index_set: true,
-                index: id,
-            },
+            book_key_index: id + 1,
             ..Self::new(base, quote)
         }
     }
@@ -219,14 +197,6 @@ impl Orderbook {
     /// Returns true if this orderbook is initialized
     pub fn is_initialized(&self) -> bool {
         self.base != Address::ZERO
-    }
-
-    pub fn best_bid_tick(&self) -> i16 {
-        self.state.best_bid_tick
-    }
-
-    pub fn best_ask_tick(&self) -> i16 {
-        self.state.best_ask_tick
     }
 
     /// Returns true if the base and quote tokens match the provided base and quote token options.
@@ -254,14 +224,6 @@ impl Orderbook {
 }
 
 impl OrderbookHandler {
-    pub fn best_bid_tick(&mut self) -> &mut <i16 as StorableType>::Handler {
-        &mut self.state.best_bid_tick
-    }
-
-    pub fn best_ask_tick(&mut self) -> &mut <i16 as StorableType>::Handler {
-        &mut self.state.best_ask_tick
-    }
-
     /// Returns a reference to the tick level handler for the given tick and side.
     pub fn tick_level_handler(&self, tick: i16, is_bid: bool) -> &TickLevelHandler {
         if is_bid {
@@ -473,8 +435,8 @@ impl From<Orderbook> for IStablecoinDEX::Orderbook {
         Self {
             base: value.base,
             quote: value.quote,
-            bestBidTick: value.best_bid_tick(),
-            bestAskTick: value.best_ask_tick(),
+            bestBidTick: value.best_bid_tick,
+            bestAskTick: value.best_ask_tick,
         }
     }
 }
@@ -542,8 +504,8 @@ mod tests {
 
         assert_eq!(book.base, base);
         assert_eq!(book.quote, quote);
-        assert_eq!(book.best_bid_tick(), i16::MIN);
-        assert_eq!(book.best_ask_tick(), i16::MAX);
+        assert_eq!(book.best_bid_tick, i16::MIN);
+        assert_eq!(book.best_ask_tick, i16::MAX);
         assert!(book.is_initialized());
     }
 

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -89,9 +89,7 @@ fn test_fee_manager_layout() {
 #[test]
 fn test_stablecoin_dex_layout() {
     use tempo_precompiles::stablecoin_dex::{
-        order::__packing_legacy_order::*,
-        orderbook::{__packing_orderbook::*, __packing_orderbook_state::*},
-        slots,
+        order::__packing_legacy_order::*, orderbook::__packing_orderbook::*, slots,
     };
 
     let sol_path = testdata("stablecoin_dex.sol");
@@ -131,27 +129,14 @@ fn test_stablecoin_dex_layout() {
         quote,
         bids,
         asks,
-        state,
+        best_bid_tick,
+        best_ask_tick,
+        book_key_index,
         bid_bitmap,
         ask_bitmap
     );
     if let Err(errors) = compare_struct_members(&solc_layout, "books", &rust_orderbook) {
         panic_layout_mismatch("Orderbook struct member layout", errors, &sol_path);
-    }
-
-    // Verify `OrderbookState` struct members
-    let orderbook_state_base_slot = slots::BOOKS + U256::from(4);
-    let rust_orderbook_state = struct_fields!(
-        orderbook_state_base_slot,
-        best_bid_tick,
-        best_ask_tick,
-        is_index_set,
-        index
-    );
-    if let Err(errors) =
-        compare_nested_struct_type(&solc_layout, "OrderbookState", &rust_orderbook_state)
-    {
-        panic_layout_mismatch("OrderbookState struct member layout", errors, &sol_path);
     }
 }
 
@@ -300,9 +285,7 @@ fn export_all_storage_constants() {
     // Stablecoin DEX
     {
         use tempo_precompiles::stablecoin_dex::{
-            order::__packing_legacy_order::*,
-            orderbook::{__packing_orderbook::*, __packing_orderbook_state::*},
-            slots,
+            order::__packing_legacy_order::*, orderbook::__packing_orderbook::*, slots,
         };
 
         let fields = layout_fields!(books, orders, balances, next_order_id, book_keys);
@@ -330,18 +313,11 @@ fn export_all_storage_constants() {
             quote,
             bids,
             asks,
-            state,
-            bid_bitmap,
-            ask_bitmap
-        );
-
-        let orderbook_state_base_slot = slots::BOOKS + U256::from(4);
-        let orderbook_state_struct = struct_fields!(
-            orderbook_state_base_slot,
             best_bid_tick,
             best_ask_tick,
-            is_index_set,
-            index
+            book_key_index,
+            bid_bitmap,
+            ask_bitmap
         );
 
         all_constants.insert(
@@ -350,8 +326,7 @@ fn export_all_storage_constants() {
                 "fields": fields.iter().map(field_to_json).collect::<Vec<_>>(),
                 "structs": {
                     "orders": order_struct.iter().map(field_to_json).collect::<Vec<_>>(),
-                    "books": orderbook_struct.iter().map(field_to_json).collect::<Vec<_>>(),
-                    "OrderbookState": orderbook_state_struct.iter().map(field_to_json).collect::<Vec<_>>()
+                    "books": orderbook_struct.iter().map(field_to_json).collect::<Vec<_>>()
                 }
             }),
         );

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/stablecoin_dex.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/stablecoin_dex.layout.json
@@ -229,7 +229,7 @@
                 "type": "t_address"
               },
               {
-                "astId": 27,
+                "astId": 32,
                 "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
                 "label": "bids",
                 "offset": 0,
@@ -237,7 +237,7 @@
                 "type": "t_mapping(t_int16,t_struct(TickLevel)9_storage)"
               },
               {
-                "astId": 32,
+                "astId": 35,
                 "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
                 "label": "asks",
                 "offset": 0,
@@ -245,12 +245,28 @@
                 "type": "t_mapping(t_int16,t_struct(TickLevel)9_storage)"
               },
               {
-                "astId": 35,
+                "astId": 36,
                 "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
-                "label": "state",
+                "label": "bestBidTick",
                 "offset": 0,
                 "slot": "4",
-                "type": "t_struct(OrderbookState)18_storage"
+                "type": "t_int16"
+              },
+              {
+                "astId": 37,
+                "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
+                "label": "bestAskTick",
+                "offset": 2,
+                "slot": "4",
+                "type": "t_int16"
+              },
+              {
+                "astId": 27,
+                "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
+                "label": "bookKeyIndex",
+                "offset": 4,
+                "slot": "4",
+                "type": "t_uint32"
               },
               {
                 "astId": 39,
@@ -270,45 +286,6 @@
               }
             ],
             "numberOfBytes": "224"
-          },
-          "t_struct(OrderbookState)18_storage": {
-            "encoding": "inplace",
-            "label": "struct StablecoinDEX.OrderbookState",
-            "members": [
-              {
-                "astId": 11,
-                "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
-                "label": "bestBidTick",
-                "offset": 0,
-                "slot": "0",
-                "type": "t_int16"
-              },
-              {
-                "astId": 13,
-                "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
-                "label": "bestAskTick",
-                "offset": 2,
-                "slot": "0",
-                "type": "t_int16"
-              },
-              {
-                "astId": 15,
-                "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
-                "label": "isIndexSet",
-                "offset": 4,
-                "slot": "0",
-                "type": "t_bool"
-              },
-              {
-                "astId": 17,
-                "contract": "tests/storage_tests/solidity/testdata/stablecoin_dex.sol:StablecoinDEX",
-                "label": "index",
-                "offset": 5,
-                "slot": "0",
-                "type": "t_uint32"
-              }
-            ],
-            "numberOfBytes": "32"
           },
           "t_struct(TickLevel)9_storage": {
             "encoding": "inplace",

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/stablecoin_dex.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/stablecoin_dex.sol
@@ -12,20 +12,15 @@ contract StablecoinDEX {
         uint128 totalLiquidity;
     }
 
-    struct OrderbookState {
-        int16 bestBidTick;
-        int16 bestAskTick;
-        // Only applicable for T8 and above. Always set to zero beforehand.
-        bool isIndexSet;
-        uint32 index;
-    }
-
     struct Orderbook {
         address base;
         address quote;
         mapping(int16 => TickLevel) bids;
         mapping(int16 => TickLevel) asks;
-        OrderbookState state;
+        int16 bestBidTick;
+        int16 bestAskTick;
+        // Only applicable for T8 and above. One-based; zero means unset.
+        uint32 bookKeyIndex;
         mapping(int16 => uint256) bidBitmap;
         mapping(int16 => uint256) askBitmap;
     }


### PR DESCRIPTION
## Summary
- remove the persisted `isIndexSet` flag from `OrderbookState`
- store `bookKeyIdx` as one-based with zero as unset
- convert back to zero-based for `bookIndexForKey` and V2 order writes
- update storage layout fixtures and add a focused T8 invariant test

## Testing
- cargo test -p tempo-precompiles --features test-utils test_stablecoin_dex_layout --test storage
- cargo test -p tempo-precompiles --features test-utils stablecoin_dex::
- cargo fmt --check

Stacked on: https://github.com/tempoxyz/tempo/pull/6691
Spec change: https://github.com/tempoxyz/tempo/pull/6682/commits/625e0a26ff5a2bf0c52bafcdc642a392adb9cc07

Prompted by: @0xrusowsky