### PR TITLE
docs(tip-1042): clarify T8 transition semantics

### DIFF
--- a/tips/tip-1042.md
+++ b/tips/tip-1042.md
@@ -42,6 +42,25 @@ Currently checks both the user as sender and the FeeManager as recipient.
 
 The recipient check is moved to `mint` time, rather than re-checked on every transaction.
 
+### `transferFeePostTx`
+
+When fee pre-collection exceeds the transaction's actual spending, `transferFeePostTx` returns the
+unused amount to the original fee payer. This refund does not perform a separate TIP-403 recipient
+authorization check on the fee payer. The payer was authorized as a sender during
+`collectFeePreTx`, and the refund only restores part of the balance collected from that same
+account; it cannot be redirected to another recipient.
+
+## Activation and Existing Pools
+
+The authorization checks added to `mint` apply only when liquidity is added under T8. Activation
+does not revalidate or migrate pools created before T8. Existing pools are grandfathered and remain
+eligible for fee routing, even if the tokens' current policies would reject a new T8 `mint` call.
+
+Policy checks on later public operations still use the policy in effect when each operation runs.
+Consequently, an issuer can prevent new liquidity or block a subsequent `burn`, `rebalanceSwap`, or
+`distributeFees`, but a policy change does not retroactively remove an existing pool from fee-route
+selection.
+
 ## Public AMM Operations — Full TIP-403 Enforcement
 
 The public AMM operations continue to enforce TIP-403 on all participants, including the FeeManager address, via the underlying `transfer()` and `systemTransferFrom()` calls on TIP-20 tokens.
@@ -148,15 +167,19 @@ This is an expected consequence: the issuer has not opted their token into the f
 
 1. **Fee collection never checks FeeManager**: In `collectFeePreTx`, the FeeManager address is never checked against TIP-403 policies. Only the fee payer is checked as a sender.
 
-2. **Public AMM operations always check FeeManager**: `distributeFees`, `mint`, `burn`, and `rebalanceSwap` continue to enforce TIP-403 on the FeeManager address via the underlying TIP-20 `transfer()` and `systemTransferFrom()` calls.
+2. **Refunds return to the original payer without a recipient check**: `transferFeePostTx` may only restore unused pre-collected tokens to the original fee payer; it does not perform a separate TIP-403 recipient-authorization check.
 
-3. **Mint requires `userToken` sender authorization and recipient authorization for both `address(this)` and `to`**: A call to `mint(userToken, validatorToken, ..., to)` must revert with `PolicyForbids` if any of the following are false under the tokens' current transfer policies: the caller is authorized as a sender on `userToken`; the FeeManager (`address(this)`) is authorized as a recipient on `userToken`; `to` is authorized as a recipient on `userToken`; `to` is authorized as a recipient on `validatorToken`.
+3. **Existing pools remain routable**: T8 does not revalidate pools created before activation. A legacy pool remains eligible for fee routing even if a new `mint` would fail under the current policy.
 
-4. **Burn requires LP-side authorization**: A call to `burn(userToken, validatorToken, ...)` must revert with `PolicyForbids` if `msg.sender` is not authorized as a sender on either `userToken` or `validatorToken`, under their current transfer policies. This is in addition to the existing TIP-403 checks performed by the underlying `transfer()` calls (FeeManager as sender, `to` as recipient).
+4. **Public AMM operations always check FeeManager**: `distributeFees`, `mint`, `burn`, and `rebalanceSwap` continue to enforce TIP-403 on the FeeManager address via the underlying TIP-20 `transfer()` and `systemTransferFrom()` calls.
 
-5. **Policy 0 blocks all paths**: A token with `transferPolicyId = 0` (always-reject) blocks all operations — fee collection (user fails sender check), AMM operations (all participants fail), and fee distribution (all participants fail).
+5. **Mint requires `userToken` sender authorization and recipient authorization for both `address(this)` and `to`**: A call to `mint(userToken, validatorToken, ..., to)` must revert with `PolicyForbids` if any of the following are false under the tokens' current transfer policies: the caller is authorized as a sender on `userToken`; the FeeManager (`address(this)`) is authorized as a recipient on `userToken`; `to` is authorized as a recipient on `userToken`; `to` is authorized as a recipient on `validatorToken`.
 
-6. **Policy 1 allows all paths**: A token with `transferPolicyId = 1` (always-allow) permits all operations without restriction (existing behavior, unchanged).
+6. **Burn requires LP-side authorization**: A call to `burn(userToken, validatorToken, ...)` must revert with `PolicyForbids` if `msg.sender` is not authorized as a sender on either `userToken` or `validatorToken`, under their current transfer policies. This is in addition to the existing TIP-403 checks performed by the underlying `transfer()` calls (FeeManager as sender, `to` as recipient).
+
+7. **Policy 0 blocks new paths**: A token with `transferPolicyId = 0` (always-reject) blocks fee collection and new public AMM operations. This does not by itself remove a grandfathered pool from fee-route selection.
+
+8. **Policy 1 allows all paths**: A token with `transferPolicyId = 1` (always-allow) permits all operations without restriction (existing behavior, unchanged).
 
 ## Test Cases
 

--- a/tips/tip-1042.md
+++ b/tips/tip-1042.md
@@ -177,7 +177,7 @@ This is an expected consequence: the issuer has not opted their token into the f
 
 6. **Burn requires LP-side authorization**: A call to `burn(userToken, validatorToken, ...)` must revert with `PolicyForbids` if `msg.sender` is not authorized as a sender on either `userToken` or `validatorToken`, under their current transfer policies. This is in addition to the existing TIP-403 checks performed by the underlying `transfer()` calls (FeeManager as sender, `to` as recipient).
 
-7. **Policy 0 blocks new paths**: A token with `transferPolicyId = 0` (always-reject) blocks fee collection and new public AMM operations. This does not by itself remove a grandfathered pool from fee-route selection.
+7. **Policy 0 and existing pools**: Policy 0 on the user fee token blocks pre-collection because the fee payer fails the sender check. Policy changes do not remove an existing pool from fee-route selection, including when policy 0 applies to the validator token. Route eligibility does not guarantee that fee collection, public AMM operations, or fee distribution will succeed; those paths apply their own authorization checks.
 
 8. **Policy 1 allows all paths**: A token with `transferPolicyId = 1` (always-allow) permits all operations without restriction (existing behavior, unchanged).
 


### PR DESCRIPTION
Refs SIGP-315, SIGP-316.

Documents that pre-T8 pools remain eligible for routing without revalidation, and that post-transaction refunds return unused fees to the original payer without a separate recipient-authorization check.

Validation: documentation-only change; `git diff --check` passed.

Prompted by: @jenpaff