### PR TITLE
fix(ci): prompt Cyclops to review reth commits

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -554,7 +554,7 @@ jobs:
                   gh pr comment "$PR_NUMBER" --body "$BENCH_COMMAND"
                 fi
 
-                CYCLOPS_COMMAND="cyclops audit fast"
+                CYCLOPS_COMMAND='cyclops audit fast note="Review every upstream reth commit included in the revision diff."'
                 echo "Posting Cyclops command on PR #${PR_NUMBER}"
                 gh pr comment "$PR_NUMBER" --body "$CYCLOPS_COMMAND"
                 exit 0

--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -554,7 +554,7 @@ jobs:
                   gh pr comment "$PR_NUMBER" --body "$BENCH_COMMAND"
                 fi
 
-                CYCLOPS_COMMAND='cyclops audit fast note="Review every upstream reth commit included in the revision diff."'
+                CYCLOPS_COMMAND='cyclops audit note="Review every upstream reth commit included in the revision diff."'
                 echo "Posting Cyclops command on PR #${PR_NUMBER}"
                 gh pr comment "$PR_NUMBER" --body "$CYCLOPS_COMMAND"
                 exit 0


### PR DESCRIPTION
## Summary
- add per-run Cyclops guidance to the automated Reth update audit
- require review of every upstream Reth commit included in the revision diff

## Validation
- `git diff --check`
- actionlint unavailable in the sandbox

Prompted by: @shekhirin