### PR TITLE
docs(tip-1087): match DEX book index ABI

### DIFF
--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -115,12 +115,12 @@ Pre-activation orderbooks MUST NOT be migrated by linearly scanning `book_keys` 
 The DEX MUST expose:
 
 ```solidity
-function setBookIndex(bytes32 bookKey, uint32 index) external;
-function bookIndexForKey(bytes32 bookKey) external view returns (bool isSet, uint32 idx);
+function setBookIndex(uint32 index) external;
+function bookIndexForKey(bytes32 bookKey) external view returns (bool set, uint32 index);
 function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
 ```
 
-`setBookIndex` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index + 1` on the orderbook record. If the orderbook already has `bookKeyIdx != 0`, `setBookIndex` MUST be idempotent when the supplied `index + 1` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index + 1` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
+`setBookIndex` MUST resolve `bookKey = book_keys[index]`, verify that `bookKey` is initialized, and verify that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index + 1` on the orderbook record. If the orderbook already has `bookKeyIdx != 0`, `setBookIndex` MUST be idempotent when the supplied `index + 1` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index + 1` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
 
 `bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It MUST fail with
 `PairDoesNotExist` if `bookKey` does not identify an initialized orderbook. For an initialized
@@ -179,7 +179,7 @@ Deleting an order clears the storage slots used by that order's versioned layout
 
 # Tooling
 
-Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setBookIndex(bookKey, index)`, and verifies that each corresponding orderbook has the expected 1-based `bookKeyIdx = index + 1`. The workflow MUST avoid onchain linear scans over `book_keys`.
+Operators need an offchain migration workflow that enumerates existing `book_keys`, derives indexes offchain, calls `setBookIndex(index)`, and verifies that each corresponding orderbook has the expected 1-based `bookKeyIdx = index + 1`. The workflow MUST avoid onchain linear scans over `book_keys`.
 
 Tools that decode raw DEX storage MUST add support for the 1-based orderbook `bookKeyIdx` field packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
 

--- a/tips/tip-1087.md
+++ b/tips/tip-1087.md
@@ -26,13 +26,13 @@ The DEX already maintains an append-only `book_keys` vector. Storing the vector 
 
 - Versioned order-storage abstraction, as defined in TIP-1062, is active before this TIP. If order reads and writes bypass that abstraction, mixed-version linked lists can be corrupted.
 - `book_keys` is append-only and indexes are stable for the lifetime of the DEX. Reordering or removing entries would make existing `V2Order.bookIndex` values decode to the wrong orderbook.
-- Every initialized orderbook has exactly one entry in `book_keys`. If a pre-activation orderbook key is missing from `book_keys`, `setIndexForKey` MUST fail instead of assigning a synthetic index.
+- Every initialized orderbook has exactly one entry in `book_keys`. If a pre-activation orderbook key is missing from `book_keys`, `setBookIndex` MUST fail instead of assigning a synthetic index.
 - Off-chain migration tooling can derive each pre-activation orderbook's `book_keys` index. If an orderbook remains unmigrated after activation, new orders for that book continue to use `V1Order` until its index is persisted.
 
 ## Threat Model
 
 - DEX users may place, cancel, and match orders across legacy, V1, and V2 linked lists. They are untrusted and MUST NOT be able to make pointer updates use the wrong layout version.
-- DEX users may create many orderbooks before activation in an attempt to make migration expensive or DoS V2 adoption. The fallback-to-V1 write path and explicit `setIndexForKey` migration keep the optimization opt-in per orderbook: unmigrated books remain functional without forcing onchain scans or blocking indexed books from using V2.
+- DEX users may create many orderbooks before activation in an attempt to make migration expensive or DoS V2 adoption. The fallback-to-V1 write path and explicit `setBookIndex` migration keep the optimization opt-in per orderbook: unmigrated books remain functional without forcing onchain scans or blocking indexed books from using V2.
 - DEX implementation code is trusted to route all order field reads, writes, deletions, and flip rewrites through the versioned order-storage abstraction.
 
 ---
@@ -115,12 +115,12 @@ Pre-activation orderbooks MUST NOT be migrated by linearly scanning `book_keys` 
 The DEX MUST expose:
 
 ```solidity
-function setIndexForKey(bytes32 bookKey, uint32 index) external;
+function setBookIndex(bytes32 bookKey, uint32 index) external;
 function bookIndexForKey(bytes32 bookKey) external view returns (bool isSet, uint32 idx);
 function bookKeyForIndex(uint32 index) external view returns (bytes32 bookKey);
 ```
 
-`setIndexForKey` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index + 1` on the orderbook record. If the orderbook already has `bookKeyIdx != 0`, `setIndexForKey` MUST be idempotent when the supplied `index + 1` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index + 1` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
+`setBookIndex` MUST verify that `book_keys[index] == bookKey`, that `bookKey` is initialized, and that the corresponding orderbook exists. If verification succeeds, it MUST store `bookKeyIdx = index + 1` on the orderbook record. If the orderbook already has `bookKeyIdx != 0`, `setBookIndex` MUST be idempotent when the supplied `index + 1` matches the existing value and MUST NOT rewrite `bookKeyIdx`. If the supplied `index + 1` differs from the existing value, it MUST revert with `IndexAlreadySet` and MUST NOT rewrite `bookKeyIdx`.
 
 `bookIndexForKey` is a view helper and MUST NOT scan `book_keys`. It MUST fail with
 `PairDoesNotExist` if `bookKey` does not identify an initialized orderbook. For an initialized
@@ -179,7 +179,7 @@ Deleting an order clears the storage slots used by that order's versioned layout
 
 # Tooling
 
-Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setIndexForKey(bookKey, index)`, and verifies that each corresponding orderbook has the expected 1-based `bookKeyIdx = index + 1`. The workflow MUST avoid onchain linear scans over `book_keys`.
+Operators need an offchain migration workflow that enumerates existing `book_keys`, derives `(bookKey, index)` pairs offchain, calls `setBookIndex(bookKey, index)`, and verifies that each corresponding orderbook has the expected 1-based `bookKeyIdx = index + 1`. The workflow MUST avoid onchain linear scans over `book_keys`.
 
 Tools that decode raw DEX storage MUST add support for the 1-based orderbook `bookKeyIdx` field packed in slot `4`, version `2` orders, and resolving `bookIndex` through `book_keys`. Existing tools that consume order events or call `getOrder(uint128)` can continue using the same interface.
 
@@ -187,7 +187,7 @@ Tools that decode raw DEX storage MUST add support for the 1-based orderbook `bo
 
 No new order lifecycle events are required. Existing DEX order events and `getOrder(uint128)` remain sufficient to observe user-visible order behavior.
 
-The migration workflow MUST produce an operator-verifiable report with the total `book_keys` count, migrated orderbook count, and any failed `setIndexForKey` calls. This report tracks V2 coverage, but activation does not require every pre-activation orderbook to be migrated because unmigrated books fall back to `V1Order` writes.
+The migration workflow MUST produce an operator-verifiable report with the total `book_keys` count, migrated orderbook count, and any failed `setBookIndex` calls. This report tracks V2 coverage, but activation does not require every pre-activation orderbook to be migrated because unmigrated books fall back to `V1Order` writes.
 
 # Invariants
 


### PR DESCRIPTION
## Summary
- rename TIP-1087 spec references from `setIndexForKey` to `setBookIndex`
- keep the existing migration semantics unchanged while matching the implementation ABI

Prompted by: @0xrusowsky