### PR TITLE
Prepare v1.10.2 backport patch for #6545 and #6714

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -3554,9 +3554,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12935,6 +12935,7 @@ dependencies = [
  "reth-node-builder",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-prune-types",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12885,7 +12885,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13037,7 +13037,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13098,7 +13098,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13127,7 +13127,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13141,7 +13141,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13192,7 +13192,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13237,7 +13237,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13256,7 +13256,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "eyre",
  "indenter",
@@ -13264,7 +13264,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13277,7 +13277,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13347,7 +13347,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13385,7 +13385,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13405,7 +13405,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13437,7 +13437,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13486,7 +13486,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13519,7 +13519,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "clap",
@@ -13544,7 +13544,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "eyre",
  "jiff",
@@ -13553,7 +13553,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13595,7 +13595,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13607,7 +13607,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -93,6 +93,7 @@ reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-prune-types.workspace = true
 reth-rpc-server-types.workspace = true
 secp256k1.workspace = true
 reth-storage-api.workspace = true

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -4,14 +4,18 @@ use jiff::SignedDuration;
 use reth_cli_commands::download::DownloadDefaults;
 use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
-    DefaultTraceValues, DefaultTxPoolValues,
+    DefaultPruningValues, DefaultTraceValues, DefaultTxPoolValues,
 };
+use reth_prune_types::PruneMode;
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::spec::TEMPO_T7_BASE_FEE_FLOOR;
 use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
+const MAINNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
+const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_EPOCH_LENGTH_BLOCKS;
+const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
 
 /// Default OTLP logs filter level for telemetry.
 const DEFAULT_LOGS_OTLP_FILTER: &str = "debug";
@@ -217,6 +221,20 @@ fn init_engine_defaults() {
         .expect("failed to initialize engine defaults");
 }
 
+fn init_pruning_defaults() {
+    let mut minimal_prune_modes = DefaultPruningValues::default().minimal_prune_modes;
+    // This defines Tempo's minimum peer sync window: nodes should retain enough
+    // block bodies to serve peers up to three mainnet epochs behind the finalized
+    // tip, plus Reth's normal 64-block safety margin.
+    minimal_prune_modes.bodies_history =
+        Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+
+    DefaultPruningValues::default()
+        .with_minimal_prune_modes(minimal_prune_modes)
+        .try_init()
+        .expect("failed to initialize pruning defaults");
+}
+
 fn init_trace_defaults() {
     DefaultTraceValues::default()
         .with_service_name("tempo")
@@ -263,6 +281,7 @@ pub(crate) fn init_defaults() {
     init_payload_builder_defaults();
     init_txpool_defaults();
     init_engine_defaults();
+    init_pruning_defaults();
     init_trace_defaults();
     init_otlp_defaults();
     init_network_defaults();

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -6,15 +6,15 @@ use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
     DefaultPruningValues, DefaultTraceValues, DefaultTxPoolValues,
 };
-use reth_prune_types::PruneMode;
+use reth_prune_types::{PruneMode, PruneModes};
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::spec::TEMPO_T7_BASE_FEE_FLOOR;
 use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
-const MAINNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
-const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_EPOCH_LENGTH_BLOCKS;
+const MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
+const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS;
 const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
 
 /// Default OTLP logs filter level for telemetry.
@@ -222,12 +222,16 @@ fn init_engine_defaults() {
 }
 
 fn init_pruning_defaults() {
-    let mut minimal_prune_modes = DefaultPruningValues::default().minimal_prune_modes;
-    // This defines Tempo's minimum peer sync window: nodes should retain enough
-    // block bodies to serve peers up to three mainnet epochs behind the finalized
-    // tip, plus Reth's normal 64-block safety margin.
-    minimal_prune_modes.bodies_history =
-        Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+    let minimal_history_retention = Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+    // This defines Tempo's minimum history retention window: nodes should retain
+    // enough block and state history for peers and unwinds up to three mainnet
+    // epochs behind the finalized tip, plus Reth's normal 64-block safety margin.
+    let minimal_prune_modes = PruneModes {
+        account_history: minimal_history_retention,
+        storage_history: minimal_history_retention,
+        bodies_history: minimal_history_retention,
+        ..DefaultPruningValues::default().minimal_prune_modes
+    };
 
     DefaultPruningValues::default()
         .with_minimal_prune_modes(minimal_prune_modes)

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -1,7 +1,6 @@
 use std::{
-    collections::BTreeSet,
     fs, io,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     time::Instant,
 };
 
@@ -17,9 +16,7 @@ use tokio_util::io::StreamReader;
 use tracing::info;
 use url::Url;
 
-use crate::snapshot_manifest::{
-    CONSENSUS_ARCHIVE_ROOT, TEMPO_CONSENSUS_MANIFEST_KEY, TempoConsensusManifest,
-};
+use crate::snapshot_manifest::{TEMPO_CONSENSUS_MANIFEST_KEY, TempoConsensusManifest};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -57,6 +54,7 @@ pub(crate) fn run_with_runner(matches: &ArgMatches, runner: CliRunner) -> eyre::
 
     let manifest_url = matches.get_one::<String>("manifest_url").cloned();
     let manifest_path = matches.get_one::<PathBuf>("manifest_path").cloned();
+    let force = matches.get_one::<bool>("force").copied().unwrap_or(false);
 
     runner.block_on(async move {
         info!("running execution layer download...");
@@ -81,7 +79,7 @@ pub(crate) fn run_with_runner(matches: &ArgMatches, runner: CliRunner) -> eyre::
             .unwrap_or_else(|| datadir.join("consensus"));
 
         let loaded_consensus = load_consensus_manifest(manifest_url, manifest_path).await?;
-        install_consensus_archive(&consensus_dir, &loaded_consensus).await?;
+        install_consensus_archive(&consensus_dir, &loaded_consensus, force).await?;
 
         Ok(())
     })
@@ -246,6 +244,7 @@ fn archive_source_from_url(url: Url) -> eyre::Result<ConsensusArchiveSource> {
 async fn install_consensus_archive(
     consensus_dir: &Path,
     loaded: &LoadedConsensusManifest,
+    force: bool,
 ) -> eyre::Result<()> {
     let (archive_file, actual_archive_hash) =
         write_consensus_archive_to_temp(&loaded.archive_source).await?;
@@ -260,9 +259,7 @@ async fn install_consensus_archive(
 
     fs::create_dir_all(consensus_dir)
         .wrap_err_with(|| format!("failed to create {}", consensus_dir.display()))?;
-    let partitions = consensus_archive_storage_partitions(archive_file.path())?;
-    clear_consensus_partitions(consensus_dir, &partitions)?;
-    extract_zstd_tar_archive(archive_file.path(), consensus_dir)?;
+    extract_zstd_tar_archive(archive_file.path(), consensus_dir, force)?;
     verify_consensus_output_files(
         consensus_dir,
         &loaded.manifest.consensus_archive.output_files,
@@ -349,96 +346,24 @@ where
     Ok(hasher.finalize())
 }
 
-fn clear_consensus_partitions(
-    consensus_dir: &Path,
-    partitions: &BTreeSet<String>,
+fn extract_zstd_tar_archive(
+    archive_path: &Path,
+    target_dir: &Path,
+    overwrite: bool,
 ) -> eyre::Result<()> {
-    for partition in partitions {
-        let path = safe_output_path(consensus_dir, partition)?;
-        if !path.exists() {
-            continue;
-        }
-        let meta =
-            fs::metadata(&path).wrap_err_with(|| format!("failed to stat {}", path.display()))?;
-        if meta.is_dir() {
-            fs::remove_dir_all(&path)
-                .wrap_err_with(|| format!("failed to remove {}", path.display()))?;
-        } else {
-            fs::remove_file(&path)
-                .wrap_err_with(|| format!("failed to remove {}", path.display()))?;
-        }
-    }
-    Ok(())
-}
-
-fn consensus_archive_storage_partitions(archive_path: &Path) -> eyre::Result<BTreeSet<String>> {
     let file = fs::File::open(archive_path)
         .wrap_err_with(|| format!("failed to open {}", archive_path.display()))?;
     let decoder = zstd::stream::read::Decoder::new(file)?;
     let mut archive = tar::Archive::new(decoder);
-    let entries = archive
-        .entries()
-        .wrap_err("failed to read consensus archive")?;
-    let mut partitions = BTreeSet::new();
-    for entry in entries {
-        let entry = entry.wrap_err("failed to read consensus archive entry")?;
-        let entry_type = entry.header().entry_type();
-        let entry_path = entry
-            .path()
-            .wrap_err("failed reading consensus archive entry path")?
-            .to_string_lossy()
-            .to_string();
-        if let Some((partition, _)) = consensus_archive_entry(&entry_path, entry_type)? {
-            partitions.insert(partition);
-        }
-    }
-    Ok(partitions)
-}
-
-fn extract_zstd_tar_archive(archive_path: &Path, target_dir: &Path) -> eyre::Result<()> {
-    let file = fs::File::open(archive_path)
-        .wrap_err_with(|| format!("failed to open {}", archive_path.display()))?;
-    let decoder = zstd::stream::read::Decoder::new(file)?;
-    let mut archive = tar::Archive::new(decoder);
-    let entries = archive
-        .entries()
-        .wrap_err("failed to read consensus archive")?;
-    for entry in entries {
-        let mut entry = entry.wrap_err("failed to read consensus archive entry")?;
-        let entry_type = entry.header().entry_type();
-
-        let entry_path = entry
-            .path()
-            .wrap_err("failed reading consensus archive entry path")?
-            .to_string_lossy()
-            .to_string();
-        let Some((_, output_relative)) = consensus_archive_entry(&entry_path, entry_type)? else {
-            continue;
-        };
-        let output_relative = output_relative.to_string_lossy().to_string();
-        if entry_type.is_dir() {
-            let output_path = safe_output_path(target_dir, &output_relative)?;
-            fs::create_dir_all(&output_path)
-                .wrap_err_with(|| format!("failed to create {}", output_path.display()))?;
-            continue;
-        }
-
-        ensure!(
-            entry_type.is_file(),
-            "consensus archive contains a non-file entry",
-        );
-
-        let output_path = safe_output_path(target_dir, &output_relative)
-            .wrap_err_with(|| format!("path is not safe: {output_relative}"))?;
-        if let Some(parent) = output_path.parent() {
-            fs::create_dir_all(parent)
-                .wrap_err_with(|| format!("failed to create {}", parent.display()))?;
-        }
-        entry
-            .unpack(&output_path)
-            .wrap_err_with(|| format!("failed to extract {}", output_path.display()))?;
-    }
-    Ok(())
+    archive.set_overwrite(overwrite);
+    // `Archive::unpack` delegates each member to `Entry::unpack_in`, which skips
+    // paths that would escape `target_dir` and validates link targets.
+    archive.unpack(target_dir).wrap_err_with(|| {
+        format!(
+            "failed to extract consensus archive into {}",
+            target_dir.display()
+        )
+    })
 }
 
 fn verify_consensus_output_files(
@@ -451,19 +376,13 @@ fn verify_consensus_output_files(
     );
 
     for expected in output_files {
-        let output_path = safe_output_path(consensus_dir, &expected.path)
-            .wrap_err_with(|| format!("path is not safe: {}", expected.path))?;
+        let output_path = consensus_dir.join(&expected.path);
         let metadata = fs::metadata(&output_path).wrap_err_with(|| {
             format!(
                 "failed to stat consensus archive output {}",
                 output_path.display()
             )
         })?;
-        ensure!(
-            metadata.is_file(),
-            "consensus archive output is not a file: {}",
-            expected.path,
-        );
         ensure!(
             metadata.len() == expected.size,
             "consensus archive output size mismatch for {}: expected {}, got {}",
@@ -493,72 +412,6 @@ fn hash_file_blake3(path: &Path) -> eyre::Result<String> {
         .update_reader(file)
         .wrap_err_with(|| format!("failed reading {}", path.display()))?;
     Ok(hasher.finalize().to_hex().to_string())
-}
-
-fn consensus_archive_entry(
-    relative: &str,
-    entry_type: tar::EntryType,
-) -> eyre::Result<Option<(String, PathBuf)>> {
-    let path = safe_relative_path(relative)?;
-    let mut components = path.components();
-    let Some(Component::Normal(root)) = components.next() else {
-        bail!("consensus archive entry path must not be empty");
-    };
-    ensure!(
-        root == std::ffi::OsStr::new(CONSENSUS_ARCHIVE_ROOT),
-        "consensus archive entry must be under `{CONSENSUS_ARCHIVE_ROOT}`: {relative}",
-    );
-    let Some(Component::Normal(partition)) = components.next() else {
-        ensure!(
-            entry_type.is_dir(),
-            "consensus archive root entry must be a directory: {relative}",
-        );
-        return Ok(None);
-    };
-    let partition = partition.to_string_lossy().to_string();
-    ensure!(
-        tempo_consensus::storage::snapshot::is_snapshot_storage_partition(&partition),
-        "consensus archive contains unexpected storage partition: {partition}",
-    );
-    let mut output_relative = PathBuf::from(&partition);
-    let mut is_partition_root = true;
-    for component in components {
-        is_partition_root = false;
-        let Component::Normal(component) = component else {
-            bail!("invalid consensus archive entry path: {relative}");
-        };
-        output_relative.push(component);
-    }
-    if is_partition_root {
-        ensure!(
-            entry_type.is_dir(),
-            "consensus archive partition entry must be a directory: {relative}",
-        );
-    }
-    ensure!(
-        entry_type.is_dir() || entry_type.is_file(),
-        "consensus archive contains a non-file entry",
-    );
-    Ok(Some((partition, output_relative)))
-}
-
-fn safe_output_path(root: &Path, relative: &str) -> eyre::Result<PathBuf> {
-    Ok(root.join(safe_relative_path(relative).wrap_err("path is not safe")?))
-}
-
-fn safe_relative_path(relative: &str) -> eyre::Result<PathBuf> {
-    let path = Path::new(relative);
-    ensure!(path.is_relative(), "path must be relative");
-
-    let mut components = path.components().peekable();
-    ensure!(components.peek().is_some(), "path must not be empty");
-
-    ensure!(
-        components.all(|comp| matches!(comp, Component::Normal(_))),
-        "all path components must be normal (no root, ., .., etc)",
-    );
-
-    Ok(path.to_path_buf())
 }
 
 #[cfg(test)]
@@ -677,15 +530,13 @@ mod tests {
 
         let encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
         let mut builder = tar::Builder::new(encoder);
-        builder
-            .append_dir_all(CONSENSUS_ARCHIVE_ROOT, source.path())
-            .unwrap();
+        builder.append_dir_all("", source.path()).unwrap();
         builder.finish().unwrap();
         let encoder = builder.into_inner().unwrap();
         let archive = encoder.finish().unwrap();
         let archive_file = write_test_archive(&archive);
 
-        extract_zstd_tar_archive(archive_file.path(), target.path()).unwrap();
+        extract_zstd_tar_archive(archive_file.path(), target.path(), false).unwrap();
 
         assert_eq!(
             fs::read(target.path().join(partition_name).join("nested").join("00")).unwrap(),
@@ -694,24 +545,126 @@ mod tests {
     }
 
     #[test]
-    fn extract_zstd_tar_archive_rejects_unexpected_partition() {
+    fn extract_zstd_tar_archive_accepts_new_partition_names() {
         let source = tempfile::tempdir().unwrap();
         let target = tempfile::tempdir().unwrap();
-        let partition = source.path().join("unexpected-partition");
+        let partition_name = "new-storage-partition";
+        let partition = source.path().join(partition_name);
         fs::create_dir_all(&partition).unwrap();
         fs::write(partition.join("00"), b"abc").unwrap();
 
         let encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
         let mut builder = tar::Builder::new(encoder);
+        builder.append_dir_all("", source.path()).unwrap();
+        builder.finish().unwrap();
+        let encoder = builder.into_inner().unwrap();
+        let archive = encoder.finish().unwrap();
+        let archive_file = write_test_archive(&archive);
+
+        extract_zstd_tar_archive(archive_file.path(), target.path(), false).unwrap();
+
+        assert_eq!(
+            fs::read(target.path().join(partition_name).join("00")).unwrap(),
+            b"abc"
+        );
+    }
+
+    #[test]
+    fn extract_zstd_tar_archive_installs_bare_archive_contents() {
+        let target = tempfile::tempdir().unwrap();
+
+        let encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
+        let mut builder = tar::Builder::new(encoder);
+
+        let mut header = tar::Header::new_gnu();
+        header.set_size(3);
+        header.set_cksum();
         builder
-            .append_dir_all(CONSENSUS_ARCHIVE_ROOT, source.path())
+            .append_data(&mut header, "partition/00", &mut &b"abc"[..])
+            .unwrap();
+
+        builder.finish().unwrap();
+        let encoder = builder.into_inner().unwrap();
+        let archive = encoder.finish().unwrap();
+        let archive_file = write_test_archive(&archive);
+
+        extract_zstd_tar_archive(archive_file.path(), target.path(), false).unwrap();
+
+        assert_eq!(
+            fs::read(target.path().join("partition").join("00")).unwrap(),
+            b"abc"
+        );
+    }
+
+    #[test]
+    fn extract_zstd_tar_archive_allows_existing_directories() {
+        let target = tempfile::tempdir().unwrap();
+        let existing = target.path().join("partition");
+        fs::create_dir_all(&existing).unwrap();
+        fs::write(existing.join("old"), b"old").unwrap();
+
+        let source = tempfile::tempdir().unwrap();
+        let partition = source.path().join("partition");
+        fs::create_dir_all(&partition).unwrap();
+        fs::write(partition.join("00"), b"new").unwrap();
+
+        let encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
+        let mut builder = tar::Builder::new(encoder);
+        builder.append_dir_all("", source.path()).unwrap();
+        builder.finish().unwrap();
+        let encoder = builder.into_inner().unwrap();
+        let archive = encoder.finish().unwrap();
+        let archive_file = write_test_archive(&archive);
+
+        extract_zstd_tar_archive(archive_file.path(), target.path(), false).unwrap();
+        assert_eq!(fs::read(existing.join("old")).unwrap(), b"old");
+        assert_eq!(fs::read(existing.join("00")).unwrap(), b"new");
+    }
+
+    #[test]
+    fn extract_zstd_tar_archive_refuses_to_overwrite_existing_file() {
+        let target = tempfile::tempdir().unwrap();
+        let existing = target.path().join("00");
+        fs::write(&existing, b"old").unwrap();
+
+        let encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(3);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "00", &mut &b"new"[..])
             .unwrap();
         builder.finish().unwrap();
         let encoder = builder.into_inner().unwrap();
         let archive = encoder.finish().unwrap();
         let archive_file = write_test_archive(&archive);
 
-        assert!(extract_zstd_tar_archive(archive_file.path(), target.path()).is_err());
+        assert!(extract_zstd_tar_archive(archive_file.path(), target.path(), false).is_err());
+        assert_eq!(fs::read(existing).unwrap(), b"old");
+    }
+
+    #[test]
+    fn extract_zstd_tar_archive_overwrites_existing_file_when_forced() {
+        let target = tempfile::tempdir().unwrap();
+        let existing = target.path().join("00");
+        fs::write(&existing, b"old").unwrap();
+
+        let encoder = zstd::Encoder::new(Vec::new(), 0).unwrap();
+        let mut builder = tar::Builder::new(encoder);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(3);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "00", &mut &b"new"[..])
+            .unwrap();
+        builder.finish().unwrap();
+        let encoder = builder.into_inner().unwrap();
+        let archive = encoder.finish().unwrap();
+        let archive_file = write_test_archive(&archive);
+
+        extract_zstd_tar_archive(archive_file.path(), target.path(), true).unwrap();
+        assert_eq!(fs::read(existing).unwrap(), b"new");
     }
 
     #[tokio::test]
@@ -795,33 +748,5 @@ mod tests {
             )
             .is_err()
         );
-    }
-
-    #[test]
-    fn verify_consensus_output_files_rejects_unsafe_output_path() {
-        let dir = tempfile::tempdir().unwrap();
-
-        assert!(
-            verify_consensus_output_files(
-                dir.path(),
-                &[OutputFileChecksum {
-                    path: "../engine-finalized-blocks-prunable-key/00".to_string(),
-                    size: 3,
-                    blake3: blake3::hash(b"abc").to_hex().to_string(),
-                }],
-            )
-            .is_err()
-        );
-    }
-
-    #[test]
-    fn safe_output_path_rejects_unsafe_paths() {
-        let dir = tempfile::tempdir().unwrap();
-
-        assert!(safe_output_path(dir.path(), "").is_err());
-        assert!(safe_output_path(dir.path(), ".").is_err());
-        assert!(safe_output_path(dir.path(), "../partition").is_err());
-        assert!(safe_output_path(dir.path(), "/partition").is_err());
-        assert!(safe_output_path(dir.path(), "partition/00").is_ok());
     }
 }

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -26,7 +26,6 @@ use tempo_node::node::TempoNode;
 use tempo_telemetry_util::display_duration;
 
 pub(crate) const TEMPO_CONSENSUS_MANIFEST_KEY: &str = "consensus";
-pub(crate) const CONSENSUS_ARCHIVE_ROOT: &str = "consensus";
 const CONSENSUS_ARCHIVE_FILE: &str = "consensus.tar.zst";
 
 type TempoExecutionProvider = BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>;
@@ -341,14 +340,12 @@ fn write_zstd_tar_archive(path: &Path, source_dir: &Path) -> eyre::Result<()> {
     let mut encoder = zstd::Encoder::new(file, 0)?;
     encoder.include_checksum(true)?;
     let mut builder = tar::Builder::new(encoder);
-    builder
-        .append_dir_all(CONSENSUS_ARCHIVE_ROOT, source_dir)
-        .wrap_err_with(|| {
-            format!(
-                "failed to append consensus archive from {}",
-                source_dir.display()
-            )
-        })?;
+    builder.append_dir_all("", source_dir).wrap_err_with(|| {
+        format!(
+            "failed to append consensus archive from {}",
+            source_dir.display()
+        )
+    })?;
 
     builder.finish()?;
     let encoder = builder.into_inner()?;
@@ -495,8 +492,8 @@ mod tests {
             .collect::<Vec<_>>();
         paths.sort();
 
-        assert!(paths.contains(&"consensus/partition-key/nested/00".to_string()));
-        assert!(paths.contains(&"consensus/partition-value/00".to_string()));
+        assert!(paths.contains(&"partition-key/nested/00".to_string()));
+        assert!(paths.contains(&"partition-value/00".to_string()));
     }
 
     #[test]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -193,7 +193,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         let Some(observed) = observed_build_time_multiplier(total_work, work_at_tx_cutoff) else {
             return;
         };
-        let _ = self.build_time_multiplier.fetch_update(
+        let _ = self.build_time_multiplier.try_update(
             Ordering::Relaxed,
             Ordering::Relaxed,
             |current| Some(decay_build_time_multiplier(current, observed)),

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -45,7 +45,7 @@ pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
     let observed = observed.min(u128::from(u64::MAX)) as u64;
 
     let _ =
-        MARSHAL_PERSIST_NS_PER_BYTE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        MARSHAL_PERSIST_NS_PER_BYTE.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(if current == 0 || observed >= current {
                 observed
             } else {

--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
-  # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
-  # the fix, and no patched hickory-proto release exists
-  "RUSTSEC-2026-0118",
   # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
   # and is pulled in transitively by upstream crates with no safe upgrade available.
   "RUSTSEC-2026-0173",


### PR DESCRIPTION
## Summary
- branch from `v1.10.1` and bump workspace package version to `1.10.2`
- backport #6545 only: minimal pruning retention override
- backport #6714 only: reduced snapshot download constraints

## Verification
- `cargo metadata --locked --offline --no-deps --format-version 1`
- `cargo +nightly fmt --check`
- `cargo check --workspace --locked`

Prompted by: @hamdiallam
