### PR TITLE
fix(rpc): make finalization block optional

### DIFF
--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -209,7 +209,7 @@ impl<TContext: Spawner> Actor<TContext> {
         let certified = CertifiedBlock {
             epoch: round.epoch().get(),
             view: round.view().get(),
-            block,
+            block: Some(block),
             digest,
             certificate: hex::encode(certificate),
         };
@@ -226,7 +226,12 @@ impl<TContext: Spawner> Actor<TContext> {
             .map(|b| Round::new(Epoch::new(b.epoch), View::new(b.view)));
 
         // Update state and broadcast events
-        let height = certified.block.inner.number;
+        let height = certified
+            .block
+            .as_ref()
+            .expect("feed events always include the resolved block")
+            .inner
+            .number;
         let subscribers = self.state.events_tx().receiver_count();
         match activity {
             Activity::Notarization(_) => {

--- a/crates/consensus/src/feed/state.rs
+++ b/crates/consensus/src/feed/state.rs
@@ -118,14 +118,15 @@ impl ConsensusFeed for FeedStateHandle {
                 let Some(finalization) = marshal.get_finalization(height).await else {
                     break 'process Response::Missing("certificate");
                 };
-                let Some(block) = marshal.get_block(height).await else {
-                    break 'process Response::Missing("block");
-                };
+                let block = marshal
+                    .get_block(height)
+                    .await
+                    .map(|block| block.into_execution_block());
 
                 Response::Success(CertifiedBlock {
                     epoch: finalization.proposal.round.epoch().get(),
                     view: finalization.proposal.round.view().get(),
-                    block: block.into_execution_block(),
+                    block,
                     digest: finalization.proposal.payload.0,
                     certificate: hex::encode(finalization.encode()),
                 })

--- a/crates/consensus/src/follow/driver.rs
+++ b/crates/consensus/src/follow/driver.rs
@@ -313,8 +313,11 @@ where
             })
             .wrap_err("event contained a malformed finalization certificate")?;
 
-        let height = Height::new(certified.block.number());
-        let consensus_block = Block::from_execution_block_unchecked(certified.block, None);
+        let block = certified
+            .block
+            .ok_or_else(|| eyre::eyre!("finalization event did not include a block"))?;
+        let height = Height::new(block.number());
+        let consensus_block = Block::from_execution_block_unchecked(block, None);
         ensure!(
             finalization.proposal.payload == consensus_block.digest(),
             "mismatch in finalization and block digest"

--- a/crates/consensus/src/follow/resolver.rs
+++ b/crates/consensus/src/follow/resolver.rs
@@ -245,9 +245,13 @@ async fn resolve_finalized_new(
         return Err(false);
     };
 
+    let Some(block) = certified_block.block else {
+        return Err(false);
+    };
+
     // Upstream finalization responses carry persisted EL blocks only; no p2p BAL
     // is available when reconstructing this consensus block.
-    let consensus_block = Block::from_execution_block_unchecked(certified_block.block, None);
+    let consensus_block = Block::from_execution_block_unchecked(block, None);
     Ok((finalization, consensus_block).encode())
 }
 

--- a/crates/e2e/src/tests/consensus_rpc.rs
+++ b/crates/e2e/src/tests/consensus_rpc.rs
@@ -71,14 +71,14 @@ async fn consensus_subscribe_and_query_finalization() {
 
         match event {
             Event::Notarized { block, .. } => {
-                let height = block.block.inner.number;
+                let height = block.block.as_ref().unwrap().inner.number;
                 assert!(height > notarized_height);
 
                 notarized_height = height;
                 saw_notarized = true;
             }
             Event::Finalized { block, .. } => {
-                let height = block.block.inner.number;
+                let height = block.block.as_ref().unwrap().inner.number;
                 assert!(height > finalized_height);
 
                 let queried_block = http_client

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use alloy_primitives::B256;
 use futures::Future;
-use reth_primitives_traits::SealedOrRecoveredBlock;
+use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
 use serde::{Deserialize, Serialize};
 use tempo_payload_types::serde_sealed_or_recovered_block;
 use tempo_primitives::Block;
@@ -21,9 +21,36 @@ pub struct CertifiedBlock {
     /// Hex-encoded full notarization or finalization.
     pub certificate: String,
 
-    /// The Tempo block.
-    #[serde(with = "serde_sealed_or_recovered_block")]
-    pub block: SealedOrRecoveredBlock<Block>,
+    /// The Tempo block, if available.
+    #[serde(with = "optional_block")]
+    pub block: Option<SealedOrRecoveredBlock<Block>>,
+}
+
+mod optional_block {
+    use super::*;
+
+    pub fn serialize<S>(
+        block: &Option<SealedOrRecoveredBlock<Block>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match block {
+            Some(block) => serde_sealed_or_recovered_block::serialize(block, serializer),
+            None => serializer.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<Option<SealedOrRecoveredBlock<Block>>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Option::<Block>::deserialize(deserializer)
+            .map(|block| block.map(|block| SealedBlock::seal_slow(block).into()))
+    }
 }
 
 impl Display for CertifiedBlock {
@@ -176,6 +203,22 @@ mod tests {
                     "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
                 }
             }
+        });
+
+        let certified: CertifiedBlock = serde_json::from_value(fixture.clone()).unwrap();
+        let roundtripped = serde_json::to_value(certified).unwrap();
+
+        assert_eq!(roundtripped, fixture);
+    }
+
+    #[test]
+    fn certified_block_roundtrips_missing_block_json() {
+        let fixture = serde_json::json!({
+            "epoch": 7,
+            "view": 11,
+            "digest": "0x1111111111111111111111111111111111111111111111111111111111111111",
+            "certificate": "0x1234",
+            "block": null
         });
 
         let certified: CertifiedBlock = serde_json::from_value(fixture.clone()).unwrap();


### PR DESCRIPTION
Makes `CertifiedBlock.block` optional so `consensus_getFinalization` can return finalization metadata when the archived execution block is unavailable. Existing block JSON remains unchanged when present, and block-dependent follower paths handle the missing case explicitly.

Validation: `cargo +nightly fmt --all -- --check` and `git diff --check` pass. Targeted tests could not start because this environment cannot authenticate to the pinned private `commonwarexyz/monorepo` dependency.

Prompted by: @hamdiallam
