### PR TITLE
deps: reorder bitflags dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,6 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-bitflags = "2.11.1"
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
 reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6", default-features = false }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bbc5e6" }
@@ -326,6 +325,7 @@ zeroize = "1"
 zstd = "0.13.3"
 age = { version = "0.11", default-features = false }
 secrecy = "0.10"
+bitflags = "2.11.1"
 
 # build deps
 vergen = { version = "10.0.1", features = ["build", "cargo", "emit_and_set"] }


### PR DESCRIPTION
## Summary
- Move the workspace bitflags dependency to follow secrecy in Cargo.toml.

## Testing
- Not run; dependency ordering only.

Prompted by: @shekhirin