### PR TITLE
fix(follower): redact follow upstream URL credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13491,6 +13491,7 @@ dependencies = [
  "eyre",
  "jiff",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -14,7 +14,7 @@ use jsonrpsee::{
 };
 use rand_08::Rng as _;
 use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query, TempoConsensusApiClient};
-use tempo_telemetry_util::display_duration;
+use tempo_telemetry_util::{display_duration, display_redacted_url};
 use tokio::{
     select,
     sync::{mpsc, oneshot},
@@ -89,7 +89,7 @@ where
                                 %reason,
                                 attempts,
                                 reconnect_in = %display_duration(reconnect_in),
-                                url = %self.url,
+                                url = %display_redacted_url(self.url),
                                 "connecting to upstream node failed, attempting again",
                             ));
                             self.pending_connect.replace({
@@ -139,7 +139,7 @@ where
                         }
                         None => {
                             warn_span!("event_subscription").in_scope(|| warn!(
-                                url = %self.url,
+                                url = %display_redacted_url(self.url),
                                 "event stream terminated",
                             ));
                             self.event_stream = inactive_event_stream();
@@ -176,7 +176,10 @@ where
         if client.is_connected() {
             self.pending_stream.replace(subscribe(client));
         } else {
-            warn!(url = %self.url, "upstream client disconnected, reconnecting");
+            warn!(
+                url = %display_redacted_url(self.url),
+                "upstream client disconnected, reconnecting"
+            );
             self.connection.take();
             self.pending_connect.replace(connect(self.url, 1));
         }

--- a/crates/consensus/src/follow/upstream/mod.rs
+++ b/crates/consensus/src/follow/upstream/mod.rs
@@ -1,6 +1,6 @@
 //! Actors to communicate with the upstream node.
 //!
-//! Maintains a regular connection to an upstream node over websocker
+//! Maintains a regular connection to an upstream node over websocket
 //! or `in_process::Actor` as an in-process actor working off of channels.
 
 use alloy_rpc_client::BuiltInConnectionString;
@@ -8,6 +8,7 @@ use commonware_consensus::Reporter;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
 use eyre::WrapErr as _;
 use tempo_node::rpc::consensus::Event;
+use tempo_telemetry_util::display_redacted_url;
 use tokio::sync::mpsc;
 use url::Url;
 
@@ -50,14 +51,9 @@ pub(crate) fn init<TContext>(
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = ingress::Mailbox::new(tx);
 
-    let url = Box::leak(Box::from(
-        parse_upstream_url(&config.upstream_url).wrap_err_with(|| {
-            format!(
-                "failed parsing upstream location as websocket URL: `{}`",
-                config.upstream_url
-            )
-        })?,
-    ));
+    let url = parse_upstream_url(&config.upstream_url)
+        .wrap_err_with(|| redact_upstream_url_for_error(&config.upstream_url))?;
+    let url = Box::leak(Box::from(url));
     let actor = Actor {
         context: ContextCell::new(context),
         connection: None,
@@ -82,6 +78,16 @@ fn parse_upstream_url(url: &str) -> eyre::Result<Url> {
         unreachable!("try_as_ws always returns a websocket connection string on success")
     };
     Ok(url)
+}
+
+fn redact_upstream_url_for_error(url: &str) -> String {
+    match Url::parse(url) {
+        Ok(url) => format!(
+            "failed parsing upstream location as websocket URL: `{}`",
+            display_redacted_url(&url)
+        ),
+        Err(_) => format!("failed parsing upstream location as websocket URL: `{url}`"),
+    }
 }
 
 #[cfg(test)]
@@ -119,5 +125,24 @@ mod tests {
     fn parse_upstream_url_rejects_non_url_values() {
         assert!(parse_upstream_url("not a url").is_err());
         assert!(parse_upstream_url("localhost").is_err());
+    }
+
+    #[test]
+    fn redact_upstream_url_for_error_removes_userinfo() {
+        assert_eq!(
+            redact_upstream_url_for_error("http://user:secret@upstream.example:8546"),
+            concat!(
+                "failed parsing upstream location as websocket URL: ",
+                "`http://redacted:redacted@upstream.example:8546/`"
+            )
+        );
+    }
+
+    #[test]
+    fn redact_upstream_url_for_error_preserves_unparseable_input() {
+        assert_eq!(
+            redact_upstream_url_for_error("not a url"),
+            "failed parsing upstream location as websocket URL: `not a url`"
+        );
     }
 }

--- a/crates/telemetry-util/Cargo.toml
+++ b/crates/telemetry-util/Cargo.toml
@@ -16,3 +16,4 @@ publish.workspace = true
 eyre.workspace = true
 jiff.workspace = true
 tracing.workspace = true
+url.workspace = true

--- a/crates/telemetry-util/src/lib.rs
+++ b/crates/telemetry-util/src/lib.rs
@@ -201,3 +201,66 @@ impl<T: std::fmt::Display> std::fmt::Display for DisplayOption<'_, T> {
         }
     }
 }
+
+/// Formats a [`url::Url`] with any embedded username or password redacted.
+///
+/// This is useful for logging endpoints that may include HTTP basic auth
+/// credentials in their userinfo component.
+///
+/// # Example
+///
+/// ```
+/// use tempo_telemetry_util::display_redacted_url;
+///
+/// let url = url::Url::parse("wss://user:secret@example.com").unwrap();
+/// tracing::warn!(
+///     url = %display_redacted_url(&url),
+///     "connection lost",
+/// );
+/// ```
+pub fn display_redacted_url(url: &url::Url) -> DisplayRedactedUrl<'_> {
+    DisplayRedactedUrl(url)
+}
+
+pub struct DisplayRedactedUrl<'a>(&'a url::Url);
+
+impl std::fmt::Display for DisplayRedactedUrl<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut redacted = self.0.clone();
+
+        if !redacted.username().is_empty() {
+            let _ = redacted.set_username("redacted");
+        }
+
+        if redacted.password().is_some() {
+            let _ = redacted.set_password(Some("redacted"));
+        }
+
+        write!(f, "{redacted}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_redacted_url_removes_userinfo() {
+        let url = url::Url::parse("wss://user:secret@example.com:8546/path").unwrap();
+
+        assert_eq!(
+            display_redacted_url(&url).to_string(),
+            "wss://redacted:redacted@example.com:8546/path"
+        );
+    }
+
+    #[test]
+    fn display_redacted_url_leaves_public_url_unchanged() {
+        let url = url::Url::parse("wss://example.com:8546/path").unwrap();
+
+        assert_eq!(
+            display_redacted_url(&url).to_string(),
+            "wss://example.com:8546/path"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a telemetry display helper for logging URLs with userinfo redacted.
- Uses it for follow-upstream reconnect and stream termination logs so credentialed `--follow` URLs are not emitted verbatim.
- Redacts parseable URL userinfo in follow-upstream parse errors while preserving unparseable input as-is.
- Fixes a small `websocker` typo in the follow upstream module docs.

## Validation

- `cargo test -p tempo-telemetry-util display_redacted_url`
- `cargo test -p tempo-telemetry-util --doc display_redacted_url`
- `cargo test -p tempo-consensus follow::upstream`
- `cargo fmt`
- `git diff --check`
