### PR TITLE
test: update FeeAMM invariant for T8

### DIFF
--- a/tips/verify/foundry.toml
+++ b/tips/verify/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-hardfork = "tempo:T7"
+hardfork = "tempo:T8"
 
 # layout and file system
 src = "src"

--- a/tips/verify/test/invariants/FeeAMM.t.sol
+++ b/tips/verify/test/invariants/FeeAMM.t.sol
@@ -884,6 +884,9 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
     function tryFirstMintBoundary(uint256 actorSeed, uint256 pairSeed) external {
         (address userToken, address validatorToken) = _selectTokenPair(pairSeed);
         address actor = _selectAuthorizedActor(actorSeed, validatorToken);
+        // T8 mint policy gates run before liquidity checks, so skip actors that cannot reach the
+        // boundary condition.
+        if (!_isAuthorized(userToken, actor)) return;
 
         bytes32 poolId = amm.getPoolId(userToken, validatorToken);
         uint256 totalSupplyBefore = amm.totalSupply(poolId);


### PR DESCRIPTION
[TIP-1042](https://tips.sh/1042) added T8 user-token policy gates before FeeAMM liquidity validation. The invariant run shrank the failure to `toggleBlacklist(...)` → `tryFirstMintBoundary(...)`, where `PolicyForbids` took precedence over the expected `InsufficientLiquidity`.

Skip boundary cases blocked by the user-token policy and make T8 the default hardfork for TIP verification.
