### PR TITLE
chore: make pending changelogs patch bumps

### DIFF
--- a/.changelog/lively-fish-wink.md
+++ b/.changelog/lively-fish-wink.md
@@ -1,5 +1,5 @@
 ---
-tempo-alloy: minor
+tempo-alloy: patch
 ---
 
 Added typed `RecoveryAuthority` selector and `set_receive_policy_for_receiver` helper for building validated TIP-1028 receive-policy calls, rejecting recovery authorities that can never pass `ReceivePolicyGuard.claim()`.

--- a/.changelog/storage-credits-mode-str.md
+++ b/.changelog/storage-credits-mode-str.md
@@ -1,5 +1,5 @@
 ---
-tempo-contracts: minor
+tempo-contracts: patch
 ---
 
 Added `IStorageCredits::Mode::as_str` returning the lowercase string label for a storage credit mode.


### PR DESCRIPTION
Updates the changelog fragments deleted by #6732 so they request patch releases instead of minor releases.

Prompted by: @0xrusowsky