### PR TITLE
refactor(consensus): backfill to finalized floor before main loop

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -4,7 +4,7 @@
 //! execution layer and tracks the digest of the latest finalized block.
 //! It also advances the canonical chain by sending forkchoice-updates.
 
-use std::{collections::VecDeque, ops::RangeInclusive, sync::Arc, time::Duration};
+use std::{collections::VecDeque, sync::Arc, time::Duration};
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
 use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
@@ -13,7 +13,7 @@ use commonware_runtime::{
     Clock, ContextCell, FutureExt, Handle, Metrics as RuntimeMetrics, Pacer, Spawner, spawn_cell,
 };
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
-use eyre::{Report, WrapErr as _, ensure};
+use eyre::{Report, WrapErr as _, bail, ensure};
 use futures::{
     FutureExt as _, StreamExt as _,
     channel::{
@@ -26,12 +26,11 @@ use futures::{
 use prometheus_client::metrics::counter::Counter;
 use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
 use reth_node_builder::PayloadKind;
+use reth_provider::{BlockReader as _, BlockSource};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
 use tokio::select;
-use tracing::{
-    Level, Span, debug, error, error_span, info, info_span, instrument, warn, warn_span,
-};
+use tracing::{Level, Span, debug, error, error_span, info, info_span, instrument, warn};
 
 use super::{
     Config,
@@ -104,9 +103,9 @@ pub(crate) struct Actor<TContext> {
     /// and to update the canonical chain by sending forkchoice updates.
     execution_node: Arc<TempoFullNode>,
 
-    /// Highest finalized height the executor should backfill to on startup.
-    backfill_target_height: Height,
-    execution_finalized_height: Height,
+    /// Highest finalized height the executor should backfill to on startup so
+    /// that CL and EL have a consistent view.
+    finalized_floor: Height,
 
     /// The channel over which the agent will receive new commands from the
     /// application actor.
@@ -115,6 +114,8 @@ pub(crate) struct Actor<TContext> {
     /// The mailbox of the marshal actor. Used to backfill blocks.
     marshal: crate::alias::marshal::Mailbox,
 
+    /// The latest state that the executor canonicalized. On startup, contains
+    /// the latest execution layer state.
     last_canonicalized: LastCanonicalized,
 
     /// The interval at which to send a forkchoice update heartbeat to the
@@ -125,14 +126,6 @@ pub(crate) struct Actor<TContext> {
     ///
     /// Armed only when no execution request is active or queued.
     fcu_heartbeat_timer: OptionFuture<BoxFuture<'static, ()>>,
-
-    /// Gap between the execution layer's finalized watermark and the startup
-    /// backfill target. Needs to be handled on startup because the execution
-    /// layer does not reliably flush all blocks.
-    finalized_heights_to_backfill: RangeInclusive<u64>,
-
-    /// Backfills that are currently in-flight and are awaiting resolution.
-    pending_backfill: OptionFuture<BoxFuture<'static, (u64, Option<Block>)>>,
 
     /// Execution-layer requests waiting for the active execution task to finish.
     execution_queue: VecDeque<ExecutionRequest>,
@@ -197,27 +190,18 @@ where
             public_key,
         } = config;
         let metrics = Metrics::init(&context);
+
         let canonical_state = execution_node.provider.canonical_in_memory_state();
+
         let head_num_hash: BlockNumHash = canonical_state.chain_info().into();
         let execution_finalized_num_hash = canonical_state
             .get_finalized_num_hash()
             .unwrap_or_else(|| BlockNumHash::new(0, execution_node.chain_spec().genesis_hash()));
-        let execution_finalized_height = Height::new(execution_finalized_num_hash.number);
-        let head_num_hash = if head_num_hash.number >= execution_finalized_num_hash.number {
-            head_num_hash
-        } else {
-            execution_finalized_num_hash
-        };
 
-        let fcu_heartbeat_timer = OptionFuture::some(context.sleep(fcu_heartbeat_interval).boxed());
-        let backfill_target_height = finalized_floor;
-        let finalized_heights_to_backfill =
-            (execution_finalized_height.get() + 1)..=backfill_target_height.get();
         Ok(Self {
             context: ContextCell::new(context),
             execution_node,
-            backfill_target_height,
-            execution_finalized_height,
+            finalized_floor,
             mailbox,
             marshal,
             last_canonicalized: LastCanonicalized {
@@ -227,13 +211,10 @@ where
                     finalized_block_hash: execution_finalized_num_hash.hash,
                 },
                 head_height: Height::new(head_num_hash.number),
-                finalized_height: execution_finalized_height,
+                finalized_height: Height::new(execution_finalized_num_hash.number),
             },
             fcu_heartbeat_interval,
-            fcu_heartbeat_timer,
-
-            finalized_heights_to_backfill,
-            pending_backfill: OptionFuture::none(),
+            fcu_heartbeat_timer: OptionFuture::none(),
             execution_queue: VecDeque::new(),
             execution_task: OptionFuture::none(),
             payload_jobs: FuturesUnordered::new(),
@@ -250,27 +231,27 @@ where
     }
 
     async fn run(mut self) {
+        if let Err(error) = self.backfill_to_finalized_floor().await {
+            error_span!("shutdown").in_scope(|| {
+                error!(
+                    %error,
+                    "executor failed startup backfill",
+                )
+            });
+            return;
+        }
+
         info_span!("start").in_scope(|| {
             info!(
-                backfill_target_height = %self.backfill_target_height,
-                execution_finalized_height = %self.execution_finalized_height,
-                finalized_tip_height = %self.latest_observed_finalized_tip.0,
-                finalized_tip_digest = %self.latest_observed_finalized_tip.1,
-                "executor initialized finalized startup state; backfilling blocks \
-                from consensus to execution if necessary",
+                finalized_height = %self.last_canonicalized.finalized_height,
+                finalized_digest = %self.last_canonicalized.forkchoice.finalized_block_hash,
+                head_height = %self.last_canonicalized.head_height,
+                head_digest = %self.last_canonicalized.forkchoice.head_block_hash,
+                "entering executor loop",
             );
         });
 
         loop {
-            if self.pending_backfill.is_none()
-                && let Some(height) = self.finalized_heights_to_backfill.next()
-            {
-                self.pending_backfill.replace({
-                    let marshal = self.marshal.clone();
-                    async move { (height, marshal.get_block(Height::new(height)).await) }.boxed()
-                });
-            }
-
             self.start_next_execution_task();
             self.update_fcu_heartbeat_timer();
 
@@ -308,30 +289,6 @@ where
                     }
                 }
 
-                block = &mut self.pending_backfill => {
-                    match block {
-                        (height, Some(block)) => {
-                            let (ack, _wait) = Exact::handle();
-                            let span = info_span!("backfill_on_start", %height);
-                            self.enqueue_execution_request(ExecutionRequest::FinalizeBlock(
-                                Box::new(FinalizedBlockRequest {
-                                    cause: span,
-                                    block,
-                                    acknowledgment: ack,
-                                    is_backfill: true,
-                                }),
-                            ));
-                        }
-                        (height, None) => {
-                            warn_span!("backfill_on_start", %height)
-                            .in_scope(|| warn!(
-                                "marshal actor did not have block even though \
-                                it must have finalized it previously",
-                            ));
-                        }
-                    }
-                }
-
                 Some(()) = self.payload_jobs.next() => {}
 
                 msg = self.mailbox.next() => {
@@ -353,6 +310,56 @@ where
         }
     }
 
+    async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
+        let start = self.last_canonicalized.finalized_height.get() + 1;
+        let end = self.finalized_floor.get();
+        let heights = start..=end;
+        if !heights.is_empty() {
+            info!(
+                start = *heights.start(),
+                end = *heights.end(),
+                "backfilling finalized blocks before entering executor loop"
+            );
+        }
+        for height in heights {
+            let span = info_span!("backfill_on_start", %height);
+            let block = get_block(
+                self.marshal.clone(),
+                self.execution_node.clone(),
+                Height::new(height),
+            )
+            .await
+            .wrap_err_with(|| format!("failed backfilling block for height `{height}`"))?;
+
+            let (ack, _wait) = Exact::handle();
+            let request = FinalizedBlockRequest {
+                cause: span,
+                block,
+                acknowledgment: ack,
+            };
+
+            if let Some(canonicalized) = forward_finalized(
+                &self.context,
+                self.execution_node.clone(),
+                self.public_key.clone(),
+                self.metrics.clone(),
+                self.last_canonicalized,
+                request,
+            )
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed forwarding backfilled finalized block at height `{height}` \
+                    to execution layer"
+                )
+            })? {
+                self.last_canonicalized = canonicalized;
+            }
+        }
+
+        Ok(())
+    }
+
     fn arm_fcu_heartbeat_timer(&mut self) {
         if !self.fcu_heartbeat_timer.is_none() {
             return;
@@ -366,10 +373,7 @@ where
     }
 
     fn update_fcu_heartbeat_timer(&mut self) {
-        if !self.is_backfilling()
-            && self.execution_task.is_none()
-            && self.execution_queue.is_empty()
-        {
+        if self.execution_task.is_none() && self.execution_queue.is_empty() {
             self.arm_fcu_heartbeat_timer();
         } else {
             self.disarm_fcu_heartbeat_timer();
@@ -385,17 +389,12 @@ where
 
     fn handle_message(&mut self, message: Message) -> eyre::Result<()> {
         let cause = message.cause;
-        let is_backfilling = self.is_backfilling();
         match message.command {
             Command::CanonicalizeHead(CanonicalizeHead {
                 height,
                 digest,
                 response,
             }) => {
-                if is_backfilling {
-                    info_span!("handle_message")
-                        .in_scope(|| info!("request to canonicalize deferred while backfilling"));
-                }
                 self.enqueue_execution_request(ExecutionRequest::Canonicalize(Box::new(
                     Canonicalize {
                         cause,
@@ -413,11 +412,6 @@ where
                 attributes,
                 response,
             }) => {
-                if is_backfilling {
-                    info_span!("handle_message").in_scope(|| {
-                        info!("request to canonicalize and build deferred while backfilling")
-                    });
-                }
                 self.enqueue_execution_request(ExecutionRequest::Canonicalize(Box::new(
                     Canonicalize {
                         cause,
@@ -439,7 +433,6 @@ where
                             cause,
                             block,
                             acknowledgment: acknowledgement,
-                            is_backfill: false,
                         },
                     )));
                 }
@@ -450,23 +443,12 @@ where
 
     fn enqueue_execution_request(&mut self, request: ExecutionRequest) {
         if matches!(&request, ExecutionRequest::Heartbeat { .. })
-            && (!self.execution_queue.is_empty()
-                || !self.execution_task.is_none()
-                || self.is_backfilling())
+            && (!self.execution_queue.is_empty() || !self.execution_task.is_none())
         {
             return;
         }
 
-        if request.is_backfill() {
-            let insert_at = self
-                .execution_queue
-                .iter()
-                .position(|request| !request.is_backfill())
-                .unwrap_or(self.execution_queue.len());
-            self.execution_queue.insert(insert_at, request);
-        } else {
-            self.execution_queue.push_back(request);
-        }
+        self.execution_queue.push_back(request);
     }
 
     fn start_next_execution_task(&mut self) {
@@ -476,7 +458,7 @@ where
 
         // If nothing is currently scheduled and a newer finalized tip was
         // observed, push it into the queue so that it will be picked up next.
-        if self.execution_queue.is_empty() && !self.is_backfilling() {
+        if self.execution_queue.is_empty() {
             let (height, digest) = self.latest_observed_finalized_tip;
             let new_canonicalized = self.last_canonicalized.update_finalized(height, digest);
             if new_canonicalized != self.last_canonicalized {
@@ -492,10 +474,7 @@ where
             }
         }
 
-        let Some(request) = self.execution_queue.front() else {
-            return;
-        };
-        if self.is_backfilling() && !request.is_backfill() {
+        if self.execution_queue.is_empty() {
             return;
         }
         let request = self.execution_queue.pop_front().expect("front exists");
@@ -510,10 +489,45 @@ where
         );
         self.execution_task.replace(task.boxed());
     }
+}
 
-    fn is_backfilling(&self) -> bool {
-        self.pending_backfill.is_some() || !self.finalized_heights_to_backfill.is_empty()
+#[instrument(skip_all, fields(height), err)]
+async fn get_block(
+    marshal: crate::alias::marshal::Mailbox,
+    execution_node: Arc<TempoFullNode>,
+    height: Height,
+) -> eyre::Result<Block> {
+    if let Some(block) = marshal.get_block(height).await {
+        return Ok(block);
     }
+
+    warn!(
+        "marshal did not have backfill block; looking up its finalized digest \
+        to look for it in the execution layer"
+    );
+    let Some((_, digest)) = marshal.get_info(height).await else {
+        bail!("marshal actor did not have finalization info at height");
+    };
+
+    info!(
+        %digest,
+        "found finalized digest for block height; checking execution layer",
+    );
+    let Some(block) = execution_node
+        .provider
+        .find_sealed_or_recovered_block(digest.0, BlockSource::Any)
+        .wrap_err_with(|| {
+            format!("failed querying execution layer for backfill block `{digest}`")
+        })?
+    else {
+        warn!(%digest, "execution layer did not have missing backfill block");
+        bail!(
+            "marshal actor did not have block at height `{height}` and \
+            execution layer did not have block `{digest}`"
+        );
+    };
+
+    Ok(Block::from_execution_block_unchecked(block, None))
 }
 
 enum ExecutionRequest {
@@ -522,20 +536,10 @@ enum ExecutionRequest {
     FinalizeBlock(Box<FinalizedBlockRequest>),
 }
 
-impl ExecutionRequest {
-    fn is_backfill(&self) -> bool {
-        let Self::FinalizeBlock(req) = self else {
-            return false;
-        };
-        req.is_backfill
-    }
-}
-
 struct FinalizedBlockRequest {
     cause: Span,
     block: Block,
     acknowledgment: Exact,
-    is_backfill: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -616,7 +620,6 @@ where
             }
         }
         ExecutionRequest::FinalizeBlock(request) => {
-            let fatal_on_error = !request.is_backfill;
             match forward_finalized(
                 &context,
                 execution_node,
@@ -631,14 +634,7 @@ where
                     canonicalized,
                     payload_job: None,
                 },
-                Err(error) if fatal_on_error => ExecutionTaskResult::Fatal { error },
-                Err(error) => {
-                    warn!(%error, "failed forwarding backfilled finalized block to execution layer");
-                    ExecutionTaskResult::Completed {
-                        canonicalized: None,
-                        payload_job: None,
-                    }
-                }
+                Err(error) => ExecutionTaskResult::Fatal { error },
             }
         }
     }
@@ -866,7 +862,6 @@ async fn forward_finalized<TContext: Pacer>(
         cause,
         block,
         acknowledgment,
-        is_backfill: _,
     } = request;
 
     let new_canonicalized = canonicalized.update_finalized(block.height(), block.digest());


### PR DESCRIPTION
Backfills blocks from CL to EL before entering the core executor actor loop.

Significantly simplifies the actor. In https://github.com/tempoxyz/tempo/pull/6517 we removed the blocking await for reporting finalized tips and blocks to the actor, ensuring that the marshal actor does not block at startup.

That made this refactor possible.

Being unable to backfill blocks from CL to EL given an existing archive is a hard error now.