### PR TITLE
docs: align TIP-1087 orderbook layout

### DIFF
--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -76,7 +76,7 @@ slot 2:
 
 ## Orderbook layout
 
-Orderbooks keep their existing logical shape and gain a persisted book index in the same slot as the best-tick cache:
+Orderbooks keep their existing logical shape and gain a persisted book index in the existing unused bytes after `quote`:
 
 ```text
 slot 0:
@@ -85,7 +85,8 @@ slot 0:
 
 slot 1:
   offset 0   quote        address  20 bytes
-  offset 20  unused                 12 bytes
+  offset 20  bookKeyIdx   uint32    4 bytes
+  offset 24  unused                 8 bytes
 
 slot 2:
   bids        mapping(int16 => TickLevel)
@@ -96,8 +97,7 @@ slot 3:
 slot 4:
   offset 0   bestBidTick  int16     2 bytes
   offset 2   bestAskTick  int16     2 bytes
-  offset 4   bookKeyIdx   uint32    4 bytes
-  offset 8   unused                 24 bytes
+  offset 4   unused                 28 bytes
 
 slot 5:
   bidBitmap   mapping(int16 => uint256)
@@ -106,9 +106,9 @@ slot 6:
   askBitmap   mapping(int16 => uint256)
 ```
 
-`bookKeyIdx` is the 1-based `book_keys` vector index for this orderbook. A value of `0` means no active index is set, distinguishing the unset state from the active `book_keys[0]` index. This field is packed after `bestBidTick` and `bestAskTick` in slot `4`, so this TIP does not increase the orderbook slot count or move any existing orderbook fields.
+`bookKeyIdx` is the 1-based `book_keys` vector index for this orderbook. A value of `0` means no active index is set, distinguishing the unset state from the active `book_keys[0]` index. This field is packed after `quote` in slot `1`, so this TIP does not increase the orderbook slot count or move any existing orderbook fields.
 
-Starting at activation, newly created orderbooks MUST store `bookKeyIdx = book_keys.length + 1` in slot `4` on the orderbook record before appending the key to `book_keys`. Orderbooks created before activation have `bookKeyIdx = 0` and no active stored index.
+Starting at activation, newly created orderbooks MUST store `bookKeyIdx = book_keys.length + 1` in slot `1` on the orderbook record before appending the key to `book_keys`. Orderbooks created before activation have `bookKeyIdx = 0` and no active stored index.
 
 Pre-activation orderbooks MUST NOT be migrated by linearly scanning `book_keys` onchain. The DEX already has hundreds of thousands of orderbooks on testnet, so an onchain full-array scan cannot fit within the transaction execution budget. Instead, migration tooling MUST derive the index offchain and submit it to the DEX for verification and persistence.
 
@@ -177,7 +177,7 @@ Deleting an order clears the storage slots used by that order's versioned layout
 
 Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setIndexForKey(bookKey, index)`, and verifies that each corresponding orderbook has the expected 1-based `bookKeyIdx = index + 1`. The workflow MUST avoid onchain linear scans over `book_keys`.
 
-Tools that decode raw DEX storage MUST add support for the 1-based orderbook `bookKeyIdx` field packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
+Tools that decode raw DEX storage MUST add support for the 1-based orderbook `bookKeyIdx` field packed in slot `1`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
 
 # Observability
 


### PR DESCRIPTION
## Summary
- move the TIP-1087 orderbook `bookKeyIdx` layout from slot 4 to slot 1 after `quote`
- restore slot 4 to only `bestBidTick` and `bestAskTick` plus unused bytes
- update prose and tooling guidance to match the simplified implementation in #6704

## Testing
- `git diff --check`

Prompted by: @0xrusowsky