### PR TITLE
revert: Derek clear comment deletion

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -130,7 +130,7 @@ jobs:
               content: 'eyes',
             });
 
-            const shouldDeleteComment = (comment) => {
+            const shouldHideComment = (comment) => {
               const body = comment.body.trim();
               return comment.user.login === 'decofe' || body.startsWith('derek') || body.startsWith('@decofe');
             };
@@ -140,19 +140,25 @@ jobs:
               issue_number: context.issue.number,
               per_page: 100,
             });
-            let deleted = 0;
+            let hidden = 0;
             for (const comment of comments) {
-              if (!shouldDeleteComment(comment)) continue;
+              if (!shouldHideComment(comment)) continue;
 
-              await github.rest.issues.deleteComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: comment.id,
+              await github.graphql(`
+                mutation($subjectId: ID!) {
+                  minimizeComment(input: {subjectId: $subjectId, classifier: OUTDATED}) {
+                    minimizedComment {
+                      isMinimized
+                    }
+                  }
+                }
+              `, {
+                subjectId: comment.node_id,
               });
-              deleted += 1;
+              hidden += 1;
             }
 
-            core.notice(`Deleted ${deleted} Derek comment(s).`);
+            core.notice(`Hid ${hidden} Derek comment(s).`);
 
       - name: Parse arguments
         id: args


### PR DESCRIPTION
## Summary
- Revert `derek clear` / `@decofe clear` back to minimizing benchmark comments instead of deleting them.
- Restores the pre-#6717 behavior because GitHub deletion timeline events are noisier than hidden comments.

## Test
- Not run; workflow-only revert.

Prompted by: @shekhirin