### PR TITLE
fix(multisig): address native multisig review comments and merge-readiness fixes

### DIFF
--- a/.changelog/native-multisig.md
+++ b/.changelog/native-multisig.md
@@ -8,4 +8,4 @@ tempo-revm: minor
 tempo-node: minor
 ---
 
-Added native multisig account support, including a new multisig precompile, signature-carried `InitMultisig` bootstrap configs, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Native 1-of-1 secp256k1 multisigs now pay a 2,100 gas authorization surcharge over equivalent primitive secp256k1 transactions.
+Added native multisig account support, including a new multisig precompile, signature-carried `InitMultisig` bootstrap configs, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Native 1-of-1 secp256k1 multisigs now pay a 4,200 gas authorization surcharge (2,100 validation + 2,100 owner-weight lookup) over equivalent primitive secp256k1 transactions.

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -569,7 +569,12 @@ mod tests {
         assert_eq!(multisig_sig.init(), None);
         assert_eq!(multisig_sig.account(), account);
         assert_eq!(multisig_sig.signature_count(), 2);
-        assert!(multisig_sig.signatures().iter().all(|sig| sig.len() > 65));
+        assert!(
+            multisig_sig
+                .signatures()
+                .iter()
+                .all(|sig| sig.encoded_length() > 65)
+        );
     }
 
     #[test]

--- a/crates/precompiles/src/native_multisig/mod.rs
+++ b/crates/precompiles/src/native_multisig/mod.rs
@@ -15,6 +15,7 @@ use tempo_primitives::transaction::{
 };
 
 use crate::{
+    account_keychain::{AccountKeychain, getTransactionKeyCall},
     error::{Result, TempoPrecompileError},
     storage::{Handler, Mapping},
 };
@@ -182,6 +183,16 @@ impl NativeMultisig {
     ) -> Result<()> {
         let tx_origin = self.tx_origin.t_read()?;
         if tx_origin.is_zero() || tx_origin != msg_sender {
+            return Err(NativeMultisigError::unauthorized_caller().into());
+        }
+        // Config updates are authorized only by the current native multisig owner threshold. Native
+        // multisig accounts may authorize AccountKeychain access keys, but an access-key transaction
+        // MUST NOT rotate the owner set, even when the key is unrestricted or scoped to this
+        // precompile. Owner-threshold (multisig-signed) transactions leave the shared keychain
+        // transaction key at zero; access-key transactions set it to the access key address.
+        let transaction_key =
+            AccountKeychain::new().get_transaction_key(getTransactionKeyCall {}, msg_sender)?;
+        if !transaction_key.is_zero() {
             return Err(NativeMultisigError::unauthorized_caller().into());
         }
         if self.bootstrapped_account.t_read()? == msg_sender {
@@ -461,6 +472,50 @@ mod tests {
         }
         assert_eq!(persistent_slots.len(), 1 + 2 * config.owners.len());
 
+        storage.clear_transient();
+        StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            multisig.set_tx_origin(account)?;
+            multisig.update_multisig_config(account, 2, abi_owners())?;
+            assert_eq!(multisig.get_multisig_config(account)?.threshold, 2);
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn update_config_rejects_access_key_authority() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let config = init_config();
+        let account = config.account().unwrap();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            multisig.initialize()
+        })?;
+        StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            multisig.store_initial_config(account, &config)
+        })?;
+
+        // A keychain access-key transaction (nonzero keychain transaction key) must not rotate the
+        // owner set, even though tx_origin == msg_sender for a top-level keychain call.
+        storage.clear_transient();
+        StorageCtx::enter(&mut storage, || {
+            AccountKeychain::new().set_transaction_key(Address::repeat_byte(0x77))?;
+            let mut multisig = NativeMultisig::new();
+            multisig.set_tx_origin(account)?;
+            assert!(matches!(
+                multisig.update_multisig_config(account, 2, abi_owners()),
+                Err(TempoPrecompileError::NativeMultisigError(
+                    NativeMultisigError::UnauthorizedCaller(_)
+                ))
+            ));
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+
+        // Owner-threshold authorization (keychain transaction key stays zero) still succeeds.
         storage.clear_transient();
         StorageCtx::enter(&mut storage, || {
             let mut multisig = NativeMultisig::new();

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -26,7 +26,6 @@ pub use multisig::{
     MULTISIG_SIGNATURE_DOMAIN, MultisigAddress, MultisigConfigError, MultisigOwner,
     MultisigQuorumError, MultisigSignature, MultisigWeightAccumulator, SIGNATURE_TYPE_MULTISIG,
     is_valid_multisig_account, multisig_digest, multisig_signature_count_for_threshold,
-    verify_ordered_owner_weights,
 };
 pub use tempo_transaction::{
     Call, FEE_PAYER_SIGNATURE_MARKER, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH,

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -337,25 +337,6 @@ impl InitMultisig {
             .ok()
             .map(|idx| self.owners[idx].weight)
     }
-    /// Decodes, verifies, and weight-accounts primitive owner approvals.
-    ///
-    /// This helper does not validate nested multisig owner approvals because that requires state
-    /// access to load each nested account config.
-    pub fn verify_owner_signatures(
-        &self,
-        digest: B256,
-        signatures: &[Bytes],
-    ) -> Result<u8, &'static str> {
-        self.validate().map_err(MultisigConfigError::as_str)?;
-        let signatures = signatures
-            .iter()
-            .cloned()
-            .map(decode_multisig_owner_signature)
-            .collect::<Result<Vec<_>, _>>()?;
-        let owners = recover_multisig_owner_addresses(digest, &signatures)?;
-        verify_recovered_multisig_owners(&owners, self)
-    }
-
     /// Returns a heuristic for the in-memory size of the config.
     pub fn size(&self) -> usize {
         size_of::<Self>() + self.owners.capacity() * size_of::<MultisigOwner>()
@@ -427,8 +408,6 @@ pub struct MultisigSignature {
     signatures: Vec<TempoSignature>,
     /// Cached multisig digest for the transaction hash this signature approved.
     cached_digest: OnceLock<(B256, Address, B256)>,
-    /// Cached primitive recovered owner addresses for the digest this multisig signature approved.
-    cached_recovered_owners: OnceLock<(B256, Vec<Address>)>,
 }
 
 #[cfg(feature = "serde")]
@@ -506,7 +485,6 @@ impl MultisigSignature {
             address,
             signatures,
             cached_digest: OnceLock::new(),
-            cached_recovered_owners: OnceLock::new(),
         };
         signature.validate_shape()?;
         Ok(signature)
@@ -596,52 +574,6 @@ impl MultisigSignature {
         }
 
         digest
-    }
-
-    /// Recovers primitive owner addresses for the provided multisig digest and caches them on first
-    /// use.
-    ///
-    /// This is a primitive-only helper. Full protocol validation of nested multisig owner
-    /// approvals must be performed by the stateful native multisig verifier.
-    pub fn with_recovered_owners<R>(
-        &self,
-        digest: B256,
-        f: impl FnOnce(&[Address]) -> Result<R, &'static str>,
-    ) -> Result<R, &'static str> {
-        if let Some((cached_digest, owners)) = self.cached_recovered_owners.get()
-            && *cached_digest == digest
-        {
-            return f(owners);
-        }
-
-        let owners = recover_multisig_owner_addresses(digest, &self.signatures)?;
-        if self.cached_recovered_owners.get().is_none() {
-            #[allow(clippy::useless_conversion)]
-            let _ = self
-                .cached_recovered_owners
-                .set((digest, owners.clone()).into());
-        }
-        if let Some((cached_digest, cached_owners)) = self.cached_recovered_owners.get()
-            && *cached_digest == digest
-        {
-            return f(cached_owners);
-        }
-
-        f(&owners)
-    }
-
-    /// Verifies primitive owner approvals against a config already validated by trusted storage.
-    ///
-    /// This helper does not validate nested multisig owner approvals because that requires state
-    /// access to load each nested account config.
-    pub fn verify_with_trusted_config(
-        &self,
-        digest: B256,
-        config: &InitMultisig,
-    ) -> Result<u8, &'static str> {
-        self.with_recovered_owners(digest, |owners| {
-            verify_recovered_multisig_owners(owners, config)
-        })
     }
 
     /// Returns a heuristic for the in-memory size of the signature.
@@ -847,47 +779,6 @@ pub fn multisig_signature_count_for_threshold(
     Err(MultisigQuorumError::WeightBelowThreshold)
 }
 
-/// Verifies recovered owner order, membership, and accumulated weight for a validated config.
-pub fn verify_ordered_owner_weights(
-    owners: &[Address],
-    config: &InitMultisig,
-) -> Result<u8, MultisigQuorumError> {
-    let mut accumulator = MultisigWeightAccumulator::new(config.threshold);
-    for &owner in owners {
-        let weight = config
-            .owners
-            .binary_search_by_key(&owner, |entry| entry.owner)
-            .map(|idx| config.owners[idx].weight)
-            .map_err(|_| MultisigQuorumError::SignerNotOwner)?;
-        accumulator.record_owner(owner, weight)?;
-    }
-    accumulator.finish()
-}
-
-fn recover_multisig_owner_addresses(
-    digest: B256,
-    signatures: &[TempoSignature],
-) -> Result<Vec<Address>, &'static str> {
-    if signatures.is_empty() {
-        return Err("multisig signatures cannot be empty");
-    }
-    if signatures.len() > MAX_MULTISIG_SIGNATURES {
-        return Err("too many multisig signatures");
-    }
-
-    let mut owners = Vec::with_capacity(signatures.len());
-    for signature in signatures {
-        let TempoSignature::Primitive(signature) = signature else {
-            return Err("invalid multisig owner signature");
-        };
-        let owner = signature
-            .recover_signer(&digest)
-            .map_err(|_| "invalid multisig owner signature")?;
-        owners.push(owner);
-    }
-    Ok(owners)
-}
-
 fn decode_multisig_owner_signature(signature: Bytes) -> Result<TempoSignature, &'static str> {
     if signature.is_empty() {
         return Err("multisig owner signature cannot be empty");
@@ -896,13 +787,6 @@ fn decode_multisig_owner_signature(signature: Bytes) -> Result<TempoSignature, &
         return Err("multisig owner signature too large");
     }
     TempoSignature::from_bytes(&signature).map_err(|_| "invalid multisig owner signature")
-}
-
-fn verify_recovered_multisig_owners(
-    owners: &[Address],
-    config: &InitMultisig,
-) -> Result<u8, &'static str> {
-    verify_ordered_owner_weights(owners, config).map_err(MultisigQuorumError::as_str)
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
@@ -1190,20 +1074,30 @@ mod tests {
         let owner_c = indexed_owner(3);
         let config = sorted_secp_config(&[(owner_a, 1), (owner_b, 3), (owner_c, 2)], 4);
 
+        // Reproduce the weight-accounting the native multisig verifier performs: look up each
+        // recovered owner's configured weight and feed it to the shared accumulator in order.
+        let ordered_weights = |owners: &[Address]| -> Result<u8, MultisigQuorumError> {
+            let mut accumulator = MultisigWeightAccumulator::new(config.threshold);
+            for &owner in owners {
+                let weight = config
+                    .owner_weight(owner)
+                    .ok_or(MultisigQuorumError::SignerNotOwner)?;
+                accumulator.record_owner(owner, weight)?;
+            }
+            accumulator.finish()
+        };
+
+        assert_eq!(ordered_weights(&[owner_a, owner_b]), Ok(4));
         assert_eq!(
-            verify_ordered_owner_weights(&[owner_a, owner_b], &config),
-            Ok(4)
-        );
-        assert_eq!(
-            verify_ordered_owner_weights(&[owner_b], &config),
+            ordered_weights(&[owner_b]),
             Err(MultisigQuorumError::WeightBelowThreshold)
         );
         assert_eq!(
-            verify_ordered_owner_weights(&[owner_b, owner_a], &config),
+            ordered_weights(&[owner_b, owner_a]),
             Err(MultisigQuorumError::SignersNotAscending)
         );
         assert_eq!(
-            verify_ordered_owner_weights(&[indexed_owner(4)], &config),
+            ordered_weights(&[indexed_owner(4)]),
             Err(MultisigQuorumError::SignerNotOwner)
         );
 
@@ -1263,18 +1157,14 @@ mod tests {
 
         let inner_digest = B256::repeat_byte(0x42);
         let digest_a = multisig_digest(inner_digest, account_a);
-        let signature = sign_hash(&signer, &digest_a).to_bytes();
+        let digest_b = multisig_digest(inner_digest, account_b);
+        assert_ne!(digest_a, digest_b, "digest is domain-separated by account");
 
-        assert!(
-            config_a
-                .verify_owner_signatures(digest_a, core::slice::from_ref(&signature))
-                .is_ok()
-        );
-        assert!(
-            config_b
-                .verify_owner_signatures(multisig_digest(inner_digest, account_b), &[signature],)
-                .is_err()
-        );
+        // An owner approval recovers the owner only against the account it was signed for; replaying
+        // it against another account's digest recovers a different address that is not an owner.
+        let signature = sign_hash(&signer, &digest_a);
+        assert_eq!(signature.recover_signer(&digest_a).unwrap(), owner);
+        assert_ne!(signature.recover_signer(&digest_b).unwrap(), owner);
     }
 
     #[test]
@@ -1286,26 +1176,29 @@ mod tests {
         let digest = multisig_digest(B256::repeat_byte(0x42), account);
 
         let mut signed = [
-            (owner_a, sign_hash(&signer_a, &digest).to_bytes()),
-            (owner_b, sign_hash(&signer_b, &digest).to_bytes()),
+            (owner_a, sign_hash(&signer_a, &digest)),
+            (owner_b, sign_hash(&signer_b, &digest)),
         ];
         signed.sort_by_key(|(owner, _)| *owner);
-        let signatures = signed
-            .into_iter()
-            .map(|(_, signature)| signature)
-            .collect::<Vec<_>>();
 
-        assert_eq!(
-            config.verify_owner_signatures(digest, &signatures).unwrap(),
-            2
-        );
+        // Feed the recovered owners through the shared accumulator, as the verifier does.
+        let quorum_weight = |approvals: &[&TempoSignature]| -> Result<u8, MultisigQuorumError> {
+            let mut accumulator = MultisigWeightAccumulator::new(config.threshold);
+            for approval in approvals {
+                let owner = approval.recover_signer(&digest).unwrap();
+                let weight = config
+                    .owner_weight(owner)
+                    .ok_or(MultisigQuorumError::SignerNotOwner)?;
+                accumulator.record_owner(owner, weight)?;
+            }
+            accumulator.finish()
+        };
 
-        let one_signature = vec![signatures[0].clone()];
-        assert!(
-            config
-                .verify_owner_signatures(digest, &one_signature)
-                .is_err()
-        );
+        let both = [&signed[0].1, &signed[1].1];
+        assert_eq!(quorum_weight(&both), Ok(2));
+
+        // A single owner falls short of the threshold of 2.
+        assert!(quorum_weight(&[&signed[0].1]).is_err());
     }
 
     #[test]

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -496,6 +496,12 @@ impl MultisigSignature {
         address: MultisigAddress,
         signatures: Vec<TempoSignature>,
     ) -> Result<Self, &'static str> {
+        // Guarantee the init config is valid at construction (decode/serde) time so that every
+        // constructed `MultisigSignature` upholds the invariant `MultisigAddress::account()` relies
+        // on. Without this, an invalid init config reaches the infallible `account()` and panics.
+        if let MultisigAddress::Init(init) = &address {
+            init.account().map_err(MultisigConfigError::as_str)?;
+        }
         let signature = Self {
             address,
             signatures,
@@ -1338,6 +1344,33 @@ mod tests {
         );
 
         assert_eq!(signature, Err("multisig init does not derive account"));
+    }
+
+    #[test]
+    fn multisig_signature_decode_rejects_invalid_init_config() {
+        // A bootstrap-shaped signature whose init config is structurally valid RLP but
+        // semantically invalid (empty owners / zero threshold) must be rejected at decode time
+        // instead of reaching the infallible `MultisigAddress::account()` and panicking.
+        let invalid_init = InitMultisig {
+            salt: B256::ZERO,
+            threshold: 0,
+            owners: Vec::new(),
+        };
+        let encoded = encoded_multisig_with_init_config(
+            &invalid_init,
+            vec![valid_owner_signature_bytes().to_vec()],
+        );
+
+        let mut input = encoded.as_slice();
+        assert!(
+            MultisigSignature::decode(&mut input).is_err(),
+            "decode must reject a semantically invalid init config without panicking"
+        );
+
+        // The same payload reaches the decoder through the 0x05-prefixed signature form.
+        let mut tempo_encoded = vec![SIGNATURE_TYPE_MULTISIG];
+        tempo_encoded.extend(encoded);
+        assert!(TempoSignature::from_bytes(&tempo_encoded).is_err());
     }
 
     #[test]

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -702,28 +702,69 @@ enum MultisigSignatureSerde {
     Init(InitMultisigSignatureWire),
 }
 
-impl alloy_rlp::Decodable for MultisigSignature {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        let mut payload = *buf;
-        let outer = alloy_rlp::Header::decode(&mut payload)?;
+impl MultisigSignature {
+    /// Decodes a native multisig signature while bounding recursive nesting.
+    ///
+    /// `depth` is the nesting level of this signature node; the top-level transaction signature is
+    /// depth `1` and each nested owner approval is one level deeper. Owner approvals are decoded at
+    /// `depth + 1`, and a node deeper than [`MAX_MULTISIG_NESTING_DEPTH`] is rejected. Enforcing the
+    /// bound during decoding (not only during authorization) prevents untrusted, deeply nested
+    /// input from exhausting the stack before any gas, fee, or hardfork check runs.
+    pub(crate) fn decode_with_depth(buf: &mut &[u8], depth: usize) -> alloy_rlp::Result<Self> {
+        if depth > MAX_MULTISIG_NESTING_DEPTH {
+            return Err(alloy_rlp::Error::Custom(
+                "native multisig nesting depth exceeded",
+            ));
+        }
+
+        let outer = alloy_rlp::Header::decode(buf)?;
         if !outer.list {
             return Err(alloy_rlp::Error::UnexpectedString);
         }
-        if payload.len() < outer.payload_length {
+        if buf.len() < outer.payload_length {
             return Err(alloy_rlp::Error::InputTooShort);
         }
 
-        let mut fields = &payload[..outer.payload_length];
-        let first = alloy_rlp::Header::decode(&mut fields)?;
-        if first.list {
-            let wire = InitMultisigSignatureWire::decode(buf)?;
-            Self::from_decoded_address(MultisigAddress::Init(wire.init), wire.signatures)
-                .map_err(alloy_rlp::Error::Custom)
+        let body = *buf;
+        let (mut fields, rest) = body.split_at(outer.payload_length);
+
+        // The first field distinguishes the wire shape: a bootstrap init config is an RLP list,
+        // an initialized account is a 20-byte string.
+        let mut peek = fields;
+        let first = alloy_rlp::Header::decode(&mut peek)?;
+        let address = if first.list {
+            MultisigAddress::Init(<InitMultisig as alloy_rlp::Decodable>::decode(&mut fields)?)
         } else {
-            let wire = InitializedMultisigSignatureWire::decode(buf)?;
-            Self::from_decoded_address(MultisigAddress::Initialized(wire.account), wire.signatures)
-                .map_err(alloy_rlp::Error::Custom)
+            MultisigAddress::Initialized(<Address as alloy_rlp::Decodable>::decode(&mut fields)?)
+        };
+
+        // Decode owner approvals one nesting level deeper so nested multisig approvals are bounded.
+        let sig_header = alloy_rlp::Header::decode(&mut fields)?;
+        if !sig_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
         }
+        if fields.len() < sig_header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (mut sig_fields, sig_rest) = fields.split_at(sig_header.payload_length);
+        let mut signatures = Vec::new();
+        while !sig_fields.is_empty() {
+            signatures.push(TempoSignature::decode_with_depth(&mut sig_fields, depth + 1)?);
+        }
+        if !sig_rest.is_empty() {
+            return Err(alloy_rlp::Error::Custom(
+                "unexpected trailing native multisig signature fields",
+            ));
+        }
+
+        *buf = rest;
+        Self::from_decoded_address(address, signatures).map_err(alloy_rlp::Error::Custom)
+    }
+}
+
+impl alloy_rlp::Decodable for MultisigSignature {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::decode_with_depth(buf, 1)
     }
 }
 
@@ -1020,6 +1061,22 @@ mod tests {
         signatures.encode(&mut encoded);
         encoded.push(alloy_rlp::EMPTY_STRING_CODE);
         encoded
+    }
+
+    /// Builds `levels` of nested initialized native multisig signatures, where the innermost owner
+    /// approval is a primitive signature and each outer level has a single nested multisig owner.
+    fn nested_multisig_encoding(levels: usize) -> Vec<u8> {
+        let account = Address::repeat_byte(0x11);
+        let mut current = encoded_multisig_without_init_slot(
+            account,
+            vec![valid_owner_signature_bytes().to_vec()],
+        );
+        for _ in 1..levels {
+            let mut owner_approval = vec![SIGNATURE_TYPE_MULTISIG];
+            owner_approval.extend_from_slice(&current);
+            current = encoded_multisig_without_init_slot(account, vec![owner_approval]);
+        }
+        current
     }
 
     fn encoded_legacy_multisig_with_trailing_init(
@@ -1344,6 +1401,31 @@ mod tests {
         );
 
         assert_eq!(signature, Err("multisig init does not derive account"));
+    }
+
+    #[test]
+    fn tempo_signature_decode_bounds_multisig_nesting() {
+        // Nesting up to MAX_MULTISIG_NESTING_DEPTH decodes structurally.
+        let mut ok = vec![SIGNATURE_TYPE_MULTISIG];
+        ok.extend(nested_multisig_encoding(MAX_MULTISIG_NESTING_DEPTH));
+        assert!(
+            TempoSignature::from_bytes(&ok).is_ok(),
+            "nesting within the depth bound must decode"
+        );
+
+        // One level deeper exceeds the bound and is rejected at decode time.
+        let mut too_deep = vec![SIGNATURE_TYPE_MULTISIG];
+        too_deep.extend(nested_multisig_encoding(MAX_MULTISIG_NESTING_DEPTH + 1));
+        assert!(
+            TempoSignature::from_bytes(&too_deep).is_err(),
+            "nesting past the depth bound must be rejected"
+        );
+
+        // A pathologically deep payload is rejected quickly instead of recursing into a stack
+        // overflow during decoding.
+        let mut pathological = vec![SIGNATURE_TYPE_MULTISIG];
+        pathological.extend(nested_multisig_encoding(4096));
+        assert!(TempoSignature::from_bytes(&pathological).is_err());
     }
 
     #[test]

--- a/crates/primitives/src/transaction/multisig.rs
+++ b/crates/primitives/src/transaction/multisig.rs
@@ -1309,7 +1309,11 @@ mod tests {
     }
 
     #[test]
-    fn rejects_noncanonical_p256_owner_prehash_flag() {
+    fn noncanonical_p256_owner_prehash_flag_canonicalizes() {
+        // A P256 owner approval carrying a noncanonical pre_hash flag byte decodes to the same
+        // signature and re-encodes with the canonical flag, so it cannot malleate the transaction
+        // hash even though the raw wire byte differs. This structural canonicalization replaces the
+        // (STF-breaking) strict-flag rejection that was previously attempted at decode time.
         let (signer, pub_key_x, pub_key_y, owner) = generate_p256_keypair();
         let config = sorted_secp_config(&[(owner, 1)], 1);
         let account = config.account().unwrap();
@@ -1322,18 +1326,17 @@ mod tests {
             1,
             "test setup should use canonical pre_hash=true encoding"
         );
-        assert!(
-            config
-                .verify_owner_signatures(digest, core::slice::from_ref(&canonical_signature))
-                .is_ok()
-        );
 
         let mut noncanonical_signature = canonical_signature.to_vec();
         let flag_index = noncanonical_signature.len() - 1;
         noncanonical_signature[flag_index] = 2;
+
+        let decoded = TempoSignature::from_bytes(&noncanonical_signature)
+            .expect("noncanonical pre_hash flag decodes leniently");
         assert_eq!(
-            config.verify_owner_signatures(digest, &[Bytes::from(noncanonical_signature)]),
-            Err("invalid multisig owner signature")
+            decoded.to_bytes(),
+            canonical_signature,
+            "noncanonical owner approval re-encodes to the canonical signature bytes"
         );
     }
 

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -740,6 +740,12 @@ impl TempoSignature {
     /// that the signature is valid for the keychain. They also need to check the access key is authorized
     /// in the keychain precompile.
     /// We cannot check this here, as we don't have access to the keychain precompile.
+    ///
+    /// - Multisig: returns the derived/claimed native multisig account after stateless shape
+    ///   checks only. It does NOT verify owner approvals or that the owner-weight threshold is met.
+    ///   This is the same footgun as Keychain: callers must not treat a returned account as an
+    ///   authorized transaction. Owner-threshold verification is stateful and happens in the native
+    ///   multisig verifier (`NativeMultisig::verify_authorization`), which needs the stored config.
     pub fn recover_signer(
         &self,
         sig_hash: &B256,

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -2032,16 +2032,10 @@ mod tests {
             Some(config.clone()),
         ));
 
+        // recover_signer returns the claimed account after stateless shape checks only; it does
+        // not verify owner approvals. Stateful owner-threshold verification is exercised by the
+        // native multisig precompile tests.
         assert_eq!(signature.recover_signer(&inner_hash).unwrap(), account);
-
-        let multisig_signature = signature.as_multisig().unwrap();
-        let digest = multisig_signature.digest(inner_hash);
-        assert!(
-            multisig_signature
-                .verify_with_trusted_config(digest, &config)
-                .is_err(),
-            "stateful multisig authorization should still reject a non-owner signature"
-        );
     }
 
     #[test]

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -101,7 +101,7 @@ pub struct WebAuthnSignature {
 #[expect(clippy::type_complexity)]
 fn split_p256_signature_fields(
     sig_data: &[u8; P256_SIGNATURE_LENGTH],
-) -> Result<(&[u8; 32], &[u8; 32], &[u8; 32], &[u8; 32], bool), &'static str> {
+) -> (&[u8; 32], &[u8; 32], &[u8; 32], &[u8; 32], bool) {
     let (r, sig_data) = sig_data
         .split_first_chunk::<32>()
         .expect("P256 signature length checked");
@@ -114,12 +114,12 @@ fn split_p256_signature_fields(
     let (pub_key_y, pre_hash) = sig_data
         .split_first_chunk::<32>()
         .expect("P256 signature length checked");
-    let pre_hash = match pre_hash[0] {
-        0 => false,
-        1 => true,
-        _ => return Err("Invalid P256 pre_hash flag"),
-    };
-    Ok((r, s, pub_key_x, pub_key_y, pre_hash))
+    // Any nonzero flag byte decodes as pre_hash=true. This lenient decoding matches the behavior
+    // of the deployed SignatureVerifier precompile and payment-lane classifier, which decode
+    // verbatim on-chain calldata; rejecting noncanonical flag bytes here would be STF-breaking.
+    // Noncanonical bytes cannot malleate transaction hashes because signatures are re-encoded
+    // canonically (`to_bytes` emits `0x01` for true) before hashing.
+    (r, s, pub_key_x, pub_key_y, pre_hash[0] != 0)
 }
 
 /// Primitive signature types that can be used standalone or within a Keychain signature.
@@ -177,7 +177,7 @@ impl PrimitiveSignature {
                 let sig_data: &[u8; P256_SIGNATURE_LENGTH] = sig_data
                     .try_into()
                     .map_err(|_| "Invalid P256 signature length")?;
-                let (r, s, pub_key_x, pub_key_y, pre_hash) = split_p256_signature_fields(sig_data)?;
+                let (r, s, pub_key_x, pub_key_y, pre_hash) = split_p256_signature_fields(sig_data);
                 Ok(Self::P256(P256SignatureWithPreHash {
                     r: B256::from_slice(r),
                     s: B256::from_slice(s),
@@ -1527,20 +1527,23 @@ mod tests {
     }
 
     #[test]
-    fn test_p256_from_bytes_rejects_noncanonical_prehash_flag() {
+    fn test_p256_from_bytes_canonicalizes_prehash_flag() {
+        // Decoding is lenient (any nonzero flag byte means pre_hash=true), matching the deployed
+        // network, and re-encoding is canonical, so noncanonical flag bytes cannot malleate hashes.
         let mut sig_bytes = vec![SIGNATURE_TYPE_P256];
         sig_bytes.extend_from_slice(&[0u8; P256_SIGNATURE_LENGTH]);
 
         sig_bytes[1 + P256_SIGNATURE_LENGTH - 1] = 0;
-        assert!(TempoSignature::from_bytes(&sig_bytes).is_ok());
-
-        sig_bytes[1 + P256_SIGNATURE_LENGTH - 1] = 1;
-        assert!(TempoSignature::from_bytes(&sig_bytes).is_ok());
+        let decoded = TempoSignature::from_bytes(&sig_bytes).expect("flag 0 decodes");
+        assert_eq!(decoded.to_bytes(), Bytes::from(sig_bytes.clone()));
 
         sig_bytes[1 + P256_SIGNATURE_LENGTH - 1] = 2;
+        let decoded = TempoSignature::from_bytes(&sig_bytes).expect("noncanonical flag decodes");
+        let reencoded = decoded.to_bytes();
         assert_eq!(
-            TempoSignature::from_bytes(&sig_bytes).unwrap_err(),
-            "Invalid P256 pre_hash flag"
+            reencoded[reencoded.len() - 1],
+            1,
+            "noncanonical pre_hash flag re-encodes to the canonical 0x01"
         );
     }
 

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, Bytes, Signature, U256, keccak256, uint};
-use alloy_rlp::{Decodable, Encodable};
+use alloy_rlp::Encodable;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use sha2::{Digest, Sha256};
 
@@ -593,6 +593,15 @@ impl TempoSignature {
     /// - If length is 65 bytes: treat as secp256k1 signature (no type identifier)
     /// - Otherwise: first byte is the signature type identifier
     pub fn from_bytes(data: &[u8]) -> Result<Self, &'static str> {
+        Self::from_bytes_with_depth(data, 1)
+    }
+
+    /// Parses a signature while tracking native multisig nesting `depth`.
+    ///
+    /// The top-level signature is depth `1`; each nested owner approval is parsed one level deeper.
+    /// [`MultisigSignature::decode_with_depth`] rejects nodes past [`MAX_MULTISIG_NESTING_DEPTH`],
+    /// so deeply nested untrusted input cannot recurse the parser into a stack overflow.
+    fn from_bytes_with_depth(data: &[u8], depth: usize) -> Result<Self, &'static str> {
         if data.is_empty() {
             return Err("Signature data is empty");
         }
@@ -603,7 +612,7 @@ impl TempoSignature {
 
         if data.len() > 1 && data[0] == SIGNATURE_TYPE_MULTISIG {
             let mut sig_data = &data[1..];
-            match MultisigSignature::decode(&mut sig_data) {
+            match MultisigSignature::decode_with_depth(&mut sig_data, depth) {
                 Ok(signature) if sig_data.is_empty() => return Ok(Self::Multisig(signature)),
                 _ => return Err("Invalid Multisig signature RLP"),
             }
@@ -645,6 +654,15 @@ impl TempoSignature {
         // For all non-Keychain signatures, delegate to PrimitiveSignature
         let primitive = PrimitiveSignature::from_bytes(data)?;
         Ok(Self::Primitive(primitive))
+    }
+
+    /// Decodes one RLP-encoded owner approval at the given native multisig nesting `depth`.
+    ///
+    /// Owner approvals are length-prefixed byte strings; this preserves the depth so nested
+    /// multisig approvals stay bounded by [`MultisigSignature::decode_with_depth`].
+    pub(crate) fn decode_with_depth(buf: &mut &[u8], depth: usize) -> alloy_rlp::Result<Self> {
+        let bytes: Bytes = alloy_rlp::Decodable::decode(buf)?;
+        Self::from_bytes_with_depth(&bytes, depth).map_err(alloy_rlp::Error::Custom)
     }
 
     /// Encode signature to bytes

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1029,7 +1029,13 @@ where
                                 .map_err(NativeMultisigAuthError::from)
                                 .map_err(map_native_multisig_error::<DB>)?
                             {
-                                return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
+                                // Whether an authority is a native multisig account is read from
+                                // storage, so this rejection depends on chain state and can flip
+                                // after signing/relay. Classify it as a state-dependent validation
+                                // failure (not a bad transaction) so honest relays are not penalized.
+                                // The deterministic payload-only checks in validate_env stay
+                                // NativeMultisigInvalidTransaction.
+                                return Err(TempoInvalidTransaction::NativeMultisigValidationFailed {
                                     reason: format!(
                                         "native multisig account {authority} cannot be used as an authorization-list authority"
                                     ),
@@ -3124,10 +3130,10 @@ mod tests {
             matches!(
                 result,
                 Err(EVMError::Transaction(
-                    TempoInvalidTransaction::NativeMultisigInvalidTransaction { reason }
+                    TempoInvalidTransaction::NativeMultisigValidationFailed { reason }
                 )) if reason.contains("authorization-list authority")
             ),
-            "native multisig authorization-list authority should be rejected"
+            "native multisig authorization-list authority should be rejected (state-dependent)"
         );
     }
 
@@ -3148,10 +3154,10 @@ mod tests {
             matches!(
                 result,
                 Err(EVMError::Transaction(
-                    TempoInvalidTransaction::NativeMultisigInvalidTransaction { reason }
+                    TempoInvalidTransaction::NativeMultisigValidationFailed { reason }
                 )) if reason.contains("authorization-list authority")
             ),
-            "native multisig standard authorization-list authority should be rejected"
+            "native multisig standard authorization-list authority should be rejected (state-dependent)"
         );
     }
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1022,7 +1022,7 @@ where
                         .into());
                     }
 
-                    let validate_authorization_authority =
+                    let ensure_authority_not_multisig =
                         |authority| -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
                             if multisig_precompile
                                 .is_multisig_account(authority)
@@ -1048,13 +1048,13 @@ where
                     if let Some(tempo_tx_env) = tempo_tx_env {
                         for auth in &tempo_tx_env.tempo_authorization_list {
                             if let Some(authority) = auth.authority() {
-                                validate_authorization_authority(authority)?;
+                                ensure_authority_not_multisig(authority)?;
                             }
                         }
                     } else {
                         for auth in tx.authorization_list() {
                             if let Some(authority) = auth.authority() {
-                                validate_authorization_authority(authority)?;
+                                ensure_authority_not_multisig(authority)?;
                             }
                         }
                     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1076,12 +1076,11 @@ where
                     let Some(multisig_signature) = multisig_signature else {
                         return Ok(());
                     };
-                    let Some(tempo_tx_env) = tempo_tx_env else {
-                        return Err(TempoInvalidTransaction::NativeMultisigInvalidTransaction {
-                            reason: "multisig signature requires AA transaction context".to_string(),
-                        }
-                        .into());
-                    };
+                    // `multisig_signature` is derived from `tempo_tx_env` (`aa.signature.as_multisig()`)
+                    // above, so it being Some implies `tempo_tx_env` is Some. This is an invariant,
+                    // not a reachable error path.
+                    let tempo_tx_env =
+                        tempo_tx_env.expect("multisig signature is derived from tempo_tx_env");
 
                     let caller_account_info = caller_account_info
                         .as_ref()

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -23,9 +23,12 @@ use std::{
     time::Instant,
 };
 use tempo_chainspec::TempoChainSpec;
-use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
+use tempo_contracts::precompiles::{
+    IAccountKeychain, IFeeManager, INativeMultisig, ITIP20, ITIP403Registry,
+};
 use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, NATIVE_MULTISIG_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    TIP403_REGISTRY_ADDRESS,
 };
 use tempo_primitives::{TempoAddressExt, TempoHeader, TempoPrimitives};
 use tracing::{debug, error};
@@ -101,6 +104,13 @@ pub struct TempoPoolUpdates {
     /// Pending AA transactions carrying the same `(account, witness)` key authorization are no
     /// longer executable once the account explicitly burns that witness.
     pub key_authorization_witness_burns: AddressMap<B256Set>,
+    /// Native multisig accounts whose owner set or threshold changed.
+    ///
+    /// A native-multisig-signed transaction is validated against the account's current stored
+    /// config, so once the config is rotated (or the account is initialized) any pooled multisig
+    /// transaction admitted under the previous owner set may no longer meet quorum and should be
+    /// re-validated. Indexed by account.
+    pub multisig_config_changes: AddressSet,
 }
 
 impl TempoPoolUpdates {
@@ -124,6 +134,7 @@ impl TempoPoolUpdates {
             && self.fee_balance_changes.is_empty()
             && self.spending_limit_spends.is_empty()
             && self.key_authorization_witness_burns.is_empty()
+            && self.multisig_config_changes.is_empty()
     }
 
     /// Extracts pool updates from a committed chain segment.
@@ -239,6 +250,20 @@ impl TempoPoolUpdates {
                     Some(_) | None => {}
                 }
             }
+            // Native multisig owner-set / threshold rotations and initializations.
+            else if log.address == NATIVE_MULTISIG_ADDRESS {
+                match NativeMultisigPoolEvent::decode(log) {
+                    Some(NativeMultisigPoolEvent::ConfigUpdated(event)) => {
+                        updates.multisig_config_changes.insert(event.account);
+                    }
+                    // A duplicate bootstrap for an account initialized earlier in the same block is
+                    // no longer admissible, so revalidate pending multisig transactions for it too.
+                    Some(NativeMultisigPoolEvent::Initialized(event)) => {
+                        updates.multisig_config_changes.insert(event.account);
+                    }
+                    None => {}
+                }
+            }
         }
 
         updates
@@ -254,6 +279,7 @@ impl TempoPoolUpdates {
             || !self.whitelist_removals.is_empty()
             || !self.fee_balance_changes.is_empty()
             || !self.key_authorization_witness_burns.is_empty()
+            || !self.multisig_config_changes.is_empty()
     }
 
     /// Returns true if updates may invalidate keychain-signature transactions.
@@ -299,6 +325,29 @@ impl AccountKeychainPoolEvent {
             }
             IAccountKeychain::KeyAuthorizationWitnessBurned::SIGNATURE_HASH => {
                 decode_event(log).map(Self::KeyAuthorizationWitnessBurned)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Transaction-pool relevant subset of `INativeMultisig` events.
+enum NativeMultisigPoolEvent {
+    /// [`INativeMultisig::MultisigConfigUpdated`] log.
+    ConfigUpdated(INativeMultisig::MultisigConfigUpdated),
+    /// [`INativeMultisig::MultisigInitialized`] log.
+    Initialized(INativeMultisig::MultisigInitialized),
+}
+
+impl NativeMultisigPoolEvent {
+    /// Decodes only native-multisig events used by transaction-pool maintenance.
+    fn decode(log: &Log) -> Option<Self> {
+        match first_topic(log)? {
+            INativeMultisig::MultisigConfigUpdated::SIGNATURE_HASH => {
+                decode_event(log).map(Self::ConfigUpdated)
+            }
+            INativeMultisig::MultisigInitialized::SIGNATURE_HASH => {
+                decode_event(log).map(Self::Initialized)
             }
             _ => None,
         }
@@ -1303,6 +1352,40 @@ mod tests {
                 AccountKeychainPoolEvent,
                 KeyAuthorizationWitnessBurned,
                 IAccountKeychain::KeyAuthorizationWitnessBurned,
+                log
+            );
+        }
+
+        #[test]
+        fn native_multisig_decode_matches_generated_event_decoders() {
+            let log = event_log(
+                NATIVE_MULTISIG_ADDRESS,
+                INativeMultisig::MultisigConfigUpdated {
+                    account: Address::random(),
+                    threshold: 2,
+                    owners: vec![INativeMultisig::MultisigOwner {
+                        owner: Address::random(),
+                        weight: 1,
+                    }],
+                },
+            );
+            assert_decodes_like_generated!(
+                NativeMultisigPoolEvent,
+                ConfigUpdated,
+                INativeMultisig::MultisigConfigUpdated,
+                log
+            );
+
+            let log = event_log(
+                NATIVE_MULTISIG_ADDRESS,
+                INativeMultisig::MultisigInitialized {
+                    account: Address::random(),
+                },
+            );
+            assert_decodes_like_generated!(
+                NativeMultisigPoolEvent,
+                Initialized,
+                INativeMultisig::MultisigInitialized,
                 log
             );
         }

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -217,6 +217,7 @@ where
         let mut blacklisted_count = 0;
         let mut unwhitelisted_count = 0;
         let mut insolvent_fee_payer_count = 0;
+        let mut multisig_config_count = 0;
         let has_keychain_subject_updates = updates.has_keychain_subject_updates();
         let has_key_authorization_target_updates =
             !updates.key_authorization_target_changes.is_empty();
@@ -468,6 +469,21 @@ where
             {
                 to_remove.push(*tx.hash());
                 user_token_count += 1;
+                continue;
+            }
+
+            // Check 7: Native multisig owner-set / threshold rotations
+            // A native-multisig-signed transaction is verified against the account's current stored
+            // config, so once that config is rotated (or initialized) on-chain the pooled
+            // transaction may no longer meet quorum and must be re-validated.
+            if !updates.multisig_config_changes.is_empty()
+                && tx
+                    .transaction
+                    .multisig_account()
+                    .is_some_and(|account| updates.multisig_config_changes.contains(&account))
+            {
+                to_remove.push(*tx.hash());
+                multisig_config_count += 1;
             }
         }
 
@@ -488,6 +504,7 @@ where
             blacklisted_count,
             unwhitelisted_count,
             insolvent_fee_payer_count,
+            multisig_config_count,
             "Evicting invalidated transactions"
         );
         self.remove_transactions(to_remove)
@@ -1706,6 +1723,41 @@ mod tests {
         let evicted = pool.evict_invalidated_transactions(&updates);
         assert_eq!(tx_hashes(&evicted), vec![*pooled.hash()]);
         assert!(pool.get(pooled.hash()).is_none());
+    }
+
+    #[tokio::test]
+    async fn evicts_multisig_transaction_when_its_config_rotates() {
+        let account = Address::random();
+        let pooled = crate::test_utils::TxBuilder::aa(account).build_multisig(account);
+
+        let provider = create_provider_with_tip();
+        provider.add_account(account, ExtendedAccount::new(pooled.nonce(), *pooled.cost()));
+        let pool = create_test_pool(provider);
+        add_validated(&pool, pooled.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.multisig_config_changes.insert(account);
+
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        assert_eq!(tx_hashes(&evicted), vec![*pooled.hash()]);
+        assert!(pool.get(pooled.hash()).is_none());
+    }
+
+    #[tokio::test]
+    async fn keeps_multisig_transaction_when_other_account_config_rotates() {
+        let account = Address::random();
+        let pooled = crate::test_utils::TxBuilder::aa(account).build_multisig(account);
+
+        let provider = create_provider_with_tip();
+        provider.add_account(account, ExtendedAccount::new(pooled.nonce(), *pooled.cost()));
+        let pool = create_test_pool(provider);
+        add_validated(&pool, pooled.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.multisig_config_changes.insert(Address::random());
+
+        assert!(pool.evict_invalidated_transactions(&updates).is_empty());
+        assert!(pool.get(pooled.hash()).is_some());
     }
 
     #[tokio::test]

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -473,14 +473,16 @@ where
             }
 
             // Check 7: Native multisig owner-set / threshold rotations
-            // A native-multisig-signed transaction is verified against the account's current stored
-            // config, so once that config is rotated (or initialized) on-chain the pooled
-            // transaction may no longer meet quorum and must be re-validated.
+            // A native-multisig-signed transaction is verified against the current stored config of
+            // its outer account and of every nested multisig owner, so once any of those configs is
+            // rotated (or initialized) on-chain the pooled transaction may no longer meet quorum and
+            // must be re-validated.
             if !updates.multisig_config_changes.is_empty()
                 && tx
                     .transaction
-                    .multisig_account()
-                    .is_some_and(|account| updates.multisig_config_changes.contains(&account))
+                    .multisig_accounts()
+                    .iter()
+                    .any(|account| updates.multisig_config_changes.contains(account))
             {
                 to_remove.push(*tx.hash());
                 multisig_config_count += 1;
@@ -1737,6 +1739,27 @@ mod tests {
 
         let mut updates = crate::maintain::TempoPoolUpdates::new();
         updates.multisig_config_changes.insert(account);
+
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        assert_eq!(tx_hashes(&evicted), vec![*pooled.hash()]);
+        assert!(pool.get(pooled.hash()).is_none());
+    }
+
+    #[tokio::test]
+    async fn evicts_multisig_transaction_when_nested_owner_config_rotates() {
+        let parent = Address::random();
+        let child = Address::random();
+        let pooled = crate::test_utils::TxBuilder::aa(parent).build_multisig_nested(parent, child);
+
+        let provider = create_provider_with_tip();
+        provider.add_account(parent, ExtendedAccount::new(pooled.nonce(), *pooled.cost()));
+        let pool = create_test_pool(provider);
+        add_validated(&pool, pooled.clone());
+
+        // Rotating the NESTED owner's config must evict the parent transaction, since the parent's
+        // authorization depends on the nested account's current threshold/owner weights.
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.multisig_config_changes.insert(child);
 
         let evicted = pool.evict_invalidated_transactions(&updates);
         assert_eq!(tx_hashes(&evicted), vec![*pooled.hash()]);

--- a/crates/transaction-pool/src/test_utils.rs
+++ b/crates/transaction-pool/src/test_utils.rs
@@ -270,6 +270,58 @@ impl TxBuilder {
         TempoPooledTransaction::new(recovered)
     }
 
+    /// Build an AA transaction whose outer multisig `parent` has a single nested multisig owner
+    /// approval from `child` (a 1-level-deep nested native multisig authorization).
+    pub(crate) fn build_multisig_nested(
+        self,
+        parent: Address,
+        child: Address,
+    ) -> TempoPooledTransaction {
+        use tempo_primitives::transaction::MultisigSignature;
+
+        let calls = self.calls.unwrap_or_else(|| {
+            vec![Call {
+                to: self.kind,
+                value: self.value,
+                input: Default::default(),
+            }]
+        });
+
+        let tx = TempoTransaction {
+            chain_id: self.chain_id,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            max_fee_per_gas: self.max_fee_per_gas,
+            gas_limit: self.gas_limit,
+            calls,
+            nonce_key: self.nonce_key,
+            nonce: self.nonce,
+            fee_token: self.fee_token,
+            fee_payer_signature: None,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
+            access_list: self.access_list,
+            tempo_authorization_list: self.authorization_list.unwrap_or_default(),
+            key_authorization: self.key_authorization,
+        };
+
+        // child multisig: one primitive owner approval.
+        let child_owner = PrimitiveSignature::Secp256k1(Signature::test_signature()).to_bytes();
+        let child_sig =
+            TempoSignature::Multisig(MultisigSignature::new(child, vec![child_owner], None));
+        // parent multisig: its single owner approval is the nested child multisig.
+        let parent_sig = TempoSignature::Multisig(MultisigSignature::new(
+            parent,
+            vec![child_sig.to_bytes()],
+            None,
+        ));
+
+        let aa_signed = AASigned::new_unhashed(tx, parent_sig);
+        let envelope: TempoTxEnvelope = aa_signed.into();
+
+        let recovered = Recovered::new_unchecked(envelope, parent);
+        TempoPooledTransaction::new(recovered)
+    }
+
     /// Build an AA transaction with a V2 keychain signature.
     ///
     /// The `user_address` is the account that owns the keychain key,

--- a/crates/transaction-pool/src/test_utils.rs
+++ b/crates/transaction-pool/src/test_utils.rs
@@ -225,6 +225,51 @@ impl TxBuilder {
         TempoPooledTransaction::new(recovered)
     }
 
+    /// Build an AA transaction with a native multisig outer signature for `account`.
+    ///
+    /// The sender equals `account`, matching how native multisig transactions execute.
+    pub(crate) fn build_multisig(self, account: Address) -> TempoPooledTransaction {
+        use tempo_primitives::transaction::MultisigSignature;
+
+        let calls = self.calls.unwrap_or_else(|| {
+            vec![Call {
+                to: self.kind,
+                value: self.value,
+                input: Default::default(),
+            }]
+        });
+
+        let tx = TempoTransaction {
+            chain_id: self.chain_id,
+            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
+            max_fee_per_gas: self.max_fee_per_gas,
+            gas_limit: self.gas_limit,
+            calls,
+            nonce_key: self.nonce_key,
+            nonce: self.nonce,
+            fee_token: self.fee_token,
+            fee_payer_signature: None,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
+            access_list: self.access_list,
+            tempo_authorization_list: self.authorization_list.unwrap_or_default(),
+            key_authorization: self.key_authorization,
+        };
+
+        let owner_signature =
+            PrimitiveSignature::Secp256k1(Signature::test_signature()).to_bytes();
+        let signature = TempoSignature::Multisig(MultisigSignature::new(
+            account,
+            vec![owner_signature],
+            None,
+        ));
+        let aa_signed = AASigned::new_unhashed(tx, signature);
+        let envelope: TempoTxEnvelope = aa_signed.into();
+
+        let recovered = Recovered::new_unchecked(envelope, account);
+        TempoPooledTransaction::new(recovered)
+    }
+
     /// Build an AA transaction with a V2 keychain signature.
     ///
     /// The `user_address` is the account that owns the keychain key,

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -210,6 +210,15 @@ impl TempoPooledTransaction {
         })
     }
 
+    /// Returns the native multisig account authorizing this transaction, if it carries a
+    /// `TempoSignature::Multisig` outer signature.
+    ///
+    /// For a native multisig transaction the sender equals the multisig account, so this is used to
+    /// evict pooled transactions after the account's owner set or threshold is rotated on-chain.
+    pub fn multisig_account(&self) -> Option<Address> {
+        Some(self.inner().as_aa()?.signature().as_multisig()?.account())
+    }
+
     /// Extracts the keychain subject for the signer of an inline `KeyAuthorization`.
     ///
     /// Used for revocation matching: if the access key that signed an inline authorization is

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -33,7 +33,10 @@ use tempo_precompiles::{
     tip20::{TIP20Token, tip20_slots},
     tip403_registry::tip403_registry_slots,
 };
-use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
+use tempo_primitives::{
+    TempoTxEnvelope,
+    transaction::{MultisigSignature, TempoSignature, calc_gas_balance_spending},
+};
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
 use thiserror::Error;
 
@@ -210,13 +213,32 @@ impl TempoPooledTransaction {
         })
     }
 
-    /// Returns the native multisig account authorizing this transaction, if it carries a
-    /// `TempoSignature::Multisig` outer signature.
+    /// Returns every native multisig account whose stored config this transaction's authorization
+    /// depends on: the outer `TempoSignature::Multisig` account plus every nested multisig owner
+    /// account in its approval tree.
     ///
-    /// For a native multisig transaction the sender equals the multisig account, so this is used to
-    /// evict pooled transactions after the account's owner set or threshold is rotated on-chain.
-    pub fn multisig_account(&self) -> Option<Address> {
-        Some(self.inner().as_aa()?.signature().as_multisig()?.account())
+    /// The stateful verifier recurses into nested multisig owners and reloads their
+    /// threshold/owner weights, so a config rotation of the outer account *or any nested owner*
+    /// can invalidate an already-pooled transaction. All of them must be matched against on-chain
+    /// config changes when deciding eviction. Recursion is bounded by `MAX_MULTISIG_NESTING_DEPTH`,
+    /// which is enforced at decode time.
+    pub fn multisig_accounts(&self) -> Vec<Address> {
+        fn collect(sig: &MultisigSignature, out: &mut Vec<Address>) {
+            out.push(sig.account());
+            for approval in sig.signatures() {
+                if let TempoSignature::Multisig(nested) = approval {
+                    collect(nested, out);
+                }
+            }
+        }
+
+        let mut accounts = Vec::new();
+        if let Some(aa_tx) = self.inner().as_aa()
+            && let Some(multisig) = aa_tx.signature().as_multisig()
+        {
+            collect(multisig, &mut accounts);
+        }
+        accounts
     }
 
     /// Extracts the keychain subject for the signer of an inline `KeyAuthorization`.


### PR DESCRIPTION
Stacked on top of #5178 (`tanishk/native-multisig`). Addresses the valid open review comments on #5178 and safety issues found while auditing merge-readiness against the **final** TIP-1061 specs in #6665 (access keys) and #6640 (CREATE2 recovery). Each commit fixes one item and carries a `Review-Ref:` identifier in its body (no direct links to the review threads).

The two-step CREATE2 account derivation from #6640 is intentionally **not** touched here — it lands in that stacked PR.

## Commits

| `Review-Ref` | Type | What |
|---|---|---|
| `keychain-updateconfig-authority` | 🔴 security | `updateMultisigConfig` now rejects AccountKeychain access-key authority (owner-threshold only), closing an owner-set-takeover path opened when keychain access keys were enabled for multisig accounts |
| `nested-decode-depth` | 🔴 DoS | Enforce `MAX_MULTISIG_NESTING_DEPTH` during RLP decode, not just verification — a deeply nested multisig signature could overflow the stack at decode time (mempool/block), before any gas/fee/hardfork check |
| `decode-time-init-validation` | 🔴 DoS | Validate `InitMultisig` when decoding a bootstrap signature so `MultisigAddress::account()`'s `expect` can't panic on a semantically-invalid init |
| `p256-prehash-leniency` | 🟠 STF | Revert the unconditional strict P256 `pre_hash` flag check (STF-breaking via the live T3 SignatureVerifier precompile); malleability is already prevented by canonical re-encoding |
| `authlist-badtx-classification` | 🟡 defense | Storage-dependent auth-list-authority rejection returns `NativeMultisigValidationFailed` (not a bad tx) so honest relays aren't peer-penalized |
| `txpool-multisig-invalidation` | 🟡 liveness | Evict pooled multisig txs when the account's config is rotated/initialized on-chain (parity with AccountKeychain revocation) |
| `remove-dead-verify-helpers` | 🧹 cleanup | Remove the unused primitive-only quorum verifier chain (footgun; can't handle nested multisig) |
| `unreachable-tempo-tx-env` | 🧹 cleanup | Collapse a provably-unreachable `tempo_tx_env` error branch |
| `ensure-not-multisig-name` | 🧹 cleanup | Rename `validate_authorization_authority` → `ensure_authority_not_multisig` |
| `recover-signer-footgun-doc` | 📝 docs | Document that `recover_signer` returns the multisig account without verifying owner approvals |
| `changelog-gas-figure` | 📝 docs | Correct the 1-of-1 gas surcharge (2,100 → 4,200) |
| `alloy-multisig-test-build` | 🔧 build | Fix a pre-existing broken `reth_compat` test (`.len()` on `TempoSignature` after the `Vec<Bytes>`→`Vec<TempoSignature>` change) so the test target compiles |

## Notes / out of scope

Larger **new features** introduced by the final #6665 spec are **not** in this stack (they need their own PRs, not review-comment fixes): the outbound *multisig-as-access-key* direction (`SignatureType::Multisig`, keychain inner wire, `verifyKeychain`/`verifyKeychainAdmin` support, metering), and allowing `key_authorization` on multisig-signed transactions. See the PR discussion for the full merge-readiness assessment.

All touched crates build and their multisig test suites pass.
