### PR TITLE
feat(contracts): add storage credits mode labels

### DIFF
--- a/crates/contracts/src/precompiles/storage_credits.rs
+++ b/crates/contracts/src/precompiles/storage_credits.rs
@@ -21,3 +21,27 @@ crate::sol! {
         function setBudget(uint64 credits) external;
     }
 }
+
+impl IStorageCredits::Mode {
+    /// Returns the canonical lowercase label for this storage credit mode.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Refund => "refund",
+            Self::Preserve => "preserve",
+            Self::Direct => "direct",
+            _ => "unknown",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IStorageCredits;
+
+    #[test]
+    fn mode_as_str() {
+        assert_eq!(IStorageCredits::Mode::Refund.as_str(), "refund");
+        assert_eq!(IStorageCredits::Mode::Preserve.as_str(), "preserve");
+        assert_eq!(IStorageCredits::Mode::Direct.as_str(), "direct");
+    }
+}


### PR DESCRIPTION
Related: foundry-rs/foundry#15613

Adds `IStorageCredits::Mode::as_str()` for canonical lowercase mode labels so downstream CLI code can reuse the binding instead of matching modes locally.