### PR TITLE
fix(ci): refresh cargo-deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,9 +1194,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -3561,9 +3561,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
-  # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
-  # the fix, and no patched hickory-proto release exists
-  "RUSTSEC-2026-0118",
   # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
   # and is pulled in transitively by upstream crates with no safe upgrade available.
   "RUSTSEC-2026-0173",


### PR DESCRIPTION
Removes the stale `RUSTSEC-2026-0118` cargo-deny ignore that now fails with `advisory-not-detected`.

Updates `anyhow` and `crossbeam-epoch` to patched patch releases so the current advisory database passes without adding new ignores.