### PR TITLE
backport: #6545 to release/v1.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12935,6 +12935,7 @@ dependencies = [
  "reth-node-builder",
  "reth-primitives-traits",
  "reth-provider",
+ "reth-prune-types",
  "reth-rpc-server-types",
  "reth-storage-api",
  "reth-trie",

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -93,6 +93,7 @@ reth-network-peers.workspace = true
 reth-node-builder.workspace = true
 reth-primitives-traits.workspace = true
 reth-provider.workspace = true
+reth-prune-types.workspace = true
 reth-rpc-server-types.workspace = true
 secp256k1.workspace = true
 reth-storage-api.workspace = true

--- a/bin/tempo/src/defaults.rs
+++ b/bin/tempo/src/defaults.rs
@@ -4,14 +4,18 @@ use jiff::SignedDuration;
 use reth_cli_commands::download::DownloadDefaults;
 use reth_ethereum::node::core::args::{
     DefaultDiscoveryArgs, DefaultEngineValues, DefaultNetworkArgs, DefaultPayloadBuilderValues,
-    DefaultTraceValues, DefaultTxPoolValues,
+    DefaultPruningValues, DefaultTraceValues, DefaultTxPoolValues,
 };
+use reth_prune_types::{PruneMode, PruneModes};
 use std::{borrow::Cow, str::FromStr, time::Duration};
 use tempo_chainspec::spec::TEMPO_T7_BASE_FEE_FLOOR;
 use url::Url;
 
 pub(crate) const DEFAULT_DOWNLOAD_URL: &str = "https://snapshots.tempoxyz.dev/4217";
 const SNAPSHOT_API_URL: &str = "https://snapshots.tempoxyz.dev/api/snapshots";
+const MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS: u64 = 21_600;
+const MINIMAL_PEER_SYNC_FINALIZED_BLOCKS: u64 = 3 * MAINNET_TESTNET_EPOCH_LENGTH_BLOCKS;
+const MINIMAL_PEER_SYNC_RETENTION_BLOCKS: u64 = MINIMAL_PEER_SYNC_FINALIZED_BLOCKS + 64;
 
 /// Default OTLP logs filter level for telemetry.
 const DEFAULT_LOGS_OTLP_FILTER: &str = "debug";
@@ -217,6 +221,24 @@ fn init_engine_defaults() {
         .expect("failed to initialize engine defaults");
 }
 
+fn init_pruning_defaults() {
+    let minimal_history_retention = Some(PruneMode::Distance(MINIMAL_PEER_SYNC_RETENTION_BLOCKS));
+    // This defines Tempo's minimum history retention window: nodes should retain
+    // enough block and state history for peers and unwinds up to three mainnet
+    // epochs behind the finalized tip, plus Reth's normal 64-block safety margin.
+    let minimal_prune_modes = PruneModes {
+        account_history: minimal_history_retention,
+        storage_history: minimal_history_retention,
+        bodies_history: minimal_history_retention,
+        ..DefaultPruningValues::default().minimal_prune_modes
+    };
+
+    DefaultPruningValues::default()
+        .with_minimal_prune_modes(minimal_prune_modes)
+        .try_init()
+        .expect("failed to initialize pruning defaults");
+}
+
 fn init_trace_defaults() {
     DefaultTraceValues::default()
         .with_service_name("tempo")
@@ -263,6 +285,7 @@ pub(crate) fn init_defaults() {
     init_payload_builder_defaults();
     init_txpool_defaults();
     init_engine_defaults();
+    init_pruning_defaults();
     init_trace_defaults();
     init_otlp_defaults();
     init_network_defaults();


### PR DESCRIPTION
## Summary
- Cherry-picks [`feb846c841026b98226c7df00e16ab017171b9d4`](https://github.com/tempoxyz/tempo/commit/feb846c841026b98226c7df00e16ab017171b9d4) ([#6545](https://github.com/tempoxyz/tempo/pull/6545)): defines a three-epoch minimum peer sync window by overriding Tempo `--minimal` pruning defaults

## Tests
- `cargo +nightly fmt --check --package tempo`
- `git diff --check`
- `cargo check -p tempo` (blocked: private `commonwarexyz/monorepo` git dependency fetch returns 401 in this sandbox)

Prompted by: @SuperFluffy