### PR TITLE
deps: update reth from main (2026-07-07)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8595,7 +8595,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8688,7 +8688,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8771,7 +8771,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8781,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8834,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8902,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8931,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9002,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9051,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9195,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9218,7 +9218,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9386,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9397,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "clap",
  "eyre",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9527,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9556,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9635,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9686,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9705,7 +9705,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9757,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "serde",
  "serde_json",
@@ -9767,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "bytes",
  "futures",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9830,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "bindgen",
  "cc",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "futures",
  "metrics",
@@ -9852,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9861,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9875,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9982,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10028,7 +10028,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10052,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10184,6 +10184,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "ethereum_ssz",
+ "ethereum_ssz_derive",
  "eyre",
  "http-body-util",
  "jsonrpsee",
@@ -10222,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10246,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10270,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "bytes",
  "eyre",
@@ -10299,7 +10300,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10311,7 +10312,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10335,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10347,7 +10348,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10370,7 +10371,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10413,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10461,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10490,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10597,7 +10598,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10627,7 +10628,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10670,7 +10671,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10690,7 +10691,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10721,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10768,7 +10769,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10819,7 +10820,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10833,7 +10834,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10864,7 +10865,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10915,7 +10916,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10943,7 +10944,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10957,7 +10958,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10977,7 +10978,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10992,7 +10993,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11018,7 +11019,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11057,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11083,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "clap",
  "eyre",
@@ -11102,7 +11103,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11121,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11164,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11189,7 +11190,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11216,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11235,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11260,7 +11261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=011c2fd#011c2fd2382796669bad1bf02b65f150993bee2e"
+source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "011c2fd", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", features = [
   "std",
   "optional-checks",
 ] }

--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
-  # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
-  # the fix, and no patched hickory-proto release exists
-  "RUSTSEC-2026-0118",
   # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
   # and is pulled in transitively by upstream crates with no safe upgrade available.
   "RUSTSEC-2026-0173",


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`011c2fd...39cf643`](https://github.com/paradigmxyz/reth/compare/011c2fd...39cf643)

🔗 Amp thread: https://ampcode.com/threads/T-019f3ad3-5b7a-731c-a6fb-171dd421c2f1
- **Engine**: Add SSZ payload containers ([#26133](https://github.com/paradigmxyz/reth/pull/26133))
- **RPC**: Accept positional testing build block params ([#25750](https://github.com/paradigmxyz/reth/pull/25750))
- **Trie**: Inherit spans for sparse trie parallel work ([#26273](https://github.com/paradigmxyz/reth/pull/26273)); consolidate lazy trie data ([#26139](https://github.com/paradigmxyz/reth/pull/26139))
- **Perf**: Preallocate transaction list decodes in eth-wire ([#26164](https://github.com/paradigmxyz/reth/pull/26164)); offload metric rendering ([#26180](https://github.com/paradigmxyz/reth/pull/26180)); dedupe `getBlobs` fallback reads in txpool ([#26255](https://github.com/paradigmxyz/reth/pull/26255))
- **Download**: Support file archives in modular snapshots ([#26078](https://github.com/paradigmxyz/reth/pull/26078))
- **Fixes**: Replace deprecated atomic `fetch_update` ([#26249](https://github.com/paradigmxyz/reth/pull/26249))
- **Deps**: Update alloy to 2.1.1 ([#26270](https://github.com/paradigmxyz/reth/pull/26270))

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019f3ad3-7964-74a1-a376-2741c4c09bd2
- Bumped Reth git dependency revision from `011c2fd` to `39cf643` across all `reth-*` crates in `Cargo.toml` (workspace dependency upgrade).

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/28841272422)
