### PR TITLE
fix(tip-1070): store current committee epoch

### DIFF
--- a/crates/contracts/src/precompiles/current_committee.rs
+++ b/crates/contracts/src/precompiles/current_committee.rs
@@ -12,6 +12,6 @@ crate::sol! {
             view
             returns (uint64 epoch, bytes32[] memory publicKeys);
 
-        function setCommitteeMembers(bytes32[] calldata publicKeys) external;
+        function setCommitteeMembers(uint64 epoch, bytes32[] calldata publicKeys) external;
     }
 }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -258,6 +258,7 @@ where
                         "failed decoding boundary block extra data as DKG outcome: {err}"
                     ))
                 })?;
+        let epoch = outcome.epoch.get();
         let public_keys = outcome
             .players()
             .iter()
@@ -265,6 +266,7 @@ where
             .collect();
 
         let calldata = ICurrentCommittee::setCommitteeMembersCall {
+            epoch,
             publicKeys: public_keys,
         }
         .abi_encode()

--- a/crates/precompiles/src/current_committee/dispatch.rs
+++ b/crates/precompiles/src/current_committee/dispatch.rs
@@ -65,6 +65,7 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut committee = CurrentCommittee::new();
             let call = ICurrentCommittee::setCommitteeMembersCall {
+                epoch: 42,
                 publicKeys: vec![B256::repeat_byte(0x11), B256::repeat_byte(0x22)],
             };
 
@@ -75,7 +76,7 @@ mod tests {
             assert!(system.is_ok_and(|output| output.is_success()));
 
             let ret = committee.get_committee_members()?;
-            assert_eq!(ret.epoch, 2);
+            assert_eq!(ret.epoch, call.epoch);
             assert_eq!(ret.publicKeys, call.publicKeys);
             Ok(())
         })

--- a/crates/precompiles/src/current_committee/mod.rs
+++ b/crates/precompiles/src/current_committee/mod.rs
@@ -6,26 +6,27 @@ use tempo_contracts::precompiles::CurrentCommitteeError;
 pub use tempo_contracts::precompiles::{CURRENT_COMMITTEE_ADDRESS, ICurrentCommittee};
 use tempo_precompiles_macros::contract;
 
-use crate::{
-    error::Result,
-    storage::{ContractStorage, Handler},
-};
+use crate::{error::Result, storage::Handler};
 use alloy::primitives::{Address, B256};
 
 #[contract(addr = CURRENT_COMMITTEE_ADDRESS)]
 pub struct CurrentCommittee {
+    epoch: u64,
     ids: Vec<B256>,
 }
 
 impl CurrentCommittee {
     pub fn get_committee_members(&self) -> Result<ICurrentCommittee::getCommitteeMembersReturn> {
-        let current_epoch = self.storage().epoch(self.storage().block_number());
         Ok(ICurrentCommittee::getCommitteeMembersReturn {
-            epoch: current_epoch,
+            epoch: self.epoch.read()?,
             publicKeys: self.ids.read()?,
         })
     }
 
+    /// Stores the next epoch's committee.
+    ///
+    /// Correctness assumes this system-only entrypoint is invoked only while
+    /// processing the last block of an epoch.
     pub fn set_committee_members(
         &mut self,
         msg_sender: Address,
@@ -35,6 +36,7 @@ impl CurrentCommittee {
             return Err(CurrentCommitteeError::unauthorized().into());
         }
 
+        self.epoch.write(call.epoch)?;
         self.ids.write(call.publicKeys)?;
         Ok(())
     }

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -185,7 +185,7 @@ mod tests {
     fn test_is_precompile_address() {
         for &(address, activated) in SYSTEM_PRECOMPILES {
             assert!(address.is_precompile(activated));
-            assert!(address.is_precompile(TempoHardfork::T7));
+            assert!(address.is_precompile(TempoHardfork::T8));
 
             if activated != TempoHardfork::Genesis {
                 assert!(!address.is_precompile(TempoHardfork::Genesis));

--- a/tips/tip-1070.md
+++ b/tips/tip-1070.md
@@ -70,26 +70,29 @@ function getCommitteeMembers()
     returns (uint64 epoch, bytes32[] memory publicKeys);
 ```
 
-Outside the transitional boundary-block post-state described below, `getCommitteeMembers()` MUST return the committee used by consensus for the epoch containing the block at which the call is evaluated.
-The returned `epoch` MUST be computed from the block number at which the call is evaluated and the chain's epoch schedule.
+`getCommitteeMembers()` MUST return the stored effective committee record. Outside the transitional boundary-block post-state described below, this is the committee used by consensus for the epoch containing the block at which the call is evaluated.
 
-Outside the transitional boundary-block post-state described below, the returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for that epoch. The execution-layer writer MUST NOT infer whether DKG succeeded or failed; consensus has already selected the DKG outcome whose `players` vector encodes the committee members for the rising epoch.
+The returned `publicKeys` MUST be ordered exactly as the `players` vector in the DKG outcome selected for the returned `epoch`. The execution-layer writer MUST NOT infer whether DKG succeeded or failed; consensus has already selected the DKG outcome whose `players` vector encodes the committee members for the rising epoch.
 
 ## Contract Storage
 
-The committee-state component MUST persist only the current committee member public keys:
+The committee-state component MUST persist only the current effective committee record:
 
 ```solidity
+uint64 epoch;
 bytes32[] publicKeys;
 ```
+
+This storage order is normative: `epoch` is stored in slot `0`, and the
+`publicKeys` array slot is slot `1`.
 
 ## System Call Execution
 
 The VM MUST execute the committee update as a system call while processing the last block of epoch `E`.
 
-The system call MUST run from a post-execution hook after all user transactions in the last block of epoch `E` have executed. It is not a user transaction and MUST NOT appear in the transaction list. Transactions in the last block of epoch `E` MUST continue to observe the committee for epoch `E`; the persisted committee for epoch `E+1` MUST only become visible to EVM execution in the first block of epoch `E+1`.
+The system call MUST run from a post-execution hook after all user transactions in the last block of epoch `E` have executed. It is not a user transaction and MUST NOT appear in the transaction list. Transactions in the last block of epoch `E` MUST continue to observe the committee for epoch `E`; the persisted committee record for epoch `E+1` MUST only become visible to user EVM execution in the first block of epoch `E+1`.
 
-Warning: this visibility rule applies to EVM execution. Historical `eth_call` against the committed post-state of the last block of epoch `E` is a transitional view: the post-execution hook has already written `committee(E+1)`, while `block.number` still belongs to epoch `E`. Callers MUST NOT treat boundary-block post-state reads as a canonical committee view.
+Because the hook runs after user transactions, historical `eth_call` against the committed post-state of the last block of epoch `E` is a transitional view: user transactions in that block executed with `committee(E)`, while the committed post-state contains the stored record for `epoch = E+1`.
 
 The last block of epoch `E` is the block at height `h` where `h % epoch_length == epoch_length - 1`. Implementations MUST only parse block `extra_data` as a committee DKG outcome when this predicate holds. For all other blocks, implementations MUST NOT parse `extra_data` as a committee DKG outcome and MUST NOT modify committee state.
 
@@ -102,18 +105,17 @@ This system call follows the same execution convention as EIP-4788-style system 
 The system call MUST call `CURRENT_COMMITTEE_ADDRESS` from the system address with calldata equivalent to:
 
 ```solidity
-function setCommitteeMembers(bytes32[] calldata publicKeys) external;
+function setCommitteeMembers(uint64 epoch, bytes32[] calldata publicKeys) external;
 ```
-
-The system call MUST NOT pass an epoch argument.
 
 The system call MUST read the DKG outcome from the boundary block's extra data and persist:
 
 ```text
-committee(E+1) = selected_dkg_outcome(E).players
+epoch = selected_dkg_outcome(E).epoch
+publicKeys = selected_dkg_outcome(E).players
 ```
 
-The system call MUST overwrite the stored `bytes32[] publicKeys` array with `selected_dkg_outcome(E).players`, converted to `bytes32[]` without reordering. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance. A block for the last slot of epoch `E` is invalid if processing it does not perform the system call with the committee implied by that block's extra data.
+The system call MUST overwrite the stored `uint64 epoch` and `bytes32[] publicKeys` with the epoch and players from `selected_dkg_outcome(E)`, converting the players to `bytes32[]` without reordering. Implementations MUST NOT append a new committee record per epoch or otherwise grow state as epochs advance. A block for the last slot of epoch `E` is invalid if processing it does not perform the system call with the committee implied by that block's extra data.
 
 ## Activation
 
@@ -123,6 +125,6 @@ Before the first boundary system call completes, `getCommitteeMembers()` MUST NO
 
 # Invariants
 
-- The boundary system call MUST write exactly the `players` recorded in the boundary block's DKG outcome as the committee members for the next epoch.
-- Outside the transitional boundary-block post-state described above, `getCommitteeMembers()` MUST return those same `players` as the effective committee members for the epoch in which the call is evaluated.
+- The boundary system call MUST write exactly the next epoch and the `players` recorded in the boundary block's DKG outcome as the committee record for the next epoch.
+- Outside the transitional boundary-block post-state described above, `getCommitteeMembers()` MUST return that stored record as the effective committee for the epoch in which the call is evaluated.
 - Validators MUST verify that the last block of an epoch contains the required DKG outcome in its extra data and that block processing writes exactly the committee implied by that DKG outcome.


### PR DESCRIPTION
Stores the effective epoch together with the current committee keys. The boundary hook passes the epoch and players from the decoded DKG outcome through the system setter, and the precompile stores epoch at slot 0 with the public key array at slot 1.

Validation:
- `rustup run nightly cargo fmt`
- `cargo test -p tempo-primitives address::tests::test_is_precompile_address`
- `cargo test -p tempo-primitives`
- `cargo test -p tempo-precompiles current_committee`
- `cargo check -p tempo-precompiles -p tempo-evm -p tempo-contracts`
- `git diff --check`
