### PR TITLE
backport: #6536 to release/v1.10.2

### DIFF
--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -14,11 +14,11 @@ pub(crate) mod marshal {
     use commonware_runtime::{
         BufferPooler, Clock, Metrics, Spawner, Storage, buffer::paged::CacheRef,
     };
-    use commonware_storage::archive::immutable;
+    use commonware_storage::archive::{Archive as _, Identifier, immutable};
     use commonware_utils::acknowledgement::Exact;
-    use eyre::WrapErr as _;
+    use eyre::{OptionExt as _, WrapErr as _, bail, eyre};
     use rand_08::{CryptoRng, Rng};
-    use reth_ethereum::provider::db::DatabaseEnv;
+    use reth_ethereum::{chainspec::EthChainSpec, provider::db::DatabaseEnv};
     use reth_node_builder::NodeTypesWithDBAdapter;
     use reth_provider::providers::BlockchainProvider;
     use tempo_node::{TempoFullNode, node::TempoNode};
@@ -66,6 +66,10 @@ pub(crate) mod marshal {
         /// archive. Older blocks are served from reth via [`Hybrid`].
         pub finalized_blocks_retention: u64,
 
+        /// Require startup to use the consensus finalization archive as its
+        /// finalized floor instead of falling back to the execution layer.
+        pub strict_startup: bool,
+
         /// Epoch length / boundary configuration.
         pub epoch_strategy: FixedEpocher,
 
@@ -87,17 +91,20 @@ pub(crate) mod marshal {
         /// Mailbox for sending messages to [`Self::actor`].
         pub mailbox: Mailbox,
 
-        /// `max(marshal_stored_height, reth_finalized_height)` after
-        /// advancing marshal's sync floor to that height. The engine uses
-        /// this to seed the executor and other actors that need to know
-        /// where the chain starts replaying from.
-        pub last_finalized_height: Height,
+        /// Startup backfill target, selected from marshal's stored finalized
+        /// height and the startup floor height.
+        pub finalized_floor: Height,
+
+        /// Finalized tip selected at startup. In strict mode this comes from
+        /// the archive or genesis; otherwise it is the highest available value
+        /// from the archive and execution layer.
+        pub finalized_tip: (Height, Digest),
     }
 
     /// Initialize the marshal actor and its backing finalized-blocks store
     /// (the finalizations-by-height archive plus the [`Hybrid`] finalized
-    /// blocks store), and advance marshal's sync floor to
-    /// `max(marshal_stored_height, reth_finalized_height)`.
+    /// blocks store), select the startup finalized floor, and advance
+    /// marshal's sync floor when needed.
     ///
     /// Both the consensus and follow engines must initialize marshal in
     /// exactly the same way so that nodes can switch modes without data
@@ -134,6 +141,24 @@ pub(crate) mod marshal {
         .await
         .wrap_err("failed to initialize finalizations by height archive")?;
 
+        let FinalizationRange {
+            floor: finalized_floor,
+            tip: finalized_tip,
+        } = establish_finalization_range(
+            &finalizations_by_height,
+            &execution_node,
+            config.strict_startup,
+        )
+        .await?;
+        info!(
+            floor_height = %finalized_floor.0,
+            floor_digest = %finalized_floor.1,
+            tip_height = %finalized_tip.0,
+            tip_digest = %finalized_tip.1,
+            strict_startup = config.strict_startup,
+            "selected finalized startup range"
+        );
+
         let finalized_blocks = storage::init_finalized_blocks(
             &context,
             &config.partition_prefix,
@@ -167,30 +192,147 @@ pub(crate) mod marshal {
         )
         .await;
 
-        // Floor marshal at reth's last finalized block so we don't try to
-        // re-sync history that the execution layer already finalized. The
-        // mailbox message is buffered until the actor starts; `set_floor` only
-        // ever advances, so sending it unconditionally is safe.
-        let reth_finalized_height = execution_node
-            .provider
-            .canonical_in_memory_state()
-            .get_finalized_num_hash()
-            .map(|nh| nh.number)
-            .unwrap_or(0);
-        let last_finalized_height = marshal_stored_height.max(Height::new(reth_finalized_height));
-        if last_finalized_height > marshal_stored_height {
-            info!(
-                marshal_stored = %marshal_stored_height,
-                reth_finalized = reth_finalized_height,
-                "advancing marshal sync floor to reth's finalized block"
-            );
-            mailbox.set_floor(last_finalized_height).await;
-        }
+        let startup_floor_height = finalized_floor.0;
+        let last_finalized_height = marshal_stored_height.max(startup_floor_height);
+        info!(
+            marshal_stored = %marshal_stored_height,
+            selected_floor = %startup_floor_height,
+            strict_startup = config.strict_startup,
+            "setting marshal sync floor"
+        );
+        mailbox.set_floor(last_finalized_height).await;
 
         Ok(Initialized {
             actor,
             mailbox,
-            last_finalized_height,
+            finalized_floor: last_finalized_height,
+            finalized_tip,
         })
+    }
+
+    struct FinalizationRange {
+        floor: (Height, Digest),
+        tip: (Height, Digest),
+    }
+
+    async fn establish_finalization_range<TContext>(
+        finalizations_by_height: &immutable::Archive<
+            TContext,
+            Digest,
+            Finalization<Scheme<PublicKey, MinSig>, Digest>,
+        >,
+        execution_node: &TempoFullNode,
+        strict_startup: bool,
+    ) -> eyre::Result<FinalizationRange>
+    where
+        TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Send + 'static,
+    {
+        let archive_range = finalized_archive_range(finalizations_by_height)
+            .await
+            .wrap_err("failed to establish finalized archive bounds")?;
+        let execution_finalized = execution_finalized_point(execution_node);
+
+        match (strict_startup, archive_range) {
+            (true, Some((floor, tip))) => Ok(FinalizationRange { floor, tip }),
+            (true, None) if execution_finalized.0.is_zero() => Ok(FinalizationRange {
+                floor: execution_finalized,
+                tip: execution_finalized,
+            }),
+            (true, None) => Err(eyre!(
+                "strict consensus startup requires a finalized certificate archive unless the \
+                    execution layer is empty, but no finalized certificate was found and execution \
+                    finalized block is `{}` at height `{}`",
+                execution_finalized.1,
+                execution_finalized.0,
+            )),
+            (false, Some((archive_floor, archive_tip))) => Ok(FinalizationRange {
+                floor: if archive_floor.0 >= execution_finalized.0 {
+                    archive_floor
+                } else {
+                    execution_finalized
+                },
+                tip: if archive_tip.0 >= execution_finalized.0 {
+                    archive_tip
+                } else {
+                    execution_finalized
+                },
+            }),
+            (false, None) => Ok(FinalizationRange {
+                floor: execution_finalized,
+                tip: execution_finalized,
+            }),
+        }
+    }
+
+    async fn finalized_archive_range<TContext>(
+        archive: &immutable::Archive<
+            TContext,
+            Digest,
+            Finalization<Scheme<PublicKey, MinSig>, Digest>,
+        >,
+    ) -> eyre::Result<Option<((Height, Digest), (Height, Digest))>>
+    where
+        TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Send + 'static,
+    {
+        let (first, last) = match (archive.first_index(), archive.last_index()) {
+            (None, None) => return Ok(None),
+            (Some(first), Some(last)) => (first, last),
+            (first, last) => {
+                bail!(
+                    "finalized certificate archive reported inconsistent index range: \
+                    first={first:?}, last={last:?}"
+                );
+            }
+        };
+
+        let floor = finalized_archive_point(archive, first)
+            .await
+            .wrap_err_with(|| {
+                format!("failed to read finalized floor from archive at height `{first}`")
+            })?;
+        let tip = if first == last {
+            floor
+        } else {
+            finalized_archive_point(archive, last)
+                .await
+                .wrap_err_with(|| {
+                    format!("failed to read finalized tip from archive at height `{last}`")
+                })?
+        };
+
+        Ok(Some((floor, tip)))
+    }
+
+    async fn finalized_archive_point<TContext>(
+        archive: &immutable::Archive<
+            TContext,
+            Digest,
+            Finalization<Scheme<PublicKey, MinSig>, Digest>,
+        >,
+        height: u64,
+    ) -> eyre::Result<(Height, Digest)>
+    where
+        TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Send + 'static,
+    {
+        let finalization = archive
+            .get(Identifier::Index(height))
+            .await
+            .wrap_err("failed reading certificate from archive")?
+            .ok_or_eyre("archive did not contain certificate")?;
+        Ok((Height::new(height), finalization.proposal.payload))
+    }
+
+    fn execution_finalized_point(execution_node: &TempoFullNode) -> (Height, Digest) {
+        execution_node
+            .provider
+            .canonical_in_memory_state()
+            .get_finalized_num_hash()
+            .map(|nh| (Height::new(nh.number), Digest(nh.hash)))
+            .unwrap_or_else(|| {
+                (
+                    Height::zero(),
+                    Digest(execution_node.chain_spec().genesis_hash()),
+                )
+            })
     }
 }

--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -307,6 +307,14 @@ pub struct Args {
     )]
     pub finalized_blocks_retention: u64,
 
+    /// Require startup to use a consensus finalized certificate archive.
+    ///
+    /// When disabled, startup falls back to the execution layer's finalized
+    /// watermark for compatibility with snapshots that do not include
+    /// consensus finalization state.
+    #[arg(long = "consensus.strict-startup", default_value_t = false)]
+    pub strict_startup: bool,
+
     /// Deprecated compatibility flag. Ignored because the legacy immutable
     /// finalized blocks archive has been removed.
     #[arg(
@@ -507,6 +515,12 @@ mod tests {
         ] {
             parse(&["--dev", flag, "1ms"]);
         }
+    }
+
+    #[test]
+    fn strict_startup_flag_parses() {
+        let cli = parse(&["--dev", "--consensus.strict-startup"]);
+        assert!(cli.consensus.strict_startup);
     }
 
     fn encrypt(plaintext: &[u8], passphrase: &str) -> Vec<u8> {

--- a/crates/consensus/src/consensus/digest.rs
+++ b/crates/consensus/src/consensus/digest.rs
@@ -11,6 +11,12 @@ use commonware_utils::{Array, Span};
 #[repr(transparent)]
 pub struct Digest(pub B256);
 
+impl Digest {
+    pub fn get(self) -> B256 {
+        self.0
+    }
+}
+
 impl Array for Digest {}
 
 impl AsRef<[u8]> for Digest {

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -86,6 +86,14 @@ pub struct Builder<TBlocker, TPeerManager> {
     /// Number of recently finalized blocks retained in the prunable archive
     /// passed to the marshal actor. Older blocks are served from reth.
     pub finalized_blocks_retention: u64,
+
+    /// Require startup to use the consensus finalization archive as the
+    /// finalized floor. If the archive is empty this will reject pre-populated
+    /// execution layers.
+    ///
+    /// This setting is in preparation for consensus-enriched snapshots and will
+    /// eventually become the default once tempo has fully migrated.
+    pub strict_startup: bool,
 }
 
 impl<TBlocker, TPeerManager> Builder<TBlocker, TPeerManager>
@@ -143,7 +151,8 @@ where
         let alias::marshal::Initialized {
             actor: marshal,
             mailbox: marshal_mailbox,
-            last_finalized_height,
+            finalized_floor,
+            finalized_tip,
         } = alias::marshal::init(
             context.clone(),
             page_cache_ref.clone(),
@@ -157,6 +166,7 @@ where
                 ),
                 max_pending_acks: MAX_PENDING_ACKS,
                 finalized_blocks_retention: self.finalized_blocks_retention,
+                strict_startup: self.strict_startup,
                 epoch_strategy: epoch_strategy.clone(),
                 scheme_provider: scheme_provider.clone(),
             },
@@ -168,7 +178,8 @@ where
             context.with_label("executor"),
             crate::executor::Config {
                 execution_node: execution_node.clone(),
-                last_finalized_height,
+                finalized_floor,
+                finalized_tip,
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
                 public_key: Some(self.signer.public_key()),
@@ -182,7 +193,8 @@ where
                 execution_node: execution_node.clone(),
                 oracle: self.peer_manager.clone(),
                 epoch_strategy: epoch_strategy.clone(),
-                last_finalized_height,
+                finalized_floor,
+                finalized_tip,
             },
         );
 
@@ -281,7 +293,7 @@ where
                 epoch_strategy: epoch_strategy.clone(),
                 execution_node,
                 initial_share: self.share.clone(),
-                last_finalized_height,
+                last_finalized_height: finalized_floor,
                 mailbox_size: self.mailbox_size,
                 marshal: marshal_mailbox,
                 namespace: crate::config::NAMESPACE.to_vec(),

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -104,8 +104,9 @@ pub(crate) struct Actor<TContext> {
     /// and to update the canonical chain by sending forkchoice updates.
     execution_node: Arc<TempoFullNode>,
 
-    last_consensus_finalized_height: Height,
-    last_execution_finalized_height: Height,
+    /// Highest finalized height the executor should backfill to on startup.
+    backfill_target_height: Height,
+    execution_finalized_height: Height,
 
     /// The channel over which the agent will receive new commands from the
     /// application actor.
@@ -125,9 +126,9 @@ pub(crate) struct Actor<TContext> {
     /// Armed only when no execution request is active or queued.
     fcu_heartbeat_timer: OptionFuture<BoxFuture<'static, ()>>,
 
-    /// Gap between the last finalized block on the consensus and execution
-    /// layers. Needs to be handled on startup because the execution layer does
-    /// not reliably flush all blocks.
+    /// Gap between the execution layer's finalized watermark and the startup
+    /// backfill target. Needs to be handled on startup because the execution
+    /// layer does not reliably flush all blocks.
     finalized_heights_to_backfill: RangeInclusive<u64>,
 
     /// Backfills that are currently in-flight and are awaiting resolution.
@@ -146,7 +147,7 @@ pub(crate) struct Actor<TContext> {
     /// discarded.
     payload_jobs: FuturesUnordered<BoxFuture<'static, ()>>,
 
-    latest_observed_finalized_tip: Option<(Height, Digest)>,
+    latest_observed_finalized_tip: (Height, Digest),
 
     /// The node's ed25519 public key if the node is participating in
     /// consensus. Not set if not, for example for followers.
@@ -189,37 +190,44 @@ where
     ) -> eyre::Result<Self> {
         let Config {
             execution_node,
-            last_finalized_height,
+            finalized_floor,
+            finalized_tip,
             marshal,
             fcu_heartbeat_interval,
             public_key,
         } = config;
         let metrics = Metrics::init(&context);
         let canonical_state = execution_node.provider.canonical_in_memory_state();
-        let finalized_num_hash = canonical_state
+        let head_num_hash: BlockNumHash = canonical_state.chain_info().into();
+        let execution_finalized_num_hash = canonical_state
             .get_finalized_num_hash()
             .unwrap_or_else(|| BlockNumHash::new(0, execution_node.chain_spec().genesis_hash()));
-        let head_num_hash: BlockNumHash = canonical_state.chain_info().into();
+        let execution_finalized_height = Height::new(execution_finalized_num_hash.number);
+        let head_num_hash = if head_num_hash.number >= execution_finalized_num_hash.number {
+            head_num_hash
+        } else {
+            execution_finalized_num_hash
+        };
 
         let fcu_heartbeat_timer = OptionFuture::some(context.sleep(fcu_heartbeat_interval).boxed());
-        let last_execution_finalized_height = Height::new(finalized_num_hash.number);
+        let backfill_target_height = finalized_floor;
         let finalized_heights_to_backfill =
-            (last_execution_finalized_height.get() + 1)..=last_finalized_height.get();
+            (execution_finalized_height.get() + 1)..=backfill_target_height.get();
         Ok(Self {
             context: ContextCell::new(context),
             execution_node,
-            last_consensus_finalized_height: last_finalized_height,
-            last_execution_finalized_height,
+            backfill_target_height,
+            execution_finalized_height,
             mailbox,
             marshal,
             last_canonicalized: LastCanonicalized {
                 forkchoice: ForkchoiceState {
                     head_block_hash: head_num_hash.hash,
-                    safe_block_hash: finalized_num_hash.hash,
-                    finalized_block_hash: finalized_num_hash.hash,
+                    safe_block_hash: execution_finalized_num_hash.hash,
+                    finalized_block_hash: execution_finalized_num_hash.hash,
                 },
                 head_height: Height::new(head_num_hash.number),
-                finalized_height: Height::new(finalized_num_hash.number),
+                finalized_height: execution_finalized_height,
             },
             fcu_heartbeat_interval,
             fcu_heartbeat_timer,
@@ -230,7 +238,7 @@ where
             execution_task: OptionFuture::none(),
             payload_jobs: FuturesUnordered::new(),
 
-            latest_observed_finalized_tip: None,
+            latest_observed_finalized_tip: finalized_tip,
 
             public_key,
             metrics,
@@ -244,10 +252,12 @@ where
     async fn run(mut self) {
         info_span!("start").in_scope(|| {
             info!(
-                last_finalized_consensus_height = %self.last_consensus_finalized_height,
-                last_finalized_execution_height = %self.last_execution_finalized_height,
-                "consensus and execution layers reported last finalized heights; \
-                backfilling blocks from consensus to execution if necessary",
+                backfill_target_height = %self.backfill_target_height,
+                execution_finalized_height = %self.execution_finalized_height,
+                finalized_tip_height = %self.latest_observed_finalized_tip.0,
+                finalized_tip_digest = %self.latest_observed_finalized_tip.1,
+                "executor initialized finalized startup state; backfilling blocks \
+                from consensus to execution if necessary",
             );
         });
 
@@ -421,7 +431,7 @@ where
             }
             Command::Finalize(finalized) => match *finalized {
                 Update::Tip(_, height, digest) => {
-                    self.latest_observed_finalized_tip.replace((height, digest));
+                    self.latest_observed_finalized_tip = (height, digest);
                 }
                 Update::Block(block, acknowledgement) => {
                     self.enqueue_execution_request(ExecutionRequest::FinalizeBlock(Box::new(
@@ -466,21 +476,20 @@ where
 
         // If nothing is currently scheduled and a newer finalized tip was
         // observed, push it into the queue so that it will be picked up next.
-        if self.execution_queue.is_empty()
-            && !self.is_backfilling()
-            && let Some((height, digest)) = self.latest_observed_finalized_tip
-            && let new_canonicalized = self.last_canonicalized.update_finalized(height, digest)
-            && new_canonicalized != self.last_canonicalized
-        {
-            self.execution_queue
-                .push_back(ExecutionRequest::Canonicalize(Box::new(Canonicalize {
-                    cause: Span::current(),
-                    head_or_finalized: HeadOrFinalized::Finalized,
-                    height,
-                    digest,
-                    response: None,
-                    build_attributes: None,
-                })));
+        if self.execution_queue.is_empty() && !self.is_backfilling() {
+            let (height, digest) = self.latest_observed_finalized_tip;
+            let new_canonicalized = self.last_canonicalized.update_finalized(height, digest);
+            if new_canonicalized != self.last_canonicalized {
+                self.execution_queue
+                    .push_back(ExecutionRequest::Canonicalize(Box::new(Canonicalize {
+                        cause: Span::current(),
+                        head_or_finalized: HeadOrFinalized::Finalized,
+                        height,
+                        digest,
+                        response: None,
+                        build_attributes: None,
+                    })));
+            }
         }
 
         let Some(request) = self.execution_queue.front() else {

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -14,6 +14,8 @@ use futures::channel::mpsc;
 pub(crate) use ingress::Mailbox;
 use tempo_node::TempoFullNode;
 
+use crate::consensus::Digest;
+
 pub(crate) fn init<TContext>(
     context: TContext,
     config: Config,
@@ -32,11 +34,13 @@ pub(crate) struct Config {
     /// and to update the canonical chain by sending forkchoice updates.
     pub(crate) execution_node: Arc<TempoFullNode>,
 
-    /// The last finalized height according to the consensus layer.
-    /// If on startup there is a mismatch between the execution layer and the
-    /// consensus, then the node will fill the gap by backfilling blocks to
-    /// the execution layer until `last_finalized_height` is reached.
-    pub(crate) last_finalized_height: Height,
+    /// Marshal sync floor. This is the sync target the executor actor will try
+    /// to reach because the marshal actor will only send finalized heights
+    /// above this value.
+    pub(crate) finalized_floor: Height,
+
+    /// Finalized tip reported by marshal at startup.
+    pub(crate) finalized_tip: (Height, Digest),
 
     /// The mailbox of the marshal actor. Used to backfill blocks.
     pub(crate) marshal: crate::alias::marshal::Mailbox,

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -71,6 +71,10 @@ pub struct Config<TUpstream> {
     /// Number of recently finalized blocks retained in the prunable archive
     /// passed to the marshal actor. Older blocks are served from reth.
     pub finalized_blocks_retention: u64,
+
+    /// Require startup to use the consensus finalization archive as the
+    /// finalized floor.
+    pub strict_startup: bool,
 }
 
 impl<TUpstream> Config<TUpstream> {
@@ -105,7 +109,8 @@ impl<TUpstream> Config<TUpstream> {
         let alias::marshal::Initialized {
             actor: marshal_actor,
             mailbox: marshal_mailbox,
-            last_finalized_height,
+            finalized_floor: last_finalized_height,
+            finalized_tip,
         } = alias::marshal::init(
             context.clone(),
             page_cache_ref,
@@ -116,6 +121,7 @@ impl<TUpstream> Config<TUpstream> {
                 view_retention_timeout: commonware_consensus::types::ViewDelta::new(1),
                 max_pending_acks: NZUsize!(1),
                 finalized_blocks_retention: self.finalized_blocks_retention,
+                strict_startup: self.strict_startup,
                 epoch_strategy: epoch_strategy.clone(),
                 scheme_provider: scheme_provider.clone(),
             },
@@ -151,7 +157,8 @@ impl<TUpstream> Config<TUpstream> {
             context.with_label("executor"),
             executor::Config {
                 execution_node: self.execution_node.clone(),
-                last_finalized_height,
+                finalized_floor: last_finalized_height,
+                finalized_tip,
                 marshal: marshal_mailbox.clone(),
                 fcu_heartbeat_interval: self.fcu_heartbeat_interval,
                 public_key: None,

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -131,6 +131,7 @@ pub async fn run_consensus_stack(
         feed_state,
 
         finalized_blocks_retention: config.finalized_blocks_retention,
+        strict_startup: config.strict_startup,
     }
     .try_init(context.with_label("engine"))
     .await
@@ -207,6 +208,7 @@ pub async fn run_follow_stack(
         mailbox_size: config.mailbox_size,
         fcu_heartbeat_interval: config.fcu_heartbeat_interval.into_duration(),
         finalized_blocks_retention: config.finalized_blocks_retention,
+        strict_startup: config.strict_startup,
     };
 
     let ret = config

--- a/crates/consensus/src/peer_manager/actor.rs
+++ b/crates/consensus/src/peer_manager/actor.rs
@@ -9,6 +9,7 @@ use alloy_consensus::{BlockHeader as _, Sealable as _};
 use alloy_primitives::B256;
 use commonware_codec::ReadExt as _;
 use commonware_consensus::{
+    Heightable as _,
     marshal::Update,
     types::{Epocher, FixedEpocher, Height},
 };
@@ -27,6 +28,7 @@ use tempo_primitives::TempoHeader;
 use tracing::{Span, debug, error, info_span, instrument, warn};
 
 use crate::{
+    consensus::Digest,
     utils::public_key_to_b256,
     validators::{DecodedValidatorV2, ExecutionNode, read_validator_config_at_block_hash},
 };
@@ -50,7 +52,8 @@ where
     oracle: TPeerManager,
     execution_node: Arc<TempoFullNode>,
     epoch_strategy: FixedEpocher,
-    last_finalized_height: Height,
+    finalized_floor: Height,
+    latest_observed_finalized_tip: (Height, Digest),
     mailbox: mpsc::UnboundedReceiver<MessageWithCause>,
 
     peers: Gauge,
@@ -71,7 +74,8 @@ where
             oracle,
             execution_node,
             epoch_strategy,
-            last_finalized_height,
+            finalized_floor,
+            finalized_tip,
         }: super::Config<TPeerManager>,
         mailbox: mpsc::UnboundedReceiver<MessageWithCause>,
     ) -> Self {
@@ -88,7 +92,8 @@ where
             oracle,
             execution_node,
             epoch_strategy,
-            last_finalized_height,
+            finalized_floor,
+            latest_observed_finalized_tip: finalized_tip,
             mailbox,
             peers,
             last_tracked_peer_set: None,
@@ -144,25 +149,31 @@ where
                 let _ = response.send(receiver);
             }
             Message::Finalized(update) => match *update {
-                Update::Block(_, ack) => {
+                Update::Block(block, ack) => {
+                    self.observe_finalized_tip((block.height(), block.digest()));
                     let _ = self.refresh_peers().await;
                     ack.acknowledge();
                     self.reset_peer_update_timer();
                 }
-                Update::Tip { .. } => {}
+                Update::Tip(_, height, digest) => {
+                    self.observe_finalized_tip((height, digest));
+                    let _ = self.refresh_peers().await;
+                    self.reset_peer_update_timer();
+                }
             },
         }
         Ok(())
     }
 
-    /// Reads the peers given the latest finalized state.
-    /// and finalized state.
+    /// Reads peers from the latest finalized state allowed by consensus.
     #[instrument(skip_all, err)]
     async fn refresh_peers(&mut self) -> eyre::Result<()> {
         // Always take whatever is higher: the last finalized height as per
         // consensus layer (greater than 0 only on restarts with populated
         // consensus state), or the highest finalized block number from the
-        // execution layer.
+        // execution layer. Cap the result by the latest consensus-observed
+        // finalized tip so EL-derived reads cannot move ahead of the
+        // consensus startup/archive view.
         //
         // This works even if the execution layer was replaced with a snapshot.
         //
@@ -176,8 +187,9 @@ where
             .provider
             .finalized_block_number()
             .wrap_err("unable to read highest finalized block from execution layer")?
-            .unwrap_or(self.last_finalized_height.get())
-            .max(self.last_finalized_height.get());
+            .unwrap_or(self.finalized_floor.get())
+            .max(self.finalized_floor.get())
+            .min(self.latest_observed_finalized_tip.0.get());
 
         // Short circuit - no need to read the same state if there is no new data.
         if self
@@ -248,6 +260,12 @@ where
             .await;
 
         Ok(())
+    }
+
+    fn observe_finalized_tip(&mut self, tip: (Height, Digest)) {
+        if tip.0 >= self.latest_observed_finalized_tip.0 {
+            self.latest_observed_finalized_tip = tip;
+        }
     }
 
     async fn track_or_overwrite(&mut self, height: u64, peers: Peers) {

--- a/crates/consensus/src/peer_manager/mod.rs
+++ b/crates/consensus/src/peer_manager/mod.rs
@@ -35,6 +35,8 @@ use commonware_runtime::{Clock, Metrics, Spawner};
 use futures::channel::mpsc;
 use tempo_node::TempoFullNode;
 
+use crate::consensus::Digest;
+
 mod actor;
 mod ingress;
 
@@ -50,10 +52,14 @@ pub(crate) struct Config<TOracle> {
     pub(crate) execution_node: Arc<TempoFullNode>,
     /// The  epoch strategy used by the node.
     pub(crate) epoch_strategy: FixedEpocher,
-    /// The last finalized height according to the consensus layer (marshal).
+    /// The last finalized height according to the marshal actor.
     /// Used during start to determine the correct boundary block, since
     /// the execution layer may be behind.
-    pub(crate) last_finalized_height: Height,
+    pub(crate) finalized_floor: Height,
+    /// Highest finalized tip observed from consensus at startup.
+    /// Execution-layer-derived reads must not advance beyond this tip until
+    /// marshal reports a newer finalized tip.
+    pub(crate) finalized_tip: (Height, Digest),
 }
 
 /// Initializes a peer manager actor from a `config` with runtime `context`.

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -310,6 +310,7 @@ pub async fn setup_validators(
             // Plenty of headroom for any test; the marshal will fall back to
             // reth past this depth via the hybrid finalized blocks store.
             finalized_blocks_retention: 1024,
+            strict_startup: false,
         };
 
         nodes.push(TestingNode::new(

--- a/crates/e2e/src/tests/follow.rs
+++ b/crates/e2e/src/tests/follow.rs
@@ -174,6 +174,7 @@ impl FollowerBuilder {
             // Plenty of headroom for any test; the marshal will fall back to
             // reth past this depth via the hybrid finalized blocks store.
             finalized_blocks_retention: 1024,
+            strict_startup: false,
         };
 
         let handle = config


### PR DESCRIPTION
Backports https://github.com/tempoxyz/tempo/pull/6536 to `release/v1.10.2`.

Cherry-picked commit: https://github.com/tempoxyz/tempo/commit/d0b4ca4b0ee9063dd69a7dbc6f21d49629effa5d (`feat(consensus): wire up consensus-enabled snapshots (#6536)`).

This introduces `strict_startup` and consensus-enabled snapshot startup support needed before backporting #6678 and #6714.

Prompted by: @SuperFluffy
