### PR TITLE
refactor(storage): sstore transition flags

### DIFF
--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -676,6 +676,7 @@ impl SstoreTransitionFlags {
         self.changes_present() && self.is_original_eq_present()
     }
 
+    #[inline]
     fn has(&self, flag: u8) -> bool {
         self.0 & flag != 0
     }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -266,7 +266,7 @@ impl crate::storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvi
         key: U256,
         value: U256,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, Self::Error> {
+    ) -> Result<SstoreTransitionFlags, Self::Error> {
         let val = self.sstore_journal(address, key, value, skip_cold_load)?;
         self.actions.record_always(StorageAction::Sstore(
             address,
@@ -274,7 +274,7 @@ impl crate::storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvi
             val.data.present_value,
             value,
         ));
-        Ok(val)
+        Ok(val.into())
     }
 
     #[inline]
@@ -590,6 +590,110 @@ impl EvmPrecompileStorageProvider<'_> {
             top,
             "out-of-order checkpoint {op} (expected top of stack)"
         );
+    }
+}
+
+/// SSTORE transition flags that drive gas/refund accounting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SstoreTransitionFlags(u8);
+
+impl SstoreTransitionFlags {
+    /// The slot's transaction-start value is zero.
+    const ORIGINAL_ZERO: u8 = 1 << 0;
+    /// The slot's pre-SSTORE value is zero.
+    const PRESENT_ZERO: u8 = 1 << 1;
+    /// The slot's post-SSTORE value is zero.
+    const NEW_ZERO: u8 = 1 << 2;
+    /// The slot's transaction-start value equals its pre-SSTORE value.
+    const ORIGINAL_EQ_PRESENT: u8 = 1 << 3;
+    /// The slot's transaction-start value equals its post-SSTORE value.
+    const ORIGINAL_EQ_NEW: u8 = 1 << 4;
+    /// The slot's pre-SSTORE current value equals its post-SSTORE value.
+    const PRESENT_EQ_NEW: u8 = 1 << 5;
+
+    /// Computes the SSTORE transition flags from the values that drive gas/refund accounting.
+    pub fn from_values(original: U256, present: U256, new: U256) -> Self {
+        let mut bits = 0;
+
+        if original.is_zero() {
+            bits |= Self::ORIGINAL_ZERO;
+        }
+        if present.is_zero() {
+            bits |= Self::PRESENT_ZERO;
+        }
+        if new.is_zero() {
+            bits |= Self::NEW_ZERO;
+        }
+        if original == present {
+            bits |= Self::ORIGINAL_EQ_PRESENT;
+        }
+        if original == new {
+            bits |= Self::ORIGINAL_EQ_NEW;
+        }
+        if present == new {
+            bits |= Self::PRESENT_EQ_NEW;
+        }
+
+        Self(bits)
+    }
+
+    /// Returns whether the write changes slot occupancy.
+    pub fn crosses_zero_boundary(&self) -> bool {
+        self.has(Self::PRESENT_ZERO) != self.has(Self::NEW_ZERO)
+    }
+
+    /// Returns whether the write creates an occupied slot.
+    pub fn is_zero_to_nonzero(&self) -> bool {
+        self.has(Self::PRESENT_ZERO) && !self.has(Self::NEW_ZERO)
+    }
+
+    /// Returns whether the write clears an occupied slot.
+    pub fn is_nonzero_to_zero(&self) -> bool {
+        !self.has(Self::PRESENT_ZERO) && self.has(Self::NEW_ZERO)
+    }
+
+    /// Returns whether the write changes the present value.
+    pub fn changes_present(&self) -> bool {
+        !self.has(Self::PRESENT_EQ_NEW)
+    }
+
+    /// Returns whether this slot is still clean before the write.
+    ///
+    /// In EVM SSTORE terminology, "clean" means the transaction has not changed
+    /// the slot yet, so the transaction-start value (`original`) still equals
+    /// the current pre-write value (`present`).
+    pub fn is_original_eq_present(&self) -> bool {
+        self.has(Self::ORIGINAL_EQ_PRESENT)
+    }
+
+    /// Returns whether the warm clean-update SSTORE cost applies.
+    ///
+    /// This is the `present != new && original == present` case: the write
+    /// changes a slot for the first time in the transaction. Dirty writes
+    /// (`original != present`) use different SSTORE accounting and do not pay
+    /// this clean-update charge again.
+    pub fn charges_clean_update(&self) -> bool {
+        self.changes_present() && self.is_original_eq_present()
+    }
+
+    fn has(&self, flag: u8) -> bool {
+        self.0 & flag != 0
+    }
+}
+
+impl From<&StateLoad<SStoreResult>> for SstoreTransitionFlags {
+    fn from(result: &StateLoad<SStoreResult>) -> Self {
+        Self::from_values(
+            result.data.original_value,
+            result.data.present_value,
+            result.data.new_value,
+        )
+    }
+}
+
+impl From<StateLoad<SStoreResult>> for SstoreTransitionFlags {
+    fn from(result: StateLoad<SStoreResult>) -> Self {
+        Self::from(&result)
     }
 }
 

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -11,7 +11,7 @@ use tempo_primitives::TempoBlockEnv;
 
 use crate::{
     error::TempoPrecompileError,
-    storage::PrecompileStorageProvider,
+    storage::{PrecompileStorageProvider, SstoreTransitionFlags},
     storage_credits::{NonCreditableSlots, StorageCreditsBackend, sstore_storage_credits},
 };
 
@@ -307,20 +307,17 @@ impl StorageCreditsBackend for HashMapStorageProvider {
         key: U256,
         value: U256,
         _skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, Self::Error> {
+    ) -> Result<SstoreTransitionFlags, Self::Error> {
         let present_value = self
             .internals
             .get(&(address, key))
             .copied()
             .unwrap_or(U256::ZERO);
         self.internals.insert((address, key), value);
-        Ok(StateLoad::new(
-            SStoreResult {
-                original_value: present_value,
-                present_value,
-                new_value: value,
-            },
-            false,
+        Ok(SstoreTransitionFlags::from_values(
+            present_value,
+            present_value,
+            value,
         ))
     }
 

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -7,6 +7,7 @@ pub mod actions;
 pub use actions::{StorageAction, StorageActions};
 
 pub mod evm;
+pub use evm::SstoreTransitionFlags;
 pub mod hashmap;
 
 pub mod thread_local;

--- a/crates/precompiles/src/storage_credits/accounting.rs
+++ b/crates/precompiles/src/storage_credits/accounting.rs
@@ -9,7 +9,7 @@
 //!   so precompile-driven storage writes honor the same accounting.
 
 use super::{CreditMode, StorageCredits, TransientState};
-use crate::storage::FromWord;
+use crate::storage::{FromWord, SstoreTransitionFlags};
 use alloy::primitives::{Address, U256};
 use revm::{
     context_interface::cfg::GasParams,
@@ -68,7 +68,7 @@ pub trait StorageCreditsBackend {
         key: U256,
         value: U256,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, Self::Error>;
+    ) -> Result<SstoreTransitionFlags, Self::Error>;
 
     /// TLOAD `address[key]`.
     fn tload(&mut self, address: Address, key: U256) -> U256;
@@ -108,11 +108,11 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
     key: Option<U256>,
     caller_state_load: &StateLoad<SStoreResult>,
 ) -> Result<(), B::Error> {
-    let values = &caller_state_load.data;
+    let sstore_flags = SstoreTransitionFlags::from(caller_state_load);
 
     // Only account for storage credits when the slot crosses the zero boundary (x→0 or 0→x).
     // If both values are zero or non-zero, slot occupancy is unchanged, so skip credits accounting.
-    if values.is_present_zero() == values.is_new_zero() {
+    if !sstore_flags.crosses_zero_boundary() {
         return Ok(());
     }
 
@@ -139,7 +139,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
         u64::from_word(storage_credit_state_load.data).map_err(|_| B::Error::fatal_external())?;
 
     let mut was_changed = false;
-    if values.is_new_zero() {
+    if sstore_flags.is_nonzero_to_zero() {
         // x→0: storage deletion doesn't mint on protocol fee/keychain bookkeeping slots.
         if let Some(key) = key
             && backend.is_non_creditable_slot(owner, key)
@@ -152,7 +152,7 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
             credit = credit.saturating_add(1);
             was_changed = true;
         }
-    } else {
+    } else if sstore_flags.is_zero_to_nonzero() {
         // 0→x: storage creation.
         // This hook manages the 245k creditable gas, independent of the original value.
         // revm's SSTORE function adds the 5k residual for clean writes (`original == present == 0`).
@@ -189,17 +189,15 @@ pub fn sstore_storage_credits<B: StorageCreditsBackend>(
 
     if was_changed {
         // Cold load is already checked above when we loaded the storage credits account.
-        let result = backend
-            .sstore(
-                STORAGE_CREDITS_ADDRESS,
-                account_slot,
-                U256::from(credit),
-                false,
-            )?
-            .data;
+        let flags = backend.sstore(
+            STORAGE_CREDITS_ADDRESS,
+            account_slot,
+            U256::from(credit),
+            false,
+        )?;
 
         // Only when change happens charge additional gas.
-        if result.new_values_changes_present() && result.is_original_eq_present() {
+        if flags.charges_clean_update() {
             backend.charge_gas(backend.gas_params().sstore_reset_without_cold_load_cost())?;
         };
     }

--- a/crates/revm/src/gas_credits.rs
+++ b/crates/revm/src/gas_credits.rs
@@ -10,7 +10,7 @@ use revm::{
     context::{Host as _, JournalTr, result::EVMError},
     context_interface::cfg::GasParams,
     interpreter::{
-        Gas, InstructionContext, InstructionResult, SStoreResult, StateLoad,
+        Gas, InstructionContext, InstructionResult, StateLoad,
         gas::GasTracker,
         instructions::host::{sstore_default_gas_accounting, sstore_with_gas_accounting},
         interpreter::EthInterpreter,
@@ -19,7 +19,7 @@ use revm::{
 use tempo_chainspec::constants::gas::STORAGE_CREDIT_VALUE;
 use tempo_precompiles::{
     STORAGE_CREDITS_ADDRESS,
-    storage::{FromWord, StorageAction},
+    storage::{FromWord, SstoreTransitionFlags, StorageAction},
     storage_credits::{StorageCreditsBackend, TransientState, sstore_storage_credits},
 };
 
@@ -131,10 +131,11 @@ impl<DB: Database> StorageCreditsBackend for StorageCreditsContext<'_, DB> {
         key: U256,
         value: U256,
         skip_cold_load: bool,
-    ) -> Result<StateLoad<SStoreResult>, Self::Error> {
+    ) -> Result<SstoreTransitionFlags, Self::Error> {
         Ok(self
             .context
-            .sstore_skip_cold_load(address, key, value, skip_cold_load)?)
+            .sstore_skip_cold_load(address, key, value, skip_cold_load)?
+            .into())
     }
 
     #[inline]


### PR DESCRIPTION
Introduces `SstoreTransitionFlags` that drives the gas/credits accounting.

It will be used in action replay for parallel block building, to be sure that all gas/credits logic is encapsulated in one place, and we don't miss anything. The plan is to either:
1. For every `StorageAction` that does an SSTORE to also carry the original `SstoreTransitionFlags`, and check it against replayed sstore.
2. Use `SstoreTransitionFlags` to derive action replay's own gas and credits accounting.