### PR TITLE
Increase bench-e2e txgen accounts

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -71,7 +71,7 @@ on:
         description: Number of benchmark accounts.
         type: string
         required: true
-        default: "1000"
+        default: "10000"
       max-concurrent-requests:
         description: Max concurrent sender requests.
         type: string
@@ -188,7 +188,7 @@ on:
       accounts:
         type: string
         required: false
-        default: "1000"
+        default: "10000"
       max-concurrent-requests:
         type: string
         required: false
@@ -385,7 +385,7 @@ jobs:
       BENCH_DURATION: ${{ inputs.duration }}
       BENCH_BLOAT: ${{ inputs.bloat }}
       BENCH_TPS: ${{ inputs.tps }}
-      BENCH_ACCOUNTS: ${{ inputs.accounts || '1000' }}
+      BENCH_ACCOUNTS: ${{ inputs.accounts || '10000' }}
       BENCH_MAX_CONCURRENT_REQUESTS: ${{ inputs.max-concurrent-requests || '500' }}
       BENCH_BASELINE_HARDFORK: ${{ inputs.baseline-hardfork }}
       BENCH_FEATURE_HARDFORK: ${{ inputs.feature-hardfork }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1349,7 +1349,7 @@ def "main e2e" [
     --tps: int = 50000                                  # Target TPS
     --duration: int = 90                                # Duration in seconds
     --summary-warmup-blocks: int = 5                    # Initial blocks per run excluded from summary metrics
-    --accounts: int = 1000                              # Number of accounts
+    --accounts: int = 10000                             # Number of accounts
     --max-concurrent-requests: int = 500                # Max concurrent requests
     --bloat: int = $E2E_DEFAULT_BLOAT                   # State bloat snapshot size in GiB: 0, 1, 10, or 100
     --token-count: int = 4                         # Number of TIP20 tokens to use in txgen presets


### PR DESCRIPTION
## Summary
- increase bench-e2e default txgen accounts from 1,000 to 10,000
- update workflow dispatch and workflow-call defaults to match the script default

## Testing
- `nu --commands 'source bench-e2e.nu; help main e2e | str contains "--accounts"'`\n- `git diff --check`\n\nPrompted by: @shekhirin