### PR TITLE
backport: #6731, #6699 to release/v1.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -3554,9 +3554,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -193,7 +193,7 @@ impl<Provider> TempoPayloadBuilder<Provider> {
         let Some(observed) = observed_build_time_multiplier(total_work, work_at_tx_cutoff) else {
             return;
         };
-        let _ = self.build_time_multiplier.fetch_update(
+        let _ = self.build_time_multiplier.try_update(
             Ordering::Relaxed,
             Ordering::Relaxed,
             |current| Some(decay_build_time_multiplier(current, observed)),

--- a/crates/payload/types/src/budget.rs
+++ b/crates/payload/types/src/budget.rs
@@ -45,7 +45,7 @@ pub fn observe_marshal_persist(block_size_bytes: usize, elapsed: Duration) {
     let observed = observed.min(u128::from(u64::MAX)) as u64;
 
     let _ =
-        MARSHAL_PERSIST_NS_PER_BYTE.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+        MARSHAL_PERSIST_NS_PER_BYTE.try_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
             Some(if current == 0 || observed >= current {
                 observed
             } else {

--- a/deny.toml
+++ b/deny.toml
@@ -8,10 +8,6 @@ ignore = [
   "RUSTSEC-2024-0436",
   # https://rustsec.org/advisories/RUSTSEC-2025-0141 bincode is unmaintained
   "RUSTSEC-2025-0141",
-  # https://rustsec.org/advisories/RUSTSEC-2026-0118 vulnerable DnssecDnsHandle code was
-  # moved from hickory-proto to hickory-net in 0.26.0; we use hickory-net 0.26.1 which has
-  # the fix, and no patched hickory-proto release exists
-  "RUSTSEC-2026-0118",
   # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
   # and is pulled in transitively by upstream crates with no safe upgrade available.
   "RUSTSEC-2026-0173",


### PR DESCRIPTION
## Summary
- Cherry-picks [`56b622116de642da4decd46462da766693dfe654`](https://github.com/tempoxyz/tempo/commit/56b622116de642da4decd46462da766693dfe654) ([#6731](https://github.com/tempoxyz/tempo/pull/6731)): refreshes cargo-deny advisories by removing stale `RUSTSEC-2026-0118` and updating `anyhow` / `crossbeam-epoch` in `Cargo.lock`
- Cherry-picks [`630429fdbbddbf93ba893be23b71057b9442a1b2`](https://github.com/tempoxyz/tempo/commit/630429fdbbddbf93ba893be23b71057b9442a1b2) ([#6699](https://github.com/tempoxyz/tempo/pull/6699)): replaces deprecated `AtomicU64::fetch_update` with `try_update` so clippy passes with warnings denied

## Tests
- `git diff --check`
- `cargo +nightly fmt --check --package tempo`

Prompted by: @SuperFluffy