### PR TITLE
fix(consensus): follower no longer jumps to every finalized certificate

### DIFF
--- a/crates/consensus/src/follow/driver.rs
+++ b/crates/consensus/src/follow/driver.rs
@@ -368,8 +368,7 @@ where
             ),
         };
 
-        // If we can accept this cert, jump to it and set the floor as the
-        // upstream may have pruned any intermediatery blocks.
+        // If we can accept this cert, jump to it.
         if finalization.verify(&mut self.context, &scheme, &Sequential) {
             let round = finalization.round();
             let activity = Activity::Finalization(finalization);
@@ -377,10 +376,6 @@ where
                 warn_span!("follow_driver").in_scope(
                     || warn!(?round, %height, "marshal refused to persist the verified block"),
                 )
-            }
-
-            if let Some(one_before_block) = height.previous() {
-                self.config.marshal.set_floor(one_before_block).await;
             }
 
             self.config.marshal.report(activity.clone()).await;

--- a/crates/consensus/src/follow/driver.rs
+++ b/crates/consensus/src/follow/driver.rs
@@ -368,7 +368,6 @@ where
             ),
         };
 
-        // If we can accept this cert, jump to it.
         if finalization.verify(&mut self.context, &scheme, &Sequential) {
             let round = finalization.round();
             let activity = Activity::Finalization(finalization);


### PR DESCRIPTION
Removes the `marshal.set_floor` after every verified finalized certificate.

The `set_floor` causes the marshal actor to never store finalized blocks below this threshold. In such cases where a few finalized certificates were skipped, this leads to the marshal actor dropping and never storing any blocks below the floor.

On restart this causes issues because the executor actor is not able to reconcile CL and EL state. But it is written in such a way that it assumes that the `finalized_floor` must be reachable if there is a gap between the EL finalized watermark and the CL floor.

