### PR TITLE
fix(consensus): backfill executor via ancestry fallback

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -6,7 +6,7 @@
 
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
-use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadId, PayloadStatus};
 use commonware_consensus::{
     Heightable as _,
     marshal::Update,
@@ -29,7 +29,6 @@ use futures::{
 };
 use prometheus_client::metrics::counter::Counter;
 use reth_ethereum::{chainspec::EthChainSpec, rpc::eth::primitives::BlockNumHash};
-use reth_node_builder::PayloadKind;
 use reth_provider::{BlockReader as _, BlockSource};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
@@ -100,12 +99,91 @@ impl LastCanonicalized {
     }
 }
 
-pub(crate) struct Actor<TContext> {
+pub(crate) trait ExecutionLayer: Clone + Send + Sync + 'static {
+    fn initial_state(&self) -> eyre::Result<(BlockNumHash, BlockNumHash)>;
+
+    fn find_block(&self, digest: Digest) -> eyre::Result<Option<Block>>;
+
+    fn fork_choice_updated(
+        &self,
+        state: ForkchoiceState,
+        attrs: Option<TempoPayloadAttributes>,
+    ) -> impl Future<Output = eyre::Result<ForkchoiceResponse>> + Send;
+
+    fn new_payload(
+        &self,
+        data: TempoExecutionData,
+    ) -> impl Future<Output = eyre::Result<PayloadStatus>> + Send;
+
+    fn resolve_payload(
+        &self,
+        payload_id: PayloadId,
+    ) -> impl Future<Output = Option<eyre::Result<TempoBuiltPayload>>> + Send;
+}
+
+pub(crate) struct ForkchoiceResponse {
+    pub(crate) payload_status: PayloadStatus,
+    pub(crate) payload_id: Option<PayloadId>,
+}
+
+impl ExecutionLayer for Arc<TempoFullNode> {
+    fn initial_state(&self) -> eyre::Result<(BlockNumHash, BlockNumHash)> {
+        let canonical_state = self.provider.canonical_in_memory_state();
+        let head: BlockNumHash = canonical_state.chain_info().into();
+        let finalized = canonical_state
+            .get_finalized_num_hash()
+            .unwrap_or_else(|| BlockNumHash::new(0, self.chain_spec().genesis_hash()));
+        Ok((head, finalized))
+    }
+
+    fn find_block(&self, digest: Digest) -> eyre::Result<Option<Block>> {
+        Ok(self
+            .provider
+            .find_sealed_or_recovered_block(digest.0, BlockSource::Any)?
+            .map(|block| Block::from_execution_block_unchecked(block, None)))
+    }
+
+    async fn fork_choice_updated(
+        &self,
+        state: ForkchoiceState,
+        attrs: Option<TempoPayloadAttributes>,
+    ) -> eyre::Result<ForkchoiceResponse> {
+        let response = self
+            .add_ons_handle
+            .beacon_engine_handle
+            .fork_choice_updated(state, attrs)
+            .await?;
+        Ok(ForkchoiceResponse {
+            payload_status: response.payload_status,
+            payload_id: response.payload_id,
+        })
+    }
+
+    async fn new_payload(&self, data: TempoExecutionData) -> eyre::Result<PayloadStatus> {
+        Ok(self
+            .add_ons_handle
+            .beacon_engine_handle
+            .new_payload(data)
+            .await?)
+    }
+
+    async fn resolve_payload(
+        &self,
+        payload_id: PayloadId,
+    ) -> Option<eyre::Result<TempoBuiltPayload>> {
+        self.payload_builder_handle
+            .resolve_kind(payload_id, reth_node_builder::PayloadKind::WaitForPending)
+            .await
+            .map(|result| result.map_err(Report::new))
+    }
+}
+
+pub(crate) struct Actor<TContext, TExecutionLayer = Arc<TempoFullNode>> {
     context: ContextCell<TContext>,
 
     /// A handle to the execution node layer. Used to forward finalized blocks
     /// and to update the canonical chain by sending forkchoice updates.
-    execution_node: Arc<TempoFullNode>,
+    execution_node: TExecutionLayer,
 
     /// Highest finalized height the executor should backfill to on startup so
     /// that CL and EL have a consistent view.
@@ -176,13 +254,14 @@ impl Metrics {
     }
 }
 
-impl<TContext> Actor<TContext>
+impl<TContext, TExecutionLayer> Actor<TContext, TExecutionLayer>
 where
     TContext: Clock + RuntimeMetrics + Pacer + Spawner,
+    TExecutionLayer: ExecutionLayer,
 {
     pub(super) fn init(
         context: TContext,
-        config: super::Config,
+        config: super::Config<TExecutionLayer>,
         mailbox: UnboundedReceiver<super::ingress::Message>,
     ) -> eyre::Result<Self> {
         let Config {
@@ -195,12 +274,7 @@ where
         } = config;
         let metrics = Metrics::init(&context);
 
-        let canonical_state = execution_node.provider.canonical_in_memory_state();
-
-        let head_num_hash: BlockNumHash = canonical_state.chain_info().into();
-        let execution_finalized_num_hash = canonical_state
-            .get_finalized_num_hash()
-            .unwrap_or_else(|| BlockNumHash::new(0, execution_node.chain_spec().genesis_hash()));
+        let (head_num_hash, execution_finalized_num_hash) = execution_node.initial_state()?;
 
         Ok(Self {
             context: ContextCell::new(context),
@@ -467,8 +541,7 @@ where
 
             if self
                 .execution_node
-                .provider
-                .find_sealed_or_recovered_block(parent_digest.0, BlockSource::Any)
+                .find_block(parent_digest)
                 .wrap_err_with(|| {
                     format!("failed querying execution layer for ancestor `{parent_digest}`")
                 })?
@@ -649,9 +722,9 @@ where
 }
 
 #[instrument(skip_all, fields(height), err)]
-async fn get_block(
+async fn get_block<TExecutionLayer: ExecutionLayer>(
     marshal: crate::alias::marshal::Mailbox,
-    execution_node: Arc<TempoFullNode>,
+    execution_node: TExecutionLayer,
     height: Height,
 ) -> eyre::Result<Block> {
     if let Some(block) = marshal.get_block(height).await {
@@ -670,12 +743,9 @@ async fn get_block(
         %digest,
         "found finalized digest for block height; checking execution layer",
     );
-    let Some(block) = execution_node
-        .provider
-        .find_sealed_or_recovered_block(digest.0, BlockSource::Any)
-        .wrap_err_with(|| {
-            format!("failed querying execution layer for backfill block `{digest}`")
-        })?
+    let Some(block) = execution_node.find_block(digest).wrap_err_with(|| {
+        format!("failed querying execution layer for backfill block `{digest}`")
+    })?
     else {
         warn!(%digest, "execution layer did not have missing backfill block");
         bail!(
@@ -684,7 +754,7 @@ async fn get_block(
         );
     };
 
-    Ok(Block::from_execution_block_unchecked(block, None))
+    Ok(block)
 }
 
 fn block_anchor(block: &Block) -> eyre::Result<(Round, Digest)> {
@@ -772,9 +842,9 @@ struct StartPayloadJob {
     response: oneshot::Sender<TempoBuiltPayload>,
 }
 
-async fn execute_request<TContext>(
+async fn execute_request<TContext, TExecutionLayer>(
     context: ContextCell<TContext>,
-    execution_node: Arc<TempoFullNode>,
+    execution_node: TExecutionLayer,
     public_key: Option<PublicKey>,
     metrics: Metrics,
     canonicalized: LastCanonicalized,
@@ -782,6 +852,7 @@ async fn execute_request<TContext>(
 ) -> ExecutionTaskResult
 where
     TContext: Pacer,
+    TExecutionLayer: ExecutionLayer,
 {
     match request {
         ExecutionRequest::Heartbeat { cause } => {
@@ -840,9 +911,9 @@ where
         head_or_finalized = %head_or_finalized,
     ),
 )]
-async fn run_canonicalize_task<TContext: Pacer>(
+async fn run_canonicalize_task<TContext: Pacer, TExecutionLayer: ExecutionLayer>(
     context: &TContext,
-    execution_node: Arc<TempoFullNode>,
+    execution_node: TExecutionLayer,
     canonicalized: LastCanonicalized,
     Canonicalize {
         cause,
@@ -932,9 +1003,9 @@ async fn run_canonicalize_task<TContext: Pacer>(
     parent = &cause,
     fields(%payload_id),
 )]
-async fn run_payload_job<TContext: Pacer>(
+async fn run_payload_job<TContext: Pacer, TExecutionLayer: ExecutionLayer>(
     context: TContext,
-    execution_node: Arc<TempoFullNode>,
+    execution_node: TExecutionLayer,
     StartPayloadJob {
         cause,
         payload_id,
@@ -943,8 +1014,7 @@ async fn run_payload_job<TContext: Pacer>(
 ) {
     let payload = select! {
         payload = execution_node
-            .payload_builder_handle
-            .resolve_kind(payload_id, PayloadKind::WaitForPending)
+            .resolve_payload(payload_id)
             .pace(&context, Duration::from_millis(20))
         => payload,
 
@@ -967,7 +1037,7 @@ async fn run_payload_job<TContext: Pacer>(
         }
         Some(Err(error)) => {
             warn!(
-                error = %eyre::Report::new(error),
+                %error,
                 "payload build job failed",
             );
         }
@@ -988,8 +1058,8 @@ async fn run_payload_job<TContext: Pacer>(
         ?kind,
     ),
 )]
-async fn submit_forkchoice_update<TContext: Pacer>(
-    execution_node: &TempoFullNode,
+async fn submit_forkchoice_update<TContext: Pacer, TExecutionLayer: ExecutionLayer>(
+    execution_node: &TExecutionLayer,
     context: &TContext,
     cause: Span,
     canonicalized: LastCanonicalized,
@@ -997,15 +1067,13 @@ async fn submit_forkchoice_update<TContext: Pacer>(
     kind: ForkchoiceUpdateKind,
 ) -> eyre::Result<Option<PayloadId>> {
     let fcu_response = execution_node
-        .add_ons_handle
-        .beacon_engine_handle
         .fork_choice_updated(canonicalized.forkchoice, attrs)
         .pace(context, Duration::from_millis(20))
         .await
         .wrap_err("failed requesting execution layer to update forkchoice state")?;
 
     if kind == ForkchoiceUpdateKind::Heartbeat {
-        if fcu_response.is_invalid() {
+        if fcu_response.payload_status.is_invalid() {
             warn!(
                 payload_status = %fcu_response.payload_status,
                 "execution layer reported FCU status",
@@ -1023,7 +1091,7 @@ async fn submit_forkchoice_update<TContext: Pacer>(
         );
     }
 
-    if fcu_response.is_invalid() {
+    if fcu_response.payload_status.is_invalid() {
         return Err(Report::msg(fcu_response.payload_status)
             .wrap_err("execution layer responded with error for forkchoice-update"));
     }
@@ -1041,9 +1109,9 @@ async fn submit_forkchoice_update<TContext: Pacer>(
     err(level = Level::WARN),
     ret,
 )]
-async fn forward_finalized<TContext: Pacer>(
+async fn forward_finalized<TContext: Pacer, TExecutionLayer: ExecutionLayer>(
     context: &TContext,
-    execution_node: Arc<TempoFullNode>,
+    execution_node: TExecutionLayer,
     public_key: Option<PublicKey>,
     metrics: Metrics,
     canonicalized: LastCanonicalized,
@@ -1075,8 +1143,6 @@ async fn forward_finalized<TContext: Pacer>(
     let (block, block_access_list) = block.into_parts();
     let consensus_context = block.header().consensus_context;
     let payload_status = execution_node
-        .add_ons_handle
-        .beacon_engine_handle
         .new_payload(TempoExecutionData {
             block,
             block_access_list,

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -7,7 +7,11 @@
 use std::{collections::VecDeque, sync::Arc, time::Duration};
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadId};
-use commonware_consensus::{Heightable as _, marshal::Update, types::Height};
+use commonware_consensus::{
+    Heightable as _,
+    marshal::Update,
+    types::{Epoch, Height, Round, View},
+};
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{
     Clock, ContextCell, FutureExt, Handle, Metrics as RuntimeMetrics, Pacer, Spawner, spawn_cell,
@@ -232,13 +236,17 @@ where
 
     async fn run(mut self) {
         if let Err(error) = self.backfill_to_finalized_floor().await {
-            error_span!("shutdown").in_scope(|| {
-                error!(
-                    %error,
-                    "executor failed startup backfill",
-                )
-            });
-            return;
+            warn!(%error, "height-based startup backfill failed; falling back to ancestry walk");
+
+            if let Err(error) = self.recover_startup_backfill().await {
+                error_span!("shutdown").in_scope(|| {
+                    error!(
+                        %error,
+                        "executor failed startup backfill",
+                    )
+                });
+                return;
+            }
         }
 
         info_span!("start").in_scope(|| {
@@ -351,6 +359,155 @@ where
                 format!(
                     "failed forwarding backfilled finalized block at height `{height}` \
                     to execution layer"
+                )
+            })? {
+                self.last_canonicalized = canonicalized;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn recover_startup_backfill(&mut self) -> eyre::Result<()> {
+        if let Some((round, digest)) = self.finalized_floor_anchor().await {
+            match self.backfill_ancestry(round, digest, None).await {
+                Ok(()) => {
+                    if let Err(error) = self.backfill_to_finalized_floor().await {
+                        warn!(
+                            %error,
+                            %round,
+                            %digest,
+                            "startup backfill still has gaps after certificate-anchored ancestry walk; waiting for the next finalized block"
+                        );
+                    } else {
+                        return Ok(());
+                    }
+                }
+                Err(error) => {
+                    warn!(
+                        %error,
+                        %round,
+                        %digest,
+                        "certificate-anchored ancestry backfill failed; waiting for the next finalized block"
+                    );
+                }
+            }
+        } else {
+            warn!(
+                finalized_floor = %self.finalized_floor,
+                "marshal had no finalization certificate near the startup floor; waiting for the next finalized block"
+            );
+        }
+
+        self.backfill_from_next_finalized_block().await
+    }
+
+    async fn finalized_floor_anchor(&mut self) -> Option<(Round, Digest)> {
+        let floor = self.finalized_floor.get();
+        let tip = self.latest_observed_finalized_tip.0.get().max(floor);
+        let lower_bound = self.last_canonicalized.finalized_height.get() + 1;
+
+        for height in floor..=tip {
+            if let Some(finalization) = self.marshal.get_finalization(Height::new(height)).await {
+                return Some((finalization.proposal.round, finalization.proposal.payload));
+            }
+        }
+
+        for height in (lower_bound..floor).rev() {
+            if let Some(finalization) = self.marshal.get_finalization(Height::new(height)).await {
+                return Some((finalization.proposal.round, finalization.proposal.payload));
+            }
+        }
+
+        None
+    }
+
+    async fn backfill_from_next_finalized_block(&mut self) -> eyre::Result<()> {
+        while let Some(message) = self.mailbox.next().await {
+            let Message { cause, command } = message;
+            match command {
+                Command::Finalize(finalized) => match *finalized {
+                    Update::Block(block, acknowledgment) => {
+                        let (round, digest) = block_anchor(&block)?;
+                        self.backfill_ancestry(round, digest, Some(block)).await?;
+                        acknowledgment.acknowledge();
+                        return self.backfill_to_finalized_floor().await;
+                    }
+                    Update::Tip(_, height, digest) => {
+                        self.latest_observed_finalized_tip = (height, digest);
+                    }
+                },
+                command => self.handle_message(Message { cause, command })?,
+            }
+        }
+
+        bail!("executor mailbox closed while waiting for a finalized backfill anchor")
+    }
+
+    async fn backfill_ancestry(
+        &mut self,
+        round: Round,
+        digest: Digest,
+        block: Option<Block>,
+    ) -> eyre::Result<()> {
+        let mut blocks = Vec::new();
+        let mut block = match block {
+            Some(block) => block,
+            None => subscribe_block(&self.marshal, round, digest).await?,
+        };
+        ensure!(
+            block.digest() == digest,
+            "marshal returned block `{}` for requested digest `{digest}`",
+            block.digest()
+        );
+
+        loop {
+            let (parent_round, parent_digest) = parent_anchor(&block)?;
+            blocks.push(block);
+
+            if self
+                .execution_node
+                .provider
+                .find_sealed_or_recovered_block(parent_digest.0, BlockSource::Any)
+                .wrap_err_with(|| {
+                    format!("failed querying execution layer for ancestor `{parent_digest}`")
+                })?
+                .is_some()
+            {
+                break;
+            }
+
+            block = subscribe_block(&self.marshal, parent_round, parent_digest).await?;
+        }
+
+        info!(
+            count = blocks.len(),
+            anchor_round = %round,
+            anchor_digest = %digest,
+            "forwarding ancestry backfill to execution layer"
+        );
+
+        for block in blocks.into_iter().rev() {
+            let height = block.height();
+            let (acknowledgment, _wait) = Exact::handle();
+            let request = FinalizedBlockRequest {
+                cause: info_span!("backfill_ancestry", %height),
+                block,
+                acknowledgment,
+            };
+
+            if let Some(canonicalized) = forward_finalized(
+                &self.context,
+                self.execution_node.clone(),
+                self.public_key.clone(),
+                self.metrics.clone(),
+                self.last_canonicalized,
+                request,
+            )
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed forwarding ancestry-backfilled block at height `{height}` to execution layer"
                 )
             })? {
                 self.last_canonicalized = canonicalized;
@@ -528,6 +685,40 @@ async fn get_block(
     };
 
     Ok(Block::from_execution_block_unchecked(block, None))
+}
+
+fn block_anchor(block: &Block) -> eyre::Result<(Round, Digest)> {
+    let context = block
+        .header()
+        .consensus_context
+        .ok_or_else(|| eyre::eyre!("finalized block did not contain consensus context"))?;
+    Ok((
+        Round::new(Epoch::new(context.epoch), View::new(context.view)),
+        block.digest(),
+    ))
+}
+
+fn parent_anchor(block: &Block) -> eyre::Result<(Round, Digest)> {
+    let context = block
+        .header()
+        .consensus_context
+        .ok_or_else(|| eyre::eyre!("backfill block did not contain consensus context"))?;
+    Ok((
+        Round::new(Epoch::new(context.epoch), View::new(context.parent_view)),
+        block.parent_digest(),
+    ))
+}
+
+async fn subscribe_block(
+    marshal: &crate::alias::marshal::Mailbox,
+    round: Round,
+    digest: Digest,
+) -> eyre::Result<Block> {
+    marshal
+        .subscribe_by_digest(Some(round), digest)
+        .await
+        .await
+        .map_err(|_| eyre::eyre!("marshal dropped block subscription for `{digest}`"))
 }
 
 enum ExecutionRequest {
@@ -931,5 +1122,64 @@ impl std::fmt::Display for HeadOrFinalized {
             Self::Finalized => "finalized",
         };
         f.write_str(msg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::B256;
+    use commonware_consensus::types::{Epoch, Round, View};
+    use reth_primitives_traits::SealedBlock;
+    use tempo_primitives::{
+        Block as TempoBlock, TempoConsensusContext, TempoHeader, ed25519::PublicKey,
+    };
+
+    use super::{Block, Digest, block_anchor, parent_anchor};
+
+    fn block_with_context(context: Option<TempoConsensusContext>, parent_hash: B256) -> Block {
+        let execution_block = SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: alloy_consensus::Header {
+                    parent_hash,
+                    number: 42,
+                    ..Default::default()
+                },
+                consensus_context: context,
+                ..Default::default()
+            },
+            body: Default::default(),
+        });
+        Block::from_execution_block_unchecked(execution_block, None)
+    }
+
+    #[test]
+    fn derives_block_and_parent_anchors_from_consensus_context() {
+        let parent_digest = Digest(B256::repeat_byte(0x42));
+        let block = block_with_context(
+            Some(TempoConsensusContext {
+                epoch: 7,
+                view: 11,
+                parent_view: 9,
+                proposer: PublicKey::from_seed([1; 32]),
+            }),
+            parent_digest.0,
+        );
+
+        assert_eq!(
+            block_anchor(&block).unwrap(),
+            (Round::new(Epoch::new(7), View::new(11)), block.digest())
+        );
+        assert_eq!(
+            parent_anchor(&block).unwrap(),
+            (Round::new(Epoch::new(7), View::new(9)), parent_digest)
+        );
+    }
+
+    #[test]
+    fn rejects_backfill_anchor_without_consensus_context() {
+        let block = block_with_context(None, B256::ZERO);
+
+        assert!(block_anchor(&block).is_err());
+        assert!(parent_anchor(&block).is_err());
     }
 }

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -7,6 +7,8 @@ use commonware_runtime::{Clock, Metrics, Pacer, Spawner};
 
 mod actor;
 mod ingress;
+#[cfg(test)]
+mod test;
 
 pub(crate) use actor::Actor;
 use eyre::WrapErr as _;
@@ -16,12 +18,13 @@ use tempo_node::TempoFullNode;
 
 use crate::consensus::Digest;
 
-pub(crate) fn init<TContext>(
+pub(crate) fn init<TContext, TExecutionLayer>(
     context: TContext,
-    config: Config,
-) -> eyre::Result<(Actor<TContext>, Mailbox)>
+    config: Config<TExecutionLayer>,
+) -> eyre::Result<(Actor<TContext, TExecutionLayer>, Mailbox)>
 where
     TContext: Clock + Metrics + Pacer + Spawner,
+    TExecutionLayer: actor::ExecutionLayer,
 {
     let (tx, rx) = mpsc::unbounded();
     let mailbox = Mailbox { inner: tx };
@@ -29,10 +32,10 @@ where
     Ok((actor, mailbox))
 }
 
-pub(crate) struct Config {
+pub(crate) struct Config<TExecutionLayer = Arc<TempoFullNode>> {
     /// A handle to the execution node layer. Used to forward finalized blocks
     /// and to update the canonical chain by sending forkchoice updates.
-    pub(crate) execution_node: Arc<TempoFullNode>,
+    pub(crate) execution_node: TExecutionLayer,
 
     /// Marshal sync floor. This is the sync target the executor actor will try
     /// to reach because the marshal actor will only send finalized heights

--- a/crates/consensus/src/executor/test.rs
+++ b/crates/consensus/src/executor/test.rs
@@ -1,0 +1,403 @@
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+use alloy_consensus::Header;
+use alloy_primitives::B256;
+use alloy_rpc_types_engine::{ForkchoiceState, PayloadId, PayloadStatus, PayloadStatusEnum};
+use commonware_codec::{Encode as _, FixedSize as _, Read as _};
+use commonware_consensus::{
+    marshal::{
+        core::{self, Buffer},
+        resolver::handler::{Handler, Request},
+        standard::Standard,
+    },
+    simplex::{
+        scheme::bls12381_threshold::vrf,
+        types::{Finalization, Proposal},
+    },
+    types::{Epoch, FixedEpocher, Height, Round, View, ViewDelta},
+};
+use commonware_cryptography::bls12381::primitives::variant::MinSig;
+use commonware_p2p::Recipients;
+use commonware_parallel::Sequential;
+use commonware_resolver::{Consumer as _, Resolver};
+use commonware_runtime::{
+    Clock as _, Metrics as _, Runner as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::archive::{Archive as _, immutable};
+use commonware_utils::{
+    NZU64, NZUsize,
+    acknowledgement::Exact,
+    channel::{mpsc, oneshot},
+    sync::Mutex,
+    vec::NonEmptyVec,
+};
+use reth_ethereum::rpc::eth::primitives::BlockNumHash;
+use reth_node_core::primitives::SealedBlock;
+use reth_provider::ProviderResult;
+use tempo_node::TempoExecutionData;
+use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
+use tempo_primitives::{
+    Block as TempoBlock, BlockBody, TempoConsensusContext, TempoHeader,
+    ed25519::PublicKey as TempoPublicKey,
+};
+
+use super::{
+    Config,
+    actor::{ExecutionLayer, ForkchoiceResponse},
+};
+use crate::{
+    alias,
+    consensus::{Digest, block::Block},
+    epoch::SchemeProvider,
+    storage::{self, FinalizedBlocksProvider, Hybrid},
+};
+
+#[derive(Clone, Default)]
+struct MockExecutionLayer {
+    blocks: Arc<Mutex<HashMap<B256, Block>>>,
+    direct_lookup_failed: Arc<AtomicBool>,
+    submitted_payloads: Arc<Mutex<Vec<Digest>>>,
+    genesis: Arc<Mutex<Option<Block>>>,
+}
+
+impl MockExecutionLayer {
+    fn with_genesis(genesis: Block) -> Self {
+        let this = Self::default();
+        this.blocks
+            .lock()
+            .insert(genesis.block_hash(), genesis.clone());
+        *this.genesis.lock() = Some(genesis);
+        this
+    }
+
+    fn direct_lookup_failed(&self) -> bool {
+        self.direct_lookup_failed.load(Ordering::SeqCst)
+    }
+
+    fn submitted_payloads(&self) -> Vec<Digest> {
+        self.submitted_payloads.lock().clone()
+    }
+}
+
+impl FinalizedBlocksProvider for MockExecutionLayer {
+    fn finalized_height(&self) -> Option<u64> {
+        Some(0)
+    }
+
+    fn block_by_height(&self, height: u64) -> ProviderResult<Option<Block>> {
+        Ok((height == 0).then(|| self.genesis.lock().clone()).flatten())
+    }
+
+    fn block_by_hash(&self, hash: B256) -> ProviderResult<Option<Block>> {
+        Ok(self.blocks.lock().get(&hash).cloned())
+    }
+}
+
+impl ExecutionLayer for MockExecutionLayer {
+    fn initial_state(&self) -> eyre::Result<(BlockNumHash, BlockNumHash)> {
+        let genesis = self.genesis.lock().clone().expect("genesis configured");
+        let state = BlockNumHash::new(0, genesis.block_hash());
+        Ok((state, state))
+    }
+
+    fn find_block(&self, digest: Digest) -> eyre::Result<Option<Block>> {
+        let block = self.blocks.lock().get(&digest.0).cloned();
+        if block.is_none() {
+            self.direct_lookup_failed.store(true, Ordering::SeqCst);
+        }
+        Ok(block)
+    }
+
+    async fn fork_choice_updated(
+        &self,
+        state: ForkchoiceState,
+        _attrs: Option<TempoPayloadAttributes>,
+    ) -> eyre::Result<ForkchoiceResponse> {
+        Ok(ForkchoiceResponse {
+            payload_status: PayloadStatus::new(
+                PayloadStatusEnum::Valid,
+                Some(state.head_block_hash),
+            ),
+            payload_id: None,
+        })
+    }
+
+    async fn new_payload(&self, data: TempoExecutionData) -> eyre::Result<PayloadStatus> {
+        let block = Block::from_execution_block_unchecked(data.block, data.block_access_list);
+        let digest = block.digest();
+        self.blocks.lock().insert(digest.0, block);
+        self.submitted_payloads.lock().push(digest);
+        Ok(PayloadStatus::new(PayloadStatusEnum::Valid, Some(digest.0)))
+    }
+
+    async fn resolve_payload(
+        &self,
+        _payload_id: PayloadId,
+    ) -> Option<eyre::Result<TempoBuiltPayload>> {
+        None
+    }
+}
+
+#[derive(Clone, Default)]
+struct EmptyBuffer {
+    subscriptions: Arc<Mutex<Vec<oneshot::Sender<Block>>>>,
+}
+
+impl Buffer<Standard<Block>> for EmptyBuffer {
+    type PublicKey = commonware_cryptography::ed25519::PublicKey;
+    type CachedBlock = Block;
+
+    async fn find_by_digest(&self, _digest: Digest) -> Option<Block> {
+        None
+    }
+
+    async fn find_by_commitment(&self, _commitment: Digest) -> Option<Block> {
+        None
+    }
+
+    async fn subscribe_by_digest(&self, _digest: Digest) -> oneshot::Receiver<Block> {
+        let (sender, receiver) = oneshot::channel();
+        self.subscriptions.lock().push(sender);
+        receiver
+    }
+
+    async fn subscribe_by_commitment(&self, _commitment: Digest) -> oneshot::Receiver<Block> {
+        self.subscribe_by_digest(Digest(B256::ZERO)).await
+    }
+
+    async fn finalized(&self, _commitment: Digest) {}
+
+    async fn send(&self, _round: Round, _block: Block, _recipients: Recipients<Self::PublicKey>) {}
+}
+
+#[derive(Clone)]
+struct MockResolver {
+    handler: Handler<Digest>,
+    blocks: Arc<Mutex<HashMap<Digest, Block>>>,
+    requests: Arc<Mutex<Vec<Request<Digest>>>>,
+}
+
+impl MockResolver {
+    fn new(handler: Handler<Digest>, blocks: impl IntoIterator<Item = Block>) -> Self {
+        Self {
+            handler,
+            blocks: Arc::new(Mutex::new(
+                blocks
+                    .into_iter()
+                    .map(|block| (block.digest(), block))
+                    .collect(),
+            )),
+            requests: Arc::default(),
+        }
+    }
+
+    fn requested_block(&self, digest: Digest) -> bool {
+        self.requests
+            .lock()
+            .iter()
+            .any(|request| matches!(request, Request::Block(requested) if *requested == digest))
+    }
+
+    async fn deliver_block(&self, digest: Digest) -> bool {
+        let block = self
+            .blocks
+            .lock()
+            .get(&digest)
+            .cloned()
+            .expect("network block");
+        self.handler
+            .clone()
+            .deliver(Request::Block(digest), block.encode())
+            .await
+    }
+}
+
+impl Resolver for MockResolver {
+    type Key = Request<Digest>;
+    type PublicKey = commonware_cryptography::ed25519::PublicKey;
+
+    async fn fetch(&mut self, key: Self::Key) {
+        self.requests.lock().push(key);
+    }
+
+    async fn fetch_all(&mut self, keys: Vec<Self::Key>) {
+        self.requests.lock().extend(keys);
+    }
+
+    async fn fetch_targeted(&mut self, key: Self::Key, _targets: NonEmptyVec<Self::PublicKey>) {
+        self.fetch(key).await;
+    }
+
+    async fn fetch_all_targeted(
+        &mut self,
+        requests: Vec<(Self::Key, NonEmptyVec<Self::PublicKey>)>,
+    ) {
+        self.fetch_all(requests.into_iter().map(|(key, _)| key).collect())
+            .await;
+    }
+
+    async fn cancel(&mut self, _key: Self::Key) {}
+
+    async fn clear(&mut self) {}
+
+    async fn retain(&mut self, _predicate: impl Fn(&Self::Key) -> bool + Send + 'static) {}
+}
+
+fn make_block(height: u64, parent_hash: B256, context: Option<TempoConsensusContext>) -> Block {
+    Block::from_execution_block_unchecked(
+        SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: Header {
+                    parent_hash,
+                    number: height,
+                    ..Default::default()
+                },
+                consensus_context: context,
+                ..Default::default()
+            },
+            body: BlockBody::default(),
+        }),
+        None,
+    )
+}
+
+fn finalization(block: &Block, round: Round) -> Finalization<MarshalScheme, Digest> {
+    let signature_bytes = vec![0; vrf::Certificate::<MinSig>::SIZE];
+    let certificate = vrf::Certificate::<MinSig>::read_cfg(&mut signature_bytes.as_slice(), &())
+        .expect("lazy certificate bytes");
+    Finalization {
+        proposal: Proposal {
+            round,
+            parent: View::zero(),
+            payload: block.digest(),
+        },
+        certificate,
+    }
+}
+
+type MarshalScheme = vrf::Scheme<commonware_cryptography::ed25519::PublicKey, MinSig>;
+
+#[commonware_macros::test_traced]
+fn falls_back_to_network_ancestry_when_direct_backfill_misses() {
+    let runner = deterministic::Runner::default();
+    runner.start(|context| async move {
+        let genesis = make_block(0, B256::ZERO, None);
+        let round = Round::new(Epoch::zero(), View::new(1));
+        let missing = make_block(
+            1,
+            genesis.block_hash(),
+            Some(TempoConsensusContext {
+                epoch: 0,
+                view: 1,
+                parent_view: 0,
+                proposer: TempoPublicKey::from_seed([1; 32]),
+            }),
+        );
+        let mock_el = MockExecutionLayer::with_genesis(genesis);
+        let page_cache = CacheRef::from_pooler(
+            &context,
+            storage::BUFFER_POOL_PAGE_SIZE,
+            storage::BUFFER_POOL_CAPACITY,
+        );
+        let mut finalizations = storage::init_finalizations_archive(
+            &context,
+            "executor-backfill-test",
+            page_cache.clone(),
+        )
+        .await
+        .expect("init finalizations archive");
+        let certificate = finalization(&missing, round);
+        finalizations
+            .put(1, missing.digest(), certificate)
+            .await
+            .expect("store finalization");
+        finalizations.sync().await.expect("sync finalizations");
+
+        let finalized_blocks = storage::init_finalized_blocks(
+            &context,
+            "executor-backfill-test",
+            page_cache.clone(),
+            mock_el.clone(),
+            16,
+        )
+        .await
+        .expect("init hybrid storage");
+        let scheme_provider = SchemeProvider::new();
+        type TestMarshal<TContext> = core::Actor<
+            TContext,
+            Standard<Block>,
+            SchemeProvider,
+            immutable::Archive<TContext, Digest, Finalization<MarshalScheme, Digest>>,
+            Hybrid<TContext, MockExecutionLayer>,
+            FixedEpocher,
+            Sequential,
+            Exact,
+        >;
+        let (marshal_actor, marshal_mailbox, _): (TestMarshal<_>, alias::marshal::Mailbox, Height) =
+            core::Actor::init(
+                context.with_label("marshal"),
+                finalizations,
+                finalized_blocks,
+                commonware_consensus::marshal::Config {
+                    provider: scheme_provider,
+                    epocher: FixedEpocher::new(NZU64!(10)),
+                    partition_prefix: "executor-backfill-test".into(),
+                    mailbox_size: 16,
+                    view_retention_timeout: ViewDelta::new(10),
+                    prunable_items_per_section: NZU64!(16),
+                    page_cache,
+                    replay_buffer: storage::REPLAY_BUFFER,
+                    key_write_buffer: storage::WRITE_BUFFER,
+                    value_write_buffer: storage::WRITE_BUFFER,
+                    block_codec_config: (),
+                    max_repair: storage::MAX_REPAIR,
+                    max_pending_acks: NZUsize!(16),
+                    strategy: Sequential,
+                },
+            )
+            .await;
+
+        let (executor_actor, executor_mailbox) = super::init(
+            context.with_label("executor"),
+            Config {
+                execution_node: mock_el.clone(),
+                finalized_floor: Height::new(1),
+                finalized_tip: (Height::new(1), missing.digest()),
+                marshal: marshal_mailbox,
+                fcu_heartbeat_interval: Duration::from_secs(30),
+                public_key: None,
+            },
+        )
+        .expect("init executor");
+
+        let (resolver_tx, resolver_rx) = mpsc::channel(16);
+        let resolver = MockResolver::new(Handler::new(resolver_tx), [missing.clone()]);
+        let resolver_probe = resolver.clone();
+        marshal_actor.start(
+            executor_mailbox,
+            EmptyBuffer::default(),
+            (resolver_rx, resolver),
+        );
+        executor_actor.start();
+
+        while !mock_el.direct_lookup_failed() {
+            context.sleep(Duration::from_millis(10)).await;
+        }
+        while !resolver_probe.requested_block(missing.digest()) {
+            context.sleep(Duration::from_millis(10)).await;
+        }
+        assert!(resolver_probe.deliver_block(missing.digest()).await);
+
+        while !mock_el.submitted_payloads().contains(&missing.digest()) {
+            context.sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(mock_el.submitted_payloads(), vec![missing.digest()]);
+    });
+}


### PR DESCRIPTION
Keep the existing height-based startup backfill as the fast path, then fall back to a marshal ancestry walk when local block lookup fails. The fallback anchors from the finalization certificate nearest the startup floor or the next finalized block delivered by marshal, and queues other executor work until recovery completes.

Prompted by: @SuperFluffy