### PR TITLE
ci(bench): correct bench e2e merge-base label

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -726,7 +726,7 @@ jobs:
              } catch {
                baselineRef = process.env.INPUT_SHA;
              }
-             baselineName = baselineNameArg || baseRef;
+             baselineName = baselineNameArg && baselineNameArg !== 'merge-base' ? baselineNameArg : baselineRef;
            }
 
            if (featureArg) {


### PR DESCRIPTION
## Summary
- replace the default `merge-base` baseline display label with the resolved merge-base commit SHA in `bench-e2e.yml`
- preserve explicit baseline names for manual and scheduled benchmark runs

Prompted by: @shekhirin

## Test
- `node` assertion for merge-base label selection behavior

