### PR TITLE
backport: #6754 to release/v1.10.2

### DIFF
--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -10,7 +10,7 @@ use futures::{
 };
 use jsonrpsee::{
     core::{client, client::Subscription},
-    ws_client::{WsClient, WsClientBuilder},
+    ws_client::{PingConfig, WsClient, WsClientBuilder},
 };
 use rand_08::Rng as _;
 use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query, TempoConsensusApiClient};
@@ -29,6 +29,16 @@ pub(super) type EventStream =
 const RECONNECT_BACKOFF_FACTOR: u64 = 2;
 const RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(20);
 const RECONNECT_JITTER: Duration = Duration::from_secs(1);
+
+/// How often websocket pings are sent to keep the connection to the upstream
+/// node alive (and to detect dead connections, triggering a reconnect).
+const PING_INTERVAL: Duration = Duration::from_secs(5);
+/// How long the connection may stay inactive (no pongs or other messages)
+/// before it is considered dead and closed.
+const PING_INACTIVE_LIMIT: Duration = Duration::from_secs(10);
+/// How many times the connection may exceed the inactivity limit before it is
+/// closed.
+const PING_MAX_FAILURES: usize = 1;
 
 /// Manages the connection to the upstream node.
 ///
@@ -203,7 +213,13 @@ fn connect(url: &'static str, attempts: u64) -> BoxFuture<'static, (u64, eyre::R
         (
             attempts,
             WsClientBuilder::default()
-                .build(&url)
+                .enable_ws_ping(
+                    PingConfig::new()
+                        .ping_interval(PING_INTERVAL)
+                        .inactive_limit(PING_INACTIVE_LIMIT)
+                        .max_failures(PING_MAX_FAILURES),
+                )
+                .build(url)
                 .await
                 .map_err(Report::new),
         )


### PR DESCRIPTION
Backports #6754 to release/v1.10.2.

Original commit: ad060da7ba3967b8cd8f04af31a097081dbdfdc9

Validation:
- cargo +nightly fmt --check
- cargo check -p consensus (blocked: Cargo cannot fetch commonwarexyz/monorepo over GitHub HTTPS; dependency fetch returns 401 before compilation)

Prompted by: @SuperFluffy