### PR TITLE
fix(consensus): correct invalid dealer log error

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -635,7 +635,7 @@ where
         .and_then(|log| {
             log.check(round.info())
                 .map(|(dealer, _)| dealer)
-                .ok_or_eyre("not a dealer in the current round")
+                .ok_or_eyre("dealer log signature is invalid")
         })
         .inspect(|_| {
             self.metrics.dealings_read.inc();


### PR DESCRIPTION
Refs SIGP-312.

Rewords the error to report the condition actually established by `SignedDealerLog::check()`: an invalid dealer-log signature, rather than incorrect dealer-set membership.

Validation: `cargo +nightly fmt --all -- --check` and `git diff --check` passed.

Prompted by: @jenpaff