### PR TITLE
refactor(storage): use bitflags for sstore transition flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13370,6 +13370,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
+ "bitflags 2.11.1",
  "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -260,6 +260,7 @@ async-trait = "0.1"
 auto_impl = "1"
 axum = "0.8.8"
 base64 = { version = "0.22", features = ["alloc"], default-features = false }
+bitflags = "2.11.1"
 blake3 = "1.8.5"
 bytes = "1.11.1"
 clap = { version = "4.5.57", features = ["derive", "env"] }

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -26,6 +26,7 @@ alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["map-foldhash"] }
 revm.workspace = true
 paste.workspace = true
+bitflags.workspace = true
 
 commonware-cryptography.workspace = true
 commonware-codec.workspace = true

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -593,68 +593,70 @@ impl EvmPrecompileStorageProvider<'_> {
     }
 }
 
-/// SSTORE transition flags that drive gas/refund accounting.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct SstoreTransitionFlags(u8);
+bitflags::bitflags! {
+    /// SSTORE transition flags that drive gas/refund accounting.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SstoreTransitionFlags: u8 {
+        /// The slot's transaction-start value is zero.
+        const ORIGINAL_ZERO = 1 << 0;
+        /// The slot's pre-SSTORE value is zero.
+        const PRESENT_ZERO = 1 << 1;
+        /// The slot's post-SSTORE value is zero.
+        const NEW_ZERO = 1 << 2;
+        /// The slot's transaction-start value equals its pre-SSTORE value.
+        const ORIGINAL_EQ_PRESENT = 1 << 3;
+        /// The slot's transaction-start value equals its post-SSTORE value.
+        const ORIGINAL_EQ_NEW = 1 << 4;
+        /// The slot's pre-SSTORE current value equals its post-SSTORE value.
+        const PRESENT_EQ_NEW = 1 << 5;
+    }
+}
 
 impl SstoreTransitionFlags {
-    /// The slot's transaction-start value is zero.
-    const ORIGINAL_ZERO: u8 = 1 << 0;
-    /// The slot's pre-SSTORE value is zero.
-    const PRESENT_ZERO: u8 = 1 << 1;
-    /// The slot's post-SSTORE value is zero.
-    const NEW_ZERO: u8 = 1 << 2;
-    /// The slot's transaction-start value equals its pre-SSTORE value.
-    const ORIGINAL_EQ_PRESENT: u8 = 1 << 3;
-    /// The slot's transaction-start value equals its post-SSTORE value.
-    const ORIGINAL_EQ_NEW: u8 = 1 << 4;
-    /// The slot's pre-SSTORE current value equals its post-SSTORE value.
-    const PRESENT_EQ_NEW: u8 = 1 << 5;
-
     /// Computes the SSTORE transition flags from the values that drive gas/refund accounting.
     pub fn from_values(original: U256, present: U256, new: U256) -> Self {
-        let mut bits = 0;
+        let mut flags = Self::empty();
 
         if original.is_zero() {
-            bits |= Self::ORIGINAL_ZERO;
+            flags |= Self::ORIGINAL_ZERO;
         }
         if present.is_zero() {
-            bits |= Self::PRESENT_ZERO;
+            flags |= Self::PRESENT_ZERO;
         }
         if new.is_zero() {
-            bits |= Self::NEW_ZERO;
+            flags |= Self::NEW_ZERO;
         }
         if original == present {
-            bits |= Self::ORIGINAL_EQ_PRESENT;
+            flags |= Self::ORIGINAL_EQ_PRESENT;
         }
         if original == new {
-            bits |= Self::ORIGINAL_EQ_NEW;
+            flags |= Self::ORIGINAL_EQ_NEW;
         }
         if present == new {
-            bits |= Self::PRESENT_EQ_NEW;
+            flags |= Self::PRESENT_EQ_NEW;
         }
 
-        Self(bits)
+        flags
     }
 
     /// Returns whether the write changes slot occupancy.
     pub fn crosses_zero_boundary(&self) -> bool {
-        self.has(Self::PRESENT_ZERO) != self.has(Self::NEW_ZERO)
+        self.contains(Self::PRESENT_ZERO) != self.contains(Self::NEW_ZERO)
     }
 
     /// Returns whether the write creates an occupied slot.
     pub fn is_zero_to_nonzero(&self) -> bool {
-        self.has(Self::PRESENT_ZERO) && !self.has(Self::NEW_ZERO)
+        self.contains(Self::PRESENT_ZERO) && !self.contains(Self::NEW_ZERO)
     }
 
     /// Returns whether the write clears an occupied slot.
     pub fn is_nonzero_to_zero(&self) -> bool {
-        !self.has(Self::PRESENT_ZERO) && self.has(Self::NEW_ZERO)
+        !self.contains(Self::PRESENT_ZERO) && self.contains(Self::NEW_ZERO)
     }
 
     /// Returns whether the write changes the present value.
     pub fn changes_present(&self) -> bool {
-        !self.has(Self::PRESENT_EQ_NEW)
+        !self.contains(Self::PRESENT_EQ_NEW)
     }
 
     /// Returns whether this slot is still clean before the write.
@@ -663,7 +665,7 @@ impl SstoreTransitionFlags {
     /// the slot yet, so the transaction-start value (`original`) still equals
     /// the current pre-write value (`present`).
     pub fn is_original_eq_present(&self) -> bool {
-        self.has(Self::ORIGINAL_EQ_PRESENT)
+        self.contains(Self::ORIGINAL_EQ_PRESENT)
     }
 
     /// Returns whether the warm clean-update SSTORE cost applies.
@@ -674,11 +676,6 @@ impl SstoreTransitionFlags {
     /// this clean-update charge again.
     pub fn charges_clean_update(&self) -> bool {
         self.changes_present() && self.is_original_eq_present()
-    }
-
-    #[inline]
-    fn has(&self, flag: u8) -> bool {
-        self.0 & flag != 0
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the manual `u8` SSTORE transition flag wrapper with `bitflags`
- add `bitflags` as an explicit workspace dependency for `tempo-precompiles`
- keep the existing `SstoreTransitionFlags` helper API used by storage credit accounting

## Testing
- `cargo fmt --check`
- `cargo check -p tempo-precompiles`

Prompted by: @DaniPopes