### PR TITLE
chore: hide `--builder.parallel` flag from node help

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -34,7 +34,7 @@ use reth_rpc_eth_api::{
     helpers::config::{EthConfigApiServer, EthConfigHandler},
 };
 use reth_storage_api::{AccountInfoReader, EmptyBodyStorage};
-use reth_tracing::tracing::{debug, info};
+use reth_tracing::tracing::{debug, info, warn};
 use reth_transaction_pool::{
     Pool, StatefulValidationFn, StatelessValidationFn, TransactionOrigin,
     TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
@@ -135,6 +135,10 @@ impl TempoNodeArgs {
 
     /// Returns a [`TempoPayloadBuilderBuilder`] configured from these args.
     pub fn payload_builder_builder(&self) -> TempoPayloadBuilderBuilder {
+        if self.builder_parallel {
+            warn!("parallel builder is still in development and should not be used");
+        }
+
         TempoPayloadBuilderBuilder {
             state_provider_metrics: self.builder_state_provider_metrics,
             enable_prewarming: !self.builder_disable_prewarming,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -136,7 +136,7 @@ impl TempoNodeArgs {
     /// Returns a [`TempoPayloadBuilderBuilder`] configured from these args.
     pub fn payload_builder_builder(&self) -> TempoPayloadBuilderBuilder {
         if self.builder_parallel {
-            warn!("parallel builder is still in development and should not be used");
+            warn!("Parallel block builder is still in development and should not be used");
         }
 
         TempoPayloadBuilderBuilder {

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -86,7 +86,7 @@ pub struct TempoNodeArgs {
     pub builder_enable_prewarming: bool,
 
     /// Enable speculative parallel payload builder.
-    #[arg(long = "builder.parallel", default_value_t = false)]
+    #[arg(long = "builder.parallel", default_value_t = false, hide = true)]
     pub builder_parallel: bool,
 
     /// Disable sharing the execution cache with the payload builder.


### PR DESCRIPTION
## Summary
- Hide the legacy `--builder.parallel` node flag from generated help output while keeping the argument accepted.

## Verification
- `cargo +nightly fmt --check`
- `cargo check -p tempo-node`
- `cargo run -p tempo -- node --help | rg "builder\.parallel|builder\.state-provider|builder\.disable-prewarming"` confirmed neighboring builder flags still show and `--builder.parallel` does not.

Prompted by: @shekhirin