### PR TITLE
bench: support baseline-only e2e runs

### DIFF
--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -134,6 +134,7 @@ function bootstrapCiPct(baseline, feature, base, rand) {
 
 function axisChange(axis, summary, baselineRuns, featureRuns, rand) {
   const meta = AXES[axis];
+  const runSide = summary.config?.run_side || 'comparison';
   const base = summary.results.baseline[axis];
   const feature = summary.results.feature[axis];
   const changePct = pct(base, feature);
@@ -146,6 +147,12 @@ function axisChange(axis, summary, baselineRuns, featureRuns, rand) {
     floor_pct: meta.floor,
     sig: 'neutral',
   };
+
+  if (runSide !== 'comparison') {
+    change.informational = true;
+    change.informational_reason = `${runSide}-only run`;
+    return change;
+  }
 
   if (base <= 0 || ciPct == null) {
     change.informational = true;
@@ -215,12 +222,14 @@ function buildMarkdown(summary) {
   const derekCommand = summary.config?.derek_command || '';
   const baselineRemovedArgs = summary.config?.baseline_removed_args || '';
   const featureRemovedArgs = summary.config?.feature_removed_args || '';
-  const featureOnly = summary.config?.run_side === 'feature';
+  const runSide = summary.config?.run_side || 'comparison';
+  const featureOnly = runSide === 'feature';
+  const baselineOnly = runSide === 'baseline';
   const lines = [
-    featureOnly ? `# ${c.emoji} Feature Bench: ${c.label}` : `# ${c.emoji} Bench Comparison: ${c.label}`,
+    featureOnly ? `# ${c.emoji} Feature Bench: ${c.label}` : baselineOnly ? `# ${c.emoji} Baseline Bench: ${c.label}` : `# ${c.emoji} Bench Comparison: ${c.label}`,
     '',
     `**Refs:** ${summary.baseline_ref} vs ${summary.feature_ref}`,
-    featureOnly ? `**Criteria:** Feature-only run; baseline columns are intentionally empty.` : `**Criteria:** 95% run-bootstrap CI must clear floor; cells show delta (+/-CI/floor).`,
+    featureOnly ? `**Criteria:** Feature-only run; baseline columns are intentionally empty.` : baselineOnly ? `**Criteria:** Baseline-only run; feature columns are intentionally empty.` : `**Criteria:** 95% run-bootstrap CI must clear floor; cells show delta (+/-CI/floor).`,
     '',
     '## Configuration',
     ...(derekCommand ? [`- Derek command: \`${derekCommand}\``] : []),
@@ -230,7 +239,7 @@ function buildMarkdown(summary) {
     `- Target TPS: ${summary.config.tps}`,
     `- Duration: ${summary.config.duration}s`,
     `- Run pairs: ${summary.config.run_pairs}`,
-    ...(featureOnly ? [`- Run side: feature`] : []),
+    ...(runSide !== 'comparison' ? [`- Run side: ${runSide}`] : []),
     ...(baselineRemovedArgs ? [`- Baseline removed args: \`${baselineRemovedArgs}\``] : []),
     ...(featureRemovedArgs ? [`- Feature removed args: \`${featureRemovedArgs}\``] : []),
     `- Baseline blocks: ${summary.results.baseline.blocks}`,

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -865,9 +865,12 @@ jobs:
             echo "::error::run-pairs must be a positive integer"
             exit 1
           fi
-          if [ "$BENCH_RUN_SIDE" != "comparison" ] && [ "$BENCH_RUN_SIDE" != "feature" ]; then
-            echo "::error::run-side must be one of: comparison, feature"
+          if [ "$BENCH_RUN_SIDE" != "comparison" ] && [ "$BENCH_RUN_SIDE" != "feature" ] && [ "$BENCH_RUN_SIDE" != "baseline" ]; then
+            echo "::error::run-side must be one of: comparison, feature, baseline"
             exit 1
+          fi
+          if [ "$BENCH_RUN_SIDE" = "baseline" ] && [ "$BENCH_CLICKHOUSE_RUN" = "feature-1" ]; then
+            BENCH_CLICKHOUSE_RUN="baseline-1"
           fi
           if ! [[ "$BENCH_TOKEN_COUNT" =~ ^[1-9][0-9]*$ ]]; then
             echo "::error::token-count must be a positive integer"

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1245,6 +1245,9 @@ def e2e-run-sides [run_pairs: int, run_side: string] {
     if $run_side == "feature" {
         return (0..<$run_pairs | each { "feature" })
     }
+    if $run_side == "baseline" {
+        return (0..<$run_pairs | each { "baseline" })
+    }
 
     mut sides = []
     if ($run_pairs mod 2) == 0 {
@@ -1371,7 +1374,7 @@ def "main e2e" [
     --clickhouse-run: string = "feature-1"              # Run label allowed to use the ClickHouse reporter; empty = every run
     --runner-metrics-url: string = $E2E_RUNNER_METRICS_URL # Runner node-exporter metrics URL (empty disables runner metrics)
     --run-pairs: int = 3                                # Number of baseline/feature run pairs
-    --run-side: string = "comparison"                   # Phases to run: comparison or feature
+    --run-side: string = "comparison"                   # Phases to run: comparison, feature, or baseline
     --run-type: string = ""                             # Run type label (dispatch, nightly, release)
     --baseline-args: string = ""                        # Additional node args for baseline phases
     --feature-args: string = ""                         # Additional node args for feature phases
@@ -1405,8 +1408,8 @@ def "main e2e" [
         print "Error: --run-pairs must be a positive integer"
         exit 1
     }
-    if $run_side not-in ["comparison" "feature"] {
-        print $"Error: --run-side must be one of: comparison, feature \(got '($run_side)'\)"
+    if $run_side not-in ["comparison" "feature" "baseline"] {
+        print $"Error: --run-side must be one of: comparison, feature, baseline \(got '($run_side)'\)"
         exit 1
     }
     if $summary_warmup_blocks < 0 {
@@ -1590,8 +1593,15 @@ def "main e2e" [
     let baseline_wt = $"($BENCH_WORKTREES_DIR)/e2e-local-baseline"
     let feature_wt = $"($BENCH_WORKTREES_DIR)/e2e-local-feature"
     let regenesis_needed = $hardfork_mode or $gas_limit != "" or $general_gas_limit != ""
-    let needs_baseline = $run_side == "comparison"
-    let worktrees = if $needs_baseline { [$baseline_wt $feature_wt] } else { [$feature_wt] }
+    let needs_baseline = $run_side in ["comparison" "baseline"]
+    let needs_feature = $run_side in ["comparison" "feature"]
+    mut worktrees = []
+    if $needs_baseline {
+        $worktrees = ($worktrees | append $baseline_wt)
+    }
+    if $needs_feature {
+        $worktrees = ($worktrees | append $feature_wt)
+    }
     for wt in $worktrees {
         if ($wt | path exists) {
             print $"Removing stale local e2e worktree: ($wt)"
@@ -1601,7 +1611,9 @@ def "main e2e" [
     if $needs_baseline {
         git worktree add $baseline_wt $baseline
     }
-    git worktree add $feature_wt $feature
+    if $needs_feature {
+        git worktree add $feature_wt $feature
+    }
 
     let global_build_features = (merge-e2e-features $DEFAULT_FEATURES $features)
     let baseline_build_features = if $baseline_features != "" { merge-e2e-features $global_build_features $baseline_features } else { $global_build_features }
@@ -1615,7 +1627,9 @@ def "main e2e" [
     if $needs_baseline {
         $builds = ($builds | append { wt: $baseline_wt, ref_name: $baseline, sha: $baseline, label: "baseline", features: $baseline_tbc.features, extra_rustflags: $baseline_tbc.extra_rustflags, bench_features: $baseline_build_features })
     }
-    $builds = ($builds | append { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, extra_rustflags: $feature_tbc.extra_rustflags, bench_features: $feature_build_features })
+    if $needs_feature {
+        $builds = ($builds | append { wt: $feature_wt, ref_name: $feature, sha: $feature, label: "feature", features: $feature_tbc.features, extra_rustflags: $feature_tbc.extra_rustflags, bench_features: $feature_build_features })
+    }
     $builds | par-each { |b|
         if $effective_no_cache {
             build-in-worktree --no-cache --no-default-features=$no_default_features --extra-rustflags $b.extra_rustflags --bench-features $b.bench_features $b.wt $b.ref_name $profile $b.features $b.sha
@@ -1624,10 +1638,12 @@ def "main e2e" [
         }
     } | ignore
     let baseline_tempo = if $needs_baseline { worktree-bin $baseline_wt $profile "tempo" } else { "" }
-    let feature_tempo = (worktree-bin $feature_wt $profile "tempo")
-    let regenesis_tempo = if $regenesis_needed { $feature_tempo } else { "" }
+    let feature_tempo = if $needs_feature { worktree-bin $feature_wt $profile "tempo" } else { "" }
+    let regenesis_tempo = if $regenesis_needed {
+        if $needs_feature { $feature_tempo } else { $baseline_tempo }
+    } else { "" }
     let baseline_arg_filter = if $needs_baseline { supported-node-arg-filter $baseline_tempo $E2E_LOCAL_RETH_ARGS } else { { supported: [], removed: [] } }
-    let feature_arg_filter = (supported-node-arg-filter $feature_tempo $E2E_LOCAL_RETH_ARGS)
+    let feature_arg_filter = if $needs_feature { supported-node-arg-filter $feature_tempo $E2E_LOCAL_RETH_ARGS } else { { supported: [], removed: [] } }
     let removed_arg_config = $"(format-removed-node-arg-config 'baseline' $baseline_arg_filter.removed)(format-removed-node-arg-config 'feature' $feature_arg_filter.removed)"
     if $removed_arg_config != "" {
         let current_config = ($env | get -o BENCH_CONFIG | default "")
@@ -1788,7 +1804,9 @@ def "main e2e" [
     if $needs_baseline {
         try { git worktree remove --force $baseline_wt } catch { }
     }
-    try { git worktree remove --force $feature_wt } catch { }
+    if $needs_feature {
+        try { git worktree remove --force $feature_wt } catch { }
+    }
     cleanup-local-e2e-processes
     bench-restore-at $E2E_A_STATE_PATH $E2E_A_MOUNT $a_db
     bench-restore-at $E2E_B_STATE_PATH $E2E_B_MOUNT $b_db


### PR DESCRIPTION
## Summary
- accept `run-side=baseline` in `bench-e2e.yml` and `bench-e2e.nu`
- run only baseline worktrees/builds/phases for baseline-only e2e benchmarks
- report baseline-only summaries as informational single-sided runs

## Tests
- `nu --commands 'source bench-e2e.nu'`\n- `node --check .github/scripts/bench-e2e-classify.js`\n- synthetic baseline-only classifier smoke test\n\nPrompted by: @shekhirin