### PR TITLE
perf(dex): avoid useless deletes + double `maker()` reads

### DIFF
--- a/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_lifecycle_gas_snapshot_t8.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_lifecycle_gas_snapshot_t8.snap
@@ -7,11 +7,11 @@ cancel_bid_earn_credits:
   storage_credits: "user1: 0 -> 2"
   pooled_storage_credits: "DEX TIP-1060: 0 -> 4"
 cancel_head_bid_tracks_successor_prev:
-  gas: 342041
+  gas: 341941
   storage_credits: "user11: 0 -> 3; user12: 0 -> 1"
   pooled_storage_credits: "DEX TIP-1060: 20 -> 22"
 cancel_tail_bid_credits_predecessor_next:
-  gas: 342041
+  gas: 341941
   storage_credits: "user10: 0 -> 3; user9: 0 -> 1"
   pooled_storage_credits: "DEX TIP-1060: 16 -> 18"
 create_pair:
@@ -19,39 +19,39 @@ create_pair:
   storage_credits: n/a
   pooled_storage_credits: "DEX TIP-1060: 0 -> 0"
 place_ask_wallet:
-  gas: 1590285
+  gas: 1583685
   storage_credits: "user2: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 6 -> 6"
 place_bid_append_same_level:
-  gas: 1095969
+  gas: 1089369
   storage_credits: "user16: 0 -> 0; user15: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 3 -> 3"
 place_bid_cross_user_after_cancel_credits:
-  gas: 1091069
+  gas: 1084469
   storage_credits: "user7: 0 -> 0; user6: 2 -> 2"
   pooled_storage_credits: "DEX TIP-1060: 6 -> 6"
 place_bid_cross_user_after_fill_credits:
-  gas: 1091069
+  gas: 1084469
   storage_credits: "user7: 0 -> 0; user4: 2 -> 2"
   pooled_storage_credits: "DEX TIP-1060: 12 -> 12"
 place_bid_reuse_cancel_credits:
-  gas: 849413
+  gas: 842813
   storage_credits: "user1: 2 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 4 -> 3"
 place_bid_reuse_predecessor_next_credit:
-  gas: 852469
+  gas: 845869
   storage_credits: "user9: 1 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 18 -> 18"
 place_bid_reuse_swap_credits:
-  gas: 602113
+  gas: 595513
   storage_credits: "user3: 2 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 10 -> 9"
 place_bid_wallet:
-  gas: 1837585
+  gas: 1830985
   storage_credits: "user1: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 0 -> 0"
 place_flip_bid_wallet:
-  gas: 1341043
+  gas: 1334443
   storage_credits: "user5: 0 -> 0"
   pooled_storage_credits: "DEX TIP-1060: 12 -> 12"
 swap_exact_in_full_ask_earn_credits:

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -148,7 +148,7 @@ impl StablecoinDEX {
             return Ok(());
         }
 
-        let maker = self.orders[order_id].maker()?.read()?;
+        let maker = self.orders[order_id].maker()?;
         self.credit_dex_storage_slots(maker, credits)
     }
 

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -245,6 +245,7 @@ impl OrderHandler {
             OrderVersion::V1 | OrderVersion::V2 => __packing_v1_order::MAKER_LOC,
         };
 
+        // T8+ version detection loads slot 0. We reuse it when the maker is stored there.
         if let Some(slot0) = slot0
             && loc.offset_slots == 0
         {

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -237,14 +237,25 @@ impl OrderHandler {
         }
     }
 
-    /// Returns a storage handler for the order's maker address.
-    pub(crate) fn maker(&self) -> StorageResult<Slot<Address>> {
-        let loc = match self.version()? {
+    /// Returns the order's maker address.
+    pub(crate) fn maker(&self) -> StorageResult<Address> {
+        let (version, slot0) = self.version_and_slot()?;
+        let loc = match version {
             OrderVersion::Legacy => __packing_legacy_order::MAKER_LOC,
             OrderVersion::V1 | OrderVersion::V2 => __packing_v1_order::MAKER_LOC,
         };
 
-        Ok(Slot::new_at_loc(self.base_slot, loc, self.address))
+        if let Some(slot0) = slot0
+            && loc.offset_slots == 0
+        {
+            Address::load(
+                &packing::PackedSlot(slot0),
+                U256::ZERO,
+                LayoutCtx::packed(loc.offset_bytes),
+            )
+        } else {
+            Slot::new_at_loc(self.base_slot, loc, self.address).read()
+        }
     }
 
     /// Returns a storage handler for the order's remaining amount.
@@ -285,12 +296,19 @@ impl OrderHandler {
         Ok(Slot::new_at_loc(self.base_slot, loc, self.address))
     }
 
+    /// Returns the physical storage version and the loaded base slot, when read.
+    pub(crate) fn version_and_slot(&self) -> StorageResult<(OrderVersion, Option<U256>)> {
+        if !StorageCtx.spec().is_t8() {
+            return Ok((OrderVersion::Legacy, None));
+        }
+
+        let slot0 = self.load(self.base_slot)?;
+        Ok((OrderVersion::try_from(slot0)?, Some(slot0)))
+    }
+
     /// Returns the physical storage version.
     pub(crate) fn version(&self) -> StorageResult<OrderVersion> {
-        if !StorageCtx.spec().is_t8() {
-            return Ok(OrderVersion::Legacy);
-        }
-        OrderVersion::try_from(self.load(self.base_slot)?)
+        self.version_and_slot().map(|(version, _)| version)
     }
 
     /// Reads this order using a known owning book key, skipping V2 index resolution.
@@ -328,7 +346,8 @@ impl OrderHandler {
             return value.store(self, self.base_slot, LayoutCtx::FULL);
         }
 
-        let old_slots = match self.version()? {
+        let (old_version, slot0) = self.version_and_slot()?;
+        let old_slots = match old_version {
             OrderVersion::Legacy => LegacyOrder::SLOTS,
             OrderVersion::V1 => V1Order::SLOTS,
             OrderVersion::V2 => V2Order::SLOTS,
@@ -348,8 +367,10 @@ impl OrderHandler {
             V1Order::SLOTS
         };
 
-        for offset in new_slots..old_slots {
-            self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
+        if slot0.is_none_or(|val| !val.is_zero()) {
+            for offset in new_slots..old_slots {
+                self.store(self.base_slot.wrapping_add(U256::from(offset)), U256::ZERO)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
This PR optimizes T8+ DEX order storage writes by skipping trailing slot zeroing for fresh order records.

It also reuses the order version slot read when loading the maker address, avoiding an extra storage read when crediting makers for rewritten neighbor orders.