### PR TITLE
chore: bump workspace version to 1.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12885,7 +12885,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13037,7 +13037,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13098,7 +13098,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13127,7 +13127,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13141,7 +13141,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13192,7 +13192,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13237,7 +13237,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13256,7 +13256,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "eyre",
  "indenter",
@@ -13264,7 +13264,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13277,7 +13277,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13347,7 +13347,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13385,7 +13385,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13405,7 +13405,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13437,7 +13437,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13486,7 +13486,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13519,7 +13519,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "clap",
@@ -13544,7 +13544,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "eyre",
  "jiff",
@@ -13553,7 +13553,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13595,7 +13595,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13607,7 +13607,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.10.1"
+version = "1.10.2"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.1"
+version = "1.10.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
## Summary
- Bumps the repository-wide workspace package version in root `Cargo.toml` from `1.10.1` to `1.10.2`.

## Backported PRs on top of v1.10.1 / release v1.10.2
- #6757 backports #6731 and #6699: refresh cargo-deny advisories and fix deprecated atomic update usage
- #6755 backports #6545
- #6762 backports #6517
- #6761 backports #6536
- #6760 backports #6678
- #6756 backports #6714
- #6758 backports #6754

## Tests
- Not run; manifest-only version bump.

Prompted by: @SuperFluffy
