### PR TITLE
fix(dex): avoid masking unset book id

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -6,7 +6,10 @@ use tempo_contracts::precompiles::IStablecoinDEX;
 
 use crate::{
     Precompile, charge_input_cost, dispatch, mutate, mutate_void, preserve_storage_credits,
-    stablecoin_dex::{StablecoinDEX, orderbook::compute_book_key},
+    stablecoin_dex::{
+        StablecoinDEX,
+        orderbook::{BookId, compute_book_key},
+    },
     view,
 };
 
@@ -82,7 +85,10 @@ impl Precompile for StablecoinDEX {
                     storageCredits(call) => view(call, |c| self.storage_credits(c.user)),
 
                     #[schedule(since = T8)]
-                    bookIndexForKey(call) => view(call, |c| Ok(self.book_key_index(c.bookKey)?.into())),
+                    bookIndexForKey(call) => view(call, |c| {
+                        let index = self.book_key_index(c.bookKey)?;
+                        Ok((index.is_some(), index.unwrap_or(*BookId::UNSET)).into())
+                    }),
                     #[schedule(since = T8)]
                     bookKeyForIndex(call) => view(call, |c| self.book_key_for_index(c.index)),
                     #[schedule(since = T8)]

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -514,11 +514,13 @@ impl StablecoinDEX {
         self.book_keys.read()
     }
 
-    /// Returns whether `book_key` has a persisted index and its zero-based `book_keys` index.
-    pub(crate) fn book_key_index(&self, book_key: B256) -> Result<(bool, u32)> {
-        self.books[book_key]
-            .read()
-            .and_then(|book| book.id().index())
+    /// Returns the zero-based `book_keys` index persisted for `book_key`, if one is set.
+    pub(crate) fn book_key_index(&self, book_key: B256) -> Result<Option<u32>> {
+        let book = self.books[book_key].read()?;
+        if !book.is_initialized() {
+            return Err(StablecoinDEXError::pair_does_not_exist().into());
+        }
+        Ok(book.id().index())
     }
 
     /// Resolves a book key by index from the append-only `book_keys` vector.
@@ -532,8 +534,7 @@ impl StablecoinDEX {
     /// Persists the `book_keys` vector index for an existing orderbook.
     pub fn set_book_index(&mut self, index: u32) -> Result<()> {
         let book_key = self.book_key_for_index(index)?;
-        let (is_index_set, current_index) = self.book_key_index(book_key)?;
-        if is_index_set {
+        if let Some(current_index) = self.book_key_index(book_key)? {
             if index == current_index {
                 return Ok(());
             }
@@ -1914,11 +1915,38 @@ mod tests {
 
             exchange.create_pair(base)?;
 
-            assert_eq!(exchange.book_key_index(book_key)?, (true, 0));
+            assert_eq!(exchange.book_key_index(book_key)?, Some(0));
             assert_eq!(exchange.book_key_for_index(0)?, book_key);
 
             exchange.set_book_index(0)?;
-            assert_eq!(exchange.book_key_index(book_key)?, (true, 0));
+            assert_eq!(exchange.book_key_index(book_key)?, Some(0));
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t8_book_index_rejects_uninitialized_book_key() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let book_key = B256::random();
+            exchange.book_keys.push(book_key)?;
+
+            assert!(matches!(
+                exchange.book_key_index(book_key),
+                Err(TempoPrecompileError::StablecoinDEX(
+                    StablecoinDEXError::PairDoesNotExist(_)
+                ))
+            ));
+            assert!(matches!(
+                exchange.set_book_index(0),
+                Err(TempoPrecompileError::StablecoinDEX(
+                    StablecoinDEXError::PairDoesNotExist(_)
+                ))
+            ));
 
             Ok(())
         })

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -335,12 +335,12 @@ impl OrderHandler {
         };
 
         // If known, use the book ID. Otherwise resolve it from storage.
-        let (is_index_set, book_index) = match known_id {
+        let book_index = match known_id {
             None => StablecoinDEX::new().book_key_index(value.book_key)?,
-            Some(id) => id.index()?,
+            Some(id) => id.index(),
         };
 
-        let new_slots = if is_index_set {
+        let new_slots = if let Some(book_index) = book_index {
             V2Order::new(value, book_index).store(self, self.base_slot, LayoutCtx::FULL)?;
             V2Order::SLOTS
         } else {
@@ -500,8 +500,8 @@ mod tests {
     use super::*;
     use crate::{
         stablecoin_dex::{
-            IStablecoinDEX, MIN_ORDER_AMOUNT, StablecoinDEX,
-            orderbook::{RoundingDirection, base_to_quote},
+            IStablecoinDEX, MIN_ORDER_AMOUNT, StablecoinDEX, StablecoinDEXError,
+            orderbook::{Orderbook, RoundingDirection, base_to_quote},
         },
         storage::{ContractStorage, Handler, StorageCtx, hashmap::HashMapStorageProvider},
         storage_credits::StorageCredits,
@@ -514,6 +514,8 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
 
     const TEST_MAKER: Address = address!("0x1111111111111111111111111111111111111111");
+    const TEST_BASE: Address = address!("0x2222222222222222222222222222222222222222");
+    const TEST_QUOTE: Address = address!("0x3333333333333333333333333333333333333333");
     const TEST_BOOK_KEY: B256 =
         b256!("0x0000000000000000000000000000000000000000000000000000000000000001");
 
@@ -969,12 +971,7 @@ mod tests {
                 V1Order::new(order).store(&mut storage, handler.base_slot, LayoutCtx::FULL)
             }
             OrderVersion::V2 => {
-                if !exchange.book_key_index(order.book_key)?.0 {
-                    let index = exchange.book_keys.len()? as u32;
-                    exchange.book_keys.push(order.book_key)?;
-                    exchange.set_book_index(index)?;
-                }
-                let (_, book_index) = exchange.book_key_index(order.book_key)?;
+                let book_index = ensure_test_book_index(exchange, order.book_key)?;
                 let handler = &exchange.orders[order.order_id()];
                 let mut storage = handler.clone();
                 V2Order::new(order, book_index).store(
@@ -983,6 +980,26 @@ mod tests {
                     LayoutCtx::FULL,
                 )
             }
+        }
+    }
+
+    fn ensure_test_book_index(exchange: &mut StablecoinDEX, book_key: B256) -> StorageResult<u32> {
+        match exchange.book_key_index(book_key) {
+            Ok(Some(index)) => Ok(index),
+            Ok(None) => {
+                let index = exchange.book_keys.len()? as u32;
+                exchange.book_keys.push(book_key)?;
+                exchange.set_book_index(index)?;
+                Ok(index)
+            }
+            Err(TempoPrecompileError::StablecoinDEX(StablecoinDEXError::PairDoesNotExist(_))) => {
+                let index = exchange.book_keys.len()? as u32;
+                exchange.books[book_key]
+                    .write(Orderbook::new_with_index(TEST_BASE, TEST_QUOTE, index))?;
+                exchange.book_keys.push(book_key)?;
+                Ok(index)
+            }
+            Err(err) => Err(err),
         }
     }
 

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -114,14 +114,9 @@ impl BookId {
         Self(index + 1)
     }
 
-    /// Returns whether this ID is set and its zero-based `book_keys` vector index.
-    pub(crate) fn index(self) -> Result<(bool, u32)> {
-        Ok((
-            self.0 != 0,
-            self.0
-                .checked_sub(1)
-                .ok_or_else(StablecoinDEXError::pair_does_not_exist)?,
-        ))
+    /// Returns the zero-based `book_keys` vector index, if this ID is set.
+    pub(crate) fn index(self) -> Option<u32> {
+        self.0.checked_sub(1)
     }
 }
 

--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -122,7 +122,11 @@ function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
 
 `setIndexForKey` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index + 1` on the orderbook record. If the orderbook already has `bookKeyIdx != 0`, `setIndexForKey` MUST be idempotent when the supplied `index + 1` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index + 1` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
 
-`bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It returns whether `bookKeyIdx != 0` and the 0-based index `bookKeyIdx - 1` when set. `bookKeyForIndex` MUST fail if the requested index is not present in `book_keys`.
+`bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It MUST fail with
+`PairDoesNotExist` if `bookKey` does not identify an initialized orderbook. For an initialized
+orderbook, it returns `(false, 0)` when `bookKeyIdx == 0`; otherwise it returns `(true,
+bookKeyIdx - 1)`. `bookKeyForIndex` MUST fail with `PairDoesNotExist` if the requested index is
+not present in `book_keys`.
 
 ## Read behavior
 


### PR DESCRIPTION
Closes https://github.com/tempoxyz/tempo/pull/6691#discussion_r3538857038

Stops `BookId::index` from mapping the unset sentinel to book index zero. Internal book-index lookup now returns `Option<u32>` and rejects uninitialized book state with `PairDoesNotExist`, while the public ABI reports `(false, UNSET)` for initialized books whose persisted index is not set.

Updates TIP-1087 to specify the same cases for `bookIndexForKey`: missing or uninitialized book keys fail with `PairDoesNotExist`; initialized orderbooks with `bookKeyIdx == 0` return `(false, 0)`.

Validated with:

```text
cargo +nightly fmt --package tempo-precompiles --check
cargo test -p tempo-precompiles test_t8_book_index --lib
```