### PR TITLE
backport: #6678 to release/v1.10.2

### DIFF
--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -517,7 +517,10 @@ fn consensus_archive_entry(
     };
     let partition = partition.to_string_lossy().to_string();
     ensure!(
-        tempo_consensus::storage::snapshot::is_snapshot_storage_partition(&partition),
+        tempo_consensus::storage::snapshot::is_snapshot_storage_partition(
+            tempo_consensus::PARTITION_PREFIX,
+            &partition,
+        ),
         "consensus archive contains unexpected storage partition: {partition}",
     );
     let mut output_relative = PathBuf::from(&partition);

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -230,7 +230,12 @@ fn prepare_snapshot_consensus_archive(
             .with_storage_directory(archive_storage_dir);
         let output_runner = commonware_runtime::tokio::Runner::new(output_runtime_config);
         output_runner.start(|context| async move {
-            tempo_consensus::storage::snapshot::write_archive(&context, archive_entries_rx).await
+            tempo_consensus::storage::snapshot::write_archive(
+                &context,
+                tempo_consensus::PARTITION_PREFIX,
+                archive_entries_rx,
+            )
+            .await
         })
     });
 
@@ -241,6 +246,7 @@ fn prepare_snapshot_consensus_archive(
     let state = source_runner.start(|context| async move {
         tempo_consensus::storage::snapshot::prepare(
             &context,
+            tempo_consensus::PARTITION_PREFIX,
             execution_provider,
             archive_entries_tx,
         )

--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -227,18 +227,24 @@ impl<TContext: Spawner> Actor<TContext> {
             .latest_finalized
             .as_ref()
             .map(|b| Round::new(Epoch::new(b.epoch), View::new(b.view)));
+
         let latest_notarized_round = state
             .latest_notarized
             .as_ref()
             .map(|b| Round::new(Epoch::new(b.epoch), View::new(b.view)));
 
         // Update state and broadcast events
+        let height = certified.block.inner.number;
+        let subscribers = self.state.events_tx().receiver_count();
         match activity {
             Activity::Notarization(_) => {
-                let _ = self.state.events_tx().send(Event::Notarized {
-                    block: certified.clone(),
-                    seen: now_millis(),
-                });
+                if latest_notarized_round.is_none_or(|previous| round > previous) {
+                    debug!(subscribers, height, "sending new notarized event");
+                    let _ = self.state.events_tx().send(Event::Notarized {
+                        block: certified.clone(),
+                        seen: now_millis(),
+                    });
+                }
 
                 if latest_finalized_round.is_none_or(|r| r < round)
                     && latest_notarized_round.is_none_or(|r| r < round)
@@ -248,14 +254,13 @@ impl<TContext: Spawner> Actor<TContext> {
             }
 
             Activity::Finalization(_) => {
-                debug!(
-                    subscribers = self.state.events_tx().receiver_count(),
-                    "sending finalized event",
-                );
-                let _ = self.state.events_tx().send(Event::Finalized {
-                    block: certified.clone(),
-                    seen: now_millis(),
-                });
+                if latest_finalized_round.is_none_or(|previous| round > previous) {
+                    debug!(subscribers, height, "sending new finalized event");
+                    let _ = self.state.events_tx().send(Event::Finalized {
+                        block: certified.clone(),
+                        seen: now_millis(),
+                    });
+                }
 
                 if latest_finalized_round.is_none_or(|r| r < round) {
                     if latest_notarized_round.is_none_or(|r| r < round) {

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -42,7 +42,7 @@ pub use args::{Args, PositiveDuration};
 
 // Shared by both the consensus and follow engines such that
 // snapshots for overlapping archives can be reused.
-const PARTITION_PREFIX: &str = "engine";
+pub const PARTITION_PREFIX: &str = "engine";
 
 pub async fn run_consensus_stack(
     context: commonware_runtime::tokio::Context,

--- a/crates/consensus/src/storage/snapshot.rs
+++ b/crates/consensus/src/storage/snapshot.rs
@@ -58,6 +58,7 @@ enum ArchiveEntryKind {
 /// contiguous path from execution finalized to the anchor.
 pub async fn prepare<TContext, P>(
     context: &TContext,
+    storage_partition_prefix: &str,
     execution_provider: P,
     archive_entries: tokio::sync::mpsc::Sender<ArchiveEntry>,
 ) -> eyre::Result<State>
@@ -74,11 +75,11 @@ where
     let execution_finalized_digest = Digest(execution_finalized.hash);
 
     let finalizations =
-        init_finalizations_archive(context, crate::PARTITION_PREFIX, page_cache.clone())
+        init_finalizations_archive(context, storage_partition_prefix, page_cache.clone())
             .await
             .wrap_err("failed to open finalizations-by-height archive")?;
     let prunable =
-        init_prunable_finalized_blocks_archive(context, crate::PARTITION_PREFIX, page_cache)
+        init_prunable_finalized_blocks_archive(context, storage_partition_prefix, page_cache)
             .await
             .wrap_err("failed to open prunable finalized blocks archive")?;
 
@@ -108,24 +109,30 @@ where
 
 /// Returns whether `name` is one of the finalized-block prunable storage
 /// partitions that must be copied into a consensus snapshot archive.
-pub fn is_prunable_finalized_blocks_partition(name: &str) -> bool {
-    name.starts_with(&partition_prefix(super::PRUNABLE_FINALIZED_BLOCKS))
+pub fn is_prunable_finalized_blocks_partition(storage_partition_prefix: &str, name: &str) -> bool {
+    name.starts_with(&archive_partition_prefix(
+        storage_partition_prefix,
+        super::PRUNABLE_FINALIZED_BLOCKS,
+    ))
 }
 
 /// Returns whether `name` is a consensus storage partition that can appear in a
 /// consensus snapshot archive.
-pub fn is_snapshot_storage_partition(name: &str) -> bool {
-    name.starts_with(&partition_prefix(super::FINALIZATIONS_BY_HEIGHT))
-        || is_prunable_finalized_blocks_partition(name)
+pub fn is_snapshot_storage_partition(storage_partition_prefix: &str, name: &str) -> bool {
+    name.starts_with(&archive_partition_prefix(
+        storage_partition_prefix,
+        super::FINALIZATIONS_BY_HEIGHT,
+    )) || is_prunable_finalized_blocks_partition(storage_partition_prefix, name)
 }
 
-fn partition_prefix(archive_name: &str) -> String {
-    format!("{}-{archive_name}-", crate::PARTITION_PREFIX)
+fn archive_partition_prefix(storage_partition_prefix: &str, archive_name: &str) -> String {
+    format!("{storage_partition_prefix}-{archive_name}-")
 }
 
 /// Materialize consensus archive entries into fresh storage archives.
 pub async fn write_archive<TContext>(
     context: &TContext,
+    storage_partition_prefix: &str,
     mut entries: tokio::sync::mpsc::Receiver<ArchiveEntry>,
 ) -> eyre::Result<()>
 where
@@ -133,11 +140,11 @@ where
 {
     let page_cache = CacheRef::from_pooler(context, BUFFER_POOL_PAGE_SIZE, BUFFER_POOL_CAPACITY);
     let mut finalizations =
-        init_finalizations_archive(context, crate::PARTITION_PREFIX, page_cache.clone())
+        init_finalizations_archive(context, storage_partition_prefix, page_cache.clone())
             .await
             .wrap_err("failed to open snapshot finalizations-by-height archive")?;
     let mut blocks =
-        init_prunable_finalized_blocks_archive(context, crate::PARTITION_PREFIX, page_cache)
+        init_prunable_finalized_blocks_archive(context, storage_partition_prefix, page_cache)
             .await
             .wrap_err("failed to open snapshot prunable finalized blocks archive")?;
 

--- a/crates/e2e/src/consensus_snapshot.rs
+++ b/crates/e2e/src/consensus_snapshot.rs
@@ -1,0 +1,37 @@
+use commonware_runtime::{Metrics as _, deterministic};
+use reth_db::DatabaseEnv;
+use reth_ethereum::provider::providers::BlockchainProvider;
+use reth_node_builder::NodeTypesWithDBAdapter;
+use tempo_node::node::TempoNode;
+
+use crate::TestingNode;
+
+pub async fn write_consensus_snapshot(
+    context: &deterministic::Context,
+    source: &TestingNode<deterministic::Context>,
+    execution_provider: BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>,
+    target_partition_prefix: &str,
+) {
+    let source_partition_prefix = source.consensus_config.partition_prefix.clone();
+    let (archive_entries_tx, archive_entries_rx) = tokio::sync::mpsc::channel(64);
+
+    let state = tempo_consensus::storage::snapshot::prepare(
+        &context.with_label("snapshot_prepare"),
+        &source_partition_prefix,
+        execution_provider,
+        archive_entries_tx,
+    )
+    .await
+    .expect("snapshot must prepare");
+
+    tempo_consensus::storage::snapshot::write_archive(
+        &context.with_label("snapshot_write"),
+        target_partition_prefix,
+        archive_entries_rx,
+    )
+    .await
+    .expect("snapshot must write");
+
+    assert!(state.anchor_finalization_height > 0);
+    assert!(state.tip_finalization_height >= state.anchor_finalization_height);
+}

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -37,6 +37,7 @@ use rand_core::CryptoRngCore;
 use reth_node_metrics::recorder::PrometheusRecorder;
 use tempo_consensus::{consensus, feed::FeedStateHandle};
 
+pub mod consensus_snapshot;
 pub mod execution_runtime;
 pub mod metrics;
 pub use execution_runtime::ExecutionNodeConfig;
@@ -310,7 +311,7 @@ pub async fn setup_validators(
             // Plenty of headroom for any test; the marshal will fall back to
             // reth past this depth via the hybrid finalized blocks store.
             finalized_blocks_retention: 1024,
-            strict_startup: false,
+            strict_startup: true,
         };
 
         nodes.push(TestingNode::new(

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -173,6 +173,17 @@ where
         &mut self.consensus_config
     }
 
+    pub fn adopt_identity_from(&mut self, identity_source: Self) {
+        let peer_manager = self.consensus_config.peer_manager.clone();
+
+        self.uid = identity_source.uid;
+        self.private_key = identity_source.private_key;
+        self.consensus_config = identity_source.consensus_config;
+        self.consensus_config.peer_manager = peer_manager;
+        self.network_address = identity_source.network_address;
+        self.chain_address = identity_source.chain_address;
+    }
+
     /// Get a reference to the oracle.
     pub fn oracle(&self) -> &Oracle<PublicKey, TClock> {
         &self.oracle

--- a/crates/e2e/src/tests/consensus_rpc.rs
+++ b/crates/e2e/src/tests/consensus_rpc.rs
@@ -73,7 +73,8 @@ async fn consensus_subscribe_and_query_finalization() {
 
     let mut saw_notarized = false;
     let mut saw_finalized = false;
-    let mut current_height = initial_height;
+    let mut notarized_height = initial_height;
+    let mut finalized_height = initial_height;
 
     while !saw_notarized || !saw_finalized {
         let event = tokio::time::timeout(Duration::from_secs(10), subscription.next())
@@ -84,16 +85,15 @@ async fn consensus_subscribe_and_query_finalization() {
 
         match event {
             Event::Notarized { block, .. } => {
-                if block.block.inner.number > current_height {
-                    saw_notarized = true;
-                }
+                let height = block.block.inner.number;
+                assert!(height > notarized_height);
+
+                notarized_height = height;
+                saw_notarized = true;
             }
             Event::Finalized { block, .. } => {
                 let height = block.block.inner.number;
-                assert!(
-                    height > current_height,
-                    "finalized height should be > {current_height}"
-                );
+                assert!(height > finalized_height);
 
                 let queried_block = http_client
                     .get_finalization(Query::Height(height))
@@ -102,7 +102,7 @@ async fn consensus_subscribe_and_query_finalization() {
 
                 assert_eq!(queried_block, block);
 
-                current_height = height;
+                finalized_height = height;
                 saw_finalized = true;
             }
             Event::Nullified { .. } => {}

--- a/crates/e2e/src/tests/dkg/share_loss.rs
+++ b/crates/e2e/src/tests/dkg/share_loss.rs
@@ -117,6 +117,10 @@ fn validator_loses_consensus_state_becomes_observer() {
         specimen.uid = format!("{}_new", specimen.uid);
         // Remove the share from config since post-setup we may still be in Epoch 0
         specimen.consensus_config.share.take();
+        // TODO: Remove this test when strict startup is the default; losing
+        // consensus state while retaining execution state is only supported by
+        // the legacy non-strict startup path.
+        specimen.consensus_config.strict_startup = false;
 
         specimen.start(&context).await;
 

--- a/crates/e2e/src/tests/follow.rs
+++ b/crates/e2e/src/tests/follow.rs
@@ -174,7 +174,7 @@ impl FollowerBuilder {
             // Plenty of headroom for any test; the marshal will fall back to
             // reth past this depth via the hybrid finalized blocks store.
             finalized_blocks_retention: 1024,
-            strict_startup: false,
+            strict_startup: true,
         };
 
         let handle = config

--- a/crates/e2e/src/tests/snapshot.rs
+++ b/crates/e2e/src/tests/snapshot.rs
@@ -20,9 +20,8 @@ use tracing::info;
 
 use crate::{
     Setup, connect_execution_peers, connect_execution_to_peers,
-    metrics::{
-        MetricsExt, wait_for_height_with_interval, wait_for_metrics, wait_for_metrics_with_interval,
-    },
+    consensus_snapshot::write_consensus_snapshot,
+    metrics::{wait_for_height_with_interval, wait_for_metrics, wait_for_metrics_with_interval},
     setup_validators,
     tests::dkg::common::wait_for_outcome,
 };
@@ -163,33 +162,28 @@ fn joins_from_snapshot() {
 
         info!("new validator was added to the committee, but not started");
 
+        let last_epoch_before_stop = target_epoch.next().get();
+        let execution_provider = donor.execution_provider();
+
         donor.stop().await;
-        let stopped_donor_metrics = context.to_metrics().for_scope(&donor);
-        let last_epoch_before_stop = stopped_donor_metrics
-            .latest_consensus_epoch()
-            .expect("validator had no entry for latest epoch");
-        let last_height_before_stop = stopped_donor_metrics
-            .latest_consensus_height()
-            .expect("validator had no entry for latest height");
-        info!(
-            last_epoch_before_stop,
-            last_height_before_stop, "stopped the original validator",
-        );
+        info!(last_epoch_before_stop, "stopped the original validator");
 
         // Now the old validator donates its database to the new validator.
         //
         // This works by assigning the replacement validator's fields to the
         // old validator's. This way, the old validator "donates" its database
         // to the replacement. This is to simulate a snapshot.
-        donor.uid = replacement.uid;
-        donor.private_key = replacement.private_key;
-        {
-            let peer_manager = replacement.consensus_config.peer_manager.clone();
-            donor.consensus_config = replacement.consensus_config;
-            donor.consensus_config.peer_manager = peer_manager;
-        }
-        donor.network_address = replacement.network_address;
-        donor.chain_address = replacement.chain_address;
+        let target_partition_prefix = replacement.consensus_config.partition_prefix.clone();
+        write_consensus_snapshot(
+            &context,
+            &donor,
+            execution_provider,
+            &target_partition_prefix,
+        )
+        .await;
+
+        replacement.consensus_config.strict_startup = true;
+        donor.adopt_identity_from(replacement);
 
         donor.start(&context).await;
         connect_execution_to_peers(&donor, &validators).await;
@@ -209,15 +203,13 @@ fn joins_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&replacement).latest_consensus_epoch() {
-                assert!(
-                    epoch > 0,
-                    "when starting from snapshot a sufficiently advanced \
-                    snapshot, the node should never boot into the genesis epoch"
-                );
-            }
-
-            metrics.consensus_at_epoch(last_epoch_before_stop + 1) == 4
+            // Since the snapshot does not include secret material, there's an epoch's
+            // worth of downtime before the replacement enters/participates.
+            metrics
+                .for_scope(&replacement)
+                .latest_consensus_epoch()
+                .is_some_and(|epoch| epoch > 0)
+                && metrics.consensus_at_epoch(last_epoch_before_stop + 2) == 4
         })
         .await;
     });
@@ -358,12 +350,10 @@ fn can_restart_after_joining_from_snapshot() {
 
         info!("new validator was added to the committee, but not started");
 
+        let last_epoch_before_stop = target_epoch.next().get();
+        let execution_provider = donor.execution_provider();
+
         donor.stop().await;
-        let last_epoch_before_stop = context
-            .to_metrics()
-            .for_scope(&donor)
-            .latest_consensus_epoch()
-            .expect("validator had no entry for latest epoch");
         info!(%last_epoch_before_stop, "stopped the original validator");
 
         // Now the old validator donates its database to the new validator.
@@ -371,15 +361,17 @@ fn can_restart_after_joining_from_snapshot() {
         // This works by assigning the replacement validator's fields to the
         // old validator's. This way, the old validator "donates" its database
         // to the replacement. This is to simulate a snapshot.
-        donor.uid = replacement.uid;
-        donor.private_key = replacement.private_key;
-        {
-            let peer_manager = replacement.consensus_config.peer_manager.clone();
-            donor.consensus_config = replacement.consensus_config;
-            donor.consensus_config.peer_manager = peer_manager;
-        }
-        donor.network_address = replacement.network_address;
-        donor.chain_address = replacement.chain_address;
+        let target_partition_prefix = replacement.consensus_config.partition_prefix.clone();
+        write_consensus_snapshot(
+            &context,
+            &donor,
+            execution_provider,
+            &target_partition_prefix,
+        )
+        .await;
+
+        replacement.consensus_config.strict_startup = true;
+        donor.adopt_identity_from(replacement);
 
         donor.start(&context).await;
         connect_execution_to_peers(&donor, &validators).await;
@@ -399,15 +391,13 @@ fn can_restart_after_joining_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&replacement).latest_consensus_epoch() {
-                assert!(
-                    epoch > 0,
-                    "when starting from snapshot a sufficiently advanced \
-                    snapshot, the node should never boot into the genesis epoch"
-                );
-            }
-
-            metrics.consensus_at_epoch(last_epoch_before_stop + 1) == 4
+            // Since the snapshot does not include secret material, there's an epoch's
+            // worth of downtime before the replacement enters/participates.
+            metrics
+                .for_scope(&replacement)
+                .latest_consensus_epoch()
+                .is_some_and(|epoch| epoch > 0)
+                && metrics.consensus_at_epoch(last_epoch_before_stop + 2) == 4
         })
         .await;
 

--- a/crates/e2e/src/tests/sync.rs
+++ b/crates/e2e/src/tests/sync.rs
@@ -18,6 +18,7 @@ use tracing::info;
 
 use crate::{
     Setup, connect_execution_peers, connect_execution_to_peers,
+    consensus_snapshot::write_consensus_snapshot,
     metrics::{
         MetricsExt, wait_for_height_with_interval, wait_for_metrics,
         wait_for_metrics_with_interval, wait_for_participants, wait_for_participants_with_interval,
@@ -47,7 +48,7 @@ fn joins_from_snapshot() {
 
         // The validator that will donate its address to the snapshot syncing
         // validator.
-        let donor = {
+        let mut donor = {
             let idx = validators
                 .iter()
                 .position(|node| node.consensus_config().share.is_none())
@@ -108,25 +109,27 @@ fn joins_from_snapshot() {
 
         info!("new validator was added to the committee, but not started");
 
-        receiver.stop().await;
         let last_epoch_before_stop = context
             .to_metrics()
             .for_scope(&receiver)
             .latest_consensus_epoch()
             .expect("validator had no entry for latest epoch");
+        let execution_provider = receiver.execution_provider();
+        receiver.stop().await;
         info!(%last_epoch_before_stop, "stopped the original validator");
 
         // Now turn the receiver into the donor - except for the database dir and
         // env. This simulates a start from a snapshot.
-        receiver.uid = donor.uid;
-        receiver.private_key = donor.private_key;
-        {
-            let peer_manager = receiver.consensus_config.peer_manager.clone();
-            receiver.consensus_config = donor.consensus_config;
-            receiver.consensus_config.peer_manager = peer_manager;
-        }
-        receiver.network_address = donor.network_address;
-        receiver.chain_address = donor.chain_address;
+        let target_partition_prefix = donor.consensus_config.partition_prefix.clone();
+        write_consensus_snapshot(
+            &context,
+            &receiver,
+            execution_provider,
+            &target_partition_prefix,
+        )
+        .await;
+        donor.consensus_config.strict_startup = true;
+        receiver.adopt_identity_from(donor);
         receiver.start(&context).await;
         connect_execution_to_peers(&receiver, &validators).await;
 
@@ -142,11 +145,13 @@ fn joins_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&receiver).latest_consensus_epoch() {
-                assert!(epoch > 0, "validator should never boot into genesis epoch");
-            }
-
-            metrics.consensus_at_epoch(last_epoch_before_stop + 1) == 4
+            // Since the snapshot does not include secret material, there's an epoch's
+            // worth of downtime before the replacement enters/participates.
+            metrics
+                .for_scope(&receiver)
+                .latest_consensus_epoch()
+                .is_some_and(|epoch| epoch > 0)
+                && metrics.consensus_at_epoch(last_epoch_before_stop + 2) == 4
         })
         .await;
     });
@@ -172,7 +177,7 @@ fn can_restart_after_joining_from_snapshot() {
 
         // The validator that will donate its address to the snapshot syncing
         // validator.
-        let donor = {
+        let mut donor = {
             let idx = validators
                 .iter()
                 .position(|node| node.consensus_config().share.is_none())
@@ -233,13 +238,13 @@ fn can_restart_after_joining_from_snapshot() {
 
         info!("new validator was added to the committee, but not started");
 
-        receiver.stop().await;
-
         let last_epoch_before_stop = context
             .to_metrics()
             .for_scope(&receiver)
             .latest_consensus_epoch()
             .expect("validator had no entry for latest epoch");
+        let execution_provider = receiver.execution_provider();
+        receiver.stop().await;
 
         info!(
             %last_epoch_before_stop,
@@ -249,15 +254,16 @@ fn can_restart_after_joining_from_snapshot() {
 
         // Now turn the receiver into the donor - except for the database dir and
         // env. This simulates a start from a snapshot.
-        receiver.uid = donor.uid;
-        receiver.private_key = donor.private_key;
-        {
-            let peer_manager = receiver.consensus_config.peer_manager.clone();
-            receiver.consensus_config = donor.consensus_config;
-            receiver.consensus_config.peer_manager = peer_manager;
-        }
-        receiver.network_address = donor.network_address;
-        receiver.chain_address = donor.chain_address;
+        let target_partition_prefix = donor.consensus_config.partition_prefix.clone();
+        write_consensus_snapshot(
+            &context,
+            &receiver,
+            execution_provider,
+            &target_partition_prefix,
+        )
+        .await;
+        donor.consensus_config.strict_startup = true;
+        receiver.adopt_identity_from(donor);
         receiver.start(&context).await;
         connect_execution_to_peers(&receiver, &validators).await;
 
@@ -273,11 +279,13 @@ fn can_restart_after_joining_from_snapshot() {
                 validator catching up; there is likely a bug",
             );
 
-            if let Some(epoch) = metrics.for_scope(&receiver).latest_consensus_epoch() {
-                assert!(epoch > 0, "validator should never boot into genesis epoch");
-            }
-
-            metrics.consensus_at_epoch(last_epoch_before_stop + 1) == 4
+            // Since the snapshot does not include secret material, there's an epoch's
+            // worth of downtime before the replacement enters/participates.
+            metrics
+                .for_scope(&receiver)
+                .latest_consensus_epoch()
+                .is_some_and(|epoch| epoch > 0)
+                && metrics.consensus_at_epoch(last_epoch_before_stop + 2) == 4
         })
         .await;
 


### PR DESCRIPTION
Backports #6678 to `release/v1.10.2`.

Cherry-picked commit: https://github.com/tempoxyz/tempo/commit/8dca58cb4194678232cca204ae2d75978199c084 (`chore(consensus): tempo-e2e strict-startup (#6678)`).

This carries over `chore(consensus): tempo-e2e strict-startup`, including the e2e snapshot flow and increasing-feed-event behavior needed before backporting #6714.

Prompted by: @SuperFluffy
