### PR TITLE
chore(deps): pin reth tx propagation optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8595,7 +8595,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8688,7 +8688,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8759,6 +8759,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "socket2",
  "tar",
  "tokio",
  "tokio-stream",
@@ -8771,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8781,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8834,7 +8835,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8850,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8864,7 +8865,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8877,7 +8878,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8902,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8931,7 +8932,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8957,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8987,7 +8988,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9002,7 +9003,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9027,7 +9028,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9051,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9075,7 +9076,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9111,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9167,7 +9168,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9195,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9218,7 +9219,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9243,7 +9244,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9299,7 +9300,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9329,7 +9330,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9347,7 +9348,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9363,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9386,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9397,7 +9398,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9425,7 +9426,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9447,7 +9448,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9488,7 +9489,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "clap",
  "eyre",
@@ -9511,7 +9512,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9527,7 +9528,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9543,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9556,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9586,7 +9587,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9600,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9610,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9635,7 +9636,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9655,7 +9656,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9673,7 +9674,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9686,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9705,7 +9706,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9757,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "serde",
  "serde_json",
@@ -9767,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9793,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "bytes",
  "futures",
@@ -9813,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9830,7 +9831,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "bindgen",
  "cc",
@@ -9839,7 +9840,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "futures",
  "metrics",
@@ -9852,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9861,7 +9862,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9875,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9933,7 +9934,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9958,7 +9959,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9982,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9997,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10011,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10028,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10052,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10120,7 +10121,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10175,7 +10176,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10223,7 +10224,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10247,7 +10248,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10271,7 +10272,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "bytes",
  "eyre",
@@ -10300,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10312,7 +10313,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10336,7 +10337,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10348,7 +10349,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10371,7 +10372,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10414,7 +10415,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10462,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10490,7 +10491,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10506,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10521,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10598,7 +10599,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10628,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10671,7 +10672,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10691,7 +10692,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10722,7 +10723,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10769,7 +10770,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10820,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10834,7 +10835,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10865,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10916,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10944,7 +10945,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10958,7 +10959,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10978,7 +10979,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10993,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11019,7 +11020,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11036,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11057,7 +11058,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11073,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11083,7 +11084,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "clap",
  "eyre",
@@ -11103,7 +11104,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11122,7 +11123,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11165,7 +11166,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11190,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11217,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11236,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11261,7 +11262,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=39cf643#39cf643dbaf5f92c201839a7a624cce8cc535735"
+source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11276,6 +11277,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "smallvec",
+ "strum",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,15 +2258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5701,7 +5692,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -8595,7 +8585,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8612,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8645,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8675,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8688,7 +8678,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8772,7 +8762,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8782,7 +8772,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8835,7 +8825,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8851,7 +8841,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8865,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8878,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8903,7 +8893,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8932,7 +8922,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8958,7 +8948,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8988,7 +8978,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9003,7 +8993,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9028,7 +9018,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9052,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9076,7 +9066,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9111,7 +9101,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9168,12 +9158,11 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "aes",
  "alloy-primitives",
  "alloy-rlp",
- "block-padding",
  "byteorder",
  "cipher",
  "concat-kdf",
@@ -9196,7 +9185,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9219,7 +9208,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9244,7 +9233,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9300,7 +9289,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9330,7 +9319,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9348,7 +9337,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9364,7 +9353,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9387,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9398,7 +9387,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9426,7 +9415,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9448,7 +9437,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9489,7 +9478,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "clap",
  "eyre",
@@ -9512,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9528,7 +9517,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9544,7 +9533,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9557,7 +9546,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9587,7 +9576,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9601,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9611,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9636,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9656,7 +9645,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9674,7 +9663,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9687,7 +9676,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9706,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9744,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9758,7 +9747,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "serde",
  "serde_json",
@@ -9768,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9794,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "bytes",
  "futures",
@@ -9814,7 +9803,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9831,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "bindgen",
  "cc",
@@ -9840,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "futures",
  "metrics",
@@ -9853,7 +9842,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9862,7 +9851,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9876,7 +9865,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9934,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9959,7 +9948,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9983,7 +9972,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9998,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10012,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10029,7 +10018,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10053,7 +10042,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10121,7 +10110,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10176,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10224,7 +10213,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10248,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10272,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "bytes",
  "eyre",
@@ -10301,7 +10290,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10313,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10337,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10349,7 +10338,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10372,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10415,7 +10404,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10463,7 +10452,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10491,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10507,7 +10496,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10522,7 +10511,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10599,7 +10588,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10629,7 +10618,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10672,7 +10661,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10692,7 +10681,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10723,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10770,7 +10759,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10821,7 +10810,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10835,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10866,7 +10855,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10917,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10945,7 +10934,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10959,7 +10948,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10979,7 +10968,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10994,7 +10983,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11020,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11037,7 +11026,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11058,7 +11047,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11074,7 +11063,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11084,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "clap",
  "eyre",
@@ -11104,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11123,7 +11112,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11166,7 +11155,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11191,7 +11180,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11218,7 +11207,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11237,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11262,7 +11251,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=674ab5cae0c2a196b55914b244760df9aed5aa48#674ab5cae0c2a196b55914b244760df9aed5aa48"
+source = "git+https://github.com/paradigmxyz/reth?rev=7e7434b99e4f040e3ddf52e22134d99f30d91e90#7e7434b99e4f040e3ddf52e22134d99f30d91e90"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "7e7434b99e4f040e3ddf52e22134d99f30d91e90", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,66 +146,66 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", default-features = false }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", default-features = false }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "39cf643", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "674ab5cae0c2a196b55914b244760df9aed5aa48", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -473,6 +473,11 @@ async fn run_p2p_network(
             IncomingEthRequest::GetCells { response, .. } => {
                 let _ = response.send(Ok(Default::default()));
             }
+            // The proxy never negotiates snap/2, so no inbound snap requests are expected;
+            // dropping the sender cancels the request.
+            IncomingEthRequest::GetSnap { response, .. } => {
+                drop(response);
+            }
         }
     }
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -47,8 +47,9 @@ use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
     EthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
-        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, LoadBlock,
-        LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction, SpawnBlocking, Trace,
+        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthSubscriptions, EthTransactions,
+        LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction,
+        SpawnBlocking, Trace,
         bal::GetBlockAccessList,
         estimate::EstimateCall,
         pending_block::{BuildPendingEnv, PendingEnvBuilder},
@@ -382,6 +383,8 @@ impl<N> Trace for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> EthCall for TempoEthApi<N> where N: TempoEthApiBounds {}
 
 impl<N> GetBlockAccessList for TempoEthApi<N> where N: TempoEthApiBounds {}
+
+impl<N> EthSubscriptions for TempoEthApi<N> where N: TempoEthApiBounds {}
 
 impl<N> Call for TempoEthApi<N>
 where


### PR DESCRIPTION
Pins Reth dependencies to `paradigmxyz/reth@674ab5cae0c2a196b55914b244760df9aed5aa48`, built from `mattsse/tx-propagation-opt`.

That branch reduces per-message overhead in the rlpx session pipeline: the ECIES MAC no longer re-expands the AES key schedule per frame (-36% per frame op), P2PStream reuses its snappy compression buffer instead of zeroing a worst-case buffer per message, sessions flush the connection once per poll with a 64KiB transport write boundary instead of one flush per loop pass and one write syscall per 8KiB, and the session receive budget is raised from 4 to 16 messages per poll.

The pin also picks up reth main up to `2371711069` (13 commits over the previous pin), which required implementing the new `EthSubscriptions` trait for `TempoEthApi` and handling the new `IncomingEthRequest::GetSnap` variant in the p2p proxy.