### PR TITLE
feat(telemetry): propagate span attributes to logs by default

### DIFF
--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -136,6 +136,7 @@ keccak-cache-global = [
 
 otlp = [
 	"reth-ethereum-cli/otlp",
+	# Enables reth's opentelemetry-appender-tracing experimental span attributes.
 	"reth-ethereum-cli/otlp-logs",
 	"reth-ethereum/otlp",
 	"tempo-node/otlp",


### PR DESCRIPTION
## Summary
- Keep `otlp` as the single Tempo feature switch.
- Document that `reth-ethereum-cli/otlp-logs` is intentionally enabled under `otlp` because reth wires it to `opentelemetry-appender-tracing/experimental_span_attributes` and `TracingSpanAttributes::all()`.

## Testing
- `cargo +nightly fmt --check`
- `git diff --check`

Prompted by: @SuperFluffy