### PR TITLE
Add Grafana group-by value filter

### DIFF
--- a/contrib/bench/grafana/dashboards/tempo-benchmarking.json
+++ b/contrib/bench/grafana/dashboards/tempo-benchmarking.json
@@ -141,7 +141,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_total_transactions_last{namespace=\"$namespace\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_total_transactions_last{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
@@ -240,7 +240,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(reth_tempo_payload_builder_block_time_millis{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (quantile) < 5000",
+          "expr": "avg(reth_tempo_payload_builder_block_time_millis{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (quantile) < 5000",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -351,7 +351,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_transaction_pool_total_transactions{namespace=\"$namespace\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_transaction_pool_total_transactions{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
@@ -449,7 +449,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_transaction_pool_aa_2d_total_transactions{namespace=\"$namespace\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_transaction_pool_aa_2d_total_transactions{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
@@ -561,7 +561,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_total_transaction_execution_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_total_transaction_execution_duration_seconds{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -660,7 +660,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_payload_finalization_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_payload_finalization_duration_seconds{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -759,7 +759,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_payload_build_duration_seconds{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_payload_build_duration_seconds{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -858,7 +858,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_tempo_payload_builder_gas_per_second_last{namespace=\"$namespace\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_tempo_payload_builder_gas_per_second_last{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
@@ -970,7 +970,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_sync_execution_execution_histogram{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_sync_execution_execution_histogram{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -1069,7 +1069,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_sync_block_validation_state_root_histogram{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_sync_block_validation_state_root_histogram{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -1168,7 +1168,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_consensus_engine_beacon_new_payload_latency{namespace=\"$namespace\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_consensus_engine_beacon_new_payload_latency{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=~\"0.5|0.9|0.99\"}) by (job, quantile), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}} p{{quantile}}",
           "range": true,
           "refId": "A"
@@ -1267,7 +1267,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "label_replace(avg(reth_consensus_engine_beacon_new_payload_gas_per_second_last{namespace=\"$namespace\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
+          "expr": "label_replace(avg(reth_consensus_engine_beacon_new_payload_gas_per_second_last{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\"}) by (job), \"job\", \"$1\", \"job\", \"^$namespace/(.*)\")",
           "legendFormat": "{{job}}",
           "range": true,
           "refId": "A"
@@ -1379,7 +1379,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", container=\"tempo-node\"}[5m])) by (pod)",
+          "expr": "avg(rate(container_cpu_usage_seconds_total{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", container=\"tempo-node\"}[5m])) by (pod)",
           "legendFormat": "{{pod}} - usage",
           "range": true,
           "refId": "A"
@@ -1390,7 +1390,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"cpu\", container=\"tempo-node\"}) by (pod)",
+          "expr": "avg(kube_pod_container_resource_limits{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", resource=\"cpu\", container=\"tempo-node\"}) by (pod)",
           "instant": false,
           "legendFormat": "{{pod}} - limit",
           "range": true,
@@ -1490,7 +1490,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(container_memory_working_set_bytes{namespace=\"$namespace\", container=\"tempo-node\"}) by (pod)",
+          "expr": "avg(container_memory_working_set_bytes{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", container=\"tempo-node\"}) by (pod)",
           "legendFormat": "{{pod}} - usage",
           "range": true,
           "refId": "A"
@@ -1501,7 +1501,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(kube_pod_container_resource_limits{namespace=\"$namespace\", resource=\"memory\", container=\"tempo-node\"}) by (pod)",
+          "expr": "avg(kube_pod_container_resource_limits{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", resource=\"memory\", container=\"tempo-node\"}) by (pod)",
           "instant": false,
           "legendFormat": "{{pod}} - limit",
           "range": true,
@@ -1614,7 +1614,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(reth_sync_state_provider_account_fetch_latency{namespace=\"$namespace\", quantile=\"0.5\"} < 0.0001) by (source)",
+          "expr": "avg(reth_sync_state_provider_account_fetch_latency{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=\"0.5\"} < 0.0001) by (source)",
           "legendFormat": "{{source}} p50",
           "range": true,
           "refId": "A"
@@ -1713,7 +1713,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(reth_sync_state_provider_storage_fetch_latency{namespace=\"$namespace\", quantile=\"0.5\"} < 0.001) by (source)",
+          "expr": "avg(reth_sync_state_provider_storage_fetch_latency{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=\"0.5\"} < 0.001) by (source)",
           "legendFormat": "{{source}} p50",
           "range": true,
           "refId": "A"
@@ -1812,7 +1812,7 @@
             "uid": "Prometheus"
           },
           "editorMode": "code",
-          "expr": "avg(reth_sync_state_provider_code_fetch_latency{namespace=\"$namespace\", quantile=\"0.5\"} < 0.00001) by (source)",
+          "expr": "avg(reth_sync_state_provider_code_fetch_latency{namespace=\"$namespace\", ${group_by}=~\"$group_by_value\", quantile=\"0.5\"} < 0.00001) by (source)",
           "legendFormat": "{{source}} p50",
           "range": true,
           "refId": "A"
@@ -1940,6 +1940,74 @@
           "qryType": 1,
           "query": "label_values(reth_info,namespace)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "benchmark_run",
+          "value": "benchmark_run"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Group By",
+        "multi": false,
+        "name": "group_by",
+        "options": [
+          {
+            "selected": true,
+            "text": "benchmark_run",
+            "value": "benchmark_run"
+          },
+          {
+            "selected": false,
+            "text": "benchmark_id",
+            "value": "benchmark_id"
+          },
+          {
+            "selected": false,
+            "text": "job",
+            "value": "job"
+          },
+          {
+            "selected": false,
+            "text": "pod",
+            "value": "pod"
+          },
+          {
+            "selected": false,
+            "text": "instance",
+            "value": "instance"
+          }
+        ],
+        "query": "benchmark_run,benchmark_id,job,pod,instance",
+        "type": "custom"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "Prometheus"
+        },
+        "definition": "label_values({namespace=\"$namespace\"}, $group_by)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Group By Value",
+        "multi": false,
+        "name": "group_by_value",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values({namespace=\"$namespace\"}, $group_by)",
+          "refId": "PrometheusVariableQueryEditor-GroupByValue"
         },
         "refresh": 1,
         "regex": "",

--- a/tempo.nu
+++ b/tempo.nu
@@ -899,7 +899,7 @@ def grafana-performance-url [benchmark_id: string, from_ms: int, to_ms: int] {
 
     let from = (iso-from-epoch-ms $from_ms)
     let to = (iso-from-epoch-ms $to_ms)
-    $"https://tempoxyz.grafana.net/d/performance/performance?orgId=1&from=($from)&to=($to)&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=($benchmark_id)&var-group_by=benchmark_run"
+    $"https://tempoxyz.grafana.net/d/performance/performance?orgId=1&from=($from)&to=($to)&timezone=browser&var-datasource=efk1hcn87dnnkd&var-filter_label=benchmark_id&var-filter_value=($benchmark_id)&var-group_by=benchmark_id&var-group_by_value=($benchmark_id)"
 }
 
 def internal-perf-url [clickhouse_run_id: string] {


### PR DESCRIPTION
## Summary
- add a `group_by_value` dashboard variable driven by the selected `group_by` label
- apply the selected group-by value as a matcher across namespace-scoped benchmark/resource charts
- update generated Grafana benchmark URLs to pass the benchmark id as the selected group-by value

## Validation
- `jq empty contrib/bench/grafana/dashboards/tempo-benchmarking.json`
- `nu --commands 'source tempo.nu'`\n\nPrompted by: @shekhirin