### PR TITLE
fix(tip-1070): reject trailing DKG outcome bytes

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -19,7 +19,7 @@ use alloy_signer_local::PrivateKeySigner;
 use alloy_signer_trezor::{HDPath as TrezorHDPath, TrezorSigner};
 use alloy_sol_types::SolCall;
 use clap::Subcommand;
-use commonware_codec::{DecodeExt as _, Encode as _, ReadExt as _};
+use commonware_codec::{DecodeExt as _, Encode as _};
 use commonware_consensus::types::{Epocher as _, FixedEpocher, Height};
 use commonware_cryptography::{
     Signer as _,
@@ -1152,7 +1152,7 @@ impl ValidatorInfo {
                 ));
             }
 
-            let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
+            let dkg_outcome = OnchainDkgOutcome::decode(extra_data.as_ref())
                 .wrap_err("failed to decode DKG outcome from extra_data")?;
 
             let key = PublicKey::decode(&mut &pubkey_bytes[..])
@@ -1282,7 +1282,7 @@ impl Info {
             ));
         }
 
-        let dkg_outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
+        let dkg_outcome = OnchainDkgOutcome::decode(extra_data.as_ref())
             .wrap_err("failed to decode DKG outcome from extra_data")?;
 
         let next_dkg_result = provider

--- a/crates/chainspec/src/network_identity.rs
+++ b/crates/chainspec/src/network_identity.rs
@@ -52,9 +52,8 @@ impl NetworkIdentity {
     }
 
     pub(crate) fn from_extra_data(extra_data: &[u8]) -> eyre::Result<Self> {
-        let mut extra_data = extra_data;
         let outcome =
-            OnchainDkgOutcome::read(&mut extra_data).wrap_err("unable to parse dkg outcome")?;
+            OnchainDkgOutcome::decode(extra_data).wrap_err("unable to parse dkg outcome")?;
 
         Ok(Self {
             from_epoch: outcome.epoch.get(),

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -17,7 +17,7 @@ use std::{
 
 use alloy_consensus::BlockHeader;
 use alloy_primitives::{B256, Bytes};
-use commonware_codec::{Encode as _, EncodeSize as _, ReadExt as _};
+use commonware_codec::{Encode as _, EncodeSize as _};
 use commonware_consensus::{
     Heightable as _,
     simplex::Plan,
@@ -1096,7 +1096,7 @@ async fn verify_header(
                 "failed getting public dkg ceremony outcome; cannot verify end \
                 of epoch block",
             )?;
-        let block_outcome = OnchainDkgOutcome::read(&mut block.header().extra_data().as_ref())
+        let block_outcome = OnchainDkgOutcome::decode(block.header().extra_data().as_ref())
             .wrap_err(
                 "failed decoding extra data header as DKG ceremony \
                 outcome; cannot verify end of epoch block",

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -762,7 +762,7 @@ where
         info!("reached last block of epoch; reading DKG outcome from header");
 
         let onchain_outcome =
-            tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
+            tempo_dkg_onchain_artifacts::OnchainDkgOutcome::decode(header.extra_data().as_ref())
                 .expect("the last block of an epoch must contain the DKG outcome");
 
         info!("reading validator from contract");
@@ -1299,7 +1299,7 @@ async fn read_outcome_from_boundary(
             format!("failed to read latest boundary header at height `{boundary}`")
         })?;
 
-    OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
+    OnchainDkgOutcome::decode(header.extra_data().as_ref())
         .wrap_err("the boundary block did not contain the on-chain DKG outcome")
 }
 

--- a/crates/consensus/src/epoch/manager/actor.rs
+++ b/crates/consensus/src/epoch/manager/actor.rs
@@ -44,7 +44,6 @@
 use std::{collections::BTreeMap, num::NonZeroUsize};
 
 use alloy_consensus::BlockHeader as _;
-use commonware_codec::ReadExt as _;
 use commonware_consensus::{
     Reporters,
     marshal::Update,
@@ -474,8 +473,8 @@ where
                 .await
                 .await
                 .map_err(|_| eyre!("marshal never returned the block"))?;
-            let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
-                &mut block.header().extra_data().as_ref(),
+            let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::decode(
+                block.header().extra_data().as_ref(),
             )
             .expect("boundary blocks must contain DKG outcomes");
             self.config.scheme_provider.register(

--- a/crates/consensus/src/follow/driver.rs
+++ b/crates/consensus/src/follow/driver.rs
@@ -7,7 +7,7 @@
 use std::sync::Arc;
 
 use alloy_consensus::BlockHeader as _;
-use commonware_codec::{DecodeExt as _, ReadExt as _};
+use commonware_codec::DecodeExt as _;
 use commonware_consensus::{
     Epochable, Heightable as _, Reporter, marshal,
     simplex::{
@@ -75,8 +75,8 @@ pub(super) fn try_init<TContext>(
     } else {
         Height::zero()
     };
-    let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
-        &mut config
+    let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::decode(
+        config
             .execution_node
             .provider
             .header_by_number(last_boundary.get())
@@ -271,8 +271,8 @@ where
                 return Ok(());
             };
 
-            let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
-                &mut boundary_block.header().extra_data().as_ref(),
+            let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::decode(
+                boundary_block.header().extra_data().as_ref(),
             )
             .wrap_err_with(|| {
                 format!(
@@ -405,8 +405,8 @@ where
             .expect("strategy valid for all heights");
 
         if epoch_info.last() == block.height() {
-            let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(
-                &mut block.header().extra_data().as_ref(),
+            let onchain_outcome = tempo_dkg_onchain_artifacts::OnchainDkgOutcome::decode(
+                block.header().extra_data().as_ref(),
             )
             .expect("boundary blocks must contain DKG outcomes");
 

--- a/crates/consensus/src/peer_manager/actor.rs
+++ b/crates/consensus/src/peer_manager/actor.rs
@@ -7,7 +7,6 @@ use std::{
 
 use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_primitives::B256;
-use commonware_codec::ReadExt as _;
 use commonware_consensus::{
     Heightable as _,
     marshal::Update,
@@ -229,13 +228,12 @@ where
             read_header_at_height(&self.execution_node, highest_finalized)
                 .wrap_err("failed reading highest finalized header")?;
 
-        let onchain_outcome =
-            OnchainDkgOutcome::read(&mut latest_boundary_header.extra_data().as_ref())
-                .wrap_err_with(|| {
-                    format!(
-                        "boundary block at `{latest_boundary}` did not contain a valid DKG outcome"
-                    )
-                })?;
+        let onchain_outcome = OnchainDkgOutcome::decode(
+            latest_boundary_header.extra_data().as_ref(),
+        )
+        .wrap_err_with(|| {
+            format!("boundary block at `{latest_boundary}` did not contain a valid DKG outcome")
+        })?;
 
         let peers = PeersBuilder::with_dkg_outcome(&onchain_outcome)
             .resolve_at_hash(

--- a/crates/dkg-onchain-artifacts/src/lib.rs
+++ b/crates/dkg-onchain-artifacts/src/lib.rs
@@ -3,7 +3,7 @@
 use std::num::NonZeroU32;
 
 use bytes::{Buf, BufMut};
-use commonware_codec::{EncodeSize, RangeCfg, Read, ReadExt, Write};
+use commonware_codec::{DecodeExt, EncodeSize, RangeCfg, Read, ReadExt, Write};
 use commonware_consensus::types::Epoch;
 use commonware_cryptography::{
     bls12381::{
@@ -44,6 +44,11 @@ pub struct OnchainDkgOutcome {
 }
 
 impl OnchainDkgOutcome {
+    /// Decode an on-chain DKG outcome and reject any trailing bytes.
+    pub fn decode(buf: impl Buf) -> Result<Self, commonware_codec::Error> {
+        <Self as DecodeExt<()>>::decode(buf)
+    }
+
     pub fn dealers(&self) -> &ordered::Set<PublicKey> {
         self.output.dealers()
     }
@@ -107,7 +112,7 @@ impl EncodeSize for OnchainDkgOutcome {
 mod tests {
     use std::iter::repeat_with;
 
-    use commonware_codec::{Encode as _, ReadExt as _};
+    use commonware_codec::{Encode as _, Error};
     use commonware_consensus::types::Epoch;
     use commonware_cryptography::{Signer as _, bls12381::dkg, ed25519::PrivateKey};
     use commonware_math::algebra::Random as _;
@@ -141,9 +146,40 @@ mod tests {
             is_next_full_dkg: false,
         };
         let bytes = on_chain.encode();
-        assert_eq!(
-            OnchainDkgOutcome::read(&mut bytes.as_ref()).unwrap(),
-            on_chain,
-        );
+        assert_eq!(OnchainDkgOutcome::decode(bytes.as_ref()).unwrap(), on_chain,);
+    }
+
+    #[test]
+    fn onchain_dkg_outcome_decode_rejects_trailing_bytes() {
+        let mut rng = rand_08::rngs::StdRng::seed_from_u64(42);
+
+        let mut player_keys = repeat_with(|| PrivateKey::random(&mut rng))
+            .take(10)
+            .collect::<Vec<_>>();
+        player_keys.sort_by_key(|key| key.public_key());
+        let (output, _shares) = dkg::deal::<_, _, N3f1>(
+            &mut rng,
+            Default::default(),
+            ordered::Set::try_from_iter(player_keys.iter().map(|key| key.public_key())).unwrap(),
+        )
+        .unwrap();
+
+        let on_chain = OnchainDkgOutcome {
+            epoch: Epoch::new(42),
+            output,
+            next_players: ordered::Set::try_from_iter(
+                player_keys.iter().map(|key| key.public_key()),
+            )
+            .unwrap(),
+            is_next_full_dkg: false,
+        };
+
+        let mut bytes = on_chain.encode().to_vec();
+        bytes.push(0xff);
+
+        assert!(matches!(
+            OnchainDkgOutcome::decode(bytes.as_slice()),
+            Err(Error::ExtraData(1))
+        ));
     }
 }

--- a/crates/e2e/src/tests/dkg/common.rs
+++ b/crates/e2e/src/tests/dkg/common.rs
@@ -2,7 +2,6 @@
 
 use std::time::Duration;
 
-use commonware_codec::ReadExt as _;
 use commonware_consensus::types::{Epoch, Epocher as _, FixedEpocher, Height};
 use commonware_runtime::{Clock as _, deterministic::Context};
 use commonware_utils::NZU64;
@@ -39,7 +38,7 @@ pub(crate) fn read_outcome_from_validator(
         return None;
     }
 
-    Some(OnchainDkgOutcome::read(&mut extra_data.as_ref()).expect("valid DKG outcome"))
+    Some(OnchainDkgOutcome::decode(extra_data.as_ref()).expect("valid DKG outcome"))
 }
 
 /// Waits for and reads the DKG outcome from the last block of the given epoch.

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -14,7 +14,7 @@ use alloy_evm::{
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolCall;
-use commonware_codec::{DecodeExt, ReadExt};
+use commonware_codec::DecodeExt;
 use commonware_cryptography::{
     Verifier,
     ed25519::{PublicKey, Signature},
@@ -252,7 +252,7 @@ where
         }
 
         let outcome =
-            tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(&mut self.extra_data.as_ref())
+            tempo_dkg_onchain_artifacts::OnchainDkgOutcome::decode(self.extra_data.as_ref())
                 .map_err(|err| {
                     BlockValidationError::msg(format!(
                         "failed decoding boundary block extra data as DKG outcome: {err}"

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -631,7 +631,7 @@ fn read_private_genesis_outcome(manifest_dir: &Path) -> eyre::Result<OnchainDkgO
 fn decode_outcome(hex: &str) -> eyre::Result<OnchainDkgOutcome> {
     let bytes = const_hex::decode(hex.trim_start_matches("0x"))
         .wrap_err("failed decoding shadow_dkg_outcome hex")?;
-    OnchainDkgOutcome::read(&mut bytes.as_slice())
+    OnchainDkgOutcome::decode(bytes.as_slice())
         .wrap_err("failed decoding shadow_dkg_outcome payload")
 }
 
@@ -1003,7 +1003,7 @@ where
         "patched boundary block `{block_number}` has canonical hash `{canonical_hash}`, expected `{expected_hash}`",
     );
 
-    let decoded = OnchainDkgOutcome::read(&mut header.inner.extra_data.as_ref())
+    let decoded = OnchainDkgOutcome::decode(header.inner.extra_data.as_ref())
         .wrap_err("patched boundary header did not contain a valid generated shadow DKG outcome")?;
     ensure!(
         decoded.players() == expected_outcome.players()

--- a/xtask/src/get_dkg_outcome.rs
+++ b/xtask/src/get_dkg_outcome.rs
@@ -4,7 +4,7 @@ use alloy::{
     primitives::{B256, Bytes},
     providers::{Provider, ProviderBuilder},
 };
-use commonware_codec::{Encode as _, ReadExt as _};
+use commonware_codec::Encode as _;
 use commonware_consensus::types::{Epoch, Epocher as _, FixedEpocher};
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_utils::{N3f1, NZU64};
@@ -107,7 +107,7 @@ impl GetDkgOutcome {
             block_number
         );
 
-        let outcome = OnchainDkgOutcome::read(&mut extra_data.as_ref())
+        let outcome = OnchainDkgOutcome::decode(extra_data.as_ref())
             .wrap_err("failed to parse DKG outcome from extra_data")?;
 
         let sharing = outcome.sharing();


### PR DESCRIPTION
Rejects boundary DKG `extra_data` with trailing bytes by using full-buffer decoding for `OnchainDkgOutcome` across EL, CL, CLI, and tooling readers.

This keeps boundary headers canonical instead of accepting `outcome.encode()` followed by arbitrary suffix bytes.

Validation:
- `rustup run nightly cargo fmt`
- `cargo test -p tempo-dkg-onchain-artifacts`
- `cargo check -p tempo-evm -p tempo-consensus -p tempo-chainspec -p tempo -p tempo-xtask`
- `git diff --check`