### PR TITLE
fix(payload): combine sparse trie changed path fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8595,7 +8595,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8688,7 +8688,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8759,6 +8759,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "socket2",
  "tar",
  "tokio",
  "tokio-stream",
@@ -8771,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8781,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8834,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8850,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8864,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8877,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8902,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8931,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8957,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8987,7 +8988,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9002,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9027,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9051,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9075,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9167,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9195,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9218,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9243,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9299,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9329,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9347,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9363,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9386,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9397,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9425,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9447,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9488,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "clap",
  "eyre",
@@ -9511,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9527,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9543,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9556,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9586,7 +9587,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9600,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9610,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9635,7 +9636,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9655,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9673,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9686,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9705,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9757,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "serde",
  "serde_json",
@@ -9767,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9793,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "bytes",
  "futures",
@@ -9813,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9830,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "bindgen",
  "cc",
@@ -9839,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "futures",
  "metrics",
@@ -9852,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9861,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9875,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9933,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9958,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9982,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9997,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10011,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10028,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10052,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10120,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10175,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10223,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10247,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10271,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "bytes",
  "eyre",
@@ -10300,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10312,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10336,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10348,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10371,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10414,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10462,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10490,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10506,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10521,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10598,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10628,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10671,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10691,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10722,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10769,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10820,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10834,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10865,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10916,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10944,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10958,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10978,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10993,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11019,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11036,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11057,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11073,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11083,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "clap",
  "eyre",
@@ -11103,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11122,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11166,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11190,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11217,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11236,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11261,7 +11262,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af#05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11276,6 +11277,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "smallvec",
+ "strum",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -18,7 +18,8 @@ use reth_eth_wire_types::{
 use reth_ethereum::{
     network::{
         NetworkConfig, NetworkEventListenerProvider, NetworkInfo, NetworkManager, PeersConfig,
-        PeersInfo, eth_requests::IncomingEthRequest, transactions::NetworkTransactionEvent,
+        PeersInfo, eth_requests::IncomingEthRequest, p2p::error::RequestError,
+        transactions::NetworkTransactionEvent,
     },
     tasks::Runtime,
 };
@@ -472,6 +473,9 @@ async fn run_p2p_network(
             }
             IncomingEthRequest::GetCells { response, .. } => {
                 let _ = response.send(Ok(Default::default()));
+            }
+            IncomingEthRequest::GetSnap { response, .. } => {
+                let _ = response.send(Err(RequestError::UnsupportedCapability));
             }
         }
     }

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -47,8 +47,9 @@ use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
     EthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
-        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, LoadBlock,
-        LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction, SpawnBlocking, Trace,
+        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthSubscriptions, EthTransactions,
+        LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction,
+        SpawnBlocking, Trace,
         bal::GetBlockAccessList,
         estimate::EstimateCall,
         pending_block::{BuildPendingEnv, PendingEnvBuilder},
@@ -376,6 +377,8 @@ where
 }
 
 impl<N> EthFees for TempoEthApi<N> where N: TempoEthApiBounds {}
+
+impl<N> EthSubscriptions for TempoEthApi<N> where N: TempoEthApiBounds {}
 
 impl<N> Trace for TempoEthApi<N> where N: TempoEthApiBounds {}
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1077,16 +1077,24 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if self.config.skip_state_root {
-            (parent_header.state_root(), Arc::new(Default::default()))
+        let (state_root, trie_updates, changed_paths) = if self.config.skip_state_root {
+            (
+                parent_header.state_root(),
+                Arc::new(Default::default()),
+                None,
+            )
         } else if let Some(outcome) = state_root_outcome {
-            (outcome.state_root, outcome.trie_updates)
+            (
+                outcome.state_root,
+                outcome.trie_updates,
+                outcome.changed_paths,
+            )
         } else {
             let (state_root, trie_updates) = finish_provider
                 .state_root_with_updates(hashed_state.clone())
                 .map_err(BlockExecutionError::other)?;
 
-            (state_root, Arc::new(trie_updates))
+            (state_root, Arc::new(trie_updates), None)
         };
 
         let RootsTaskResult {
@@ -1290,7 +1298,7 @@ where
             execution_output: Arc::new(execution_output),
             hashed_state: Arc::new(hashed_state),
             trie_updates,
-            changed_paths: None,
+            changed_paths,
         };
 
         let payload = TempoBuiltPayload::new(


### PR DESCRIPTION
Combines paradigmxyz/reth#25952, paradigmxyz/reth#26332, and tempoxyz/tempo#6763.

Pins Reth to paradigmxyz/reth@05bffd7eb7cd9cbe28179ca46a6fd8c0b6ada9af from the mediocregopher/combined-sparse-trie-prune-paths branch and carries the Tempo payload changed-path propagation.