### PR TITLE
fix: show base branch for default e2e baseline

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -726,7 +726,7 @@ jobs:
              } catch {
                baselineRef = process.env.INPUT_SHA;
              }
-             baselineName = baselineNameArg && baselineNameArg !== 'merge-base' ? baselineNameArg : baselineRef;
+             baselineName = baselineNameArg && baselineNameArg !== 'merge-base' ? baselineNameArg : baseRef;
            }
 
            if (featureArg) {


### PR DESCRIPTION
## Summary
- show the PR base branch (for example `main`) for default e2e benchmark baseline display
- continue resolving the actual baseline ref to the merge-base commit SHA for checkout, reports, and links
- preserve explicit baseline names for manual and scheduled runs

Prompted by: @shekhirin

## Test
- `node` assertion for default and explicit baseline display selection
