### PR TITLE
test: add storage credits invariants

### DIFF
--- a/tips/verify/test/invariants/README.md
+++ b/tips/verify/test/invariants/README.md
@@ -204,6 +204,22 @@ The following are enforced at the protocol level and tested in Rust:
 - **TEMPO-GAS7**: First tx minimum gas (271k) → `crates/transaction-pool/src/validator.rs`
 - **TEMPO-GAS9-14**: Various protocol-level gas rules → `crates/revm/`
 
+## TIP-1060: Storage Credits
+
+### Storage Credit Invariants (`StorageCredits.t.sol`)
+
+Tested through `vmExec.executeTransaction()` so SSTORE accounting and end-of-transaction refund
+settlement run through the production execution path:
+
+- **TEMPO-SC1**: The persistent credit balance follows an independent zero-crossing model across
+  Refund, Preserve, Direct, and bounded-Direct modes.
+- **TEMPO-SC2**: Non-boundary writes do not change credits; committed storage always matches ghost
+  state, including dirty `x -> 0 -> y` recreations.
+- **TEMPO-SC3**: Reverted storage writes atomically unwind their credit and transient-mode effects.
+- **TEMPO-SC4**: Credits remain local to the account whose storage changed, regardless of the
+  transaction sender.
+- **TEMPO-SC5**: Mode and Direct budget are transaction-local and reset between transactions.
+
 ## TIP-1010: Mainnet Gas Parameters (Block Limits)
 
 TIP-1010 defines Tempo's mainnet block gas parameters, including a 500M total block gas limit with a 30M general lane and 470M payment lane allocation.

--- a/tips/verify/test/invariants/README.md
+++ b/tips/verify/test/invariants/README.md
@@ -212,12 +212,12 @@ Tested through `vmExec.executeTransaction()` so SSTORE accounting and end-of-tra
 settlement run through the production execution path:
 
 - **TEMPO-SC1**: The persistent credit balance follows an independent zero-crossing model across
-  Refund, Preserve, Direct, and bounded-Direct modes.
+  Refund, Preserve, Direct, and bounded-Direct modes, including multi-create budget exhaustion.
 - **TEMPO-SC2**: Non-boundary writes do not change credits; committed storage always matches ghost
   state, including dirty `x -> 0 -> y` recreations.
-- **TEMPO-SC3**: Reverted storage writes atomically unwind their credit and transient-mode effects.
+- **TEMPO-SC3**: Reverted storage writes atomically unwind their credit, mode, and budget effects.
 - **TEMPO-SC4**: Credits remain local to the account whose storage changed, regardless of the
-  transaction sender.
+  transaction sender or intermediate caller.
 - **TEMPO-SC5**: Mode and Direct budget are transaction-local and reset between transactions.
 
 ## TIP-1010: Mainnet Gas Parameters (Block Limits)

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -146,34 +146,12 @@ contract StorageCreditsHarness {
 
 /// @title TIP-1060 Storage Credits Invariant Tests
 /// @notice Stateful model-based tests for storage-credit conservation and account locality
-/// forge-config: default.invariant.runs = 10
-/// forge-config: default.invariant.depth = 100
 contract StorageCreditsInvariantTest is InvariantBase {
 
     using TxBuilder for *;
 
     uint256 internal constant NUM_SLOTS = 16;
     uint64 internal constant TX_GAS_LIMIT = 1_500_000;
-    string internal constant BRANCH_LOG = "storage-credits-branches.log";
-
-    bytes32 internal constant BRANCH_CREATE_REFUND_EMPTY = keccak256("create/refund/no-credit");
-    bytes32 internal constant BRANCH_CREATE_REFUND_CONSUME = keccak256("create/refund/consume");
-    bytes32 internal constant BRANCH_CREATE_PRESERVE = keccak256("create/preserve");
-    bytes32 internal constant BRANCH_CREATE_DIRECT_EMPTY = keccak256("create/direct/no-credit");
-    bytes32 internal constant BRANCH_CREATE_DIRECT_ZERO = keccak256("create/direct/zero-budget");
-    bytes32 internal constant BRANCH_CREATE_DIRECT_BOUNDED =
-        keccak256("create/direct/consume-bounded");
-    bytes32 internal constant BRANCH_CREATE_DIRECT_UNLIMITED =
-        keccak256("create/direct/consume-unlimited");
-    bytes32 internal constant BRANCH_CLEAR = keccak256("transition/clear");
-    bytes32 internal constant BRANCH_NON_BOUNDARY = keccak256("transition/non-boundary");
-    bytes32 internal constant BRANCH_RECREATE_REFUND = keccak256("recreate/refund");
-    bytes32 internal constant BRANCH_RECREATE_PRESERVE = keccak256("recreate/preserve");
-    bytes32 internal constant BRANCH_RECREATE_DIRECT_ZERO =
-        keccak256("recreate/direct/zero-budget");
-    bytes32 internal constant BRANCH_RECREATE_DIRECT_CONSUME = keccak256("recreate/direct/consume");
-    bytes32 internal constant BRANCH_REVERT_ATOMICITY = keccak256("revert/atomicity");
-    bytes32 internal constant BRANCH_KNOWN_ERRORS = keccak256("revert/known-errors");
 
     IStorageCredits internal constant CREDITS = IStorageCredits(PC.STORAGE_CREDITS_ADDRESS);
 
@@ -182,8 +160,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
     mapping(uint256 slot => uint256 value) internal ghost_values;
     uint64 internal ghost_credits;
-    mapping(bytes32 branch => uint256 hits) internal branch_hits;
-    bool internal branch_sweep_complete;
 
     function setUp() public override {
         super.setUp();
@@ -198,7 +174,11 @@ contract StorageCreditsInvariantTest is InvariantBase {
         selectors[2] = this.handler_revertingMutation.selector;
         targetSelector(FuzzSelector({ addr: address(this), selectors: selectors }));
 
-        vm.writeFile(BRANCH_LOG, "");
+    }
+
+    /// @notice Asserts exact revert data for every reachable precompile error/halt path.
+    function test_knownExpectedCustomErrors() public {
+        harness.assertKnownReverts();
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -214,8 +194,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
-        _ensureBranchSweep(actorSeed);
-
         uint256 slot = slotSeed % NUM_SLOTS;
         uint256 oldValue = ghost_values[slot];
         uint256 newValue = valueSeed % 4 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
@@ -223,7 +201,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
         bool useBudget = mode == IStorageCredits.Mode.Direct && budgetSeed % 2 == 0;
         uint64 budget = uint64(budgetSeed % 3);
 
-        uint64 creditsBefore = ghost_credits;
         uint64 expectedCredits = _expectedAfterTransition(
             ghost_credits, oldValue, newValue, mode, useBudget ? budget : type(uint64).max
         );
@@ -235,7 +212,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
         ghost_values[slot] = newValue;
         ghost_credits = expectedCredits;
-        _recordTransition(oldValue, newValue, mode, useBudget, budget, creditsBefore);
         _assertModel();
     }
 
@@ -248,8 +224,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
-        _ensureBranchSweep(actorSeed);
-
         uint256 slot = slotSeed % NUM_SLOTS;
         if (ghost_values[slot] == 0) return;
 
@@ -271,22 +245,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
         ghost_values[slot] = newValue;
         ghost_credits = expectedCredits;
-        _hit(
-            mode == IStorageCredits.Mode.Refund
-                ? BRANCH_RECREATE_REFUND
-                : mode == IStorageCredits.Mode.Preserve
-                    ? BRANCH_RECREATE_PRESERVE
-                    : (useBudget && budget == 0)
-                        ? BRANCH_RECREATE_DIRECT_ZERO
-                        : BRANCH_RECREATE_DIRECT_CONSUME,
-            mode == IStorageCredits.Mode.Refund
-                ? "recreate/refund"
-                : mode == IStorageCredits.Mode.Preserve
-                    ? "recreate/preserve"
-                    : (useBudget && budget == 0)
-                        ? "recreate/direct/zero-budget"
-                        : "recreate/direct/consume"
-        );
         _assertModel();
     }
 
@@ -298,8 +256,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
-        _ensureBranchSweep(actorSeed);
-
         uint256 slot = slotSeed % NUM_SLOTS;
         uint256 newValue = valueSeed % 2 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
         IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
@@ -308,7 +264,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
             StorageCreditsHarness.assertAtomicRevert, (slot, newValue, mode, uint64(1), false)
         );
         _execute(actorSeed, data, true);
-        _hit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
 
         // The storage transition, credit update, and transient mode change must all unwind.
         _assertModel();
@@ -323,24 +278,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModel();
         _invariantAccountLocality();
         _invariantTransientStateReset();
-    }
-
-    function afterInvariant() public view {
-        _assertHit(BRANCH_CREATE_REFUND_EMPTY, "create/refund/no-credit");
-        _assertHit(BRANCH_CREATE_REFUND_CONSUME, "create/refund/consume");
-        _assertHit(BRANCH_CREATE_PRESERVE, "create/preserve");
-        _assertHit(BRANCH_CREATE_DIRECT_EMPTY, "create/direct/no-credit");
-        _assertHit(BRANCH_CREATE_DIRECT_ZERO, "create/direct/zero-budget");
-        _assertHit(BRANCH_CREATE_DIRECT_BOUNDED, "create/direct/consume-bounded");
-        _assertHit(BRANCH_CREATE_DIRECT_UNLIMITED, "create/direct/consume-unlimited");
-        _assertHit(BRANCH_CLEAR, "transition/clear");
-        _assertHit(BRANCH_NON_BOUNDARY, "transition/non-boundary");
-        _assertHit(BRANCH_RECREATE_REFUND, "recreate/refund");
-        _assertHit(BRANCH_RECREATE_PRESERVE, "recreate/preserve");
-        _assertHit(BRANCH_RECREATE_DIRECT_ZERO, "recreate/direct/zero-budget");
-        _assertHit(BRANCH_RECREATE_DIRECT_CONSUME, "recreate/direct/consume");
-        _assertHit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
-        _assertHit(BRANCH_KNOWN_ERRORS, "revert/known-errors");
     }
 
     function _assertModel() internal view {
@@ -401,141 +338,6 @@ contract StorageCreditsInvariantTest is InvariantBase {
             if (mode == IStorageCredits.Mode.Direct && budget != 0) return credits - 1;
         }
         return credits;
-    }
-
-    function _ensureBranchSweep(uint256 actorSeed) internal {
-        if (branch_sweep_complete) return;
-        branch_sweep_complete = true;
-
-        _sweepMutation(actorSeed, 0, 1, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 0, 2, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 1, 1, IStorageCredits.Mode.Direct, 1, true);
-        _sweepMutation(actorSeed, 2, 1, IStorageCredits.Mode.Direct, 0, false);
-        _sweepMutation(actorSeed, 3, 1, IStorageCredits.Mode.Refund, 0, false);
-
-        _sweepMutation(actorSeed, 0, 0, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 4, 1, IStorageCredits.Mode.Refund, 0, false);
-        _sweepMutation(actorSeed, 1, 0, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 5, 1, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 5, 0, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 6, 1, IStorageCredits.Mode.Direct, 0, true);
-        _sweepMutation(actorSeed, 6, 0, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 7, 1, IStorageCredits.Mode.Direct, 1, true);
-        _sweepMutation(actorSeed, 7, 0, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepMutation(actorSeed, 8, 1, IStorageCredits.Mode.Direct, 0, false);
-
-        _sweepRecreate(actorSeed, 8, 2, IStorageCredits.Mode.Refund, 0, false);
-        _sweepRecreate(actorSeed, 8, 3, IStorageCredits.Mode.Preserve, 0, false);
-        _sweepRecreate(actorSeed, 8, 4, IStorageCredits.Mode.Direct, 0, true);
-        _sweepRecreate(actorSeed, 8, 5, IStorageCredits.Mode.Direct, 1, true);
-
-        bytes memory knownErrorsData = abi.encodeCall(StorageCreditsHarness.assertKnownReverts, ());
-        _execute(actorSeed, knownErrorsData, true);
-        _hit(BRANCH_KNOWN_ERRORS, "revert/known-errors");
-
-        bytes memory revertData = abi.encodeCall(
-            StorageCreditsHarness.assertAtomicRevert,
-            (uint256(9), uint256(1), IStorageCredits.Mode.Direct, uint64(1), true)
-        );
-        _execute(actorSeed, revertData, true);
-        _hit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
-    }
-
-    function _sweepMutation(
-        uint256 actorSeed,
-        uint256 slot,
-        uint256 newValue,
-        IStorageCredits.Mode mode,
-        uint64 budget,
-        bool useBudget
-    )
-        internal
-    {
-        uint256 oldValue = ghost_values[slot];
-        uint64 creditsBefore = ghost_credits;
-        uint64 expectedCredits = _expectedAfterTransition(
-            creditsBefore, oldValue, newValue, mode, useBudget ? budget : type(uint64).max
-        );
-        bytes memory data = abi.encodeCall(
-            StorageCreditsHarness.mutate, (slot, newValue, mode, budget, useBudget, false)
-        );
-        _execute(actorSeed, data, true);
-        ghost_values[slot] = newValue;
-        ghost_credits = expectedCredits;
-        _recordTransition(oldValue, newValue, mode, useBudget, budget, creditsBefore);
-        _assertModel();
-    }
-
-    function _sweepRecreate(
-        uint256 actorSeed,
-        uint256 slot,
-        uint256 newValue,
-        IStorageCredits.Mode mode,
-        uint64 budget,
-        bool useBudget
-    )
-        internal
-    {
-        uint64 expectedCredits = _expectedAfterTransition(
-            ghost_credits + 1, 0, newValue, mode, useBudget ? budget : type(uint64).max
-        );
-        bytes memory data = abi.encodeCall(
-            StorageCreditsHarness.recreate, (slot, newValue, mode, budget, useBudget)
-        );
-        _execute(actorSeed, data, true);
-        ghost_values[slot] = newValue;
-        ghost_credits = expectedCredits;
-
-        if (mode == IStorageCredits.Mode.Refund) {
-            _hit(BRANCH_RECREATE_REFUND, "recreate/refund");
-        } else if (mode == IStorageCredits.Mode.Preserve) {
-            _hit(BRANCH_RECREATE_PRESERVE, "recreate/preserve");
-        } else if (useBudget && budget == 0) {
-            _hit(BRANCH_RECREATE_DIRECT_ZERO, "recreate/direct/zero-budget");
-        } else {
-            _hit(BRANCH_RECREATE_DIRECT_CONSUME, "recreate/direct/consume");
-        }
-        _assertModel();
-    }
-
-    function _recordTransition(
-        uint256 oldValue,
-        uint256 newValue,
-        IStorageCredits.Mode mode,
-        bool useBudget,
-        uint64 budget,
-        uint64 creditsBefore
-    )
-        internal
-    {
-        if (oldValue != 0 && newValue == 0) {
-            _hit(BRANCH_CLEAR, "transition/clear");
-        } else if ((oldValue == 0) == (newValue == 0)) {
-            _hit(BRANCH_NON_BOUNDARY, "transition/non-boundary");
-        } else if (mode == IStorageCredits.Mode.Refund && creditsBefore == 0) {
-            _hit(BRANCH_CREATE_REFUND_EMPTY, "create/refund/no-credit");
-        } else if (mode == IStorageCredits.Mode.Refund) {
-            _hit(BRANCH_CREATE_REFUND_CONSUME, "create/refund/consume");
-        } else if (mode == IStorageCredits.Mode.Preserve) {
-            _hit(BRANCH_CREATE_PRESERVE, "create/preserve");
-        } else if (creditsBefore == 0) {
-            _hit(BRANCH_CREATE_DIRECT_EMPTY, "create/direct/no-credit");
-        } else if (useBudget && budget == 0) {
-            _hit(BRANCH_CREATE_DIRECT_ZERO, "create/direct/zero-budget");
-        } else if (useBudget) {
-            _hit(BRANCH_CREATE_DIRECT_BOUNDED, "create/direct/consume-bounded");
-        } else {
-            _hit(BRANCH_CREATE_DIRECT_UNLIMITED, "create/direct/consume-unlimited");
-        }
-    }
-
-    function _hit(bytes32 branch, string memory label) internal {
-        branch_hits[branch]++;
-        vm.writeLine(BRANCH_LOG, label);
-    }
-
-    function _assertHit(bytes32 branch, string memory label) internal view {
-        assertGt(branch_hits[branch], 0, string.concat("unexercised branch: ", label));
     }
 
     function _execute(uint256 actorSeed, bytes memory data, bool expectSuccess) internal {

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -93,6 +93,20 @@ contract StorageCreditsHarness {
         _assertRevert(success, result, bytes(""));
     }
 
+    function assertAtomicRevert(
+        uint256 slot,
+        uint256 value,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget
+    )
+        external
+    {
+        (bool success, bytes memory result) = address(this)
+            .call(abi.encodeCall(this.mutate, (slot, value, mode, budget, useBudget, true)));
+        _assertRevert(success, result, abi.encodeWithSelector(ForcedRevert.selector));
+    }
+
     function _assertRevert(bool success, bytes memory actual, bytes memory expected) internal pure {
         require(!success, "expected Storage Credits call to revert");
         require(keccak256(actual) == keccak256(expected), "unexpected Storage Credits revert");
@@ -273,12 +287,9 @@ contract StorageCreditsInvariantTest is InvariantBase {
         IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
 
         bytes memory data = abi.encodeCall(
-            StorageCreditsHarness.mutate, (slot, newValue, mode, uint64(1), false, true)
+            StorageCreditsHarness.assertAtomicRevert, (slot, newValue, mode, uint64(1), false)
         );
-        bytes memory reason = _execute(actorSeed, data, false);
-        assertEq(
-            bytes4(reason), StorageCreditsHarness.ForcedRevert.selector, "wrong revert selector"
-        );
+        _execute(actorSeed, data, true);
         _hit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
 
         // The storage transition, credit update, and transient mode change must all unwind.
@@ -405,13 +416,10 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _hit(BRANCH_KNOWN_ERRORS, "revert/known-errors");
 
         bytes memory revertData = abi.encodeCall(
-            StorageCreditsHarness.mutate,
-            (uint256(9), uint256(1), IStorageCredits.Mode.Direct, uint64(1), true, true)
+            StorageCreditsHarness.assertAtomicRevert,
+            (uint256(9), uint256(1), IStorageCredits.Mode.Direct, uint64(1), true)
         );
-        bytes memory reason = _execute(actorSeed, revertData, false);
-        assertEq(
-            bytes4(reason), StorageCreditsHarness.ForcedRevert.selector, "wrong revert selector"
-        );
+        _execute(actorSeed, revertData, true);
         _hit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
     }
 
@@ -512,14 +520,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         assertGt(branch_hits[branch], 0, string.concat("unexercised branch: ", label));
     }
 
-    function _execute(
-        uint256 actorSeed,
-        bytes memory data,
-        bool expectSuccess
-    )
-        internal
-        returns (bytes memory reason)
-    {
+    function _execute(uint256 actorSeed, bytes memory data, bool expectSuccess) internal {
         uint256 actorIndex = actorSeed % actors.length;
         address actor = actors[actorIndex];
         uint64 nonce = uint64(vm.getNonce(actor));
@@ -531,9 +532,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         bool succeeded;
         try vmExec.executeTransaction(signedTx) {
             succeeded = true;
-        } catch (bytes memory revertData) {
-            reason = revertData;
-        }
+        } catch { }
 
         assertEq(succeeded, expectSuccess, "TIP-1060 transaction result differed from expectation");
     }

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -20,12 +20,14 @@ contract StorageCreditsHarness {
 
     mapping(uint256 slot => uint256 value) public values;
 
+    /// @dev Seeds occupied slots for deterministic clear/create scenarios.
     constructor(uint256 seededSlots) {
         for (uint256 slot = 0; slot < seededSlots; slot++) {
             values[slot] = slot + 1;
         }
     }
 
+    /// @dev Applies one transition after verifying transaction-local state was reset.
     function mutate(
         uint256 slot,
         uint256 value,
@@ -160,6 +162,7 @@ contract StorageCreditsHarness {
         _assertRevert(success, result, bytes(""));
     }
 
+    /// @dev Reverts an inner mutation and verifies the outer mode and budget are restored.
     function assertAtomicRevert(
         uint256 slot,
         uint256 value,
@@ -178,6 +181,7 @@ contract StorageCreditsHarness {
         _assertTransientState(IStorageCredits.Mode.Preserve, 0);
     }
 
+    /// @dev Applies mode and storage changes that must unwind with this call frame.
     function revertingMutation(
         uint256 slot,
         uint256 value,
@@ -198,6 +202,7 @@ contract StorageCreditsHarness {
         require(keccak256(actual) == keccak256(expected), "unexpected Storage Credits revert");
     }
 
+    /// @dev Selects bounded or unbounded mode and verifies the resulting transient state.
     function _setMode(IStorageCredits.Mode mode, uint64 budget, bool useBudget) internal {
         bytes memory data = useBudget
             ? abi.encodeCall(IStorageCredits.setBudget, (budget))
@@ -215,10 +220,12 @@ contract StorageCreditsHarness {
         _assertTransientState(expectedMode, expectedBudget);
     }
 
+    /// @dev Checks the per-account mode and budget at the start of a production-path transaction.
     function _assertDefaultTransientState() internal view {
         _assertTransientState(IStorageCredits.Mode.Refund, 0);
     }
 
+    /// @dev Asserts transient mode and budget for this storage-owning account.
     function _assertTransientState(
         IStorageCredits.Mode expectedMode,
         uint64 expectedBudget
@@ -243,13 +250,18 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
     IStorageCredits internal constant CREDITS = IStorageCredits(PC.STORAGE_CREDITS_ADDRESS);
 
+    // General transitions and revert atomicity.
     StorageCreditsHarness internal harness;
+    // Nested-call account locality.
     StorageCreditsHarness internal peerHarness;
+    // Bounded Direct budget consumption.
     StorageCreditsHarness internal budgetHarness;
+    // Deferred Refund settlement.
     StorageCreditsHarness internal refundHarness;
 
     mapping(address owner => mapping(uint256 slot => uint256 value)) internal ghost_values;
     mapping(address owner => uint64 credits) internal ghost_credits;
+    // Start of the currently occupied pair in refundHarness.
     uint256 internal refund_activeStart;
 
     function setUp() public override {
@@ -284,6 +296,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
                                 HANDLERS
     //////////////////////////////////////////////////////////////*/
 
+    /// @dev Fuzzes one top-level transition across every storage-credit mode.
     function handler_mutate(
         uint256 actorSeed,
         uint256 slotSeed,
@@ -296,6 +309,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _handlerMutation(harness, false, actorSeed, slotSeed, valueSeed, modeSeed, budgetSeed);
     }
 
+    /// @dev Fuzzes the same transition through an intermediate caller to test account locality.
     function handler_nestedMutation(
         uint256 actorSeed,
         uint256 slotSeed,
@@ -308,6 +322,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _handlerMutation(peerHarness, true, actorSeed, slotSeed, valueSeed, modeSeed, budgetSeed);
     }
 
+    /// @dev Executes a direct or nested mutation and advances the selected owner's ghost model.
     function _handlerMutation(
         StorageCreditsHarness owner,
         bool nested,
@@ -349,6 +364,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModels();
     }
 
+    /// @dev Fuzzes dirty x->0->y recreation accounting within one transaction.
     function handler_recreate(
         uint256 actorSeed,
         uint256 slotSeed,
@@ -383,6 +399,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModels();
     }
 
+    /// @dev Fuzzes two Direct consumptions to expose budget decrement and exhaustion.
     function handler_directBudget(
         uint256 actorSeed,
         uint256 valueSeed,
@@ -408,6 +425,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModels();
     }
 
+    /// @dev Creates before clearing so Refund settlement must use credits minted later.
     function handler_refundCreateThenClear(uint256 actorSeed, uint256 valueSeed) external {
         address owner = address(refundHarness);
         uint256 fromStart = refund_activeStart;
@@ -428,6 +446,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModels();
     }
 
+    /// @dev Forces a zero-boundary mutation in a reverted child frame and checks full rollback.
     function handler_revertingMutation(
         uint256 actorSeed,
         uint256 slotSeed,
@@ -464,6 +483,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _invariantAccountLocality();
     }
 
+    /// @dev Checks every independently exercised storage owner against its ghost state.
     function _assertModels() internal view {
         _assertModel(harness, NUM_SLOTS);
         _assertModel(peerHarness, NUM_SLOTS);
@@ -471,6 +491,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModel(refundHarness, 4);
     }
 
+    /// @dev Compares one owner's persistent credit balance and storage with its ghost model.
     function _assertModel(StorageCreditsHarness owner, uint256 slots) internal view {
         address ownerAddress = address(owner);
         assertEq(
@@ -488,6 +509,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         }
     }
 
+    /// @dev Ensures transaction senders never receive credits for contract-owned storage.
     function _invariantAccountLocality() internal view {
         for (uint256 i = 0; i < actors.length; i++) {
             assertEq(
@@ -502,6 +524,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
                                 HELPERS
     //////////////////////////////////////////////////////////////*/
 
+    /// @dev Models one present-to-new zero-boundary transition independently of the implementation.
     function _expectedAfterTransition(
         uint64 credits,
         uint256 oldValue,
@@ -521,6 +544,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         return credits;
     }
 
+    /// @dev Executes a signed actor call through the production transaction executor.
     function _execute(uint256 actorSeed, address target, bytes memory data) internal {
         uint256 actorIndex = actorSeed % actors.length;
         address actor = actors[actorIndex];

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -129,8 +129,8 @@ contract StorageCreditsHarness {
         IStorageCredits.Mode expectedMode = useBudget ? IStorageCredits.Mode.Direct : mode;
         require(abi.decode(data, (IStorageCredits.Mode)) == expectedMode, "mode update not applied");
 
-        (success, data) = address(CREDITS)
-            .staticcall(abi.encodeCall(IStorageCredits.budgetOf, (address(this))));
+        (success, data) =
+            address(CREDITS).staticcall(abi.encodeCall(IStorageCredits.budgetOf, (address(this))));
         require(success && data.length == 32, "budgetOf failed after mode update");
         uint64 expectedBudget =
             useBudget ? budget : mode == IStorageCredits.Mode.Direct ? type(uint64).max : 0;

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -30,11 +30,7 @@ contract StorageCreditsHarness {
     )
         external
     {
-        if (useBudget) {
-            CREDITS.setBudget(budget);
-        } else {
-            CREDITS.setMode(mode);
-        }
+        _setMode(mode, budget, useBudget);
 
         values[slot] = value;
         if (forceRevert) revert ForcedRevert();
@@ -51,11 +47,7 @@ contract StorageCreditsHarness {
     )
         external
     {
-        if (useBudget) {
-            CREDITS.setBudget(budget);
-        } else {
-            CREDITS.setMode(mode);
-        }
+        _setMode(mode, budget, useBudget);
 
         values[slot] = 0;
         values[slot] = value;
@@ -104,6 +96,18 @@ contract StorageCreditsHarness {
     function _assertRevert(bool success, bytes memory actual, bytes memory expected) internal pure {
         require(!success, "expected Storage Credits call to revert");
         require(keccak256(actual) == keccak256(expected), "unexpected Storage Credits revert");
+    }
+
+    function _setMode(IStorageCredits.Mode mode, uint64 budget, bool useBudget) internal {
+        bytes memory data = useBudget
+            ? abi.encodeCall(IStorageCredits.setBudget, (budget))
+            : abi.encodeCall(IStorageCredits.setMode, (mode));
+        (bool success, bytes memory reason) = address(CREDITS).call(data);
+        if (!success) {
+            assembly ("memory-safe") {
+                revert(add(reason, 0x20), mload(reason))
+            }
+        }
     }
 
 }

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -49,8 +49,13 @@ contract StorageCreditsHarness {
     {
         _setMode(mode, budget, useBudget);
 
-        values[slot] = 0;
+        this.clear(slot);
         values[slot] = value;
+    }
+
+    function clear(uint256 slot) external {
+        require(msg.sender == address(this), "only self");
+        values[slot] = 0;
     }
 
     /// @dev Asserts every externally reachable Storage Credits revert/halt path. `OnlyDirectCall`

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -20,20 +20,40 @@ contract StorageCreditsHarness {
 
     mapping(uint256 slot => uint256 value) public values;
 
+    constructor(uint256 seededSlots) {
+        for (uint256 slot = 0; slot < seededSlots; slot++) {
+            values[slot] = slot + 1;
+        }
+    }
+
     function mutate(
         uint256 slot,
         uint256 value,
         IStorageCredits.Mode mode,
         uint64 budget,
-        bool useBudget,
-        bool forceRevert
+        bool useBudget
     )
         external
     {
+        _assertDefaultTransientState();
         _setMode(mode, budget, useBudget);
 
         values[slot] = value;
-        if (forceRevert) revert ForcedRevert();
+    }
+
+    /// @dev Keeps the transaction sender, intermediate caller, and storage owner distinct.
+    function mutatePeer(
+        StorageCreditsHarness peer,
+        uint256 slot,
+        uint256 value,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget
+    )
+        external
+    {
+        _assertDefaultTransientState();
+        peer.mutate(slot, value, mode, budget, useBudget);
     }
 
     /// @dev Exercises an x->0->y dirty recreation within one transaction. TIP-1060 accounting
@@ -47,10 +67,52 @@ contract StorageCreditsHarness {
     )
         external
     {
+        _assertDefaultTransientState();
         _setMode(mode, budget, useBudget);
 
         this.clear(slot);
         values[slot] = value;
+    }
+
+    /// @dev Starts with slot 0 occupied and slot 1 empty. Two clear/create cycles make the exact
+    ///      number of Direct consumptions and the remaining budget independently observable.
+    function exerciseDirectBudget(
+        uint256 firstValue,
+        uint256 secondValue,
+        uint64 budget,
+        bool useBudget
+    )
+        external
+    {
+        _assertDefaultTransientState();
+        _setMode(IStorageCredits.Mode.Direct, budget, useBudget);
+
+        values[0] = 0;
+        values[1] = firstValue;
+        values[1] = 0;
+        values[0] = secondValue;
+
+        uint64 expectedBudget = type(uint64).max;
+        if (useBudget) expectedBudget = budget > 2 ? budget - 2 : 0;
+        _assertTransientState(IStorageCredits.Mode.Direct, expectedBudget);
+    }
+
+    /// @dev Creates two slots before clearing two occupied slots. In default Refund mode the later
+    ///      clears must fund both earlier creations during end-of-transaction settlement.
+    function createThenClear(
+        uint256 fromStart,
+        uint256 toStart,
+        uint256 firstValue,
+        uint256 secondValue
+    )
+        external
+    {
+        _assertDefaultTransientState();
+
+        values[toStart] = firstValue;
+        values[toStart + 1] = secondValue;
+        values[fromStart] = 0;
+        values[fromStart + 1] = 0;
     }
 
     function clear(uint256 slot) external {
@@ -107,9 +169,28 @@ contract StorageCreditsHarness {
     )
         external
     {
+        _assertDefaultTransientState();
+        _setMode(IStorageCredits.Mode.Preserve, 0, false);
+
         (bool success, bytes memory result) = address(this)
-            .call(abi.encodeCall(this.mutate, (slot, value, mode, budget, useBudget, true)));
+            .call(abi.encodeCall(this.revertingMutation, (slot, value, mode, budget, useBudget)));
         _assertRevert(success, result, abi.encodeWithSelector(ForcedRevert.selector));
+        _assertTransientState(IStorageCredits.Mode.Preserve, 0);
+    }
+
+    function revertingMutation(
+        uint256 slot,
+        uint256 value,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget
+    )
+        external
+    {
+        require(msg.sender == address(this), "only self");
+        _setMode(mode, budget, useBudget);
+        values[slot] = value;
+        revert ForcedRevert();
     }
 
     function _assertRevert(bool success, bytes memory actual, bytes memory expected) internal pure {
@@ -128,18 +209,25 @@ contract StorageCreditsHarness {
             }
         }
 
-        (success, data) =
-            address(CREDITS).staticcall(abi.encodeCall(IStorageCredits.modeOf, (address(this))));
-        require(success && data.length == 32, "modeOf failed after mode update");
         IStorageCredits.Mode expectedMode = useBudget ? IStorageCredits.Mode.Direct : mode;
-        require(abi.decode(data, (IStorageCredits.Mode)) == expectedMode, "mode update not applied");
-
-        (success, data) =
-            address(CREDITS).staticcall(abi.encodeCall(IStorageCredits.budgetOf, (address(this))));
-        require(success && data.length == 32, "budgetOf failed after mode update");
         uint64 expectedBudget =
             useBudget ? budget : mode == IStorageCredits.Mode.Direct ? type(uint64).max : 0;
-        require(abi.decode(data, (uint64)) == expectedBudget, "budget update not applied");
+        _assertTransientState(expectedMode, expectedBudget);
+    }
+
+    function _assertDefaultTransientState() internal view {
+        _assertTransientState(IStorageCredits.Mode.Refund, 0);
+    }
+
+    function _assertTransientState(
+        IStorageCredits.Mode expectedMode,
+        uint64 expectedBudget
+    )
+        internal
+        view
+    {
+        require(CREDITS.modeOf(address(this)) == expectedMode, "unexpected transient mode");
+        require(CREDITS.budgetOf(address(this)) == expectedBudget, "unexpected transient budget");
     }
 
 }
@@ -156,24 +244,35 @@ contract StorageCreditsInvariantTest is InvariantBase {
     IStorageCredits internal constant CREDITS = IStorageCredits(PC.STORAGE_CREDITS_ADDRESS);
 
     StorageCreditsHarness internal harness;
-    StorageCreditsHarness internal untouchedHarness;
+    StorageCreditsHarness internal peerHarness;
+    StorageCreditsHarness internal budgetHarness;
+    StorageCreditsHarness internal refundHarness;
 
-    mapping(uint256 slot => uint256 value) internal ghost_values;
-    uint64 internal ghost_credits;
+    mapping(address owner => mapping(uint256 slot => uint256 value)) internal ghost_values;
+    mapping(address owner => uint64 credits) internal ghost_credits;
+    uint256 internal refund_activeStart;
 
     function setUp() public override {
         super.setUp();
 
-        harness = new StorageCreditsHarness();
-        untouchedHarness = new StorageCreditsHarness();
+        harness = new StorageCreditsHarness(0);
+        peerHarness = new StorageCreditsHarness(0);
+        budgetHarness = new StorageCreditsHarness(1);
+        refundHarness = new StorageCreditsHarness(2);
+
+        ghost_values[address(budgetHarness)][0] = 1;
+        ghost_values[address(refundHarness)][0] = 1;
+        ghost_values[address(refundHarness)][1] = 2;
 
         targetContract(address(this));
-        bytes4[] memory selectors = new bytes4[](3);
+        bytes4[] memory selectors = new bytes4[](6);
         selectors[0] = this.handler_mutate.selector;
-        selectors[1] = this.handler_recreate.selector;
-        selectors[2] = this.handler_revertingMutation.selector;
+        selectors[1] = this.handler_nestedMutation.selector;
+        selectors[2] = this.handler_recreate.selector;
+        selectors[3] = this.handler_directBudget.selector;
+        selectors[4] = this.handler_refundCreateThenClear.selector;
+        selectors[5] = this.handler_revertingMutation.selector;
         targetSelector(FuzzSelector({ addr: address(this), selectors: selectors }));
-
     }
 
     /// @notice Asserts exact revert data for every reachable precompile error/halt path.
@@ -194,25 +293,60 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
+        _handlerMutation(harness, false, actorSeed, slotSeed, valueSeed, modeSeed, budgetSeed);
+    }
+
+    function handler_nestedMutation(
+        uint256 actorSeed,
+        uint256 slotSeed,
+        uint256 valueSeed,
+        uint256 modeSeed,
+        uint256 budgetSeed
+    )
+        external
+    {
+        _handlerMutation(peerHarness, true, actorSeed, slotSeed, valueSeed, modeSeed, budgetSeed);
+    }
+
+    function _handlerMutation(
+        StorageCreditsHarness owner,
+        bool nested,
+        uint256 actorSeed,
+        uint256 slotSeed,
+        uint256 valueSeed,
+        uint256 modeSeed,
+        uint256 budgetSeed
+    )
+        internal
+    {
+        address ownerAddress = address(owner);
         uint256 slot = slotSeed % NUM_SLOTS;
-        uint256 oldValue = ghost_values[slot];
+        uint256 oldValue = ghost_values[ownerAddress][slot];
         uint256 newValue = valueSeed % 4 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
         IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
         bool useBudget = mode == IStorageCredits.Mode.Direct && budgetSeed % 2 == 0;
         uint64 budget = uint64(budgetSeed % 3);
 
         uint64 expectedCredits = _expectedAfterTransition(
-            ghost_credits, oldValue, newValue, mode, useBudget ? budget : type(uint64).max
+            ghost_credits[ownerAddress],
+            oldValue,
+            newValue,
+            mode,
+            useBudget ? budget : type(uint64).max
         );
 
-        bytes memory data = abi.encodeCall(
-            StorageCreditsHarness.mutate, (slot, newValue, mode, budget, useBudget, false)
-        );
-        _execute(actorSeed, data, true);
+        bytes memory data = nested
+            ? abi.encodeCall(
+                StorageCreditsHarness.mutatePeer, (owner, slot, newValue, mode, budget, useBudget)
+            )
+            : abi.encodeCall(
+                StorageCreditsHarness.mutate, (slot, newValue, mode, budget, useBudget)
+            );
+        _execute(actorSeed, address(harness), data);
 
-        ghost_values[slot] = newValue;
-        ghost_credits = expectedCredits;
-        _assertModel();
+        ghost_values[ownerAddress][slot] = newValue;
+        ghost_credits[ownerAddress] = expectedCredits;
+        _assertModels();
     }
 
     function handler_recreate(
@@ -224,8 +358,9 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
+        address owner = address(harness);
         uint256 slot = slotSeed % NUM_SLOTS;
-        if (ghost_values[slot] == 0) return;
+        if (ghost_values[owner][slot] == 0) return;
 
         uint256 newValue = bound(valueSeed, 1, type(uint128).max);
         IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
@@ -233,7 +368,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         uint64 budget = uint64(budgetSeed % 3);
 
         // The clear first mints one credit. The following creation may consume it.
-        uint64 expectedCredits = ghost_credits + 1;
+        uint64 expectedCredits = ghost_credits[owner] + 1;
         expectedCredits = _expectedAfterTransition(
             expectedCredits, 0, newValue, mode, useBudget ? budget : type(uint64).max
         );
@@ -241,32 +376,82 @@ contract StorageCreditsInvariantTest is InvariantBase {
         bytes memory data = abi.encodeCall(
             StorageCreditsHarness.recreate, (slot, newValue, mode, budget, useBudget)
         );
-        _execute(actorSeed, data, true);
+        _execute(actorSeed, owner, data);
 
-        ghost_values[slot] = newValue;
-        ghost_credits = expectedCredits;
-        _assertModel();
+        ghost_values[owner][slot] = newValue;
+        ghost_credits[owner] = expectedCredits;
+        _assertModels();
+    }
+
+    function handler_directBudget(
+        uint256 actorSeed,
+        uint256 valueSeed,
+        uint256 budgetSeed
+    )
+        external
+    {
+        address owner = address(budgetHarness);
+        uint256 firstValue = bound(valueSeed, 1, type(uint128).max);
+        uint256 secondValue = firstValue == type(uint128).max ? 1 : firstValue + 1;
+        bool useBudget = budgetSeed % 2 == 0;
+        uint64 budget = uint64((budgetSeed / 2) % 4);
+        uint64 coveredCreations = useBudget && budget < 2 ? budget : 2;
+
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.exerciseDirectBudget, (firstValue, secondValue, budget, useBudget)
+        );
+        _execute(actorSeed, owner, data);
+
+        ghost_values[owner][0] = secondValue;
+        ghost_values[owner][1] = 0;
+        ghost_credits[owner] = ghost_credits[owner] + 2 - coveredCreations;
+        _assertModels();
+    }
+
+    function handler_refundCreateThenClear(uint256 actorSeed, uint256 valueSeed) external {
+        address owner = address(refundHarness);
+        uint256 fromStart = refund_activeStart;
+        uint256 toStart = fromStart == 0 ? 2 : 0;
+        uint256 firstValue = bound(valueSeed, 1, type(uint128).max);
+        uint256 secondValue = firstValue == type(uint128).max ? 1 : firstValue + 1;
+
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.createThenClear, (fromStart, toStart, firstValue, secondValue)
+        );
+        _execute(actorSeed, owner, data);
+
+        ghost_values[owner][toStart] = firstValue;
+        ghost_values[owner][toStart + 1] = secondValue;
+        ghost_values[owner][fromStart] = 0;
+        ghost_values[owner][fromStart + 1] = 0;
+        refund_activeStart = toStart;
+        _assertModels();
     }
 
     function handler_revertingMutation(
         uint256 actorSeed,
         uint256 slotSeed,
         uint256 valueSeed,
-        uint256 modeSeed
+        uint256 modeSeed,
+        uint256 budgetSeed
     )
         external
     {
         uint256 slot = slotSeed % NUM_SLOTS;
-        uint256 newValue = valueSeed % 2 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
-        IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
+        uint256 newValue =
+            ghost_values[address(harness)][slot] == 0 ? bound(valueSeed, 1, type(uint128).max) : 0;
+        bool useBudget = budgetSeed % 2 == 0;
+        IStorageCredits.Mode mode =
+            modeSeed % 2 == 0 ? IStorageCredits.Mode.Refund : IStorageCredits.Mode.Direct;
+        uint64 budget = uint64((budgetSeed / 2) % 3 + 1);
 
         bytes memory data = abi.encodeCall(
-            StorageCreditsHarness.assertAtomicRevert, (slot, newValue, mode, uint64(1), false)
+            StorageCreditsHarness.assertAtomicRevert, (slot, newValue, mode, budget, useBudget)
         );
-        _execute(actorSeed, data, true);
+        _execute(actorSeed, address(harness), data);
 
         // The storage transition, credit update, and transient mode change must all unwind.
-        _assertModel();
+        _assertModels();
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -275,46 +460,42 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
     /// @notice Runs all TIP-1060 invariant checks from one Foundry invariant entrypoint.
     function invariant_storageCreditsGlobal() public view {
-        _assertModel();
+        _assertModels();
         _invariantAccountLocality();
-        _invariantTransientStateReset();
     }
 
-    function _assertModel() internal view {
+    function _assertModels() internal view {
+        _assertModel(harness, NUM_SLOTS);
+        _assertModel(peerHarness, NUM_SLOTS);
+        _assertModel(budgetHarness, 2);
+        _assertModel(refundHarness, 4);
+    }
+
+    function _assertModel(StorageCreditsHarness owner, uint256 slots) internal view {
+        address ownerAddress = address(owner);
         assertEq(
-            CREDITS.balanceOf(address(harness)),
-            ghost_credits,
+            CREDITS.balanceOf(ownerAddress),
+            ghost_credits[ownerAddress],
             "TEMPO-SC1: persistent credit balance diverged from zero-crossing model"
         );
 
-        for (uint256 slot = 0; slot < NUM_SLOTS; slot++) {
+        for (uint256 slot = 0; slot < slots; slot++) {
             assertEq(
-                harness.values(slot),
-                ghost_values[slot],
+                owner.values(slot),
+                ghost_values[ownerAddress][slot],
                 "TEMPO-SC2: committed storage diverged from ghost state"
             );
         }
     }
 
     function _invariantAccountLocality() internal view {
-        assertEq(
-            CREDITS.balanceOf(address(untouchedHarness)),
-            0,
-            "TEMPO-SC4: credits escaped the storage-owning account"
-        );
-    }
-
-    function _invariantTransientStateReset() internal view {
-        assertEq(
-            uint256(CREDITS.modeOf(address(harness))),
-            uint256(IStorageCredits.Mode.Refund),
-            "TEMPO-SC5: mode persisted across transactions"
-        );
-        assertEq(
-            CREDITS.budgetOf(address(harness)),
-            0,
-            "TEMPO-SC5: direct budget persisted across transactions"
-        );
+        for (uint256 i = 0; i < actors.length; i++) {
+            assertEq(
+                CREDITS.balanceOf(actors[i]),
+                0,
+                "TEMPO-SC4: credits escaped to the transaction sender"
+            );
+        }
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -340,12 +521,12 @@ contract StorageCreditsInvariantTest is InvariantBase {
         return credits;
     }
 
-    function _execute(uint256 actorSeed, bytes memory data, bool expectSuccess) internal {
+    function _execute(uint256 actorSeed, address target, bytes memory data) internal {
         uint256 actorIndex = actorSeed % actors.length;
         address actor = actors[actorIndex];
         uint64 nonce = uint64(vm.getNonce(actor));
         bytes memory signedTx = TxBuilder.buildLegacyCallWithGas(
-            vmRlp, vm, address(harness), data, nonce, TX_GAS_LIMIT, actorKeys[actorIndex]
+            vmRlp, vm, target, data, nonce, TX_GAS_LIMIT, actorKeys[actorIndex]
         );
 
         vm.coinbase(validator);
@@ -354,7 +535,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
             succeeded = true;
         } catch { }
 
-        assertEq(succeeded, expectSuccess, "TIP-1060 transaction result differed from expectation");
+        assertTrue(succeeded, "TIP-1060 transaction unexpectedly reverted");
     }
 
 }

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+import { InvariantBase } from "../helpers/InvariantBase.sol";
+import { TxBuilder } from "../helpers/TxBuilder.sol";
+import { StdPrecompiles as PC } from "tempo-std/StdPrecompiles.sol";
+import { IStorageCredits } from "tempo-std/interfaces/IStorageCredits.sol";
+
+/// @dev Owns the storage exercised by the invariant. Storage credits belong to this contract,
+///      irrespective of which externally-owned account submits the transaction.
+contract StorageCreditsHarness {
+
+    error ForcedRevert();
+
+    IStorageCredits internal constant CREDITS = IStorageCredits(PC.STORAGE_CREDITS_ADDRESS);
+
+    mapping(uint256 slot => uint256 value) public values;
+
+    function mutate(
+        uint256 slot,
+        uint256 value,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget,
+        bool forceRevert
+    )
+        external
+    {
+        if (useBudget) {
+            CREDITS.setBudget(budget);
+        } else {
+            CREDITS.setMode(mode);
+        }
+
+        values[slot] = value;
+        if (forceRevert) revert ForcedRevert();
+    }
+
+    /// @dev Exercises an x->0->y dirty recreation within one transaction. TIP-1060 accounting
+    ///      intentionally depends on present/new values, not the transaction-original value.
+    function recreate(
+        uint256 slot,
+        uint256 value,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget
+    )
+        external
+    {
+        if (useBudget) {
+            CREDITS.setBudget(budget);
+        } else {
+            CREDITS.setMode(mode);
+        }
+
+        values[slot] = 0;
+        values[slot] = value;
+    }
+
+}
+
+/// @title TIP-1060 Storage Credits Invariant Tests
+/// @notice Stateful model-based tests for storage-credit conservation and account locality
+contract StorageCreditsInvariantTest is InvariantBase {
+
+    using TxBuilder for *;
+
+    uint256 internal constant NUM_SLOTS = 16;
+    uint64 internal constant TX_GAS_LIMIT = 1_500_000;
+
+    IStorageCredits internal constant CREDITS = IStorageCredits(PC.STORAGE_CREDITS_ADDRESS);
+
+    StorageCreditsHarness internal harness;
+    StorageCreditsHarness internal untouchedHarness;
+
+    mapping(uint256 slot => uint256 value) internal ghost_values;
+    uint64 internal ghost_credits;
+
+    function setUp() public override {
+        super.setUp();
+
+        harness = new StorageCreditsHarness();
+        untouchedHarness = new StorageCreditsHarness();
+
+        targetContract(address(this));
+        bytes4[] memory selectors = new bytes4[](3);
+        selectors[0] = this.handler_mutate.selector;
+        selectors[1] = this.handler_recreate.selector;
+        selectors[2] = this.handler_revertingMutation.selector;
+        targetSelector(FuzzSelector({ addr: address(this), selectors: selectors }));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                HANDLERS
+    //////////////////////////////////////////////////////////////*/
+
+    function handler_mutate(
+        uint256 actorSeed,
+        uint256 slotSeed,
+        uint256 valueSeed,
+        uint256 modeSeed,
+        uint256 budgetSeed
+    )
+        external
+    {
+        uint256 slot = slotSeed % NUM_SLOTS;
+        uint256 oldValue = ghost_values[slot];
+        uint256 newValue = valueSeed % 4 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
+        IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
+        bool useBudget = mode == IStorageCredits.Mode.Direct && budgetSeed % 2 == 0;
+        uint64 budget = uint64(budgetSeed % 3);
+
+        uint64 expectedCredits = _expectedAfterTransition(
+            ghost_credits, oldValue, newValue, mode, useBudget ? budget : type(uint64).max
+        );
+
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.mutate, (slot, newValue, mode, budget, useBudget, false)
+        );
+        _execute(actorSeed, data, true);
+
+        ghost_values[slot] = newValue;
+        ghost_credits = expectedCredits;
+        _assertModel();
+    }
+
+    function handler_recreate(
+        uint256 actorSeed,
+        uint256 slotSeed,
+        uint256 valueSeed,
+        uint256 modeSeed,
+        uint256 budgetSeed
+    )
+        external
+    {
+        uint256 slot = slotSeed % NUM_SLOTS;
+        if (ghost_values[slot] == 0) return;
+
+        uint256 newValue = bound(valueSeed, 1, type(uint128).max);
+        IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
+        bool useBudget = mode == IStorageCredits.Mode.Direct && budgetSeed % 2 == 0;
+        uint64 budget = uint64(budgetSeed % 3);
+
+        // The clear first mints one credit. The following creation may consume it.
+        uint64 expectedCredits = ghost_credits + 1;
+        expectedCredits = _expectedAfterTransition(
+            expectedCredits, 0, newValue, mode, useBudget ? budget : type(uint64).max
+        );
+
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.recreate, (slot, newValue, mode, budget, useBudget)
+        );
+        _execute(actorSeed, data, true);
+
+        ghost_values[slot] = newValue;
+        ghost_credits = expectedCredits;
+        _assertModel();
+    }
+
+    function handler_revertingMutation(
+        uint256 actorSeed,
+        uint256 slotSeed,
+        uint256 valueSeed,
+        uint256 modeSeed
+    )
+        external
+    {
+        uint256 slot = slotSeed % NUM_SLOTS;
+        uint256 newValue = valueSeed % 2 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
+        IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
+
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.mutate, (slot, newValue, mode, uint64(1), false, true)
+        );
+        _execute(actorSeed, data, false);
+
+        // The storage transition, credit update, and transient mode change must all unwind.
+        _assertModel();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                               INVARIANT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Runs all TIP-1060 invariant checks from one Foundry invariant entrypoint.
+    function invariant_storageCreditsGlobal() public view {
+        _assertModel();
+        _invariantAccountLocality();
+        _invariantTransientStateReset();
+    }
+
+    function _assertModel() internal view {
+        assertEq(
+            CREDITS.balanceOf(address(harness)),
+            ghost_credits,
+            "TEMPO-SC1: persistent credit balance diverged from zero-crossing model"
+        );
+
+        for (uint256 slot = 0; slot < NUM_SLOTS; slot++) {
+            assertEq(
+                harness.values(slot),
+                ghost_values[slot],
+                "TEMPO-SC2: committed storage diverged from ghost state"
+            );
+        }
+    }
+
+    function _invariantAccountLocality() internal view {
+        assertEq(
+            CREDITS.balanceOf(address(untouchedHarness)),
+            0,
+            "TEMPO-SC4: credits escaped the storage-owning account"
+        );
+    }
+
+    function _invariantTransientStateReset() internal view {
+        assertEq(
+            uint256(CREDITS.modeOf(address(harness))),
+            uint256(IStorageCredits.Mode.Refund),
+            "TEMPO-SC5: mode persisted across transactions"
+        );
+        assertEq(
+            CREDITS.budgetOf(address(harness)),
+            0,
+            "TEMPO-SC5: direct budget persisted across transactions"
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _expectedAfterTransition(
+        uint64 credits,
+        uint256 oldValue,
+        uint256 newValue,
+        IStorageCredits.Mode mode,
+        uint64 budget
+    )
+        internal
+        pure
+        returns (uint64)
+    {
+        if (oldValue != 0 && newValue == 0) return credits + 1;
+        if (oldValue == 0 && newValue != 0 && credits != 0) {
+            if (mode == IStorageCredits.Mode.Refund) return credits - 1;
+            if (mode == IStorageCredits.Mode.Direct && budget != 0) return credits - 1;
+        }
+        return credits;
+    }
+
+    function _execute(uint256 actorSeed, bytes memory data, bool expectSuccess) internal {
+        uint256 actorIndex = actorSeed % actors.length;
+        address actor = actors[actorIndex];
+        uint64 nonce = uint64(vm.getNonce(actor));
+        bytes memory signedTx = TxBuilder.buildLegacyCallWithGas(
+            vmRlp, vm, address(harness), data, nonce, TX_GAS_LIMIT, actorKeys[actorIndex]
+        );
+
+        vm.coinbase(validator);
+        bool succeeded;
+        try vmExec.executeTransaction(signedTx) {
+            succeeded = true;
+        } catch { }
+
+        assertEq(succeeded, expectSuccess, "TIP-1060 transaction result differed from expectation");
+    }
+
+}

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -6,6 +6,10 @@ import { TxBuilder } from "../helpers/TxBuilder.sol";
 import { StdPrecompiles as PC } from "tempo-std/StdPrecompiles.sol";
 import { IStorageCredits } from "tempo-std/interfaces/IStorageCredits.sol";
 
+error DelegateCallNotAllowed();
+error StaticCallNotAllowed();
+error UnknownFunctionSelector(bytes4 selector);
+
 /// @dev Owns the storage exercised by the invariant. Storage credits belong to this contract,
 ///      irrespective of which externally-owned account submits the transaction.
 contract StorageCreditsHarness {
@@ -57,16 +61,83 @@ contract StorageCreditsHarness {
         values[slot] = value;
     }
 
+    /// @dev Asserts every externally reachable Storage Credits revert/halt path. `OnlyDirectCall`
+    ///      exists in the current SDK ABI but is not emitted by the implementation; the shared
+    ///      precompile wrapper emits `DelegateCallNotAllowed` before dispatch instead.
+    function assertKnownReverts() external {
+        bytes memory result;
+        bool success;
+
+        (success, result) = address(CREDITS)
+            .call(abi.encodeWithSelector(IStorageCredits.setMode.selector, uint256(3)));
+        _assertRevert(success, result, abi.encodeWithSelector(IStorageCredits.InvalidMode.selector));
+
+        (success, result) = address(CREDITS)
+            .delegatecall(abi.encodeCall(IStorageCredits.balanceOf, (address(this))));
+        _assertRevert(success, result, abi.encodeWithSelector(DelegateCallNotAllowed.selector));
+
+        (success, result) =
+            address(CREDITS).staticcall(abi.encodeCall(IStorageCredits.setBudget, (uint64(1))));
+        _assertRevert(success, result, abi.encodeWithSelector(StaticCallNotAllowed.selector));
+
+        bytes4 unknownSelector = 0xdeadbeef;
+        (success, result) = address(CREDITS).call(abi.encodePacked(unknownSelector));
+        _assertRevert(
+            success,
+            result,
+            abi.encodeWithSelector(UnknownFunctionSelector.selector, unknownSelector)
+        );
+
+        (success, result) =
+            address(CREDITS).call(abi.encodePacked(IStorageCredits.balanceOf.selector));
+        _assertRevert(success, result, bytes(""));
+
+        (success, result) = address(CREDITS).call(bytes(""));
+        _assertRevert(success, result, bytes(""));
+
+        (success, result) = address(CREDITS).call{ gas: 1 }(
+            abi.encodeCall(IStorageCredits.balanceOf, (address(this)))
+        );
+        _assertRevert(success, result, bytes(""));
+    }
+
+    function _assertRevert(bool success, bytes memory actual, bytes memory expected) internal pure {
+        require(!success, "expected Storage Credits call to revert");
+        require(keccak256(actual) == keccak256(expected), "unexpected Storage Credits revert");
+    }
+
 }
 
 /// @title TIP-1060 Storage Credits Invariant Tests
 /// @notice Stateful model-based tests for storage-credit conservation and account locality
+/// forge-config: default.invariant.runs = 10
+/// forge-config: default.invariant.depth = 100
 contract StorageCreditsInvariantTest is InvariantBase {
 
     using TxBuilder for *;
 
     uint256 internal constant NUM_SLOTS = 16;
     uint64 internal constant TX_GAS_LIMIT = 1_500_000;
+    string internal constant BRANCH_LOG = "storage-credits-branches.log";
+
+    bytes32 internal constant BRANCH_CREATE_REFUND_EMPTY = keccak256("create/refund/no-credit");
+    bytes32 internal constant BRANCH_CREATE_REFUND_CONSUME = keccak256("create/refund/consume");
+    bytes32 internal constant BRANCH_CREATE_PRESERVE = keccak256("create/preserve");
+    bytes32 internal constant BRANCH_CREATE_DIRECT_EMPTY = keccak256("create/direct/no-credit");
+    bytes32 internal constant BRANCH_CREATE_DIRECT_ZERO = keccak256("create/direct/zero-budget");
+    bytes32 internal constant BRANCH_CREATE_DIRECT_BOUNDED =
+        keccak256("create/direct/consume-bounded");
+    bytes32 internal constant BRANCH_CREATE_DIRECT_UNLIMITED =
+        keccak256("create/direct/consume-unlimited");
+    bytes32 internal constant BRANCH_CLEAR = keccak256("transition/clear");
+    bytes32 internal constant BRANCH_NON_BOUNDARY = keccak256("transition/non-boundary");
+    bytes32 internal constant BRANCH_RECREATE_REFUND = keccak256("recreate/refund");
+    bytes32 internal constant BRANCH_RECREATE_PRESERVE = keccak256("recreate/preserve");
+    bytes32 internal constant BRANCH_RECREATE_DIRECT_ZERO =
+        keccak256("recreate/direct/zero-budget");
+    bytes32 internal constant BRANCH_RECREATE_DIRECT_CONSUME = keccak256("recreate/direct/consume");
+    bytes32 internal constant BRANCH_REVERT_ATOMICITY = keccak256("revert/atomicity");
+    bytes32 internal constant BRANCH_KNOWN_ERRORS = keccak256("revert/known-errors");
 
     IStorageCredits internal constant CREDITS = IStorageCredits(PC.STORAGE_CREDITS_ADDRESS);
 
@@ -75,6 +146,8 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
     mapping(uint256 slot => uint256 value) internal ghost_values;
     uint64 internal ghost_credits;
+    mapping(bytes32 branch => uint256 hits) internal branch_hits;
+    bool internal branch_sweep_complete;
 
     function setUp() public override {
         super.setUp();
@@ -88,6 +161,8 @@ contract StorageCreditsInvariantTest is InvariantBase {
         selectors[1] = this.handler_recreate.selector;
         selectors[2] = this.handler_revertingMutation.selector;
         targetSelector(FuzzSelector({ addr: address(this), selectors: selectors }));
+
+        vm.writeFile(BRANCH_LOG, "");
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -103,6 +178,8 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
+        _ensureBranchSweep(actorSeed);
+
         uint256 slot = slotSeed % NUM_SLOTS;
         uint256 oldValue = ghost_values[slot];
         uint256 newValue = valueSeed % 4 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
@@ -110,6 +187,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
         bool useBudget = mode == IStorageCredits.Mode.Direct && budgetSeed % 2 == 0;
         uint64 budget = uint64(budgetSeed % 3);
 
+        uint64 creditsBefore = ghost_credits;
         uint64 expectedCredits = _expectedAfterTransition(
             ghost_credits, oldValue, newValue, mode, useBudget ? budget : type(uint64).max
         );
@@ -121,6 +199,7 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
         ghost_values[slot] = newValue;
         ghost_credits = expectedCredits;
+        _recordTransition(oldValue, newValue, mode, useBudget, budget, creditsBefore);
         _assertModel();
     }
 
@@ -133,6 +212,8 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
+        _ensureBranchSweep(actorSeed);
+
         uint256 slot = slotSeed % NUM_SLOTS;
         if (ghost_values[slot] == 0) return;
 
@@ -154,6 +235,22 @@ contract StorageCreditsInvariantTest is InvariantBase {
 
         ghost_values[slot] = newValue;
         ghost_credits = expectedCredits;
+        _hit(
+            mode == IStorageCredits.Mode.Refund
+                ? BRANCH_RECREATE_REFUND
+                : mode == IStorageCredits.Mode.Preserve
+                    ? BRANCH_RECREATE_PRESERVE
+                    : (useBudget && budget == 0)
+                        ? BRANCH_RECREATE_DIRECT_ZERO
+                        : BRANCH_RECREATE_DIRECT_CONSUME,
+            mode == IStorageCredits.Mode.Refund
+                ? "recreate/refund"
+                : mode == IStorageCredits.Mode.Preserve
+                    ? "recreate/preserve"
+                    : (useBudget && budget == 0)
+                        ? "recreate/direct/zero-budget"
+                        : "recreate/direct/consume"
+        );
         _assertModel();
     }
 
@@ -165,6 +262,8 @@ contract StorageCreditsInvariantTest is InvariantBase {
     )
         external
     {
+        _ensureBranchSweep(actorSeed);
+
         uint256 slot = slotSeed % NUM_SLOTS;
         uint256 newValue = valueSeed % 2 == 0 ? 0 : bound(valueSeed, 1, type(uint128).max);
         IStorageCredits.Mode mode = IStorageCredits.Mode(modeSeed % 3);
@@ -172,7 +271,11 @@ contract StorageCreditsInvariantTest is InvariantBase {
         bytes memory data = abi.encodeCall(
             StorageCreditsHarness.mutate, (slot, newValue, mode, uint64(1), false, true)
         );
-        _execute(actorSeed, data, false);
+        bytes memory reason = _execute(actorSeed, data, false);
+        assertEq(
+            bytes4(reason), StorageCreditsHarness.ForcedRevert.selector, "wrong revert selector"
+        );
+        _hit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
 
         // The storage transition, credit update, and transient mode change must all unwind.
         _assertModel();
@@ -187,6 +290,24 @@ contract StorageCreditsInvariantTest is InvariantBase {
         _assertModel();
         _invariantAccountLocality();
         _invariantTransientStateReset();
+    }
+
+    function afterInvariant() public view {
+        _assertHit(BRANCH_CREATE_REFUND_EMPTY, "create/refund/no-credit");
+        _assertHit(BRANCH_CREATE_REFUND_CONSUME, "create/refund/consume");
+        _assertHit(BRANCH_CREATE_PRESERVE, "create/preserve");
+        _assertHit(BRANCH_CREATE_DIRECT_EMPTY, "create/direct/no-credit");
+        _assertHit(BRANCH_CREATE_DIRECT_ZERO, "create/direct/zero-budget");
+        _assertHit(BRANCH_CREATE_DIRECT_BOUNDED, "create/direct/consume-bounded");
+        _assertHit(BRANCH_CREATE_DIRECT_UNLIMITED, "create/direct/consume-unlimited");
+        _assertHit(BRANCH_CLEAR, "transition/clear");
+        _assertHit(BRANCH_NON_BOUNDARY, "transition/non-boundary");
+        _assertHit(BRANCH_RECREATE_REFUND, "recreate/refund");
+        _assertHit(BRANCH_RECREATE_PRESERVE, "recreate/preserve");
+        _assertHit(BRANCH_RECREATE_DIRECT_ZERO, "recreate/direct/zero-budget");
+        _assertHit(BRANCH_RECREATE_DIRECT_CONSUME, "recreate/direct/consume");
+        _assertHit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
+        _assertHit(BRANCH_KNOWN_ERRORS, "revert/known-errors");
     }
 
     function _assertModel() internal view {
@@ -249,7 +370,152 @@ contract StorageCreditsInvariantTest is InvariantBase {
         return credits;
     }
 
-    function _execute(uint256 actorSeed, bytes memory data, bool expectSuccess) internal {
+    function _ensureBranchSweep(uint256 actorSeed) internal {
+        if (branch_sweep_complete) return;
+        branch_sweep_complete = true;
+
+        _sweepMutation(actorSeed, 0, 1, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 0, 2, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 1, 1, IStorageCredits.Mode.Direct, 1, true);
+        _sweepMutation(actorSeed, 2, 1, IStorageCredits.Mode.Direct, 0, false);
+        _sweepMutation(actorSeed, 3, 1, IStorageCredits.Mode.Refund, 0, false);
+
+        _sweepMutation(actorSeed, 0, 0, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 4, 1, IStorageCredits.Mode.Refund, 0, false);
+        _sweepMutation(actorSeed, 1, 0, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 5, 1, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 5, 0, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 6, 1, IStorageCredits.Mode.Direct, 0, true);
+        _sweepMutation(actorSeed, 6, 0, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 7, 1, IStorageCredits.Mode.Direct, 1, true);
+        _sweepMutation(actorSeed, 7, 0, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepMutation(actorSeed, 8, 1, IStorageCredits.Mode.Direct, 0, false);
+
+        _sweepRecreate(actorSeed, 8, 2, IStorageCredits.Mode.Refund, 0, false);
+        _sweepRecreate(actorSeed, 8, 3, IStorageCredits.Mode.Preserve, 0, false);
+        _sweepRecreate(actorSeed, 8, 4, IStorageCredits.Mode.Direct, 0, true);
+        _sweepRecreate(actorSeed, 8, 5, IStorageCredits.Mode.Direct, 1, true);
+
+        bytes memory knownErrorsData = abi.encodeCall(StorageCreditsHarness.assertKnownReverts, ());
+        _execute(actorSeed, knownErrorsData, true);
+        _hit(BRANCH_KNOWN_ERRORS, "revert/known-errors");
+
+        bytes memory revertData = abi.encodeCall(
+            StorageCreditsHarness.mutate,
+            (uint256(9), uint256(1), IStorageCredits.Mode.Direct, uint64(1), true, true)
+        );
+        bytes memory reason = _execute(actorSeed, revertData, false);
+        assertEq(
+            bytes4(reason), StorageCreditsHarness.ForcedRevert.selector, "wrong revert selector"
+        );
+        _hit(BRANCH_REVERT_ATOMICITY, "revert/atomicity");
+    }
+
+    function _sweepMutation(
+        uint256 actorSeed,
+        uint256 slot,
+        uint256 newValue,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget
+    )
+        internal
+    {
+        uint256 oldValue = ghost_values[slot];
+        uint64 creditsBefore = ghost_credits;
+        uint64 expectedCredits = _expectedAfterTransition(
+            creditsBefore, oldValue, newValue, mode, useBudget ? budget : type(uint64).max
+        );
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.mutate, (slot, newValue, mode, budget, useBudget, false)
+        );
+        _execute(actorSeed, data, true);
+        ghost_values[slot] = newValue;
+        ghost_credits = expectedCredits;
+        _recordTransition(oldValue, newValue, mode, useBudget, budget, creditsBefore);
+        _assertModel();
+    }
+
+    function _sweepRecreate(
+        uint256 actorSeed,
+        uint256 slot,
+        uint256 newValue,
+        IStorageCredits.Mode mode,
+        uint64 budget,
+        bool useBudget
+    )
+        internal
+    {
+        uint64 expectedCredits = _expectedAfterTransition(
+            ghost_credits + 1, 0, newValue, mode, useBudget ? budget : type(uint64).max
+        );
+        bytes memory data = abi.encodeCall(
+            StorageCreditsHarness.recreate, (slot, newValue, mode, budget, useBudget)
+        );
+        _execute(actorSeed, data, true);
+        ghost_values[slot] = newValue;
+        ghost_credits = expectedCredits;
+
+        if (mode == IStorageCredits.Mode.Refund) {
+            _hit(BRANCH_RECREATE_REFUND, "recreate/refund");
+        } else if (mode == IStorageCredits.Mode.Preserve) {
+            _hit(BRANCH_RECREATE_PRESERVE, "recreate/preserve");
+        } else if (useBudget && budget == 0) {
+            _hit(BRANCH_RECREATE_DIRECT_ZERO, "recreate/direct/zero-budget");
+        } else {
+            _hit(BRANCH_RECREATE_DIRECT_CONSUME, "recreate/direct/consume");
+        }
+        _assertModel();
+    }
+
+    function _recordTransition(
+        uint256 oldValue,
+        uint256 newValue,
+        IStorageCredits.Mode mode,
+        bool useBudget,
+        uint64 budget,
+        uint64 creditsBefore
+    )
+        internal
+    {
+        if (oldValue != 0 && newValue == 0) {
+            _hit(BRANCH_CLEAR, "transition/clear");
+        } else if ((oldValue == 0) == (newValue == 0)) {
+            _hit(BRANCH_NON_BOUNDARY, "transition/non-boundary");
+        } else if (mode == IStorageCredits.Mode.Refund && creditsBefore == 0) {
+            _hit(BRANCH_CREATE_REFUND_EMPTY, "create/refund/no-credit");
+        } else if (mode == IStorageCredits.Mode.Refund) {
+            _hit(BRANCH_CREATE_REFUND_CONSUME, "create/refund/consume");
+        } else if (mode == IStorageCredits.Mode.Preserve) {
+            _hit(BRANCH_CREATE_PRESERVE, "create/preserve");
+        } else if (creditsBefore == 0) {
+            _hit(BRANCH_CREATE_DIRECT_EMPTY, "create/direct/no-credit");
+        } else if (useBudget && budget == 0) {
+            _hit(BRANCH_CREATE_DIRECT_ZERO, "create/direct/zero-budget");
+        } else if (useBudget) {
+            _hit(BRANCH_CREATE_DIRECT_BOUNDED, "create/direct/consume-bounded");
+        } else {
+            _hit(BRANCH_CREATE_DIRECT_UNLIMITED, "create/direct/consume-unlimited");
+        }
+    }
+
+    function _hit(bytes32 branch, string memory label) internal {
+        branch_hits[branch]++;
+        vm.writeLine(BRANCH_LOG, label);
+    }
+
+    function _assertHit(bytes32 branch, string memory label) internal view {
+        assertGt(branch_hits[branch], 0, string.concat("unexercised branch: ", label));
+    }
+
+    function _execute(
+        uint256 actorSeed,
+        bytes memory data,
+        bool expectSuccess
+    )
+        internal
+        returns (bytes memory reason)
+    {
         uint256 actorIndex = actorSeed % actors.length;
         address actor = actors[actorIndex];
         uint64 nonce = uint64(vm.getNonce(actor));
@@ -261,7 +527,9 @@ contract StorageCreditsInvariantTest is InvariantBase {
         bool succeeded;
         try vmExec.executeTransaction(signedTx) {
             succeeded = true;
-        } catch { }
+        } catch (bytes memory revertData) {
+            reason = revertData;
+        }
 
         assertEq(succeeded, expectSuccess, "TIP-1060 transaction result differed from expectation");
     }

--- a/tips/verify/test/invariants/StorageCredits.t.sol
+++ b/tips/verify/test/invariants/StorageCredits.t.sol
@@ -122,6 +122,19 @@ contract StorageCreditsHarness {
                 revert(add(reason, 0x20), mload(reason))
             }
         }
+
+        (success, data) =
+            address(CREDITS).staticcall(abi.encodeCall(IStorageCredits.modeOf, (address(this))));
+        require(success && data.length == 32, "modeOf failed after mode update");
+        IStorageCredits.Mode expectedMode = useBudget ? IStorageCredits.Mode.Direct : mode;
+        require(abi.decode(data, (IStorageCredits.Mode)) == expectedMode, "mode update not applied");
+
+        (success, data) = address(CREDITS)
+            .staticcall(abi.encodeCall(IStorageCredits.budgetOf, (address(this))));
+        require(success && data.length == 32, "budgetOf failed after mode update");
+        uint64 expectedBudget =
+            useBudget ? budget : mode == IStorageCredits.Mode.Direct ? type(uint64).max : 0;
+        require(abi.decode(data, (uint64)) == expectedBudget, "budget update not applied");
     }
 
 }


### PR DESCRIPTION
Adds a stateful TIP-1060 invariant suite using the existing `vmExec.executeTransaction` handler pattern and a single `invariant_storageCreditsGlobal()` entrypoint.

Covers:
- independent zero-crossing credit model across Refund, Preserve, Direct, and bounded Direct modes
- multi-create Direct budget exhaustion and create-before-clear Refund settlement
- dirty `x -> 0 -> y` recreation behavior
- storage, mode, and budget revert atomicity
- account locality across distinct transaction senders, intermediate callers, and storage owners
- transaction-local mode and budget reset

Coverage impact (vs. the initial report on #6804):
- `storage_credits/dispatch.rs`: 0.00% -> 100.00% (+16 lines)
- `storage_credits/mod.rs`: 63.21% -> 71.50% (+16 lines)
- `dispatch.rs`: 66.96% -> 78.26% (+13 lines)
- `lib.rs`: 84.78% -> 91.30% (+9 lines)
- `storage/thread_local.rs`: 69.58% -> 70.63% (+3 lines)
- `error.rs`: 30.00% -> 30.63% (+1 line)
- `storage/evm.rs`: 91.15% -> 91.39% (+1 line)
- `storage/types/bytes_like.rs`: 74.86% -> 75.42% (+1 line)
- Precompiles net: 62.30% -> 62.92% (+62 lines); total: 61.26% -> 61.86%

Validation:
- `FOUNDRY_HARDFORK=prague forge build test/invariants/StorageCredits.t.sol` (Solidity compilation only; the deployed Tempo precompile execution requires the repository-patched Foundry used in CI)
- `git diff --check`

Prompted by: @grandizzy
