### PR TITLE
fix(consensus): hybrid block storage is reth-aware across the entire storage interface

### DIFF
--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -52,6 +52,18 @@
 //! follow-mode catching up while reth has synced past the cache
 //! window).
 //!
+//! # Gap tracking
+//!
+//! The marshal uses [`Blocks::next_gap`], [`Blocks::missing_items`], and
+//! [`Blocks::last_index`] to decide what finalized blocks still need repair.
+//! These methods must expose the same logical coverage as [`Blocks::get`]:
+//! all heights at or below reth's finalized watermark are covered by reth,
+//! and heights above that watermark are covered only when present in the
+//! prunable cache.
+//!
+//! This prevents marshal from repeatedly trying to repair blocks that reth
+//! already finalized after the prunable cache evicted them.
+//!
 //! # Why reth pruning is not a concern
 //!
 //! Reth may be configured to retain only a window of recent history,
@@ -381,10 +393,18 @@ where
     }
 
     fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
-        // EL is treated as a contiguous source; gaps can only exist in the
-        // prunable archive. The marshal only ever asks about heights at or
-        // above `last_processed_height`, which the prunable archive must
-        // cover.
+        let execution_finalized_height = self
+            .execution_block_provider
+            .finalized_height()
+            .map(Height::new)
+            .unwrap_or_default();
+
+        let start = if start <= execution_finalized_height {
+            execution_finalized_height.next()
+        } else {
+            start
+        };
+
         archive::Archive::missing_items(&self.prunable, start.get(), max)
             .into_iter()
             .map(Height::new)
@@ -392,15 +412,37 @@ where
     }
 
     fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
-        let (a, b) = archive::Archive::next_gap(&self.prunable, value.get());
-        (a.map(Height::new), b.map(Height::new))
+        let execution_finalized_height = self
+            .execution_block_provider
+            .finalized_height()
+            .map(Height::new)
+            .unwrap_or_default();
+
+        // If Reth contains this value, we simply need to check if the prunable archive
+        // extends this covered range by checking `execution_finalized_height+1`. Otherwise
+        // Archive::next_gap will report is missing.
+        let value_covered_by_execution = value <= execution_finalized_height;
+        let query = if value_covered_by_execution {
+            execution_finalized_height.next()
+        } else {
+            value
+        };
+
+        let (current_end, next_start) = archive::Archive::next_gap(&self.prunable, query.get());
+        let current_end = if value_covered_by_execution {
+            Some(current_end.map_or(execution_finalized_height, Height::new))
+        } else {
+            current_end.map(Height::new)
+        };
+
+        (current_end, next_start.map(Height::new))
     }
 
     fn last_index(&self) -> Option<Height> {
-        // Only report what lives in the prunable archive. The marshal uses
-        // this to drive repair against the certificates archive; reflecting
-        // EL here would mask gaps the marshal needs to fill via the
-        // resolver.
-        archive::Archive::last_index(&self.prunable).map(Height::new)
+        archive::Archive::last_index(&self.prunable)
+            .into_iter()
+            .chain(self.execution_block_provider.finalized_height())
+            .max()
+            .map(Height::new)
     }
 }

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -64,6 +64,14 @@
 //! This prevents marshal from repeatedly trying to repair blocks that reth
 //! already finalized after the prunable cache evicted them.
 //!
+//! One nuance: if reth itself prunes history, heights below its pruning
+//! window are still reported as covered even though [`Blocks::get`] can no
+//! longer serve them. Repairing them here would be futile anyway — the
+//! prunable cache has evicted them too, so the re-fetched block's put would
+//! be silently absorbed (see "Stale puts") and the gap would reappear on
+//! the next repair tick. The marshal never asks for such heights; see
+//! "Why reth pruning is not a concern" below.
+//!
 //! # Why reth pruning is not a concern
 //!
 //! Reth may be configured to retain only a window of recent history,
@@ -119,9 +127,11 @@ pub(crate) trait FinalizedBlocksProvider: Send + Sync {
     /// Look up a finalized block by height in reth.
     ///
     /// Implementations MUST return `None` for any `height` above
-    /// [`Self::finalized_height`] (and unconditionally when
-    /// [`Self::finalized_height`] is `None`); the marshal relies on
-    /// [`Hybrid`] only serving blocks reth has marked as finalized.
+    /// [`Self::finalized_height`]; the marshal relies on [`Hybrid`] only
+    /// serving blocks reth has marked as finalized. Genesis (height 0) is
+    /// the one exception: it is implicitly finalized (it can never be
+    /// reorged), so it may be served even when [`Self::finalized_height`]
+    /// is `None`.
     fn block_by_height(&self, height: u64) -> ProviderResult<Option<Block>>;
 
     /// Look up a finalized block by hash in reth.
@@ -161,11 +171,11 @@ where
         // happily return a block that is canonical-but-not-yet-finalized
         // (or even a block reth has accepted past its finalized tip),
         // violating [`Blocks`]'s "finalized only" contract.
-        let Some(finalized) = self.finalized_height() else {
-            // Reth has not finalized anything yet — nothing below the
-            // (nonexistent) finalized watermark is reachable.
-            return Ok(None);
-        };
+        //
+        // An unset watermark still covers genesis: height 0 is implicitly
+        // finalized (it can never be reorged), which is also how the
+        // gap-tracking methods interpret an unset watermark.
+        let finalized = self.finalized_height().unwrap_or_default();
         if height > finalized {
             return Ok(None);
         }
@@ -393,6 +403,9 @@ where
     }
 
     fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
+        // An unset watermark maps to height 0: genesis is implicitly
+        // finalized, so reth's covered prefix is never empty (see
+        // [`FinalizedBlocksProvider::block_by_height`]).
         let execution_finalized_height = self
             .execution_block_provider
             .finalized_height()
@@ -412,15 +425,18 @@ where
     }
 
     fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
+        // An unset watermark maps to height 0: genesis is implicitly
+        // finalized, so reth's covered prefix is never empty (see
+        // [`FinalizedBlocksProvider::block_by_height`]).
         let execution_finalized_height = self
             .execution_block_provider
             .finalized_height()
             .map(Height::new)
             .unwrap_or_default();
 
-        // If Reth contains this value, we simply need to check if the prunable archive
+        // If reth contains this value, we simply need to check if the prunable archive
         // extends this covered range by checking `execution_finalized_height+1`. Otherwise
-        // Archive::next_gap will report is missing.
+        // Archive::next_gap will report it as missing.
         let value_covered_by_execution = value <= execution_finalized_height;
         let query = if value_covered_by_execution {
             execution_finalized_height.next()

--- a/crates/consensus/src/storage/hybrid/test/mod.rs
+++ b/crates/consensus/src/storage/hybrid/test/mod.rs
@@ -140,8 +140,8 @@ fn get_by_height_skips_reth_blocks_above_reth_finalized_watermark() {
     // The reth provider seeded a canonical-but-not-yet-finalized
     // block; the marshal must never see it. `block_by_height` is
     // gated on reth's finalized watermark — heights above it (and
-    // every height when the watermark is unset) miss, regardless of
-    // what is in reth's canonical chain.
+    // everything but genesis when the watermark is unset) miss,
+    // regardless of what is in reth's canonical chain.
     let executor = deterministic::Runner::default();
     executor.start(|context| async move {
         let (hybrid, provider) = SetupHybrid::default().build(&context).await;
@@ -307,6 +307,35 @@ fn gap_tracking_treats_reth_finalized_as_covered_prefix() {
 }
 
 #[test_traced]
+fn gap_tracking_merges_prunable_run_overlapping_reth_watermark() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let (mut hybrid, provider) = SetupHybrid::default().build(&context).await;
+
+        // Reth covers 1..=5 and the prunable archive holds 3..=7 plus a
+        // detached 10 — the production shape, where the retention window
+        // overlaps reth coverage. `next_gap`'s probe at `watermark + 1`
+        // (height 6) lands mid-run, so the merged covered range must be
+        // reported as 1..=7 with the next run starting at 10.
+        provider.set_reth_finalized(5);
+        let blocks = make_chain(3, 8); // heights 3..=10
+        for offset in [0, 1, 2, 3, 4, 7] {
+            hybrid.put(blocks[offset].clone()).await.expect("put block");
+        }
+
+        assert_eq!(
+            hybrid.next_gap(Height::new(1)),
+            (Some(Height::new(7)), Some(Height::new(10)))
+        );
+        assert_eq!(
+            hybrid.missing_items(Height::new(1), 8),
+            vec![Height::new(8), Height::new(9)]
+        );
+        assert_eq!(hybrid.last_index(), Some(Height::new(10)));
+    });
+}
+
+#[test_traced]
 fn gap_tracking_works_when_only_reth_has_blocks() {
     let executor = deterministic::Runner::default();
     executor.start(|context| async move {
@@ -320,6 +349,93 @@ fn gap_tracking_works_when_only_reth_has_blocks() {
             (Some(Height::new(5)), None)
         );
         assert_eq!(hybrid.last_index(), Some(Height::new(5)));
+    });
+}
+
+/// Walks every case of [`Blocks::next_gap`]'s documented `# Behavior`
+/// section against [`Hybrid`]'s merged view of coverage, where reth's
+/// finalized watermark forms a range starting at genesis and the prunable
+/// archive contributes the ranges above it.
+#[test_traced]
+fn next_gap_upholds_blocks_trait_behavior_contract() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let (mut hybrid, provider) = SetupHybrid::default().build(&context).await;
+
+        // "If the store is empty, both will be `None`." (Height 0 is the
+        // one exception — genesis is implicitly covered; see
+        // `genesis_is_implicitly_finalized_when_reth_watermark_is_unset`.)
+        assert_eq!(hybrid.next_gap(Height::new(1)), (None, None));
+
+        // "If `value` is before all ranges in the store,
+        // `current_range_end` will be `None`" — and `next_range_start`
+        // points at the first range.
+        let blocks = make_chain(4, 6); // heights 4..=9
+        hybrid.put(blocks[4].clone()).await.expect("put 8");
+        hybrid.put(blocks[5].clone()).await.expect("put 9");
+        assert_eq!(
+            hybrid.next_gap(Height::new(2)),
+            (None, Some(Height::new(8)))
+        );
+
+        // Coverage is now [0..=5] (reth 0..=3 merged with prunable 4..=5)
+        // and [8..=9].
+        provider.set_reth_finalized(3);
+        hybrid.put(blocks[0].clone()).await.expect("put 4");
+        hybrid.put(blocks[1].clone()).await.expect("put 5");
+
+        // "If `value` falls within an existing range `[r_start, r_end]`,
+        // `current_range_end` will be `Some(r_end)`."
+        assert_eq!(
+            hybrid.next_gap(Height::new(2)),
+            (Some(Height::new(5)), Some(Height::new(8)))
+        );
+
+        // "If `value` falls in a gap between two ranges `[..., prev_end]`
+        // and `[next_start, ...]`, `current_range_end` will be `None` and
+        // `next_range_start` will be `Some(next_start)`."
+        assert_eq!(
+            hybrid.next_gap(Height::new(6)),
+            (None, Some(Height::new(8)))
+        );
+
+        // "If `value` is [...] within the last range, `next_range_start`
+        // will be `None`."
+        assert_eq!(
+            hybrid.next_gap(Height::new(8)),
+            (Some(Height::new(9)), None)
+        );
+
+        // "If `value` is after all ranges in the store [...]" — no range
+        // contains it and none starts after it, so both are `None`.
+        assert_eq!(hybrid.next_gap(Height::new(11)), (None, None));
+    });
+}
+
+#[test_traced]
+fn genesis_is_implicitly_finalized_when_reth_watermark_is_unset() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let (hybrid, provider) = SetupHybrid::default().build(&context).await;
+
+        // Reth's finalized watermark is unset (fresh chain), but genesis
+        // can never be reorged: `get` serves it and gap tracking reports
+        // it as covered, keeping both views of coverage consistent.
+        let genesis = make_block(0, B256::ZERO);
+        provider.add_block(&genesis);
+
+        let fetched = hybrid
+            .get(Identifier::Index(0))
+            .await
+            .expect("get genesis")
+            .expect("genesis is implicitly finalized");
+        assert_eq!(fetched, genesis);
+
+        assert_eq!(
+            hybrid.next_gap(Height::zero()),
+            (Some(Height::zero()), None)
+        );
+        assert_eq!(hybrid.missing_items(Height::zero(), 8), Vec::new());
     });
 }
 

--- a/crates/consensus/src/storage/hybrid/test/mod.rs
+++ b/crates/consensus/src/storage/hybrid/test/mod.rs
@@ -253,7 +253,7 @@ fn put_trims_prunable_archive_to_retention() {
 }
 
 #[test_traced]
-fn missing_items_next_gap_and_last_index_reflect_prunable_only() {
+fn gap_tracking_treats_reth_finalized_as_covered_prefix() {
     let executor = deterministic::Runner::default();
     executor.start(|context| async move {
         let (mut hybrid, provider) = SetupHybrid {
@@ -270,23 +270,56 @@ fn missing_items_next_gap_and_last_index_reflect_prunable_only() {
             provider.add_block(block);
         }
 
-        // Put a non-contiguous set of heights (10 and 12) into prunable.
-        let blocks = make_chain(10, 3); // heights 10, 11, 12
-        hybrid.put(blocks[0].clone()).await.expect("put 10");
-        hybrid.put(blocks[2].clone()).await.expect("put 12");
+        provider.set_reth_finalized(5);
 
-        // Even though reth has 1..=5, missing_items starting at 9 only
-        // reports gaps in the prunable archive's view of the world.
-        let missing = hybrid.missing_items(Height::new(9), 8);
-        assert_eq!(missing, vec![Height::new(9), Height::new(11)]);
+        // Put a non-contiguous tail into prunable. Heights 6 and 7
+        // extend reth's covered prefix, while 10 and 12 leave real
+        // gaps above the execution layer's finalized watermark.
+        let blocks = make_chain(6, 7); // heights 6..=12
+        for offset in [0, 1, 4, 6] {
+            let block = blocks[offset].clone();
+            hybrid.put(block).await.expect("put block");
+        }
 
-        // next_gap reports the contiguous run around the queried height.
+        // Heights 1..=5 are covered by reth and 6..=7 by prunable, so
+        // only gaps above that merged range are reported.
+        let missing = hybrid.missing_items(Height::new(1), 8);
+        assert_eq!(
+            missing,
+            vec![Height::new(8), Height::new(9), Height::new(11)]
+        );
+
+        let (current_end, next_start) = hybrid.next_gap(Height::new(1));
+        assert_eq!(current_end, Some(Height::new(7)));
+        assert_eq!(next_start, Some(Height::new(10)));
+
+        let (current_end, next_start) = hybrid.next_gap(Height::new(8));
+        assert_eq!(current_end, None);
+        assert_eq!(next_start, Some(Height::new(10)));
+
         let (current_end, next_start) = hybrid.next_gap(Height::new(10));
         assert_eq!(current_end, Some(Height::new(10)));
         assert_eq!(next_start, Some(Height::new(12)));
 
-        // last_index reflects prunable, not reth.
+        // last_index reports the highest covered block from either source.
         assert_eq!(hybrid.last_index(), Some(Height::new(12)));
+    });
+}
+
+#[test_traced]
+fn gap_tracking_works_when_only_reth_has_blocks() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let (hybrid, provider) = SetupHybrid::default().build(&context).await;
+
+        provider.set_reth_finalized(5);
+
+        assert_eq!(hybrid.missing_items(Height::new(1), 8), Vec::new());
+        assert_eq!(
+            hybrid.next_gap(Height::new(1)),
+            (Some(Height::new(5)), None)
+        );
+        assert_eq!(hybrid.last_index(), Some(Height::new(5)));
     });
 }
 

--- a/crates/consensus/src/storage/hybrid/test/utils.rs
+++ b/crates/consensus/src/storage/hybrid/test/utils.rs
@@ -153,13 +153,11 @@ impl FinalizedBlocksProvider for StubProvider {
             return err;
         }
         // Mirror the production [`BlockchainProvider`] impl: only
-        // blocks at or below reth's finalized watermark are reachable.
-        // Heights above the watermark (or every height when the
-        // watermark is unset) miss, regardless of what was seeded via
-        // [`Self::add_block`].
-        let Some(finalized) = *self.reth_finalized.lock() else {
-            return Ok(None);
-        };
+        // blocks at or below reth's finalized watermark are reachable,
+        // regardless of what was seeded via [`Self::add_block`]. An
+        // unset watermark still covers genesis (height 0), which is
+        // implicitly finalized.
+        let finalized = self.reth_finalized.lock().unwrap_or_default();
         if height > finalized {
             return Ok(None);
         }


### PR DESCRIPTION
Treats reth's finalized watermark as covered storage in Hybrid gap tracking.


Example, if reth covers `1..=5` and the prunable archive contains `6, 7, 10, 12`.

1. `next_gap(1)` now returns `(Some(7), Some(10))` instead of  treating `1..=5` as missing.
2. If reth covers `1..=5` and the prunable archive is empty, `next_gap(1)` now returns `(Some(5), None)`.