### PR TITLE
chore: clarify vergen v10 build deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,8 +327,8 @@ age = { version = "0.11", default-features = false }
 secrecy = "0.10"
 
 # build deps
-vergen = { version = "10.0.1", features = ["build", "cargo", "emit_and_set"] }
-vergen-git2 = "10.0.1"
+vergen = { version = "10.0.1", default-features = false, features = ["build", "cargo", "emit_and_set"] }
+vergen-git2 = { version = "10.0.1", default-features = false, features = ["build", "cargo", "emit_and_set"] }
 
 # [patch."https://github.com/paradigmxyz/reth"]
 # reth-basic-payload-builder = { path = "../reth/crates/payload/basic" }


### PR DESCRIPTION
## Summary
- re-apply the build dependency cleanup from #6571 on latest main
- keep the current vergen 10.0.1 floor required by latest reth
- make vergen and vergen-git2 declarations explicit about disabled default features and enabled build/cargo/emit_and_set features

## Testing
- cargo check -p tempo-node

Prompted by: @DaniPopes