### PR TITLE
feat(tip-1040): epoch-scoped temporary storage precompile

### DIFF
--- a/.changelog/temporary-storage-account-type.md
+++ b/.changelog/temporary-storage-account-type.md
@@ -1,0 +1,5 @@
+---
+tempo-primitives: patch
+---
+
+Added `TemporaryStorageAccount` and `TempoAddressExt::is_temporary_storage_account` for classifying TIP-1040 per-epoch temporary storage accounts.

--- a/.changelog/temporary-storage-precompile.md
+++ b/.changelog/temporary-storage-precompile.md
@@ -1,0 +1,5 @@
+---
+tempo-contracts: patch
+---
+
+Added the TIP-1040 `ITemporaryStorage` precompile interface and `TEMPORARY_STORAGE_ADDRESS`.

--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -81,5 +81,6 @@ pub const SYSTEM_PRECOMPILES: &[(Address, TempoHardfork)] = &[
     (RECEIVE_POLICY_GUARD_ADDRESS, TempoHardfork::T6),
     (STORAGE_CREDITS_ADDRESS, TempoHardfork::T7),
     (CURRENT_COMMITTEE_ADDRESS, TempoHardfork::T8),
+    // Provisional activation hardfork until the T9 feature set is locked in.
     (TEMPORARY_STORAGE_ADDRESS, TempoHardfork::T9),
 ];

--- a/crates/contracts/src/precompiles/mod.rs
+++ b/crates/contracts/src/precompiles/mod.rs
@@ -7,6 +7,7 @@ pub mod receive_policy_guard;
 pub mod signature_verifier;
 pub mod stablecoin_dex;
 pub mod storage_credits;
+pub mod temporary_storage;
 pub mod tip20;
 pub mod tip20_channel_reserve;
 pub mod tip20_factory;
@@ -24,6 +25,7 @@ pub use receive_policy_guard::*;
 pub use signature_verifier::*;
 pub use stablecoin_dex::*;
 pub use storage_credits::*;
+pub use temporary_storage::*;
 pub use tip_fee_manager::*;
 pub use tip20::*;
 pub use tip20_channel_reserve::*;
@@ -58,6 +60,10 @@ pub const RECEIVE_POLICY_GUARD_ADDRESS: Address =
 pub const STORAGE_CREDITS_ADDRESS: Address = address!("0x1060000000000000000000000000000000000000");
 pub const CURRENT_COMMITTEE_ADDRESS: Address =
     address!("0xC077E00000000000000000000000000000000000");
+/// TIP-1040 temporary storage precompile. The address range following it is reserved
+/// for the per-epoch storage accounts at `TEMPORARY_STORAGE_ADDRESS + epoch + 1`.
+pub const TEMPORARY_STORAGE_ADDRESS: Address =
+    address!("0x1040000000000000000000000000000000000000");
 
 /// Fixed system precompile addresses and corresponding activation hardfork
 pub const SYSTEM_PRECOMPILES: &[(Address, TempoHardfork)] = &[
@@ -75,4 +81,5 @@ pub const SYSTEM_PRECOMPILES: &[(Address, TempoHardfork)] = &[
     (RECEIVE_POLICY_GUARD_ADDRESS, TempoHardfork::T6),
     (STORAGE_CREDITS_ADDRESS, TempoHardfork::T7),
     (CURRENT_COMMITTEE_ADDRESS, TempoHardfork::T8),
+    (TEMPORARY_STORAGE_ADDRESS, TempoHardfork::T9),
 ];

--- a/crates/contracts/src/precompiles/temporary_storage.rs
+++ b/crates/contracts/src/precompiles/temporary_storage.rs
@@ -1,0 +1,22 @@
+crate::sol! {
+    /// Epoch-scoped temporary key-value storage as per [TIP-1040].
+    ///
+    /// Values are stored per `msg.sender` and expire automatically: data written in a
+    /// given epoch is readable during that epoch and the next, then becomes inaccessible.
+    ///
+    /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+    #[derive(Debug, PartialEq, Eq)]
+    #[sol(abi)]
+    interface ITemporaryStorage {
+        /// Stores `value` for the caller under `key` in the current epoch.
+        /// @param key Caller-chosen 32-byte key
+        /// @param value The value to store
+        function temporaryStore(bytes32 key, bytes32 value) external;
+
+        /// Loads the caller's value for `key`, checking the current epoch first and
+        /// falling back to the previous epoch.
+        /// @param key Caller-chosen 32-byte key
+        /// @return value The stored value, or zero if not found in either epoch
+        function temporaryLoad(bytes32 key) external view returns (bytes32 value);
+    }
+}

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -32,7 +32,6 @@ use tempo_contracts::precompiles::{
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STORAGE_CREDITS_ADDRESS,
     TEMPORARY_STORAGE_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
-use tempo_precompiles::temporary_storage::EPOCH_LENGTH;
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType,
     TemporaryStorageAccount, subblock::PartialValidatorKey,
@@ -599,7 +598,7 @@ where
             // Keep the TIP-1040 epoch account non-empty so EIP-161 state clear can't drop it.
             // The marker bytes are the preimage of the spec's `EPOCH_ACCOUNT_CODE_HASH`.
             let block_number = self.evm().block().number.saturating_to::<u64>();
-            let epoch_account = TemporaryStorageAccount::for_epoch(block_number / EPOCH_LENGTH);
+            let epoch_account = TemporaryStorageAccount::for_block(block_number);
             self.deploy_marker_at_boundary(
                 epoch_account.address(),
                 Bytecode::new_legacy(TemporaryStorageAccount::MARKER_CODE.into()),

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1949,7 +1949,7 @@ mod tests {
         // The current epoch's storage account must also carry the marker, otherwise it is
         // an empty touched account and EIP-161 state clear drops its storage at commit.
         // Its code hash is TIP-1040's `EPOCH_ACCOUNT_CODE_HASH`.
-        let epoch_account = TemporaryStorageAccount::for_epoch(0).address();
+        let epoch_account = TemporaryStorageAccount::for_block(0).address();
         let acc = db.load_cache_account(epoch_account).unwrap();
         let info = acc.account_info().unwrap();
         assert_eq!(

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -30,11 +30,12 @@ use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_contracts::precompiles::{
     ADDRESS_REGISTRY_ADDRESS, CURRENT_COMMITTEE_ADDRESS, ICurrentCommittee,
     RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STORAGE_CREDITS_ADDRESS,
-    TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
+    TEMPORARY_STORAGE_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
+use tempo_precompiles::temporary_storage::EPOCH_LENGTH;
 use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType,
-    subblock::PartialValidatorKey,
+    TemporaryStorageAccount, subblock::PartialValidatorKey,
 };
 use tempo_revm::{TempoHaltReason, evm::TempoContext};
 use tracing::trace;
@@ -580,6 +581,14 @@ where
         }
         if self.inner.spec.is_t8_active_at_timestamp(timestamp) {
             self.deploy_precompile_at_boundary(CURRENT_COMMITTEE_ADDRESS)?;
+        }
+        if self.inner.spec.is_t9_active_at_timestamp(timestamp) {
+            self.deploy_precompile_at_boundary(TEMPORARY_STORAGE_ADDRESS)?;
+
+            // Keep the TIP-1040 epoch account non-empty so EIP-161 state clear can't drop it.
+            let block_number = self.evm().block().number.saturating_to::<u64>();
+            let epoch_account = TemporaryStorageAccount::for_epoch(block_number / EPOCH_LENGTH);
+            self.deploy_precompile_at_boundary(epoch_account.address())?;
         }
 
         Ok(())
@@ -1903,6 +1912,30 @@ mod tests {
         drop(executor);
 
         let acc = db.load_cache_account(RECEIVE_POLICY_GUARD_ADDRESS).unwrap();
+        let info = acc.account_info().unwrap();
+        assert!(!info.is_empty_code_hash());
+    }
+
+    #[test]
+    fn test_apply_pre_execution_deploys_temporary_storage_code() {
+        // Dev chainspec has t9Time: 0, so T9 is active at any timestamp.
+        let chainspec = Arc::new(TempoChainSpec::from_genesis(DEV.genesis().clone()));
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_parent_beacon_block_root(B256::ZERO)
+            .build(&mut db, &chainspec);
+
+        executor.apply_pre_execution_changes().unwrap();
+        drop(executor);
+
+        let acc = db.load_cache_account(TEMPORARY_STORAGE_ADDRESS).unwrap();
+        let info = acc.account_info().unwrap();
+        assert!(!info.is_empty_code_hash());
+
+        // The current epoch's storage account must also carry the marker, otherwise it is
+        // an empty touched account and EIP-161 state clear drops its storage at commit.
+        let epoch_account = TemporaryStorageAccount::for_epoch(0).address();
+        let acc = db.load_cache_account(epoch_account).unwrap();
         let info = acc.account_info().unwrap();
         assert!(!info.is_empty_code_hash());
     }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -215,6 +215,9 @@ where
     }
 
     /// Deploys `0xEF` marker bytecode to a precompile address if it doesn't already have code.
+    ///
+    /// This also dispatches the state change to the system caller's state hook so that the
+    /// sparse trie task is aware of the change.
     fn deploy_precompile_at_boundary(
         &mut self,
         address: Address,

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -215,12 +215,21 @@ where
     }
 
     /// Deploys `0xEF` marker bytecode to a precompile address if it doesn't already have code.
-    ///
-    /// This also dispatches the state change to the system caller's state hook so that the
-    /// sparse trie task is aware of the change.
     fn deploy_precompile_at_boundary(
         &mut self,
         address: Address,
+    ) -> Result<(), BlockExecutionError> {
+        self.deploy_marker_at_boundary(address, Bytecode::new_legacy([0xef].into()))
+    }
+
+    /// Deploys marker bytecode to an address if it doesn't already have code.
+    ///
+    /// This also dispatches the state change to the system caller's state hook so that the
+    /// sparse trie task is aware of the change.
+    fn deploy_marker_at_boundary(
+        &mut self,
+        address: Address,
+        code: Bytecode,
     ) -> Result<(), BlockExecutionError> {
         let info = self
             .inner
@@ -231,7 +240,6 @@ where
             .unwrap_or_default();
         if info.is_empty_code_hash() {
             let mut account = Account::from(info);
-            let code = Bytecode::new_legacy([0xef].into());
             account.info.code_hash = code.hash_slow();
             account.info.code = Some(code);
             account.mark_touch();
@@ -586,9 +594,13 @@ where
             self.deploy_precompile_at_boundary(TEMPORARY_STORAGE_ADDRESS)?;
 
             // Keep the TIP-1040 epoch account non-empty so EIP-161 state clear can't drop it.
+            // The marker bytes are the preimage of the spec's `EPOCH_ACCOUNT_CODE_HASH`.
             let block_number = self.evm().block().number.saturating_to::<u64>();
             let epoch_account = TemporaryStorageAccount::for_epoch(block_number / EPOCH_LENGTH);
-            self.deploy_precompile_at_boundary(epoch_account.address())?;
+            self.deploy_marker_at_boundary(
+                epoch_account.address(),
+                Bytecode::new_legacy(TemporaryStorageAccount::MARKER_CODE.into()),
+            )?;
         }
 
         Ok(())
@@ -1934,10 +1946,14 @@ mod tests {
 
         // The current epoch's storage account must also carry the marker, otherwise it is
         // an empty touched account and EIP-161 state clear drops its storage at commit.
+        // Its code hash is TIP-1040's `EPOCH_ACCOUNT_CODE_HASH`.
         let epoch_account = TemporaryStorageAccount::for_epoch(0).address();
         let acc = db.load_cache_account(epoch_account).unwrap();
         let info = acc.account_info().unwrap();
-        assert!(!info.is_empty_code_hash());
+        assert_eq!(
+            info.code_hash,
+            alloy_primitives::keccak256(TemporaryStorageAccount::MARKER_CODE)
+        );
     }
 
     #[test]

--- a/crates/node/tests/it/main.rs
+++ b/crates/node/tests/it/main.rs
@@ -18,6 +18,7 @@ mod simulate;
 mod stablecoin_dex;
 mod storage_credits;
 mod tempo_transaction;
+mod temporary_storage;
 mod tip20;
 mod tip20_factory;
 mod tip20_gas_fees;

--- a/crates/node/tests/it/temporary_storage.rs
+++ b/crates/node/tests/it/temporary_storage.rs
@@ -10,7 +10,7 @@ use alloy::{
 };
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::ITemporaryStorage;
-use tempo_precompiles::{TEMPORARY_STORAGE_ADDRESS, temporary_storage::EPOCH_LENGTH};
+use tempo_precompiles::TEMPORARY_STORAGE_ADDRESS;
 use tempo_primitives::TemporaryStorageAccount;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -81,7 +81,7 @@ async fn test_temporary_storage_survives_block_commit() -> eyre::Result<()> {
 
     // The boundary hook deployed the 0xEF marker to the precompile and the TIP-1040
     // marker to the current epoch's account, and the value sits in that account's storage.
-    let epoch_account = TemporaryStorageAccount::for_epoch(store_block / EPOCH_LENGTH).address();
+    let epoch_account = TemporaryStorageAccount::for_block(store_block).address();
     assert_eq!(
         provider
             .get_code_at(TEMPORARY_STORAGE_ADDRESS)

--- a/crates/node/tests/it/temporary_storage.rs
+++ b/crates/node/tests/it/temporary_storage.rs
@@ -79,8 +79,8 @@ async fn test_temporary_storage_survives_block_commit() -> eyre::Result<()> {
     let loaded = temporary_storage.temporaryLoad(oog_key).call().await?;
     assert_eq!(loaded, B256::ZERO);
 
-    // The boundary hook deployed the 0xEF marker to the precompile and the current
-    // epoch's account, and the value sits in the epoch account's storage.
+    // The boundary hook deployed the 0xEF marker to the precompile and the TIP-1040
+    // marker to the current epoch's account, and the value sits in that account's storage.
     let epoch_account = TemporaryStorageAccount::for_epoch(store_block / EPOCH_LENGTH).address();
     assert_eq!(
         provider
@@ -89,7 +89,10 @@ async fn test_temporary_storage_survives_block_commit() -> eyre::Result<()> {
             .as_ref(),
         [0xef]
     );
-    assert_eq!(provider.get_code_at(epoch_account).await?.as_ref(), [0xef]);
+    assert_eq!(
+        provider.get_code_at(epoch_account).await?.as_ref(),
+        TemporaryStorageAccount::MARKER_CODE
+    );
 
     let slot = keccak256([sender.as_slice(), key.as_slice()].concat());
     let stored = provider

--- a/crates/node/tests/it/temporary_storage.rs
+++ b/crates/node/tests/it/temporary_storage.rs
@@ -1,0 +1,101 @@
+//! TIP-1040 temporary storage precompile, exercised through the full node path:
+//! real transactions, block building, state commit, and RPC reads.
+
+use crate::utils::{TEST_MNEMONIC, TestNodeBuilder};
+use alloy::{
+    network::ReceiptResponse,
+    primitives::{B256, U256, keccak256},
+    providers::{Provider, ProviderBuilder},
+    signers::local::MnemonicBuilder,
+};
+use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+use tempo_contracts::precompiles::ITemporaryStorage;
+use tempo_precompiles::{TEMPORARY_STORAGE_ADDRESS, temporary_storage::EPOCH_LENGTH};
+use tempo_primitives::TemporaryStorageAccount;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_temporary_storage_survives_block_commit() -> eyre::Result<()> {
+    reth_tracing::init_test_tracing();
+
+    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let wallet = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
+    let sender = wallet.address();
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(setup.http_url);
+
+    let temporary_storage = ITemporaryStorage::new(TEMPORARY_STORAGE_ADDRESS, &provider);
+    let key = B256::repeat_byte(0x01);
+    let value = B256::repeat_byte(0x02);
+
+    // Store in block N.
+    let receipt = temporary_storage
+        .temporaryStore(key, value)
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(500_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(receipt.status(), "temporaryStore tx should succeed");
+    let store_block = receipt.block_number().expect("receipt has block number");
+
+    // Overwrite the same slot to measure `intrinsic + existing-slot store (~7.1k)`
+    // with identical calldata size, independent of the fee model.
+    let value2 = B256::repeat_byte(0x03);
+    let receipt = temporary_storage
+        .temporaryStore(key, value2)
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(500_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(
+        receipt.status(),
+        "overwrite temporaryStore tx should succeed"
+    );
+    let existing_store_gas = receipt.gas_used;
+
+    // A store that runs out of gas inside the precompile must fail without leaving
+    // partial state: `existing_store_gas + 10k` clears tx validation but is ~23k short
+    // of a new-slot store (40k). This tx also lands in a block > N, so the reads below
+    // are guaranteed to cross a block commit.
+    let oog_key = B256::repeat_byte(0xEE);
+    let receipt = temporary_storage
+        .temporaryStore(oog_key, value)
+        .gas_price(TEMPO_T1_BASE_FEE as u128)
+        .gas(existing_store_gas + 10_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(!receipt.status(), "underfunded temporaryStore should fail");
+    assert!(receipt.block_number().expect("receipt has block number") > store_block);
+
+    // The stored value survives block commit; the failed store left nothing behind.
+    let loaded = temporary_storage.temporaryLoad(key).call().await?;
+    assert_eq!(loaded, value2);
+    let loaded = temporary_storage.temporaryLoad(oog_key).call().await?;
+    assert_eq!(loaded, B256::ZERO);
+
+    // The boundary hook deployed the 0xEF marker to the precompile and the current
+    // epoch's account, and the value sits in the epoch account's storage.
+    let epoch_account = TemporaryStorageAccount::for_epoch(store_block / EPOCH_LENGTH).address();
+    assert_eq!(
+        provider
+            .get_code_at(TEMPORARY_STORAGE_ADDRESS)
+            .await?
+            .as_ref(),
+        [0xef]
+    );
+    assert_eq!(provider.get_code_at(epoch_account).await?.as_ref(), [0xef]);
+
+    let slot = keccak256([sender.as_slice(), key.as_slice()].concat());
+    let stored = provider
+        .get_storage_at(epoch_account, U256::from_be_bytes(slot.0))
+        .await?;
+    assert_eq!(B256::from(stored), value2);
+
+    Ok(())
+}

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -20,6 +20,7 @@ pub mod receive_policy_guard;
 pub mod signature_verifier;
 pub mod stablecoin_dex;
 pub mod storage_credits;
+pub mod temporary_storage;
 pub mod tip20;
 pub mod tip20_channel_reserve;
 pub mod tip20_factory;
@@ -41,6 +42,7 @@ use crate::{
     stablecoin_dex::StablecoinDEX,
     storage::{StorageCtx, actions::StorageActions},
     storage_credits::{NonCreditableSlots, StorageCredits},
+    temporary_storage::TemporaryStorage,
     tip_fee_manager::TipFeeManager,
     tip20::TIP20Token,
     tip20_channel_reserve::TIP20ChannelReserve,
@@ -68,9 +70,9 @@ pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, CURRENT_COMMITTEE_ADDRESS,
     DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
     SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS, STORAGE_CREDITS_ADDRESS,
-    SYSTEM_PRECOMPILES, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
-    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
-    VALIDATOR_CONFIG_V2_ADDRESS,
+    SYSTEM_PRECOMPILES, TEMPORARY_STORAGE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -206,6 +208,8 @@ pub fn extend_tempo_precompiles(
             Some(StorageCredits::create_precompile(&env))
         } else if *address == CURRENT_COMMITTEE_ADDRESS && env.cfg.spec.is_t8() {
             Some(CurrentCommittee::create_precompile(&env))
+        } else if *address == TEMPORARY_STORAGE_ADDRESS && env.cfg.spec.is_t9() {
+            Some(TemporaryStorage::create_precompile(&env))
         } else {
             None
         }
@@ -365,6 +369,13 @@ impl StorageCredits {
     /// Creates the EVM precompile for this type.
     pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
         tempo_precompile!("StorageCredits", env: env, |input| { Self::new() })
+    }
+}
+
+impl TemporaryStorage {
+    /// Creates the EVM precompile for this type.
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("TemporaryStorage", env: env, |input| { Self::new() })
     }
 }
 
@@ -1109,6 +1120,27 @@ mod tests {
                 .get(&TIP20_CHANNEL_RESERVE_ADDRESS)
                 .is_some(),
             "TIP20 channel reserve should be registered at T5"
+        );
+    }
+
+    #[test]
+    fn test_temporary_storage_registered_at_t9_only() {
+        let mut t8 = CfgEnv::<TempoHardfork>::default();
+        t8.set_spec_and_mainnet_gas_params(TempoHardfork::T8);
+        assert!(
+            test_tempo_precompiles(&t8)
+                .get(&TEMPORARY_STORAGE_ADDRESS)
+                .is_none(),
+            "TemporaryStorage should NOT be registered before T9"
+        );
+
+        let mut t9 = CfgEnv::<TempoHardfork>::default();
+        t9.set_spec_and_mainnet_gas_params(TempoHardfork::T9);
+        assert!(
+            test_tempo_precompiles(&t9)
+                .get(&TEMPORARY_STORAGE_ADDRESS)
+                .is_some(),
+            "TemporaryStorage should be registered at T9"
         );
     }
 

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -14,7 +14,7 @@ use revm::{
 };
 use std::{cell::RefCell, rc::Rc};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::TempoBlockEnv;
+use tempo_primitives::{TempoBlockEnv, TemporaryStorageAccount};
 
 /// Production [`PrecompileStorageProvider`] backed by the live EVM journal.
 ///
@@ -385,6 +385,29 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         self.sstore_inner(address, key, value, |result| {
             StorageAction::Sstore(address, key, result.present_value, value)
         })
+    }
+
+    #[inline]
+    fn temporary_sstore(
+        &mut self,
+        account: TemporaryStorageAccount,
+        key: U256,
+        value: U256,
+    ) -> Result<StateLoad<SStoreResult>, TempoPrecompileError> {
+        let address = account.address();
+
+        // Skip the expensive cold load when the remaining gas cannot cover a cold access;
+        // callers meter at least that much for cold slots.
+        let skip_cold_load =
+            self.gas_tracker.remaining() < self.gas_params.cold_storage_additional_cost();
+        let result = self.sstore_journal(address, key, value, skip_cold_load)?;
+        self.actions.record(StorageAction::Sstore(
+            address,
+            key,
+            result.data.present_value,
+            value,
+        ));
+        Ok(result)
     }
 
     #[inline]

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::TempoPrecompileError,
-    storage::{PrecompileStorageProvider, StorageActions, actions::StorageAction},
+    storage::{PrecompileStorageProvider, StorageActions, actions::StorageAction, temporary},
     storage_credits::{NonCreditableSlots, sstore_storage_credits},
 };
 use alloy::primitives::{Address, Log, LogData, U256};
@@ -388,26 +388,32 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     }
 
     #[inline]
-    fn temporary_sstore(
+    fn temporary_store(
         &mut self,
-        account: TemporaryStorageAccount,
-        key: U256,
+        namespace: Address,
+        key: alloy::primitives::B256,
         value: U256,
-    ) -> Result<StateLoad<SStoreResult>, TempoPrecompileError> {
-        let address = account.address();
+    ) -> Result<(), TempoPrecompileError> {
+        let slot = temporary::slot(namespace, key);
+        let block_number = self.block_env().number.saturating_to::<u64>();
+        let address = TemporaryStorageAccount::for_block(block_number).address();
 
-        // Skip the expensive cold load when the remaining gas cannot cover a cold access;
-        // callers meter at least that much for cold slots.
+        // Pre-charge the minimum store cost before touching storage, and skip the
+        // expensive cold load when the remaining gas cannot cover a cold access — every
+        // cold store path charges at least that much. Mirrors the metered SSTORE path.
+        self.deduct_gas(temporary::STORE_GAS_EXISTING_WARM)?;
         let skip_cold_load =
             self.gas_tracker.remaining() < self.gas_params.cold_storage_additional_cost();
-        let result = self.sstore_journal(address, key, value, skip_cold_load)?;
+        let result = self.sstore_journal(address, slot, value, skip_cold_load)?;
         self.actions.record(StorageAction::Sstore(
             address,
-            key,
+            slot,
             result.data.present_value,
             value,
         ));
-        Ok(result)
+        self.deduct_gas(
+            temporary::store_gas(&result.data, result.is_cold) - temporary::STORE_GAS_EXISTING_WARM,
+        )
     }
 
     #[inline]

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -3,7 +3,7 @@ use crate::{
     storage::{PrecompileStorageProvider, StorageActions, actions::StorageAction, temporary},
     storage_credits::{NonCreditableSlots, sstore_storage_credits},
 };
-use alloy::primitives::{Address, Log, LogData, U256};
+use alloy::primitives::{Address, B256, Log, LogData, U256};
 use alloy_evm::EvmInternals;
 use bitflags::bitflags;
 use revm::{
@@ -391,7 +391,7 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     fn temporary_store(
         &mut self,
         namespace: Address,
-        key: alloy::primitives::B256,
+        key: B256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
         let slot = temporary::slot(namespace, key);

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, LogData, U256};
+use alloy::primitives::{Address, B256, LogData, U256};
 use revm::{
     context::{BlockEnv, journaled_state::JournalCheckpoint},
     context_interface::cfg::GasParams,
@@ -164,7 +164,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     fn temporary_store(
         &mut self,
         namespace: Address,
-        key: alloy::primitives::B256,
+        key: B256,
         value: U256,
     ) -> Result<(), TempoPrecompileError> {
         let slot = temporary::slot(namespace, key);

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -7,7 +7,7 @@ use revm::{
 };
 use std::collections::HashMap;
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::TempoBlockEnv;
+use tempo_primitives::{TempoBlockEnv, TemporaryStorageAccount};
 
 use crate::{
     error::TempoPrecompileError,
@@ -156,6 +156,32 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         }
 
         Ok(())
+    }
+
+    /// NOTE: always reports `is_cold: false` — cold/warm gas assertions must run against
+    /// the journal-backed [`EvmPrecompileStorageProvider`](super::evm::EvmPrecompileStorageProvider).
+    fn temporary_sstore(
+        &mut self,
+        account: TemporaryStorageAccount,
+        key: U256,
+        value: U256,
+    ) -> Result<StateLoad<SStoreResult>, TempoPrecompileError> {
+        let address = account.address();
+        self.counter_sstore += 1;
+        let present = self
+            .internals
+            .get(&(address, key))
+            .copied()
+            .unwrap_or(U256::ZERO);
+        self.internals.insert((address, key), value);
+        Ok(StateLoad::new(
+            SStoreResult {
+                original_value: present,
+                present_value: present,
+                new_value: value,
+            },
+            false,
+        ))
     }
 
     fn tstore(
@@ -367,6 +393,11 @@ impl HashMapStorageProvider {
     /// Overrides the block timestamp.
     pub fn set_timestamp(&mut self, timestamp: U256) {
         self.block_env.timestamp = timestamp;
+    }
+
+    /// Overrides the static-call flag.
+    pub fn set_is_static(&mut self, is_static: bool) {
+        self.is_static = is_static;
     }
 
     /// Overrides the block beneficiary (coinbase).

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -11,7 +11,7 @@ use tempo_primitives::{TempoBlockEnv, TemporaryStorageAccount};
 
 use crate::{
     error::TempoPrecompileError,
-    storage::{PrecompileStorageProvider, SstoreTransitionFlags},
+    storage::{PrecompileStorageProvider, SstoreTransitionFlags, temporary},
     storage_credits::{NonCreditableSlots, StorageCreditsBackend, sstore_storage_credits},
 };
 
@@ -158,30 +158,21 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         Ok(())
     }
 
-    /// NOTE: always reports `is_cold: false` — cold/warm gas assertions must run against
-    /// the journal-backed [`EvmPrecompileStorageProvider`](super::evm::EvmPrecompileStorageProvider).
-    fn temporary_sstore(
+    /// NOTE: unmetered like all `HashMapStorageProvider` operations — gas assertions
+    /// must run against the journal-backed
+    /// [`EvmPrecompileStorageProvider`](super::evm::EvmPrecompileStorageProvider).
+    fn temporary_store(
         &mut self,
-        account: TemporaryStorageAccount,
-        key: U256,
+        namespace: Address,
+        key: alloy::primitives::B256,
         value: U256,
-    ) -> Result<StateLoad<SStoreResult>, TempoPrecompileError> {
-        let address = account.address();
+    ) -> Result<(), TempoPrecompileError> {
+        let slot = temporary::slot(namespace, key);
+        let block_number = self.block_env.number.saturating_to::<u64>();
+        let address = TemporaryStorageAccount::for_block(block_number).address();
         self.counter_sstore += 1;
-        let present = self
-            .internals
-            .get(&(address, key))
-            .copied()
-            .unwrap_or(U256::ZERO);
-        self.internals.insert((address, key), value);
-        Ok(StateLoad::new(
-            SStoreResult {
-                original_value: present,
-                present_value: present,
-                new_value: value,
-            },
-            false,
-        ))
+        self.internals.insert((address, slot), value);
+        Ok(())
     }
 
     fn tstore(

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -90,16 +90,20 @@ pub trait PrecompileStorageProvider {
     fn temporary_load(&mut self, namespace: Address, key: B256) -> Result<U256> {
         let slot = temporary::slot(namespace, key);
         let block_number = self.block_env().number.saturating_to::<u64>();
-        let epoch = block_number / tempo_primitives::TEMPORARY_STORAGE_EPOCH_LENGTH;
 
-        let value = self.sload(TemporaryStorageAccount::for_epoch(epoch).address(), slot)?;
-        if !value.is_zero() || epoch == 0 {
+        let value = self.sload(
+            TemporaryStorageAccount::for_block(block_number).address(),
+            slot,
+        )?;
+        let in_first_epoch = block_number < tempo_primitives::TEMPORARY_STORAGE_EPOCH_LENGTH;
+        if !value.is_zero() || in_first_epoch {
             return Ok(value);
         }
-        self.sload(
-            TemporaryStorageAccount::for_epoch(epoch - 1).address(),
-            slot,
-        )
+        // One epoch length back lands in the previous epoch's account.
+        let previous = TemporaryStorageAccount::for_block(
+            block_number - tempo_primitives::TEMPORARY_STORAGE_EPOCH_LENGTH,
+        );
+        self.sload(previous.address(), slot)
     }
 
     /// Increments a persistent storage slot by `delta`.

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -9,6 +9,7 @@ pub use actions::{StorageAction, StorageActions};
 pub mod evm;
 pub use evm::SstoreTransitionFlags;
 pub mod hashmap;
+pub mod temporary;
 
 pub mod thread_local;
 use alloy::primitives::keccak256;
@@ -24,10 +25,7 @@ pub use types::mapping as slots;
 use alloy::primitives::{Address, B256, LogData, Signature, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
-    interpreter::{
-        SStoreResult, StateLoad,
-        gas::{KECCAK256, KECCAK256WORD},
-    },
+    interpreter::gas::{KECCAK256, KECCAK256WORD},
     state::{AccountInfo, Bytecode},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -72,19 +70,36 @@ pub trait PrecompileStorageProvider {
     /// Performs an SSTORE operation (persistent storage write).
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()>;
 
-    /// Journal SSTORE into a TIP-1040 temporary storage account, charging no gas and
-    /// returning the value transition and whether the slot was cold.
+    /// Stores `value` for `namespace` under `key` in [TIP-1040] temporary storage.
     ///
-    /// Callers meter gas themselves per the TIP-1040 schedule. Bypasses TIP-1060
-    /// storage-credit accounting (expiring storage must neither mint nor spend credits).
-    /// Like [`sstore`](Self::sstore), static-call protection is the dispatcher's job
-    /// (`mutate`/`mutate_void`), not this method's.
-    fn temporary_sstore(
-        &mut self,
-        account: TemporaryStorageAccount,
-        key: U256,
-        value: U256,
-    ) -> Result<StateLoad<SStoreResult>>;
+    /// A complete TIP-1040 store: writes `keccak256(namespace || key)` in the current
+    /// epoch's account and charges the TIP-1040 gas schedule (see [`temporary`]).
+    /// Bypasses TIP-1060 storage-credit accounting (expiring storage must neither mint
+    /// nor spend credits). Like [`sstore`](Self::sstore), static-call protection is the
+    /// dispatcher's job (`mutate`/`mutate_void`), not this method's.
+    ///
+    /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+    fn temporary_store(&mut self, namespace: Address, key: B256, value: U256) -> Result<()>;
+
+    /// Loads `namespace`'s [TIP-1040] temporary storage value for `key`, checking the
+    /// current epoch and falling back to the previous one. Returns zero if the key is
+    /// unset in both. Each accessed slot is charged standard SLOAD pricing.
+    ///
+    /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+    fn temporary_load(&mut self, namespace: Address, key: B256) -> Result<U256> {
+        let slot = temporary::slot(namespace, key);
+        let block_number = self.block_env().number.saturating_to::<u64>();
+        let epoch = block_number / tempo_primitives::TEMPORARY_STORAGE_EPOCH_LENGTH;
+
+        let value = self.sload(TemporaryStorageAccount::for_epoch(epoch).address(), slot)?;
+        if !value.is_zero() || epoch == 0 {
+            return Ok(value);
+        }
+        self.sload(
+            TemporaryStorageAccount::for_epoch(epoch - 1).address(),
+            slot,
+        )
+    }
 
     /// Increments a persistent storage slot by `delta`.
     ///

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -1,7 +1,8 @@
 //! EVM storage abstraction layer for Tempo precompile contracts.
 //!
 //! Provides traits and types for reading/writing contract state from EVM storage,
-//! including persistent (SLOAD/SSTORE) and transient (TLOAD/TSTORE) operations.
+//! including persistent (SLOAD/SSTORE), transient (TLOAD/TSTORE), and TIP-1040
+//! [`temporary`] operations.
 
 pub mod actions;
 pub use actions::{StorageAction, StorageActions};

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -24,11 +24,14 @@ pub use types::mapping as slots;
 use alloy::primitives::{Address, B256, LogData, Signature, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
-    interpreter::gas::{KECCAK256, KECCAK256WORD},
+    interpreter::{
+        SStoreResult, StateLoad,
+        gas::{KECCAK256, KECCAK256WORD},
+    },
     state::{AccountInfo, Bytecode},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::TempoBlockEnv;
+use tempo_primitives::{TempoBlockEnv, TemporaryStorageAccount};
 
 use crate::error::{Result, TempoPrecompileError};
 
@@ -68,6 +71,20 @@ pub trait PrecompileStorageProvider {
 
     /// Performs an SSTORE operation (persistent storage write).
     fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()>;
+
+    /// Journal SSTORE into a TIP-1040 temporary storage account, charging no gas and
+    /// returning the value transition and whether the slot was cold.
+    ///
+    /// Callers meter gas themselves per the TIP-1040 schedule. Bypasses TIP-1060
+    /// storage-credit accounting (expiring storage must neither mint nor spend credits).
+    /// Like [`sstore`](Self::sstore), static-call protection is the dispatcher's job
+    /// (`mutate`/`mutate_void`), not this method's.
+    fn temporary_sstore(
+        &mut self,
+        account: TemporaryStorageAccount,
+        key: U256,
+        value: U256,
+    ) -> Result<StateLoad<SStoreResult>>;
 
     /// Increments a persistent storage slot by `delta`.
     ///

--- a/crates/precompiles/src/storage/temporary.rs
+++ b/crates/precompiles/src/storage/temporary.rs
@@ -1,0 +1,43 @@
+//! TIP-1040 temporary storage layout and gas policy.
+//!
+//! Pure helpers shared by the [`PrecompileStorageProvider`](super::PrecompileStorageProvider)
+//! implementations of `temporary_store`/`temporary_load`; the account layout lives on
+//! [`tempo_primitives::TemporaryStorageAccount`].
+
+use alloy::primitives::{Address, B256, U256, keccak256};
+use revm::interpreter::SStoreResult;
+
+/// Gas cost for `temporaryStore` when the slot is zero in the current epoch.
+pub const STORE_GAS_NEW: u64 = 40_000;
+
+/// Gas cost for `temporaryStore` when the slot is nonzero in the current epoch and cold
+/// (`COLD_SLOAD_COST` + `SSTORE_RESET_GAS`).
+pub const STORE_GAS_EXISTING_COLD: u64 = 2_100 + 5_000;
+
+/// Gas cost for `temporaryStore` when the slot is nonzero in the current epoch and warm
+/// (`WARM_STORAGE_READ_COST` + `SSTORE_WRITE_GAS_DELTA`). Also the minimum store cost,
+/// pre-charged before touching storage.
+pub const STORE_GAS_EXISTING_WARM: u64 = 200;
+
+/// Derives the storage slot for a `(namespace, key)` pair: `keccak256(namespace || key)`.
+///
+/// The namespace is the isolation boundary — ABI dispatch passes `msg.sender`, so two
+/// callers can never collide. Unmetered, like [`Mapping`](super::Mapping) slot
+/// derivation; TIP-1040 prices the hash into the flat operation costs.
+pub fn slot(namespace: Address, key: B256) -> U256 {
+    let mut buf = [0u8; 52];
+    buf[..20].copy_from_slice(namespace.as_slice());
+    buf[20..].copy_from_slice(key.as_slice());
+    keccak256(buf).into()
+}
+
+/// Returns the TIP-1040 gas for a store given the slot's value transition and cold flag.
+pub fn store_gas(result: &SStoreResult, is_cold: bool) -> u64 {
+    if result.present_value.is_zero() {
+        STORE_GAS_NEW
+    } else if is_cold {
+        STORE_GAS_EXISTING_COLD
+    } else {
+        STORE_GAS_EXISTING_WARM
+    }
+}

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -167,9 +167,7 @@ impl StorageCtx {
         Self::try_with_storage(|s| s.sstore(address, key, value))
     }
 
-    /// Journal SSTORE into a TIP-1040 temporary storage account, charging no gas and
-    /// returning the value transition and whether the slot was cold. Callers meter gas
-    /// themselves per the TIP-1040 schedule.
+    /// Journal SSTORE into a TIP-1040 temporary storage account, charging no gas.
     pub fn temporary_sstore(
         &mut self,
         account: TemporaryStorageAccount,

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -5,14 +5,13 @@ use alloy::{
 use alloy_evm::{Database, EvmInternals};
 use revm::{
     context::{CfgEnv, ContextTr, JournalTr, Transaction, journaled_state::JournalCheckpoint},
-    interpreter::{SStoreResult, StateLoad},
     precompile::{PrecompileHalt, PrecompileOutput, PrecompileResult},
     state::{AccountInfo, Bytecode},
 };
 use scoped_tls::scoped_thread_local;
 use std::{cell::RefCell, fmt::Debug};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::{TempoBlockEnv, TemporaryStorageAccount};
+use tempo_primitives::TempoBlockEnv;
 
 use crate::{
     Precompile,
@@ -167,14 +166,15 @@ impl StorageCtx {
         Self::try_with_storage(|s| s.sstore(address, key, value))
     }
 
-    /// Journal SSTORE into a TIP-1040 temporary storage account, charging no gas.
-    pub fn temporary_sstore(
-        &mut self,
-        account: TemporaryStorageAccount,
-        key: U256,
-        value: U256,
-    ) -> Result<StateLoad<SStoreResult>> {
-        Self::try_with_storage(|s| s.temporary_sstore(account, key, value))
+    /// Stores `value` for `namespace` under `key` in TIP-1040 temporary storage.
+    pub fn temporary_store(&mut self, namespace: Address, key: B256, value: U256) -> Result<()> {
+        Self::try_with_storage(|s| s.temporary_store(namespace, key, value))
+    }
+
+    /// Loads `namespace`'s TIP-1040 temporary storage value for `key`, checking the
+    /// current epoch and falling back to the previous one.
+    pub fn temporary_load(&self, namespace: Address, key: B256) -> Result<U256> {
+        Self::try_with_storage(|s| s.temporary_load(namespace, key))
     }
 
     /// Increments a persistent storage slot by `delta`.

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -5,13 +5,14 @@ use alloy::{
 use alloy_evm::{Database, EvmInternals};
 use revm::{
     context::{CfgEnv, ContextTr, JournalTr, Transaction, journaled_state::JournalCheckpoint},
+    interpreter::{SStoreResult, StateLoad},
     precompile::{PrecompileHalt, PrecompileOutput, PrecompileResult},
     state::{AccountInfo, Bytecode},
 };
 use scoped_tls::scoped_thread_local;
 use std::{cell::RefCell, fmt::Debug};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::TempoBlockEnv;
+use tempo_primitives::{TempoBlockEnv, TemporaryStorageAccount};
 
 use crate::{
     Precompile,
@@ -164,6 +165,18 @@ impl StorageCtx {
     /// Performs an SSTORE operation (persistent storage write).
     pub fn sstore(&mut self, address: Address, key: U256, value: U256) -> Result<()> {
         Self::try_with_storage(|s| s.sstore(address, key, value))
+    }
+
+    /// Journal SSTORE into a TIP-1040 temporary storage account, charging no gas and
+    /// returning the value transition and whether the slot was cold. Callers meter gas
+    /// themselves per the TIP-1040 schedule.
+    pub fn temporary_sstore(
+        &mut self,
+        account: TemporaryStorageAccount,
+        key: U256,
+        value: U256,
+    ) -> Result<StateLoad<SStoreResult>> {
+        Self::try_with_storage(|s| s.temporary_sstore(account, key, value))
     }
 
     /// Increments a persistent storage slot by `delta`.

--- a/crates/precompiles/src/temporary_storage/dispatch.rs
+++ b/crates/precompiles/src/temporary_storage/dispatch.rs
@@ -1,0 +1,109 @@
+//! ABI dispatch for the [`TemporaryStorage`] precompile.
+
+use crate::{
+    Precompile, charge_input_cost, dispatch, mutate_void, temporary_storage::TemporaryStorage, view,
+};
+use alloy::primitives::Address;
+use revm::precompile::PrecompileResult;
+use tempo_contracts::precompiles::ITemporaryStorage;
+
+impl Precompile for TemporaryStorage {
+    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
+            return err;
+        }
+
+        dispatch!(calldata, |call| match call {
+            ITemporaryStorage::ITemporaryStorageCalls {
+                temporaryStore(call) =>
+                    mutate_void(call, msg_sender, |sender, c| self.temporary_store(sender, c)),
+                temporaryLoad(call) => view(call, |c| self.temporary_load(msg_sender, c)),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        dispatch::StaticCallNotAllowed,
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::{assert_full_coverage, check_selector_coverage},
+    };
+    use alloy::{
+        primitives::B256,
+        sol_types::{SolCall, SolError},
+    };
+    use tempo_contracts::precompiles::ITemporaryStorage::ITemporaryStorageCalls;
+
+    #[test]
+    fn test_dispatch_store_load_roundtrip() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut temporary_storage = TemporaryStorage::new();
+            let sender = Address::repeat_byte(0x11);
+            let key = B256::repeat_byte(0x01);
+            let value = B256::repeat_byte(0x02);
+
+            let store = ITemporaryStorage::temporaryStoreCall { key, value }.abi_encode();
+            let output = temporary_storage.call(&store, sender)?;
+            assert!(!output.is_revert());
+            assert!(output.bytes.is_empty());
+
+            let load = ITemporaryStorage::temporaryLoadCall { key }.abi_encode();
+            let output = temporary_storage.call(&load, sender)?;
+            assert!(!output.is_revert());
+            assert_eq!(output.bytes.as_ref(), value.as_slice());
+
+            // Another sender's read of the same key returns zero.
+            let output = temporary_storage.call(&load, Address::repeat_byte(0x22))?;
+            assert!(!output.is_revert());
+            assert_eq!(output.bytes.as_ref(), B256::ZERO.as_slice());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_dispatch_static_call_rejects_store() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_is_static(true);
+        StorageCtx::enter(&mut storage, || {
+            let mut temporary_storage = TemporaryStorage::new();
+            let sender = Address::repeat_byte(0x11);
+            let key = B256::repeat_byte(0x01);
+
+            let store = ITemporaryStorage::temporaryStoreCall {
+                key,
+                value: B256::repeat_byte(0x02),
+            }
+            .abi_encode();
+            let output = temporary_storage.call(&store, sender)?;
+            assert!(output.is_revert());
+            assert!(StaticCallNotAllowed::abi_decode(&output.bytes).is_ok());
+
+            let load = ITemporaryStorage::temporaryLoadCall { key }.abi_encode();
+            let output = temporary_storage.call(&load, sender)?;
+            assert!(!output.is_revert());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_temporary_storage_selector_coverage() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut temporary_storage = TemporaryStorage::new();
+
+            let unsupported = check_selector_coverage(
+                &mut temporary_storage,
+                ITemporaryStorageCalls::SELECTORS,
+                "ITemporaryStorage",
+                ITemporaryStorageCalls::name_by_selector,
+            );
+
+            assert_full_coverage([unsupported]);
+            Ok(())
+        })
+    }
+}

--- a/crates/precompiles/src/temporary_storage/mod.rs
+++ b/crates/precompiles/src/temporary_storage/mod.rs
@@ -10,30 +10,18 @@ pub mod dispatch;
 
 pub use tempo_contracts::precompiles::ITemporaryStorage;
 use tempo_precompiles_macros::contract;
-use tempo_primitives::TemporaryStorageAccount;
+pub use tempo_primitives::TEMPORARY_STORAGE_EPOCH_LENGTH as EPOCH_LENGTH;
 
 use crate::{TEMPORARY_STORAGE_ADDRESS, error::Result};
-use alloy::primitives::{Address, B256, U256, keccak256};
-
-/// Number of blocks per TIP-1040 epoch, approximately 24 hours at 500ms slot times.
-pub const EPOCH_LENGTH: u64 = 172_800;
-
-/// Gas cost for `temporaryStore` when the slot is zero in the current epoch.
-const TEMPORARY_STORE_GAS_NEW: u64 = 40_000;
-
-/// Gas cost for `temporaryStore` when the slot is nonzero in the current epoch and cold
-/// (`COLD_SLOAD_COST` + `SSTORE_RESET_GAS`).
-const TEMPORARY_STORE_GAS_EXISTING_COLD: u64 = 2_100 + 5_000;
-
-/// Gas cost for `temporaryStore` when the slot is nonzero in the current epoch and warm
-/// (`WARM_STORAGE_READ_COST` + `SSTORE_WRITE_GAS_DELTA`).
-const TEMPORARY_STORE_GAS_EXISTING_WARM: u64 = 200;
+use alloy::primitives::{Address, B256};
 
 /// TIP-1040 temporary storage precompile.
 ///
-/// `temporaryLoad` gas follows the standard EIP-2929 SLOAD pricing; `temporaryStore`
-/// uses the TIP-1040 pricing above, metered by this precompile on top of the unmetered
-/// [`temporary_sstore`](crate::storage::StorageCtx::temporary_sstore).
+/// A thin ABI shell: the complete storage operations (slot derivation, epoch routing,
+/// fallback reads, and gas) live on the storage provider's
+/// [`temporary_store`](crate::storage::StorageCtx::temporary_store)/
+/// [`temporary_load`](crate::storage::StorageCtx::temporary_load), with `msg.sender` as
+/// the namespace.
 #[contract(addr = TEMPORARY_STORAGE_ADDRESS)]
 pub struct TemporaryStorage {}
 
@@ -43,79 +31,33 @@ impl TemporaryStorage {
         self.__initialize()
     }
 
-    /// Returns the TIP-1040 epoch containing the current block.
-    pub fn current_epoch(&self) -> u64 {
-        self.storage.block_number() / EPOCH_LENGTH
-    }
-
-    /// Derives the storage slot for a `(sender, key)` pair: `keccak256(sender || key)`.
-    ///
-    /// Unmetered, like [`Mapping`](crate::storage::Mapping) slot derivation; TIP-1040 prices
-    /// the hash into the flat operation costs.
-    fn slot(sender: Address, key: B256) -> U256 {
-        let mut buf = [0u8; 52];
-        buf[..20].copy_from_slice(sender.as_slice());
-        buf[20..].copy_from_slice(key.as_slice());
-        keccak256(buf).into()
-    }
-
-    /// Stores `value` at the derived slot in the current epoch's account.
+    /// Stores `value` for `sender` under `key` in the current epoch.
     pub fn temporary_store(
         &mut self,
         sender: Address,
         call: ITemporaryStorage::temporaryStoreCall,
     ) -> Result<()> {
-        let slot = Self::slot(sender, call.key);
-        let account = TemporaryStorageAccount::for_epoch(self.current_epoch());
-
-        // Pre-charge the minimum store cost before touching storage to avoid cheap useless
-        // work, mirroring the metered SSTORE path.
-        self.storage.deduct_gas(TEMPORARY_STORE_GAS_EXISTING_WARM)?;
-        let result = self
-            .storage
-            .temporary_sstore(account, slot, call.value.into())?;
-        let gas = if result.data.present_value.is_zero() {
-            TEMPORARY_STORE_GAS_NEW
-        } else if result.is_cold {
-            TEMPORARY_STORE_GAS_EXISTING_COLD
-        } else {
-            TEMPORARY_STORE_GAS_EXISTING_WARM
-        };
         self.storage
-            .deduct_gas(gas - TEMPORARY_STORE_GAS_EXISTING_WARM)
+            .temporary_store(sender, call.key, call.value.into())
     }
 
-    /// Loads the value for the derived slot, checking the current epoch first and falling
+    /// Loads `sender`'s value for `key`, checking the current epoch first and falling
     /// back to the previous epoch. Returns zero if the key is unset in both.
     pub fn temporary_load(
         &self,
         sender: Address,
         call: ITemporaryStorage::temporaryLoadCall,
     ) -> Result<B256> {
-        let slot = Self::slot(sender, call.key);
-        let epoch = self.current_epoch();
-
-        let value = self
-            .storage
-            .sload(TemporaryStorageAccount::for_epoch(epoch).address(), slot)?;
-        if !value.is_zero() || epoch == 0 {
-            return Ok(value.into());
-        }
-        Ok(self
-            .storage
-            .sload(
-                TemporaryStorageAccount::for_epoch(epoch - 1).address(),
-                slot,
-            )?
-            .into())
+        Ok(self.storage.temporary_load(sender, call.key)?.into())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
-    use alloy::primitives::{address, keccak256};
+    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider, temporary};
+    use alloy::primitives::{U256, address, keccak256};
+    use tempo_primitives::TemporaryStorageAccount;
 
     const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
 
@@ -395,7 +337,7 @@ mod tests {
             // Read back through the database, as the next block would.
             Ok(evm
                 .db_mut()
-                .storage(epoch_account, TemporaryStorage::slot(SENDER, key))?)
+                .storage(epoch_account, temporary::slot(SENDER, key))?)
         };
 
         assert_eq!(

--- a/crates/precompiles/src/temporary_storage/mod.rs
+++ b/crates/precompiles/src/temporary_storage/mod.rs
@@ -10,7 +10,6 @@ pub mod dispatch;
 
 pub use tempo_contracts::precompiles::ITemporaryStorage;
 use tempo_precompiles_macros::contract;
-pub use tempo_primitives::TEMPORARY_STORAGE_EPOCH_LENGTH as EPOCH_LENGTH;
 
 use crate::{TEMPORARY_STORAGE_ADDRESS, error::Result};
 use alloy::primitives::{Address, B256};
@@ -57,7 +56,7 @@ mod tests {
     use super::*;
     use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider, temporary};
     use alloy::primitives::{U256, address, keccak256};
-    use tempo_primitives::TemporaryStorageAccount;
+    use tempo_primitives::{TEMPORARY_STORAGE_EPOCH_LENGTH, TemporaryStorageAccount};
 
     const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
 
@@ -109,7 +108,7 @@ mod tests {
     #[test]
     fn test_value_stored_in_epoch_account() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
-        storage.set_block_number(5 * EPOCH_LENGTH);
+        storage.set_block_number(5 * TEMPORARY_STORAGE_EPOCH_LENGTH);
         StorageCtx::enter(&mut storage, || {
             let key = B256::repeat_byte(0x01);
             store(SENDER, key, B256::repeat_byte(0x02))
@@ -136,12 +135,15 @@ mod tests {
         let value = B256::repeat_byte(0x02);
 
         // Write in the last block of epoch 0.
-        storage.set_block_number(EPOCH_LENGTH - 1);
+        storage.set_block_number(TEMPORARY_STORAGE_EPOCH_LENGTH - 1);
         StorageCtx::enter(&mut storage, || store(SENDER, key, value))?;
 
         // Readable throughout epoch 1 via the previous-epoch fallback; the first block
         // of epoch 1 is where the "no previous epoch" guard flips off.
-        for block in [EPOCH_LENGTH, 2 * EPOCH_LENGTH - 1] {
+        for block in [
+            TEMPORARY_STORAGE_EPOCH_LENGTH,
+            2 * TEMPORARY_STORAGE_EPOCH_LENGTH - 1,
+        ] {
             storage.set_block_number(block);
             StorageCtx::enter(&mut storage, || {
                 assert_eq!(load(SENDER, key).unwrap(), value)
@@ -149,7 +151,7 @@ mod tests {
         }
 
         // Unreachable from epoch 2 onward.
-        storage.set_block_number(2 * EPOCH_LENGTH);
+        storage.set_block_number(2 * TEMPORARY_STORAGE_EPOCH_LENGTH);
         StorageCtx::enter(&mut storage, || {
             assert_eq!(load(SENDER, key).unwrap(), B256::ZERO)
         });
@@ -163,10 +165,10 @@ mod tests {
         let old = B256::repeat_byte(0x02);
         let new = B256::repeat_byte(0x03);
 
-        storage.set_block_number(3 * EPOCH_LENGTH);
+        storage.set_block_number(3 * TEMPORARY_STORAGE_EPOCH_LENGTH);
         StorageCtx::enter(&mut storage, || store(SENDER, key, old))?;
 
-        storage.set_block_number(4 * EPOCH_LENGTH);
+        storage.set_block_number(4 * TEMPORARY_STORAGE_EPOCH_LENGTH);
         StorageCtx::enter(&mut storage, || {
             // Fallback still returns the epoch-3 value until overwritten.
             assert_eq!(load(SENDER, key)?, old);
@@ -184,10 +186,10 @@ mod tests {
         let key = B256::repeat_byte(0x01);
         let value = B256::repeat_byte(0x02);
 
-        storage.set_block_number(3 * EPOCH_LENGTH);
+        storage.set_block_number(3 * TEMPORARY_STORAGE_EPOCH_LENGTH);
         StorageCtx::enter(&mut storage, || store(SENDER, key, value))?;
 
-        storage.set_block_number(4 * EPOCH_LENGTH);
+        storage.set_block_number(4 * TEMPORARY_STORAGE_EPOCH_LENGTH);
         StorageCtx::enter(&mut storage, || {
             store(SENDER, key, B256::ZERO)?;
             assert_eq!(load(SENDER, key)?, value);
@@ -272,7 +274,7 @@ mod tests {
         // account, charging both slots independently: 2 * 2,100.
         let block_epoch_1 = TempoBlockEnv {
             inner: revm::context::BlockEnv {
-                number: U256::from(EPOCH_LENGTH),
+                number: U256::from(TEMPORARY_STORAGE_EPOCH_LENGTH),
                 ..Default::default()
             },
             ..Default::default()

--- a/crates/precompiles/src/temporary_storage/mod.rs
+++ b/crates/precompiles/src/temporary_storage/mod.rs
@@ -306,7 +306,7 @@ mod tests {
 
         let key = B256::repeat_byte(0x01);
         let value = B256::repeat_byte(0x02);
-        let epoch_account = TemporaryStorageAccount::for_epoch(0).address();
+        let epoch_account = TemporaryStorageAccount::for_block(0).address();
 
         let run_block = |with_marker: bool| -> eyre::Result<U256> {
             let mut cfg = CfgEnv::<TempoHardfork>::default();

--- a/crates/precompiles/src/temporary_storage/mod.rs
+++ b/crates/precompiles/src/temporary_storage/mod.rs
@@ -1,0 +1,411 @@
+//! Epoch-scoped temporary key-value storage precompile as per [TIP-1040].
+//!
+//! Values are keyed by `keccak256(sender || key)` and stored in a separate account per
+//! epoch (`TEMPORARY_STORAGE_ADDRESS + epoch + 1`), so data written in epoch `E` is
+//! readable in epochs `E` and `E+1` and nodes can prune older epoch accounts wholesale.
+//!
+//! [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+
+pub mod dispatch;
+
+pub use tempo_contracts::precompiles::ITemporaryStorage;
+use tempo_precompiles_macros::contract;
+use tempo_primitives::TemporaryStorageAccount;
+
+use crate::{TEMPORARY_STORAGE_ADDRESS, error::Result};
+use alloy::primitives::{Address, B256, U256, keccak256};
+
+/// Number of blocks per TIP-1040 epoch, approximately 24 hours at 500ms slot times.
+pub const EPOCH_LENGTH: u64 = 172_800;
+
+/// Gas cost for `temporaryStore` when the slot is zero in the current epoch.
+const TEMPORARY_STORE_GAS_NEW: u64 = 40_000;
+
+/// Gas cost for `temporaryStore` when the slot is nonzero in the current epoch and cold
+/// (`COLD_SLOAD_COST` + `SSTORE_RESET_GAS`).
+const TEMPORARY_STORE_GAS_EXISTING_COLD: u64 = 2_100 + 5_000;
+
+/// Gas cost for `temporaryStore` when the slot is nonzero in the current epoch and warm
+/// (`WARM_STORAGE_READ_COST` + `SSTORE_WRITE_GAS_DELTA`).
+const TEMPORARY_STORE_GAS_EXISTING_WARM: u64 = 200;
+
+/// TIP-1040 temporary storage precompile.
+///
+/// The precompile address itself only hosts the dispatch logic; all values live in the
+/// per-epoch [`TemporaryStorageAccount`]s. `temporaryLoad` gas follows the standard
+/// EIP-2929 SLOAD pricing; `temporaryStore` uses the TIP-1040 pricing above, metered by
+/// this precompile on top of the unmetered [`temporary_sstore`](crate::storage::StorageCtx::temporary_sstore).
+#[contract(addr = TEMPORARY_STORAGE_ADDRESS)]
+pub struct TemporaryStorage {}
+
+impl TemporaryStorage {
+    /// Initializes the temporary storage precompile.
+    pub fn initialize(&mut self) -> Result<()> {
+        self.__initialize()
+    }
+
+    /// Returns the TIP-1040 epoch containing the current block.
+    pub fn current_epoch(&self) -> u64 {
+        self.storage.block_number() / EPOCH_LENGTH
+    }
+
+    /// Derives the storage slot for a `(sender, key)` pair: `keccak256(sender || key)`.
+    ///
+    /// Unmetered, like [`Mapping`](crate::storage::Mapping) slot derivation; TIP-1040 prices
+    /// the hash into the flat operation costs.
+    fn slot(sender: Address, key: B256) -> U256 {
+        let mut buf = [0u8; 52];
+        buf[..20].copy_from_slice(sender.as_slice());
+        buf[20..].copy_from_slice(key.as_slice());
+        keccak256(buf).into()
+    }
+
+    /// Stores `value` at the derived slot in the current epoch's account.
+    pub fn temporary_store(
+        &mut self,
+        sender: Address,
+        call: ITemporaryStorage::temporaryStoreCall,
+    ) -> Result<()> {
+        let slot = Self::slot(sender, call.key);
+        let account = TemporaryStorageAccount::for_epoch(self.current_epoch());
+
+        // Pre-charge the minimum store cost before touching storage to avoid cheap useless
+        // work, mirroring the metered SSTORE path.
+        self.storage.deduct_gas(TEMPORARY_STORE_GAS_EXISTING_WARM)?;
+        let result = self
+            .storage
+            .temporary_sstore(account, slot, call.value.into())?;
+        let gas = if result.data.present_value.is_zero() {
+            TEMPORARY_STORE_GAS_NEW
+        } else if result.is_cold {
+            TEMPORARY_STORE_GAS_EXISTING_COLD
+        } else {
+            TEMPORARY_STORE_GAS_EXISTING_WARM
+        };
+        self.storage
+            .deduct_gas(gas - TEMPORARY_STORE_GAS_EXISTING_WARM)
+    }
+
+    /// Loads the value for the derived slot, checking the current epoch first and falling
+    /// back to the previous epoch. Returns zero if the key is unset in both.
+    pub fn temporary_load(
+        &self,
+        sender: Address,
+        call: ITemporaryStorage::temporaryLoadCall,
+    ) -> Result<B256> {
+        let slot = Self::slot(sender, call.key);
+        let epoch = self.current_epoch();
+
+        let value = self
+            .storage
+            .sload(TemporaryStorageAccount::for_epoch(epoch).address(), slot)?;
+        if !value.is_zero() || epoch == 0 {
+            return Ok(value.into());
+        }
+        Ok(self
+            .storage
+            .sload(
+                TemporaryStorageAccount::for_epoch(epoch - 1).address(),
+                slot,
+            )?
+            .into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
+    use alloy::primitives::{address, keccak256};
+
+    const SENDER: Address = address!("0x1111111111111111111111111111111111111111");
+
+    fn store(sender: Address, key: B256, value: B256) -> Result<()> {
+        TemporaryStorage::new()
+            .temporary_store(sender, ITemporaryStorage::temporaryStoreCall { key, value })
+    }
+
+    fn load(sender: Address, key: B256) -> Result<B256> {
+        TemporaryStorage::new().temporary_load(sender, ITemporaryStorage::temporaryLoadCall { key })
+    }
+
+    #[test]
+    fn test_store_load_roundtrip() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let key = B256::repeat_byte(0x01);
+            let value = B256::repeat_byte(0x02);
+
+            assert_eq!(load(SENDER, key)?, B256::ZERO);
+
+            store(SENDER, key, value)?;
+            assert_eq!(load(SENDER, key)?, value);
+
+            // Overwrites replace the previous value.
+            let value2 = B256::repeat_byte(0x03);
+            store(SENDER, key, value2)?;
+            assert_eq!(load(SENDER, key)?, value2);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_sender_isolation() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let other = address!("0x2222222222222222222222222222222222222222");
+            let key = B256::repeat_byte(0x01);
+
+            store(SENDER, key, B256::repeat_byte(0xAA))?;
+
+            assert_eq!(load(other, key)?, B256::ZERO);
+            store(other, key, B256::repeat_byte(0xBB))?;
+            assert_eq!(load(SENDER, key)?, B256::repeat_byte(0xAA));
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_value_stored_in_epoch_account() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        storage.set_block_number(5 * EPOCH_LENGTH);
+        StorageCtx::enter(&mut storage, || {
+            let key = B256::repeat_byte(0x01);
+            store(SENDER, key, B256::repeat_byte(0x02))
+        })?;
+
+        let mut buf = [0u8; 52];
+        buf[..20].copy_from_slice(SENDER.as_slice());
+        buf[20..].copy_from_slice(&[0x01; 32]);
+        let slot: U256 = keccak256(buf).into();
+
+        // Epoch 5's data lives at `TEMPORARY_STORAGE_ADDRESS + 6`.
+        let expected_account = address!("0x1040000000000000000000000000000000000006");
+        assert_eq!(
+            storage.into_storage().collect::<Vec<_>>(),
+            vec![(expected_account, slot, U256::from_be_bytes([0x02; 32]))]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_epoch_expiry() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let key = B256::repeat_byte(0x01);
+        let value = B256::repeat_byte(0x02);
+
+        // Write in the last block of epoch 0.
+        storage.set_block_number(EPOCH_LENGTH - 1);
+        StorageCtx::enter(&mut storage, || store(SENDER, key, value))?;
+
+        // Readable throughout epoch 1 via the previous-epoch fallback; the first block
+        // of epoch 1 is where the "no previous epoch" guard flips off.
+        for block in [EPOCH_LENGTH, 2 * EPOCH_LENGTH - 1] {
+            storage.set_block_number(block);
+            StorageCtx::enter(&mut storage, || {
+                assert_eq!(load(SENDER, key).unwrap(), value)
+            });
+        }
+
+        // Unreachable from epoch 2 onward.
+        storage.set_block_number(2 * EPOCH_LENGTH);
+        StorageCtx::enter(&mut storage, || {
+            assert_eq!(load(SENDER, key).unwrap(), B256::ZERO)
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn test_current_epoch_shadows_previous() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let key = B256::repeat_byte(0x01);
+        let old = B256::repeat_byte(0x02);
+        let new = B256::repeat_byte(0x03);
+
+        storage.set_block_number(3 * EPOCH_LENGTH);
+        StorageCtx::enter(&mut storage, || store(SENDER, key, old))?;
+
+        storage.set_block_number(4 * EPOCH_LENGTH);
+        StorageCtx::enter(&mut storage, || {
+            // Fallback still returns the epoch-3 value until overwritten.
+            assert_eq!(load(SENDER, key)?, old);
+            store(SENDER, key, new)?;
+            assert_eq!(load(SENDER, key)?, new);
+            Ok(())
+        })
+    }
+
+    /// Storing zero does not shadow the previous epoch's value: the fallback triggers on
+    /// a zero current-epoch slot, so temporary storage has no tombstones.
+    #[test]
+    fn test_storing_zero_does_not_tombstone_previous_epoch() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let key = B256::repeat_byte(0x01);
+        let value = B256::repeat_byte(0x02);
+
+        storage.set_block_number(3 * EPOCH_LENGTH);
+        StorageCtx::enter(&mut storage, || store(SENDER, key, value))?;
+
+        storage.set_block_number(4 * EPOCH_LENGTH);
+        StorageCtx::enter(&mut storage, || {
+            store(SENDER, key, B256::ZERO)?;
+            assert_eq!(load(SENDER, key)?, value);
+            Ok(())
+        })
+    }
+
+    /// Exercises the TIP-1040 gas schedule against the journal-backed provider, which
+    /// tracks warm/cold state per `(account, slot)` like production.
+    #[test]
+    fn test_gas_costs() -> eyre::Result<()> {
+        use crate::storage::{PrecompileStorageProvider, evm::EvmPrecompileStorageProvider};
+        use alloy_evm::{EthEvmFactory, EvmEnv, EvmFactory, EvmInternals};
+        use revm::{
+            context::{CfgEnv, ContextTr, JournalTr, TxEnv},
+            database::{CacheDB, EmptyDB},
+        };
+        use tempo_chainspec::hardfork::TempoHardfork;
+        use tempo_primitives::TempoBlockEnv;
+
+        let mut cfg = CfgEnv::<TempoHardfork>::default();
+        cfg.set_spec_and_mainnet_gas_params(TempoHardfork::T9);
+        let tx = TxEnv::default();
+        let block = TempoBlockEnv::default(); // block 0, epoch 0
+
+        let db = CacheDB::new(EmptyDB::new());
+        let mut evm = EthEvmFactory::default().create_evm(db, EvmEnv::default());
+
+        let key = B256::repeat_byte(0x01);
+        let run = |journal: &mut _, block: &TempoBlockEnv, f: &dyn Fn() -> Result<()>| {
+            let internals = EvmInternals::new(journal, block, &cfg, &tx);
+            let mut provider =
+                EvmPrecompileStorageProvider::new_with_gas_limit(internals, &cfg, 1_000_000, 0);
+            StorageCtx::enter(&mut provider, f)?;
+            Ok::<_, eyre::Report>(provider.gas_used())
+        };
+
+        // New slot (zero in current epoch): flat 40,000, no cold surcharge.
+        let gas = run(evm.journal_mut(), &block, &|| {
+            store(SENDER, key, B256::repeat_byte(0x02))
+        })?;
+        assert_eq!(gas, 40_000);
+
+        // Existing warm slot: 200.
+        let gas = run(evm.journal_mut(), &block, &|| {
+            store(SENDER, key, B256::repeat_byte(0x03))
+        })?;
+        assert_eq!(gas, 200);
+
+        // Warm load: 100.
+        let gas = run(evm.journal_mut(), &block, &|| load(SENDER, key).map(|_| ()))?;
+        assert_eq!(gas, 100);
+
+        // Cold load of an unset key at epoch 0: 2,100 and no previous-epoch fallback.
+        let gas = run(evm.journal_mut(), &block, &|| {
+            load(SENDER, B256::repeat_byte(0xFF)).map(|_| ())
+        })?;
+        assert_eq!(gas, 2_100);
+
+        // New transaction: all slots are cold again.
+        evm.journal_mut().commit_tx();
+
+        // Existing cold slot: 2,100 + 5,000.
+        let gas = run(evm.journal_mut(), &block, &|| {
+            store(SENDER, key, B256::repeat_byte(0x04))
+        })?;
+        assert_eq!(gas, 7_100);
+
+        // Storing zero into an empty slot is still a "new slot" store, and leaves the slot
+        // new: a subsequent store to it is priced as new again.
+        let zero_key = B256::repeat_byte(0xAB);
+        let gas = run(evm.journal_mut(), &block, &|| {
+            store(SENDER, zero_key, B256::ZERO)
+        })?;
+        assert_eq!(gas, 40_000);
+        let gas = run(evm.journal_mut(), &block, &|| {
+            store(SENDER, zero_key, B256::repeat_byte(0x05))
+        })?;
+        assert_eq!(gas, 40_000);
+
+        // Cold load of an unset key past epoch 0 falls back to the previous epoch's
+        // account, charging both slots independently: 2 * 2,100.
+        let block_epoch_1 = TempoBlockEnv {
+            inner: revm::context::BlockEnv {
+                number: U256::from(EPOCH_LENGTH),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let gas = run(evm.journal_mut(), &block_epoch_1, &|| {
+            load(SENDER, B256::repeat_byte(0xFF)).map(|_| ())
+        })?;
+        assert_eq!(gas, 2 * 2_100);
+
+        Ok(())
+    }
+
+    /// TIP-1040 data must survive block commit. The epoch account carries storage but no
+    /// balance/nonce, so it needs the `0xEF` marker (deployed by the block executor at the
+    /// start of each block) — without it the account is touched-but-empty and EIP-161
+    /// state clear drops it, storage included.
+    #[test]
+    fn test_epoch_account_survives_state_clear_only_with_marker() -> eyre::Result<()> {
+        use crate::storage::evm::EvmPrecompileStorageProvider;
+        use alloy_evm::{EthEvmFactory, EvmEnv, EvmFactory, EvmInternals};
+        use revm::{
+            Database as _, DatabaseCommit as _,
+            context::{CfgEnv, ContextTr, JournalTr, TxEnv},
+            database::State,
+            state::Bytecode,
+        };
+        use tempo_chainspec::hardfork::TempoHardfork;
+        use tempo_primitives::TempoBlockEnv;
+
+        let key = B256::repeat_byte(0x01);
+        let value = B256::repeat_byte(0x02);
+        let epoch_account = TemporaryStorageAccount::for_epoch(0).address();
+
+        let run_block = |with_marker: bool| -> eyre::Result<U256> {
+            let mut cfg = CfgEnv::<TempoHardfork>::default();
+            cfg.set_spec_and_mainnet_gas_params(TempoHardfork::T9);
+            let tx = TxEnv::default();
+            let block = TempoBlockEnv::default(); // block 0, epoch 0
+
+            let db = State::builder().with_bundle_update().build();
+            let mut evm = EthEvmFactory::default().create_evm(db, EvmEnv::default());
+
+            {
+                let internals = EvmInternals::new(evm.journal_mut(), &block, &cfg, &tx);
+                let mut provider =
+                    EvmPrecompileStorageProvider::new_with_gas_limit(internals, &cfg, 1_000_000, 0);
+                StorageCtx::enter(&mut provider, || {
+                    if with_marker {
+                        StorageCtx.set_code(epoch_account, Bytecode::new_legacy([0xef].into()))?;
+                    }
+                    store(SENDER, key, value)
+                })?;
+            }
+
+            // Commit the block: journal -> State applies EIP-161 state clear.
+            let state = evm.journal_mut().finalize();
+            evm.db_mut().commit(state);
+
+            // Read back through the database, as the next block would.
+            Ok(evm
+                .db_mut()
+                .storage(epoch_account, TemporaryStorage::slot(SENDER, key))?)
+        };
+
+        assert_eq!(
+            run_block(true)?,
+            U256::from_be_bytes([0x02; 32]),
+            "storage must survive commit when the epoch account has the marker"
+        );
+        assert_eq!(
+            run_block(false)?,
+            U256::ZERO,
+            "without the marker, EIP-161 state clear drops the epoch account"
+        );
+        Ok(())
+    }
+}

--- a/crates/precompiles/src/temporary_storage/mod.rs
+++ b/crates/precompiles/src/temporary_storage/mod.rs
@@ -31,10 +31,9 @@ const TEMPORARY_STORE_GAS_EXISTING_WARM: u64 = 200;
 
 /// TIP-1040 temporary storage precompile.
 ///
-/// The precompile address itself only hosts the dispatch logic; all values live in the
-/// per-epoch [`TemporaryStorageAccount`]s. `temporaryLoad` gas follows the standard
-/// EIP-2929 SLOAD pricing; `temporaryStore` uses the TIP-1040 pricing above, metered by
-/// this precompile on top of the unmetered [`temporary_sstore`](crate::storage::StorageCtx::temporary_sstore).
+/// `temporaryLoad` gas follows the standard EIP-2929 SLOAD pricing; `temporaryStore`
+/// uses the TIP-1040 pricing above, metered by this precompile on top of the unmetered
+/// [`temporary_sstore`](crate::storage::StorageCtx::temporary_sstore).
 #[contract(addr = TEMPORARY_STORAGE_ADDRESS)]
 pub struct TemporaryStorage {}
 

--- a/crates/precompiles/src/temporary_storage/mod.rs
+++ b/crates/precompiles/src/temporary_storage/mod.rs
@@ -380,7 +380,10 @@ mod tests {
                     EvmPrecompileStorageProvider::new_with_gas_limit(internals, &cfg, 1_000_000, 0);
                 StorageCtx::enter(&mut provider, || {
                     if with_marker {
-                        StorageCtx.set_code(epoch_account, Bytecode::new_legacy([0xef].into()))?;
+                        StorageCtx.set_code(
+                            epoch_account,
+                            Bytecode::new_legacy(TemporaryStorageAccount::MARKER_CODE.into()),
+                        )?;
                     }
                     store(SENDER, key, value)
                 })?;

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -1,5 +1,47 @@
-use alloy_primitives::{Address, FixedBytes, hex};
-use tempo_contracts::{TempoHardfork, precompiles::SYSTEM_PRECOMPILES};
+use alloy_primitives::{Address, B256, FixedBytes, U256, hex};
+use tempo_contracts::{
+    TempoHardfork,
+    precompiles::{SYSTEM_PRECOMPILES, TEMPORARY_STORAGE_ADDRESS},
+};
+
+/// A [TIP-1040] per-epoch temporary storage account: `TEMPORARY_STORAGE_ADDRESS + epoch + 1`.
+///
+/// Only constructible via [`Self::for_epoch`], so holding one is proof the address is a
+/// temporary storage account. Writes to these accounts follow TIP-1040 gas rules and are
+/// exempt from TIP-1060 storage credits; nodes may prune their storage once the epoch
+/// expires. Code that only has a raw [`Address`] can classify it with
+/// [`TempoAddressExt::is_temporary_storage_account`].
+///
+/// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TemporaryStorageAccount(Address);
+
+impl TemporaryStorageAccount {
+    /// Returns the account storing epoch `epoch`'s data.
+    ///
+    /// The `+ 1` offset reserves `TEMPORARY_STORAGE_ADDRESS` itself for the precompile
+    /// dispatch logic. The sum cannot overflow 160 bits: the base address has its low
+    /// 144 bits zero. `epoch + 1` fits the trailing 8 bytes for all epochs except
+    /// `u64::MAX` (unreachable: ~10^13 years at 500ms blocks), which would carry into
+    /// the 12-byte prefix that [`TempoAddressExt::is_temporary_storage_account`] checks.
+    pub fn for_epoch(epoch: u64) -> Self {
+        let base: U256 = TEMPORARY_STORAGE_ADDRESS.into_word().into();
+        Self(Address::from_word(B256::from(
+            base + U256::from(epoch) + U256::ONE,
+        )))
+    }
+
+    /// Returns the underlying account address.
+    pub const fn address(&self) -> Address {
+        self.0
+    }
+}
+
+impl From<TemporaryStorageAccount> for Address {
+    fn from(account: TemporaryStorageAccount) -> Self {
+        account.0
+    }
+}
 
 /// TIP20 token address prefix (12 bytes)
 /// The full address is: TIP20_TOKEN_PREFIX (12 bytes) || derived_bytes (8 bytes)
@@ -44,6 +86,12 @@ pub trait TempoAddressExt {
     /// - A system precompile active at the specified `spec` hardfork.
     fn is_precompile(&self, spec: TempoHardfork) -> bool;
 
+    /// Returns `true` if the address is a [TIP-1040] per-epoch temporary storage account
+    /// (`TEMPORARY_STORAGE_ADDRESS + epoch + 1`).
+    ///
+    /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+    fn is_temporary_storage_account(&self) -> bool;
+
     /// Returns `true` if the address matches the [TIP-1022] virtual-address format
     /// (bytes `[4:14]` == [`Self::VIRTUAL_MAGIC`]).
     ///
@@ -70,6 +118,14 @@ impl TempoAddressExt for Address {
 
     fn is_tip20(&self) -> bool {
         is_tip20_prefix(*self)
+    }
+
+    fn is_temporary_storage_account(&self) -> bool {
+        // Epoch accounts are `TEMPORARY_STORAGE_ADDRESS + epoch + 1` with `epoch` a u64,
+        // so they share the base address's first 12 bytes and differ in the trailing 8.
+        // The base address itself is the precompile, not a storage account.
+        self.as_slice()[..12] == TEMPORARY_STORAGE_ADDRESS.as_slice()[..12]
+            && *self != TEMPORARY_STORAGE_ADDRESS
     }
 
     fn is_virtual(&self) -> bool {
@@ -182,10 +238,39 @@ mod tests {
     }
 
     #[test]
+    fn test_temporary_storage_account_for_epoch() {
+        assert_eq!(
+            TemporaryStorageAccount::for_epoch(0).address(),
+            Address::from(hex!("1040000000000000000000000000000000000001"))
+        );
+        assert_eq!(
+            TemporaryStorageAccount::for_epoch(u64::from(u32::MAX)).address(),
+            Address::from(hex!("1040000000000000000000000000000100000000"))
+        );
+
+        // Every constructible account satisfies the raw-address predicate.
+        for epoch in [0, 1, 42, u64::from(u32::MAX), u64::MAX - 1] {
+            assert!(
+                TemporaryStorageAccount::for_epoch(epoch)
+                    .address()
+                    .is_temporary_storage_account()
+            );
+        }
+
+        // The precompile itself and unrelated addresses are not storage accounts.
+        assert!(!TEMPORARY_STORAGE_ADDRESS.is_temporary_storage_account());
+        assert!(!Address::ZERO.is_temporary_storage_account());
+        assert!(
+            !Address::from(hex!("1060000000000000000000000000000000000001"))
+                .is_temporary_storage_account()
+        );
+    }
+
+    #[test]
     fn test_is_precompile_address() {
         for &(address, activated) in SYSTEM_PRECOMPILES {
             assert!(address.is_precompile(activated));
-            assert!(address.is_precompile(TempoHardfork::T8));
+            assert!(address.is_precompile(TempoHardfork::T9));
 
             if activated != TempoHardfork::Genesis {
                 assert!(!address.is_precompile(TempoHardfork::Genesis));

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -7,9 +7,7 @@ use tempo_contracts::{
 /// A [TIP-1040] per-epoch temporary storage account: `TEMPORARY_STORAGE_ADDRESS + epoch + 1`.
 ///
 /// Only constructible via [`Self::for_epoch`], so holding one is proof the address is a
-/// temporary storage account. Writes to these accounts follow TIP-1040 gas rules and are
-/// exempt from TIP-1060 storage credits; nodes may prune their storage once the epoch
-/// expires. Code that only has a raw [`Address`] can classify it with
+/// temporary storage account. Code that only has a raw [`Address`] can classify it with
 /// [`TempoAddressExt::is_temporary_storage_account`].
 ///
 /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
@@ -19,17 +17,14 @@ pub struct TemporaryStorageAccount(Address);
 impl TemporaryStorageAccount {
     /// Code deployed to epoch accounts so they are non-empty and EIP-161 state clear
     /// cannot drop their storage. These bytes are the preimage of TIP-1040's
-    /// `EPOCH_ACCOUNT_CODE_HASH` (`keccak256` of this string), the code hash the spec
-    /// mandates for epoch accounts.
+    /// `EPOCH_ACCOUNT_CODE_HASH`.
     pub const MARKER_CODE: &'static [u8] = b"tempo.tip1040.epoch_account";
 
     /// Returns the account storing epoch `epoch`'s data.
     ///
     /// The `+ 1` offset reserves `TEMPORARY_STORAGE_ADDRESS` itself for the precompile
-    /// dispatch logic. The sum cannot overflow 160 bits: the base address has its low
-    /// 144 bits zero. `epoch + 1` fits the trailing 8 bytes for all epochs except
-    /// `u64::MAX` (unreachable: ~10^13 years at 500ms blocks), which would carry into
-    /// the 12-byte prefix that [`TempoAddressExt::is_temporary_storage_account`] checks.
+    /// dispatch logic. The sum cannot overflow 160 bits; `epoch + 1` fits the trailing
+    /// 8 bytes for any reachable epoch.
     pub fn for_epoch(epoch: u64) -> Self {
         let base: U256 = TEMPORARY_STORAGE_ADDRESS.into_word().into();
         Self(Address::from_word(B256::from(

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -17,6 +17,12 @@ use tempo_contracts::{
 pub struct TemporaryStorageAccount(Address);
 
 impl TemporaryStorageAccount {
+    /// Code deployed to epoch accounts so they are non-empty and EIP-161 state clear
+    /// cannot drop their storage. These bytes are the preimage of TIP-1040's
+    /// `EPOCH_ACCOUNT_CODE_HASH` (`keccak256` of this string), the code hash the spec
+    /// mandates for epoch accounts.
+    pub const MARKER_CODE: &'static [u8] = b"tempo.tip1040.epoch_account";
+
     /// Returns the account storing epoch `epoch`'s data.
     ///
     /// The `+ 1` offset reserves `TEMPORARY_STORAGE_ADDRESS` itself for the precompile
@@ -235,6 +241,17 @@ mod tests {
         let mut tip20_bytes = [0u8; 20];
         tip20_bytes[..12].copy_from_slice(&TIP20_TOKEN_PREFIX);
         assert!(!Address::from(tip20_bytes).is_valid_master());
+    }
+
+    #[test]
+    fn test_temporary_storage_marker_code_hash() {
+        // TIP-1040 `EPOCH_ACCOUNT_CODE_HASH`.
+        assert_eq!(
+            alloy_primitives::keccak256(TemporaryStorageAccount::MARKER_CODE),
+            alloy_primitives::b256!(
+                "0x36c6e1ae22d067a9cff9a601eb89b47b7e6b9d7170ed08dd74d663e14568066c"
+            )
+        );
     }
 
     #[test]

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -11,9 +11,9 @@ pub const TEMPORARY_STORAGE_EPOCH_LENGTH: u64 = 172_800;
 
 /// A [TIP-1040] per-epoch temporary storage account: `TEMPORARY_STORAGE_ADDRESS + epoch + 1`.
 ///
-/// Only constructible via [`Self::for_block`]/[`Self::for_epoch`], so holding one is proof
-/// the address is a temporary storage account. Code that only has a raw [`Address`] can
-/// classify it with [`TempoAddressExt::is_temporary_storage_account`].
+/// Only constructible via [`Self::for_block`], so holding one is proof the address is a
+/// temporary storage account. Code that only has a raw [`Address`] can classify it with
+/// [`TempoAddressExt::is_temporary_storage_account`].
 ///
 /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -34,8 +34,9 @@ impl TemporaryStorageAccount {
     ///
     /// The `+ 1` offset reserves `TEMPORARY_STORAGE_ADDRESS` itself for the precompile
     /// dispatch logic. The sum cannot overflow 160 bits; `epoch + 1` fits the trailing
-    /// 8 bytes for any reachable epoch.
-    pub fn for_epoch(epoch: u64) -> Self {
+    /// 8 bytes for any epoch reachable from a block number, which is why only
+    /// [`Self::for_block`] is public.
+    fn for_epoch(epoch: u64) -> Self {
         let base: U256 = TEMPORARY_STORAGE_ADDRESS.into_word().into();
         Self(Address::from_word(B256::from(
             base + U256::from(epoch) + U256::ONE,

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -4,11 +4,16 @@ use tempo_contracts::{
     precompiles::{SYSTEM_PRECOMPILES, TEMPORARY_STORAGE_ADDRESS},
 };
 
+/// Number of blocks per [TIP-1040] epoch, approximately 24 hours at 500ms slot times.
+///
+/// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
+pub const TEMPORARY_STORAGE_EPOCH_LENGTH: u64 = 172_800;
+
 /// A [TIP-1040] per-epoch temporary storage account: `TEMPORARY_STORAGE_ADDRESS + epoch + 1`.
 ///
-/// Only constructible via [`Self::for_epoch`], so holding one is proof the address is a
-/// temporary storage account. Code that only has a raw [`Address`] can classify it with
-/// [`TempoAddressExt::is_temporary_storage_account`].
+/// Only constructible via [`Self::for_block`]/[`Self::for_epoch`], so holding one is proof
+/// the address is a temporary storage account. Code that only has a raw [`Address`] can
+/// classify it with [`TempoAddressExt::is_temporary_storage_account`].
 ///
 /// [TIP-1040]: <https://docs.tempo.xyz/protocol/tip1040>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -19,6 +24,11 @@ impl TemporaryStorageAccount {
     /// cannot drop their storage. These bytes are the preimage of TIP-1040's
     /// `EPOCH_ACCOUNT_CODE_HASH`.
     pub const MARKER_CODE: &'static [u8] = b"tempo.tip1040.epoch_account";
+
+    /// Returns the account storing the data of the epoch containing `block_number`.
+    pub fn for_block(block_number: u64) -> Self {
+        Self::for_epoch(block_number / TEMPORARY_STORAGE_EPOCH_LENGTH)
+    }
 
     /// Returns the account storing epoch `epoch`'s data.
     ///

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,10 @@
 pub use alloy_consensus::Header;
 
 mod address;
-pub use address::{MasterId, TempoAddressExt, TemporaryStorageAccount, UserTag, is_tip20_prefix};
+pub use address::{
+    MasterId, TEMPORARY_STORAGE_EPOCH_LENGTH, TempoAddressExt, TemporaryStorageAccount, UserTag,
+    is_tip20_prefix,
+};
 pub mod ed25519;
 
 #[cfg(feature = "evm")]

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -7,7 +7,7 @@
 pub use alloy_consensus::Header;
 
 mod address;
-pub use address::{MasterId, TempoAddressExt, UserTag, is_tip20_prefix};
+pub use address::{MasterId, TempoAddressExt, TemporaryStorageAccount, UserTag, is_tip20_prefix};
 pub mod ed25519;
 
 #[cfg(feature = "evm")]

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -1,6 +1,6 @@
 use crate::{TempoBlockEnv, TempoInvalidTransaction, TempoTxEnv};
 use alloy_consensus::transaction::{Either, Recovered};
-use alloy_primitives::{Address, Bytes, LogData, TxKind, U256};
+use alloy_primitives::{Address, B256, Bytes, LogData, TxKind, U256};
 use alloy_sol_types::SolCall;
 use core::marker::PhantomData;
 use revm::{
@@ -478,14 +478,12 @@ where
         unreachable!("'sstore' not supported in read-only context")
     }
 
-    fn temporary_sstore(
-        &mut self,
-        _: tempo_primitives::TemporaryStorageAccount,
-        _: U256,
-        _: U256,
-    ) -> TempoResult<revm::interpreter::StateLoad<revm::interpreter::SStoreResult>> {
-        unreachable!("'temporary_sstore' not supported in read-only context")
+    fn temporary_store(&mut self, _: Address, _: B256, _: U256) -> TempoResult<()> {
+        unreachable!("'temporary_store' not supported in read-only context")
     }
+
+    // `temporary_load` keeps the trait's default implementation but is unusable here
+    // until `block_env` is implemented for the read-only context.
 
     fn set_code(&mut self, _: Address, _: Bytecode) -> TempoResult<()> {
         unreachable!("'set_code' not supported in read-only context")

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -478,6 +478,15 @@ where
         unreachable!("'sstore' not supported in read-only context")
     }
 
+    fn temporary_sstore(
+        &mut self,
+        _: tempo_primitives::TemporaryStorageAccount,
+        _: U256,
+        _: U256,
+    ) -> TempoResult<revm::interpreter::StateLoad<revm::interpreter::SStoreResult>> {
+        unreachable!("'temporary_sstore' not supported in read-only context")
+    }
+
     fn set_code(&mut self, _: Address, _: Bytecode) -> TempoResult<()> {
         unreachable!("'set_code' not supported in read-only context")
     }

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -525,6 +525,26 @@ where
         Ok(())
     }
 
+    fn temporary_sstore(
+        &mut self,
+        account: tempo_primitives::TemporaryStorageAccount,
+        key: U256,
+        value: U256,
+    ) -> Result<revm::interpreter::StateLoad<revm::interpreter::SStoreResult>, TempoPrecompileError>
+    {
+        let address = account.address();
+        let present = self.sload(address, key)?;
+        self.overlay.insert((address, key), value);
+        Ok(revm::interpreter::StateLoad::new(
+            revm::interpreter::SStoreResult {
+                original_value: present,
+                present_value: present,
+                new_value: value,
+            },
+            false,
+        ))
+    }
+
     fn tstore(
         &mut self,
         _address: Address,

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -525,24 +525,17 @@ where
         Ok(())
     }
 
-    fn temporary_sstore(
+    fn temporary_store(
         &mut self,
-        account: tempo_primitives::TemporaryStorageAccount,
-        key: U256,
+        namespace: Address,
+        key: B256,
         value: U256,
-    ) -> Result<revm::interpreter::StateLoad<revm::interpreter::SStoreResult>, TempoPrecompileError>
-    {
-        let address = account.address();
-        let present = self.sload(address, key)?;
-        self.overlay.insert((address, key), value);
-        Ok(revm::interpreter::StateLoad::new(
-            revm::interpreter::SStoreResult {
-                original_value: present,
-                present_value: present,
-                new_value: value,
-            },
-            false,
-        ))
+    ) -> Result<(), TempoPrecompileError> {
+        let slot = tempo_precompiles::storage::temporary::slot(namespace, key);
+        let block_number = self.block_env.number.saturating_to::<u64>();
+        let address = tempo_primitives::TemporaryStorageAccount::for_block(block_number).address();
+        self.overlay.insert((address, slot), value);
+        Ok(())
     }
 
     fn tstore(


### PR DESCRIPTION
Implements the TIP-1040 precompile at `0x1040…0000`, gated at T9: `temporaryStore`
writes `keccak256(sender || key)` slots into a per-epoch account
(`PRECOMPILE + epoch + 1`), `temporaryLoad` reads the current epoch with fallback
to the previous one. The precompile is a thin ABI shell over complete
`temporary_store`/`temporary_load` storage-provider operations, which own slot
derivation, epoch routing, the TIP gas schedule (40k new / 7.1k cold / 200 warm;
loads at standard EIP-2929 SLOAD pricing), and the TIP-1060 credit bypass.

Epoch accounts hold storage but no code, so EIP-161 state clear would drop them at
block commit — the executor deploys the spec's `EPOCH_ACCOUNT_CODE_HASH` marker to
the current epoch account at the start of each block (idempotent, same mechanism
as the T2–T7 rollouts).

Spec: https://tips.sh/1040

**Blocked** on state pruning support 