### PR TITLE
chore(dex): harden type system by adding `BookId` wrapper

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -12,6 +12,7 @@ pub mod orderbook;
 
 pub use order::Order;
 use order::OrderMapping;
+use orderbook::BookId;
 pub use orderbook::{
     MAX_TICK, MIN_TICK, Orderbook, PRICE_SCALE, RoundingDirection, TickLevel, base_to_quote,
     quote_to_base, tick_to_price, validate_tick_spacing,
@@ -127,10 +128,10 @@ impl StablecoinDEX {
     }
 
     /// Rewrites an order and returns the number of DEX TIP-1060 credits minted.
-    fn rewrite_order(&mut self, order: Order, book_id: u32) -> Result<u64> {
+    fn rewrite_order(&mut self, order: Order, id: BookId) -> Result<u64> {
         StorageCredits::new()
             .track_minted_credits(self.address, || {
-                self.orders[order.order_id()].write_in_book(order, book_id)
+                self.orders[order.order_id()].write_in_book(order, id)
             })
             .map(|(_, credits)| credits)
     }
@@ -166,15 +167,11 @@ impl StablecoinDEX {
     ///
     /// Credits are scoped to the physical `Order` record. Shared book metadata writes performed by
     /// `commit_order_to_book` remain outside this budget and stay in preserve mode.
-    fn write_order_spending_dex_storage_credits(
-        &mut self,
-        order: Order,
-        book_id: u32,
-    ) -> Result<()> {
+    fn write_order_spending_dex_storage_credits(&mut self, order: Order, id: BookId) -> Result<()> {
         let user = order.maker();
         let user_credits = self.dex_storage_credits[user].read()?;
         if user_credits == 0 {
-            return self.orders[order.order_id()].write_in_book(order, book_id);
+            return self.orders[order.order_id()].write_in_book(order, id);
         }
 
         // Clear the user's bookkeeping slot before writing the order record. This makes the
@@ -183,7 +180,7 @@ impl StablecoinDEX {
 
         let mut storage_credits = StorageCredits::new();
         let (_, delta) = storage_credits.with_budget(self.address, user_credits, || {
-            self.orders[order.order_id()].write_in_book(order, book_id)
+            self.orders[order.order_id()].write_in_book(order, id)
         })?;
         let spent_credits = if delta < 0 { (-delta) as u64 } else { 0 };
 
@@ -519,8 +516,7 @@ impl StablecoinDEX {
 
     /// Returns whether `book_key` has a persisted index and its zero-based `book_keys` index.
     pub(crate) fn book_key_index(&self, book_key: B256) -> Result<(bool, u32)> {
-        let id = self.books[book_key].book_id.read()?;
-        Ok((id != 0, id.saturating_sub(1)))
+        self.books[book_key].read().map(|book| book.id().index())
     }
 
     /// Resolves a book key by index from the append-only `book_keys` vector.
@@ -542,8 +538,9 @@ impl StablecoinDEX {
             return Err(StablecoinDEXError::index_already_set().into());
         }
 
-        let id = index + 1;
-        self.books[book_key].book_id.write(id)
+        self.books[book_key]
+            .book_id
+            .write(*BookId::from_index(index))
     }
 
     /// Converts a relative tick to a scaled price. On T2+ validates [`TICK_SPACING`] alignment.
@@ -706,7 +703,7 @@ impl StablecoinDEX {
     /// so takers cannot consume the maker's credit balance.
     fn commit_order_to_book(&mut self, mut order: Order, charge_credits: bool) -> Result<()> {
         let orderbook = self.books[order.book_key()].read()?;
-        let book_id = orderbook.book_id;
+        let book_id = orderbook.id();
         let mut level = self.books[order.book_key()]
             .tick_level_handler(order.tick(), order.is_bid())
             .read()?;

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -17,7 +17,7 @@ use super::{__packing_legacy_order, LegacyOrder, ORDER_VERSION_V1, ORDER_VERSION
 use crate::{
     STABLECOIN_DEX_ADDRESS,
     error::{Result as StorageResult, TempoPrecompileError},
-    stablecoin_dex::{self, StablecoinDEX},
+    stablecoin_dex::{self, StablecoinDEX, orderbook::BookId},
     storage::{
         Handler, HandlerCache, Layout, LayoutCtx, Slot, Storable, StorableType, StorageCtx,
         StorageKey, StorageOps, packing,
@@ -315,15 +315,13 @@ impl OrderHandler {
         }
     }
 
-    /// Writes this order using a known one-based owning book ID, skipping index resolution.
-    /// WARN: `book_id` must be the 1-based book ID. This function handles normalization.
-    pub(crate) fn write_in_book(&mut self, value: Order, book_id: u32) -> StorageResult<()> {
+    /// Writes this order using a known owning book ID, skipping index resolution.
+    pub(crate) fn write_in_book(&mut self, value: Order, book_id: BookId) -> StorageResult<()> {
         self.write_with_book_id(value, Some(book_id))
     }
 
     /// Writes this order, skipping V2 index resolution when a book ID is provided.
-    /// WARN: `known_id` must be the 1-based book ID. This function handles normalization.
-    fn write_with_book_id(&mut self, value: Order, known_id: Option<u32>) -> StorageResult<()> {
+    fn write_with_book_id(&mut self, value: Order, known_id: Option<BookId>) -> StorageResult<()> {
         debug_assert_eq!(value.order_id, self.order_id);
 
         if !StorageCtx.spec().is_t8() {
@@ -336,10 +334,10 @@ impl OrderHandler {
             OrderVersion::V2 => V2Order::SLOTS,
         };
 
-        // If known, use the one-based orderbook id. Otherwise resolve it from storage.
+        // If known, use the book ID. Otherwise resolve it from storage.
         let (is_index_set, book_index) = match known_id {
             None => StablecoinDEX::new().book_key_index(value.book_key)?,
-            Some(id) => (id != 0, id.saturating_sub(1)),
+            Some(id) => id.index(),
         };
 
         let new_slots = if is_index_set {

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -6,6 +6,7 @@ use crate::{
     storage::{Handler, Mapping},
 };
 use alloy::primitives::{Address, B256, U256, keccak256};
+use std::ops::Deref;
 use tempo_contracts::precompiles::StablecoinDEXError;
 use tempo_precompiles_macros::Storable;
 
@@ -102,6 +103,37 @@ pub struct TickLevel {
     pub total_liquidity: u128,
 }
 
+/// 1-based ID assigned to an orderbook's `book_keys` vector index; zero means unset.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BookId(u32);
+
+impl BookId {
+    pub(crate) const UNSET: Self = Self(0);
+
+    pub(crate) fn from_index(index: u32) -> Self {
+        Self(index + 1)
+    }
+
+    /// Returns whether this ID is set and its zero-based `book_keys` vector index.
+    pub(crate) fn index(self) -> (bool, u32) {
+        (self.0 != 0, self.0.saturating_sub(1))
+    }
+}
+
+impl From<u32> for BookId {
+    fn from(id: u32) -> Self {
+        Self(id)
+    }
+}
+
+impl Deref for BookId {
+    type Target = u32;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl TickLevel {
     /// Creates a new empty tick level
     pub fn new() -> Self {
@@ -178,7 +210,7 @@ impl Orderbook {
             quote,
             best_bid_tick: i16::MIN,
             best_ask_tick: i16::MAX,
-            book_id: 0,
+            book_id: *BookId::UNSET,
             bids: Mapping::default(),
             asks: Mapping::default(),
             bid_bitmap: Mapping::default(),
@@ -187,13 +219,17 @@ impl Orderbook {
     }
 
     /// Creates a new orderbook with its zero-based `book_keys` vector index.
-    /// WARN: This function stores the virtual 1-based book ID, not the provided index.
     pub fn new_with_index(base: Address, quote: Address, index: u32) -> Self {
-        let id = index + 1;
+        let id = BookId::from_index(index);
         Self {
-            book_id: id,
+            book_id: *id,
             ..Self::new(base, quote)
         }
+    }
+
+    /// Returns this orderbook's 1-based book ID.
+    pub(crate) fn id(&self) -> BookId {
+        BookId::from(self.book_id)
     }
 
     /// Returns true if this orderbook is initialized


### PR DESCRIPTION
Adds a minimal `BookId` wrapper for the virtual one-based book ID so conversion to/from the real zero-based `book_keys` index is centralized. The persisted `Orderbook.book_id` field remains `u32` to avoid changing storage macro layout behavior.

Validation:
- `cargo +nightly fmt --check`
- `cargo test -p tempo-precompiles stablecoin_dex::tests::test_t8_book_index_state_is_one_based`
- `cargo test -p tempo-precompiles --features test-utils --test storage test_stablecoin_dex_layout`

Prompted by: @0xrusowsky