### PR TITLE
TIP-1089: Streamed State Machine Replication

### DIFF
--- a/tips/tip-1089.md
+++ b/tips/tip-1089.md
@@ -1,0 +1,388 @@
+---
+id: TIP-1089
+title: Streamed State Machine Replication
+description: Stream block transaction shards while building a proposal so validators can start execution before the final proposal arrives.
+authors: joshie, Brian Picciano
+status: Draft
+protocolVersion: TBD
+---
+
+# TIP-1089: Streamed State Machine Replication
+
+## Abstract
+
+This TIP adds Streamed State Machine Replication (SSMR), an optional consensus
+side channel that lets a proposer stream ordered transaction shards while it is
+still building a block.
+
+Validators start replaying those shards immediately using Tempo's normal
+block-execution rules. The final consensus proposal is still sent normally and
+remains the object validators vote on. SSMR is only an optimistic acceleration
+path: if the stream is missing, invalid, or does not match the final proposal,
+validators fall back to normal proposal handling.
+
+## Motivation
+
+Tempo's block latency currently pays for block construction, proposal
+propagation, and validator execution mostly in series. That makes large blocks
+expensive even when builders and validators have enough CPU to execute the
+transactions.
+
+SSMR overlaps these phases. As the proposer executes transactions, it emits the
+exact transaction bytes in final block order. Validators can decode, recover, and
+execute those transactions before the final block is marshaled and propagated.
+When the final proposal arrives, validators reconcile the stream against the
+proposal and reuse the optimistic execution result if it matches.
+
+This keeps user-visible semantics unchanged. Transactions are still executed by
+the proposer during block building, and a transaction is committed only if it is
+included in the final block accepted by consensus.
+
+## Assumptions
+
+- The existing consensus proposal path remains available and continues to carry
+  the full block and required consensus sidecars.
+- Validators can deterministically rebuild the same block from the stream's
+  key, block inputs, and transaction sequence.
+- The SSMR stream is an optimization. It is not a commitment that can replace the
+  final consensus proposal.
+- A validator that cannot use SSMR for a proposal can still validate the final
+  proposal through the existing final-proposal path.
+- Initial deployments can afford duplicate propagation: streamed shards are sent
+  in addition to the final proposal.
+
+If any assumption is violated, the validator MUST ignore the SSMR result for
+that proposal and use normal final-proposal validation.
+
+## Threat Model
+
+- **Proposer:** may send valid shards, omit shards, send conflicting shards, send
+  invalid shard access lists, or send a final proposal that differs from the
+  stream. SSMR MUST NOT allow such behavior to make an invalid block valid.
+- **Validator:** trusts its local execution stack to replay the streamed block
+  deterministically. A validator MUST NOT vote from the SSMR side channel alone.
+- **Network:** may delay, drop, duplicate, or process SSMR messages out of order.
+  SSMR messages are indexed, and the final proposal path remains the fallback.
+- **Non-proposer peers:** are not trusted to relay or repair SSMR streams in this
+  TIP. The initial design is direct proposer-to-validator fanout.
+
+SSMR does not define slashing or protocol penalties for bad streams. Invalid
+streams are local fallback events. Subblocks are out of scope for SSMR.
+
+---
+
+# Specification
+
+## Overview
+
+For each proposed block, the proposer creates one SSMR stream keyed by the block
+parent and consensus context.
+
+```text
+proposer                                  validator
+--------                                  ---------
+execute txs for block N
+  |
+  +-- Start(shard 0 txs[, AL]) ----------> start optimistic execution
+  +-- TxShard(shard 1 txs[, AL]) --------> append shard to replay transcript
+  +-- TxShard(shard 2 txs[, AL]) --------> execute available shard work
+  +-- End(total shards, total txs) ------> finalize optimistic execution
+  |
+  +-- final proposal block N -----------> reconcile stream and proposal
+                                           reuse optimistic execution result
+                                           if it matches; otherwise validate normally
+```
+
+## Activation and Configuration
+
+SSMR is disabled by default and enabled by operator configuration.
+
+Implementations SHOULD expose operator configuration to:
+
+- enable or disable the SSMR side channel; and
+- set the proposer's target for transaction bytes per shard.
+
+The shard target is a local proposer choice and is not carried in the protocol.
+Validators enforce only the bounds in [Resource Bounds](#resource-bounds).
+
+## Stream Identity
+
+Each stream has a `stream_key`: the canonical RLP encoding, in this order, of:
+
+- `parent_hash`: hash of the parent execution block.
+- `block_height`: height of the proposed block.
+- `timestamp`: block timestamp in seconds.
+- `timestamp_millis_part`: millisecond subcomponent of the block timestamp.
+- `epoch`, `view`, `parent_view`, `proposer_public_key`: the consensus context.
+
+Every message carries the `stream_key` verbatim; two messages belong to the
+same stream when their keys are byte-equal. All messages for the same proposed
+block MUST carry the same `stream_key`.
+
+The stream proposer MUST match the stream key's `proposer_public_key` and MUST
+be a validator in the stream epoch. Validators MUST discard SSMR messages whose
+authenticated sender is not the stream proposer. Because every message carries
+the full key, these checks apply to any message, including one that arrives
+before `Start`.
+
+## Messages
+
+SSMR messages are encoded with an explicit message-kind tag and an RLP body.
+The tag MUST be `0` for `Start`, `1` for `TxShard`, and `2` for `End`. Each
+message body is the RLP encoding of its fields in the order listed below.
+
+### `Start`
+
+`Start` begins a stream and carries shard `0`.
+
+Fields:
+
+- `stream_key`
+- `block_inputs`: extra data, gas limit, general gas limit, and shared gas
+  limit. Block fields already carried by `stream_key` are not repeated.
+- `shard_access_list_enabled`
+- `first_shard`
+
+`first_shard.shard_index` MUST be `0`.
+`first_shard.first_tx_index` MUST be `0`.
+
+### `TxShard`
+
+`TxShard` carries one subsequent ordered transaction shard.
+
+Fields:
+
+- `stream_key`
+- `shard`
+
+`shard.shard_index` MUST be greater than `0`.
+`shard.transactions` MUST be non-empty.
+
+### `End`
+
+`End` marks the end of the stream.
+
+Fields:
+
+- `stream_key`
+- `total_shards`
+- `total_transactions`
+
+`total_shards` MUST be greater than `0`.
+
+### Shard Payload
+
+Each shard payload contains:
+
+- `shard_index`
+- `first_tx_index`
+- `transactions`: EIP-2718 encoded transactions in final block order.
+- `shard_access_list`: optional shard-local access-list data, using the same
+  access-list encoding as the block-access-list (BAL) sidecar.
+
+If `shard_access_list_enabled` is true, every shard MUST carry a `shard_access_list`
+field, which MAY be zero-length. If it is false, shards MUST NOT carry
+shard access-list bytes.
+
+The transaction bytes are the only payload required for correctness. Shard access
+lists are an optimization described below.
+
+## Leader Behavior
+
+When SSMR is enabled, the proposer begins emitting SSMR messages while building
+the block.
+
+For every transaction actually executed and included in the block, the proposer
+appends the transaction's EIP-2718 bytes to the current shard. The proposer
+flushes a shard when it reaches the configured target, and MUST flush all
+remaining transactions before returning the final proposal.
+
+An empty block still produces a stream: `Start` carries an empty shard `0`,
+and `End` reports `total_shards = 1` and `total_transactions = 0`.
+
+The leader sends every SSMR message directly to all validators over authenticated
+consensus networking. This TIP does not require relay, erasure coding, multicast,
+or repair for SSMR shards.
+
+After the block is built, the proposer still sends the normal consensus proposal
+with the full block and all required sidecars.
+
+## Validator Behavior
+
+On `Start`, a validator starts optimistic execution using the block identity
+from the `stream_key` and the `block_inputs` from `Start`. The replay input is the streamed ordered
+transaction sequence; the validator does not select transactions itself.
+
+SSMR messages may arrive in any order. A validator SHOULD buffer `TxShard` and
+`End` messages that arrive before `Start`, subject to
+[Resource Bounds](#resource-bounds), and fold them into the transcript once
+`Start` arrives.
+
+Validators store shards by `shard_index`. Duplicate identical messages are
+idempotent. Conflicting duplicates of any message (`Start`, `TxShard`, or
+`End`) invalidate the local stream.
+
+An invalidated stream MUST be discarded along with any optimistic execution
+result, subsequent messages for its `stream_key` MUST be ignored, and the
+final proposal is validated normally.
+
+A shard is *admitted* when all lower-index shards are admitted, its
+`shard_index` and `first_tx_index` are contiguous with the transcript, its
+transactions decode as EIP-2718 transactions, and, if
+`shard_access_list_enabled`, its `shard_access_list` decodes. A shard that
+fails admission invalidates the stream. The validator executes only admitted
+shards, in index order.
+
+When `End` has arrived, all shards `[0, total_shards)` are admitted, and their
+transaction count equals `total_transactions`, the replay transcript is
+complete.
+
+## Final Proposal Reconciliation
+
+When the final proposal arrives, the validator first performs the normal proposal
+checks. If SSMR is enabled and a stream has started for the proposal's stream key,
+the validator SHOULD wait until either:
+
+- the SSMR transcript is complete and the optimistic execution result is ready; or
+- consensus cancels the verification because the view/proposal timed out.
+
+Waiting is a local trade-off. A validator MAY stop waiting at any time and
+validate the final proposal normally — for example if the stream has stalled or
+its vote deadline is near — at the cost of discarding the optimistic result.
+This TIP does not mandate a wait policy.
+
+The validator then reconciles:
+
+1. The stream key MUST equal the key computed from the final proposal and its
+   consensus context.
+2. The block inputs from `Start` MUST match the final proposal.
+3. The ordered transaction bytes reconstructed from the transcript MUST exactly
+   match the final block body.
+4. The optimistic execution result's execution block MUST equal the final
+   proposal's execution block.
+5. If the final proposal contains a block-access-list sidecar, the optimistic
+   execution result's BAL bytes MUST equal it.
+
+If all checks pass, the validator MAY reuse the optimistic execution result for
+final proposal validation.
+
+If any check fails, the validator MUST discard the optimistic execution result
+and validate the final proposal normally.
+
+Discarding SSMR MUST NOT by itself make the final proposal invalid. Proposal
+rejection or nullification follows the existing final-proposal rules, including
+the normal view timeout if validation cannot complete in time.
+
+## Baseline: Tx-Only SSMR
+
+The required baseline protocol is tx-only SSMR. Each shard contains only
+transaction bytes.
+
+Validator replay follows the same block-execution rules as ordinary proposal
+validation. The validator decodes and recovers streamed transactions, then
+executes them in final order.
+
+This design is simple and has the smallest side-channel bandwidth. Its weakness
+is that validator-side decode, sender recovery, and serial execution remain on
+the critical path, so it may not provide enough overlap for very large blocks.
+
+## Extension: Shard Access Lists
+
+The shard access-list extension is optional. When `shard_access_list_enabled` is
+true, each shard carries encoded access-list data for the transactions in that
+shard.
+
+Validators decode those shard access lists and use them to execute shards in
+parallel.
+
+A shard may be prepared only after all earlier shards are present, because later
+shard access lists must account for writes produced by earlier shards that touch
+the same state. Once prepared, consecutive ready shards MAY execute in parallel.
+Their results MUST be applied in final transaction order. Parallel shard
+execution MUST NOT enforce gas or lane limits per shard; limits are enforced at
+ordered commit, using actual execution results.
+
+This design uses more bandwidth but lets validator replay parallelize instead of
+executing strictly serially.
+
+## Resource Bounds
+
+Implementations MUST bound:
+
+- maximum SSMR message size;
+- maximum buffered SSMR bytes;
+- queued SSMR messages;
+- optimistic execution work.
+
+With shard access lists, side-channel bytes can be materially larger than raw
+transaction bytes.
+
+# Observability
+
+SSMR falls back silently, so implementations MUST make the following observable
+(as metrics, logs, or events):
+
+| Signal | Fields | Operational question |
+|---|---|---|
+| Stream lifecycle | stream key, shards sent/received, bytes | Are streams being produced and delivered? |
+| Reconciliation outcome | stream key, result (`reused`, `fallback`), fallback reason | How often does SSMR actually accelerate validation, and why does it fall back? |
+| Replay timing | time from `Start` to transcript completion, and from final proposal arrival to validation completion | How much latency does SSMR remove from the critical path? |
+| Resource-bound discards | which bound was hit | Are local bounds discarding otherwise valid streams? |
+
+Alerts SHOULD cover sustained fallback (SSMR enabled but optimistic results
+rarely reused) and resource-bound discards on production validators.
+
+# Invariants
+
+- The final consensus proposal remains the only object validators vote on.
+- SSMR MUST NOT make an invalid final proposal valid.
+- A validator MUST NOT use an optimistic execution result unless the stream key,
+  transaction bytes, execution block, and required BAL sidecar match the final
+  proposal.
+- If SSMR reconciliation fails, validation MUST fall back to normal final
+  proposal handling.
+- SSMR execution MUST produce the same block as normal proposal validation for the
+  same parent, attributes, and ordered transactions.
+- Shard indices are contiguous from `0` through `total_shards - 1`.
+- `first_tx_index` values are contiguous and match the number of transactions in
+  preceding shards.
+- Conflicting duplicates of any SSMR message invalidate the local stream.
+- `shard_access_list` data MUST NOT replace final BAL sidecar validation.
+- Shard access-list execution MAY run prepared work in parallel, but commit MUST
+  occur in final transaction order.
+- Gas and lane accounting MUST be enforced at ordered commit or normal execution,
+  using actual execution results.
+- Buffered bytes and optimistic execution work MUST be bounded.
+
+## Test Cases
+
+The test suite MUST cover:
+
+1. Message round trips for `Start`, `TxShard`, and `End`.
+2. `Start` rejects nonzero shard index, nonzero first tx index, and proposer
+   mismatch.
+3. Out-of-order `TxShard` and `End` messages are folded into a complete transcript
+   once `Start` arrives.
+4. Duplicate identical shards are idempotent.
+5. Conflicting duplicates of any message (`Start`, `TxShard`, or `End`)
+   invalidate the stream.
+6. Missing shards keep the transcript incomplete.
+7. Reconstructed ordered transaction bytes exactly match the final block body.
+8. Block inputs from `Start` exactly match the final proposal.
+9. A stream that differs from the final proposal falls back to normal validation.
+10. A matching optimistic execution result is reused for final proposal validation.
+11. `shard_access_list_enabled` requires `shard_access_list` on every shard.
+12. A missing or mismatched final BAL sidecar is rejected or falls back according
+    to the existing BAL validation rules.
+13. Tx-only SSMR replays real signed transactions under the normal
+    block-execution rules.
+14. Shard access-list SSMR executes prepared shards in parallel and commits results
+    in final transaction order.
+15. Shard access-list execution rejects blocks that exceed gas or lane limits
+    using actual committed gas accounting.
+16. Empty blocks use `Start` with an empty shard `0`, `End.total_shards == 1`,
+    and `End.total_transactions == 0`.
+17. Sender and receiver shard-size configurations can differ; shards are
+    accepted as long as they respect the receiver's resource bounds.
+18. A transcript whose shard transaction count does not equal
+    `End.total_transactions` is not complete.

--- a/tips/tip-1089.md
+++ b/tips/tip-1089.md
@@ -244,23 +244,24 @@ complete.
 
 When the final proposal arrives, the validator first performs the normal proposal
 checks. If SSMR is enabled and a stream has started for the proposal's stream key,
-the validator SHOULD wait until either:
-
-- the SSMR transcript is complete and the optimistic execution result is ready; or
-- consensus cancels the verification because the view/proposal timed out.
-
-Waiting is a local trade-off. A validator MAY stop waiting at any time and
-validate the final proposal normally — for example if the stream has stalled or
-its vote deadline is near — at the cost of discarding the optimistic result.
-This TIP does not mandate a wait policy.
-
-The validator then reconciles:
+the validator reconciles:
 
 1. The stream key MUST equal the key computed from the final proposal and its
    consensus context.
 2. The block inputs from `Start` MUST match the final proposal.
-3. The ordered transaction bytes reconstructed from the transcript MUST exactly
-   match the final block body.
+3. The ordered transaction bytes reconstructed from the admitted transcript MUST
+   be a prefix of the final block body. A complete transcript MUST exactly match
+   it.
+
+If the transcript is incomplete and checks 1–3 pass, the validator MAY complete
+it from the final proposal's remaining transactions and continue optimistic
+execution with them. The proposal is then authoritative for the stream:
+subsequent SSMR messages for its stream key MUST be ignored and MUST NOT
+invalidate the stream. In shard access-list mode, proposal-sourced transactions
+carry no shard access list and execute serially after the last streamed shard.
+
+Once optimistic execution completes:
+
 4. The optimistic execution result's execution block MUST equal the final
    proposal's execution block.
 5. If the final proposal contains a block-access-list sidecar, the optimistic
@@ -270,7 +271,9 @@ If all checks pass, the validator MAY reuse the optimistic execution result for
 final proposal validation.
 
 If any check fails, the validator MUST discard the optimistic execution result
-and validate the final proposal normally.
+and validate the final proposal normally. A validator MAY do the same at any
+time — for example if optimistic execution cannot finish before its vote
+deadline.
 
 Discarding SSMR MUST NOT by itself make the final proposal invalid. Proposal
 rejection or nullification follows the existing final-proposal rules, including
@@ -335,6 +338,8 @@ transaction bytes.
 - `first_tx_index` values are contiguous and match the number of transactions in
   preceding shards.
 - Conflicting duplicates of any SSMR message invalidate the local stream.
+- A transcript completed from the final proposal executes the proposal's own
+  transaction bytes; later SSMR messages MUST NOT invalidate it.
 - `shard_access_list` data MUST NOT replace final BAL sidecar validation.
 - Shard access-list execution MAY run prepared work in parallel, but commit MUST
   occur in final transaction order.
@@ -375,3 +380,9 @@ The test suite MUST cover:
     accepted as long as they respect the receiver's resource bounds.
 18. A transcript whose shard transaction count does not equal
     `End.total_transactions` is not complete.
+19. An incomplete transcript that is a prefix of the final block body is
+    completed from the proposal and the result is reused.
+20. A transcript that is not a prefix of the final block body falls back to
+    normal validation.
+21. SSMR messages arriving after a transcript is completed from the proposal
+    are ignored and do not invalidate the stream.

--- a/tips/tip-1089.md
+++ b/tips/tip-1089.md
@@ -320,21 +320,6 @@ Implementations MUST bound:
 With shard access lists, side-channel bytes can be materially larger than raw
 transaction bytes.
 
-# Observability
-
-SSMR falls back silently, so implementations MUST make the following observable
-(as metrics, logs, or events):
-
-| Signal | Fields | Operational question |
-|---|---|---|
-| Stream lifecycle | stream key, shards sent/received, bytes | Are streams being produced and delivered? |
-| Reconciliation outcome | stream key, result (`reused`, `fallback`), fallback reason | How often does SSMR actually accelerate validation, and why does it fall back? |
-| Replay timing | time from `Start` to transcript completion, and from final proposal arrival to validation completion | How much latency does SSMR remove from the critical path? |
-| Resource-bound discards | which bound was hit | Are local bounds discarding otherwise valid streams? |
-
-Alerts SHOULD cover sustained fallback (SSMR enabled but optimistic results
-rarely reused) and resource-bound discards on production validators.
-
 # Invariants
 
 - The final consensus proposal remains the only object validators vote on.

--- a/tips/tip-1089.md
+++ b/tips/tip-1089.md
@@ -140,7 +140,6 @@ Fields:
 - `stream_key`
 - `block_inputs`: extra data, gas limit, general gas limit, and shared gas
   limit. Block fields already carried by `stream_key` are not repeated.
-- `shard_access_list_enabled`
 - `first_shard`
 
 `first_shard.shard_index` MUST be `0`.
@@ -180,9 +179,11 @@ Each shard payload contains:
 - `shard_access_list`: optional shard-local access-list data, using the same
   access-list encoding as the block-access-list (BAL) sidecar.
 
-If `shard_access_list_enabled` is true, every shard MUST carry a `shard_access_list`
-field, which MAY be zero-length. If it is false, shards MUST NOT carry
-shard access-list bytes.
+`shard_access_list` is an optional trailing field: its presence changes the
+shard's RLP list arity, so a present-but-empty access list is distinct from an
+absent one. Shard `0` sets the stream's mode: if it carries a
+`shard_access_list` (which MAY be zero-length), every subsequent shard MUST
+carry one; if it does not, subsequent shards MUST NOT.
 
 The transaction bytes are the only payload required for correctness. Shard access
 lists are an optimization described below.
@@ -228,9 +229,9 @@ final proposal is validated normally.
 
 A shard is *admitted* when all lower-index shards are admitted, its
 `shard_index` and `first_tx_index` are contiguous with the transcript, its
-transactions decode as EIP-2718 transactions, and, if
-`shard_access_list_enabled`, its `shard_access_list` decodes. A shard that
-fails admission invalidates the stream. The validator executes only admitted
+transactions decode as EIP-2718 transactions, its `shard_access_list` presence
+matches shard `0`'s, and, when present, its `shard_access_list` decodes. A
+shard that fails admission invalidates the stream. The validator executes only admitted
 shards, in index order.
 
 When `End` has arrived, all shards `[0, total_shards)` are admitted, and their
@@ -288,9 +289,9 @@ the critical path, so it may not provide enough overlap for very large blocks.
 
 ## Extension: Shard Access Lists
 
-The shard access-list extension is optional. When `shard_access_list_enabled` is
-true, each shard carries encoded access-list data for the transactions in that
-shard.
+The shard access-list extension is optional. A stream opts in through shard
+`0`: when it carries a `shard_access_list`, each shard carries encoded
+access-list data for the transactions in that shard.
 
 Validators decode those shard access lists and use them to execute shards in
 parallel.
@@ -371,7 +372,8 @@ The test suite MUST cover:
 8. Block inputs from `Start` exactly match the final proposal.
 9. A stream that differs from the final proposal falls back to normal validation.
 10. A matching optimistic execution result is reused for final proposal validation.
-11. `shard_access_list_enabled` requires `shard_access_list` on every shard.
+11. Every shard's `shard_access_list` presence matches shard `0`'s, including
+    a zero-length access list on an empty shard `0`.
 12. A missing or mismatched final BAL sidecar is rejected or falls back according
     to the existing BAL validation rules.
 13. Tx-only SSMR replays real signed transactions under the normal

--- a/tips/tip-1089.md
+++ b/tips/tip-1089.md
@@ -91,6 +91,8 @@ execute txs for block N
   +-- final proposal block N -----------> reconcile stream and proposal
                                            reuse optimistic execution result
                                            if it matches; otherwise validate normally
+
+AL = optional shard access list (see Extension: Shard Access Lists)
 ```
 
 ## Activation and Configuration


### PR DESCRIPTION
Adds TIP-1089: Streamed State Machine Replication (SSMR) — an optional consensus side channel that lets a proposer stream ordered transaction shards while still building a block, so validators can start optimistic execution before the final proposal arrives.

- The final consensus proposal remains the only object validators vote on; SSMR is a fallback-safe acceleration path.
- Required baseline is tx-only shard streaming; an optional shard access-list extension enables parallel validator replay.
- Reconciliation reuses the optimistic execution result only on an exact match (stream key, block inputs, transaction bytes, execution block, BAL sidecar).