### PR TITLE
chore: update `_transfer`, `Recipient` visibility

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1374,7 +1374,7 @@ impl TIP20Token {
 ///
 /// [TIP-1022]: <https://docs.tempo.xyz/protocol/tip1022>
 #[derive(Debug, PartialEq)]
-pub(crate) struct Recipient {
+pub struct Recipient {
     /// The effective (resolved) address where the balance is credited.
     pub(crate) target: Address,
     /// The virtual address, if registered.

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1384,7 +1384,7 @@ pub struct Recipient {
 impl Recipient {
     /// Creates a [`Recipient`] with no virtual indirection.
     #[inline]
-    pub(crate) fn direct(addr: Address) -> Self {
+    pub fn direct(addr: Address) -> Self {
         Self {
             target: addr,
             virtual_addr: None,

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1164,7 +1164,7 @@ impl TIP20Token {
     ///
     /// For virtual recipients the event address is the virtual alias; the balance update always
     /// targets `to.target` (the resolved master).
-    pub(crate) fn _transfer(&mut self, from: Address, to: &Recipient, amount: U256) -> Result<()> {
+    pub fn _transfer(&mut self, from: Address, to: &Recipient, amount: U256) -> Result<()> {
         let from_balance = if !self.storage.spec().is_t8() {
             let from_balance = self.get_balance(from)?;
             if amount > from_balance {


### PR DESCRIPTION
This PR updates `_transfer()` and `Recipient` visibility to`pub`.


This is necessary for downstream crates that want to use TIP20 functions directly. 
[Ref](https://github.com/tempoxyz/zones/pull/600#discussion_r3543399966)