### PR TITLE
feat(contracts): add Mode::as_str

### DIFF
--- a/.changelog/storage-credits-mode-str.md
+++ b/.changelog/storage-credits-mode-str.md
@@ -1,0 +1,5 @@
+---
+tempo-contracts: minor
+---
+
+Added `IStorageCredits::Mode::as_str` returning the lowercase string label for a storage credit mode.

--- a/crates/contracts/src/precompiles/storage_credits.rs
+++ b/crates/contracts/src/precompiles/storage_credits.rs
@@ -21,3 +21,18 @@ crate::sol! {
         function setBudget(uint64 credits) external;
     }
 }
+
+impl IStorageCredits::Mode {
+    /// Returns the lowercase string label for this mode.
+    ///
+    /// Returns `"unknown"` for Alloy's synthetic invalid variant, which represents an
+    /// out-of-range decoded enum value.
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Refund => "refund",
+            Self::Preserve => "preserve",
+            Self::Direct => "direct",
+            Self::__Invalid => "unknown",
+        }
+    }
+}


### PR DESCRIPTION
Adds `IStorageCredits::Mode::as_str()` so cast can drop its hand-rolled `mode_label` helper. 
https://github.com/foundry-rs/foundry/pull/15613#discussion_r3533747773 