### PR TITLE
ci(bench): report payload builder stop reasons

### DIFF
--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -74,6 +74,9 @@ const BUILDER_DETAIL_ROWS = [
   ['Reverted Txs', 'builder_reverted_txs', v => fmtVal(v, 0)],
   ['Invalid Tx Skips', 'builder_invalid_tx_skips', v => fmtVal(v, 0)],
   ['Nonce Too Low Skips', 'builder_nonce_too_low_skips', v => fmtVal(v, 0)],
+  ['Stop Reason — RLP Size', 'builder_stop_rlp_size', v => fmtVal(v, 0), true],
+  ['Stop Reason — Pool Empty', 'builder_stop_pool_empty', v => fmtVal(v, 0), true],
+  ['Stop Reason — Build Budget', 'builder_stop_build_budget', v => fmtVal(v, 0), true],
   ['Serialized Block Size P50 [KiB]', 'serialized_block_size_p50', fmtKiB],
   ['Serialized Block Size P90 [KiB]', 'serialized_block_size_p90', fmtKiB],
   ['Serialized Block Size P99 [KiB]', 'serialized_block_size_p99', fmtKiB],
@@ -208,9 +211,10 @@ function appendBuilderDetails(lines, summary) {
   lines.push('');
   lines.push('| Metric | Baseline | Feature | Delta |');
   lines.push('|--------|----------|---------|-------|');
-  for (const [label, axis, formatter] of BUILDER_DETAIL_ROWS) {
+  for (const [label, axis, formatter, omitIfBothZero = false] of BUILDER_DETAIL_ROWS) {
     const base = summary.results.baseline[axis];
     const feature = summary.results.feature[axis];
+    if (omitIfBothZero && base === 0 && feature === 0) continue;
     lines.push(`| ${label} | ${formatter(base)} | ${formatter(feature)} | ${fmtInfoChange(base, feature)} |`);
   }
   lines.push('');

--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -62,18 +62,18 @@ const BUILDER_DETAIL_ROWS = [
   ['Pool Fetch P50 [ms]', 'builder_pool_fetch_p50', v => fmtVal(v, 1)],
   ['Pool Fetch P90 [ms]', 'builder_pool_fetch_p90', v => fmtVal(v, 1)],
   ['Pool Fetch P99 [ms]', 'builder_pool_fetch_p99', v => fmtVal(v, 1)],
-  ['Included Tx Exec P50 [ms]', 'builder_included_tx_execution_p50', v => fmtVal(v, 1)],
-  ['Included Tx Exec P90 [ms]', 'builder_included_tx_execution_p90', v => fmtVal(v, 1)],
-  ['Included Tx Exec P99 [ms]', 'builder_included_tx_execution_p99', v => fmtVal(v, 1)],
-  ['Invalid Tx Exec P50 [ms]', 'builder_invalid_tx_execution_p50', v => fmtVal(v, 1)],
-  ['Invalid Tx Exec P90 [ms]', 'builder_invalid_tx_execution_p90', v => fmtVal(v, 1)],
-  ['Invalid Tx Exec P99 [ms]', 'builder_invalid_tx_execution_p99', v => fmtVal(v, 1)],
-  ['Invalid Tx Attempts P50', 'builder_invalid_tx_execution_attempts_p50', v => fmtVal(v, 1)],
-  ['Invalid Tx Attempts P90', 'builder_invalid_tx_execution_attempts_p90', v => fmtVal(v, 1)],
-  ['Invalid Tx Attempts P99', 'builder_invalid_tx_execution_attempts_p99', v => fmtVal(v, 1)],
-  ['Reverted Txs', 'builder_reverted_txs', v => fmtVal(v, 0)],
-  ['Invalid Tx Skips', 'builder_invalid_tx_skips', v => fmtVal(v, 0)],
-  ['Nonce Too Low Skips', 'builder_nonce_too_low_skips', v => fmtVal(v, 0)],
+  ['Included Tx Exec P50 [ms]', 'builder_included_tx_execution_p50', v => fmtVal(v, 1), true],
+  ['Included Tx Exec P90 [ms]', 'builder_included_tx_execution_p90', v => fmtVal(v, 1), true],
+  ['Included Tx Exec P99 [ms]', 'builder_included_tx_execution_p99', v => fmtVal(v, 1), true],
+  ['Invalid Tx Exec P50 [ms]', 'builder_invalid_tx_execution_p50', v => fmtVal(v, 1), true],
+  ['Invalid Tx Exec P90 [ms]', 'builder_invalid_tx_execution_p90', v => fmtVal(v, 1), true],
+  ['Invalid Tx Exec P99 [ms]', 'builder_invalid_tx_execution_p99', v => fmtVal(v, 1), true],
+  ['Invalid Tx Attempts P50', 'builder_invalid_tx_execution_attempts_p50', v => fmtVal(v, 1), true],
+  ['Invalid Tx Attempts P90', 'builder_invalid_tx_execution_attempts_p90', v => fmtVal(v, 1), true],
+  ['Invalid Tx Attempts P99', 'builder_invalid_tx_execution_attempts_p99', v => fmtVal(v, 1), true],
+  ['Reverted Txs', 'builder_reverted_txs', v => fmtVal(v, 0), true],
+  ['Invalid Tx Skips', 'builder_invalid_tx_skips', v => fmtVal(v, 0), true],
+  ['Nonce Too Low Skips', 'builder_nonce_too_low_skips', v => fmtVal(v, 0), true],
   ['Stop Reason — RLP Size', 'builder_stop_rlp_size', v => fmtVal(v, 0), true],
   ['Stop Reason — Pool Empty', 'builder_stop_pool_empty', v => fmtVal(v, 0), true],
   ['Stop Reason — Build Budget', 'builder_stop_build_budget', v => fmtVal(v, 0), true],
@@ -83,9 +83,9 @@ const BUILDER_DETAIL_ROWS = [
   ['Serialized Block Size / Tx P50 [B/tx]', 'serialized_block_size_per_tx_p50', v => fmtVal(v, 1)],
   ['Serialized Block Size / Tx P90 [B/tx]', 'serialized_block_size_per_tx_p90', v => fmtVal(v, 1)],
   ['Serialized Block Size / Tx P99 [B/tx]', 'serialized_block_size_per_tx_p99', v => fmtVal(v, 1)],
-  ['Fill Overhead P50 [ms]', 'builder_fill_overhead_p50', v => fmtVal(v, 1)],
-  ['Fill Overhead P90 [ms]', 'builder_fill_overhead_p90', v => fmtVal(v, 1)],
-  ['Fill Overhead P99 [ms]', 'builder_fill_overhead_p99', v => fmtVal(v, 1)],
+  ['Fill Overhead P50 [ms]', 'builder_fill_overhead_p50', v => fmtVal(v, 1), true],
+  ['Fill Overhead P90 [ms]', 'builder_fill_overhead_p90', v => fmtVal(v, 1), true],
+  ['Fill Overhead P99 [ms]', 'builder_fill_overhead_p99', v => fmtVal(v, 1), true],
   ['Fill Idle P50 [ms]', 'builder_fill_idle_p50', v => fmtVal(v, 1)],
   ['Fill Idle P90 [ms]', 'builder_fill_idle_p90', v => fmtVal(v, 1)],
   ['Fill Idle P99 [ms]', 'builder_fill_idle_p99', v => fmtVal(v, 1)],
@@ -211,10 +211,11 @@ function appendBuilderDetails(lines, summary) {
   lines.push('');
   lines.push('| Metric | Baseline | Feature | Delta |');
   lines.push('|--------|----------|---------|-------|');
-  for (const [label, axis, formatter, omitIfBothZero = false] of BUILDER_DETAIL_ROWS) {
+  const isEmpty = value => !Number.isFinite(value) || value === 0;
+  for (const [label, axis, formatter, omitIfBothEmpty = false] of BUILDER_DETAIL_ROWS) {
     const base = summary.results.baseline[axis];
     const feature = summary.results.feature[axis];
-    if (omitIfBothZero && base === 0 && feature === 0) continue;
+    if (omitIfBothEmpty && isEmpty(base) && isEmpty(feature)) continue;
     lines.push(`| ${label} | ${formatter(base)} | ${formatter(feature)} | ${fmtInfoChange(base, feature)} |`);
   }
   lines.push('');

--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -74,6 +74,7 @@ const BUILDER_DETAIL_ROWS = [
   ['Reverted Txs', 'builder_reverted_txs', v => fmtVal(v, 0), true],
   ['Invalid Tx Skips', 'builder_invalid_tx_skips', v => fmtVal(v, 0), true],
   ['Nonce Too Low Skips', 'builder_nonce_too_low_skips', v => fmtVal(v, 0), true],
+  ['Stop Reason — Gas Limit', 'builder_stop_gas_limit', v => fmtVal(v, 0), true],
   ['Stop Reason — RLP Size', 'builder_stop_rlp_size', v => fmtVal(v, 0), true],
   ['Stop Reason — Pool Empty', 'builder_stop_pool_empty', v => fmtVal(v, 0), true],
   ['Stop Reason — Build Budget', 'builder_stop_build_budget', v => fmtVal(v, 0), true],

--- a/tempo.nu
+++ b/tempo.nu
@@ -955,6 +955,12 @@ def generate-summary [
     mut feature_builder_invalid_tx_skips = []
     mut baseline_builder_nonce_too_low_skips = []
     mut feature_builder_nonce_too_low_skips = []
+    mut baseline_builder_stop_rlp_size = []
+    mut feature_builder_stop_rlp_size = []
+    mut baseline_builder_stop_pool_empty = []
+    mut feature_builder_stop_pool_empty = []
+    mut baseline_builder_stop_build_budget = []
+    mut feature_builder_stop_build_budget = []
     mut baseline_builder_fill_idle_samples = []
     mut feature_builder_fill_idle_samples = []
     mut baseline_validation_latency_values = []
@@ -1128,6 +1134,7 @@ def generate-summary [
         "reth_tempo_payload_builder_reverted_transactions_sum"
         "reth_tempo_payload_builder_reverted_transactions_count"
         "reth_tempo_payload_builder_pool_transactions_skipped_total"
+        "reth_tempo_payload_builder_block_build_stop_total"
         "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds_sum"
         "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds_count"
         "reth_tempo_payload_builder_payload_build_duration_seconds_sum"
@@ -1258,6 +1265,17 @@ def generate-summary [
         }
         let builder_invalid_tx_skips = do $builder_pool_tx_skips_for_reason "invalid_tx"
         let builder_nonce_too_low_skips = do $builder_pool_tx_skips_for_reason "nonce_too_low"
+        let builder_stop_samples = ($metric_samples | where name == "reth_tempo_payload_builder_block_build_stop_total")
+        let builder_stops_for_reason = { |reason: string|
+            let samples = (
+                $builder_stop_samples
+                    | where { |sample| ($sample.labels | get -o reason | default "") == $reason }
+            )
+            do $counter_delta_total $samples "reth_tempo_payload_builder_block_build_stop_total"
+        }
+        let builder_stop_rlp_size = do $builder_stops_for_reason "rlp_block_size_limit"
+        let builder_stop_pool_empty = do $builder_stops_for_reason "tx_pool_empty"
+        let builder_stop_build_budget = do $builder_stops_for_reason "build_budget"
         let builder_fill_idle_samples = (do $optional_counter_metric_values "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds" 1000.0)
         let validation_latency_values = (do $optional_counter_metric_values "reth_consensus_engine_beacon_new_payload_latency" 1000.0)
         let builder_gas_values = (do $optional_counter_metric_values "reth_tempo_payload_builder_gas_per_second" 1.0)
@@ -1279,6 +1297,9 @@ def generate-summary [
             $baseline_builder_reverted_txs = ($baseline_builder_reverted_txs | append $builder_reverted_txs)
             $baseline_builder_invalid_tx_skips = ($baseline_builder_invalid_tx_skips | append $builder_invalid_tx_skips)
             $baseline_builder_nonce_too_low_skips = ($baseline_builder_nonce_too_low_skips | append $builder_nonce_too_low_skips)
+            $baseline_builder_stop_rlp_size = ($baseline_builder_stop_rlp_size | append $builder_stop_rlp_size)
+            $baseline_builder_stop_pool_empty = ($baseline_builder_stop_pool_empty | append $builder_stop_pool_empty)
+            $baseline_builder_stop_build_budget = ($baseline_builder_stop_build_budget | append $builder_stop_build_budget)
             $baseline_builder_fill_idle_samples = ($baseline_builder_fill_idle_samples | append $builder_fill_idle_samples)
             $baseline_validation_latency_values = ($baseline_validation_latency_values | append $validation_latency_values)
             $baseline_builder_gas_values = ($baseline_builder_gas_values | append $builder_gas_values)
@@ -1295,6 +1316,9 @@ def generate-summary [
             $feature_builder_reverted_txs = ($feature_builder_reverted_txs | append $builder_reverted_txs)
             $feature_builder_invalid_tx_skips = ($feature_builder_invalid_tx_skips | append $builder_invalid_tx_skips)
             $feature_builder_nonce_too_low_skips = ($feature_builder_nonce_too_low_skips | append $builder_nonce_too_low_skips)
+            $feature_builder_stop_rlp_size = ($feature_builder_stop_rlp_size | append $builder_stop_rlp_size)
+            $feature_builder_stop_pool_empty = ($feature_builder_stop_pool_empty | append $builder_stop_pool_empty)
+            $feature_builder_stop_build_budget = ($feature_builder_stop_build_budget | append $builder_stop_build_budget)
             $feature_builder_fill_idle_samples = ($feature_builder_fill_idle_samples | append $builder_fill_idle_samples)
             $feature_validation_latency_values = ($feature_validation_latency_values | append $validation_latency_values)
             $feature_builder_gas_values = ($feature_builder_gas_values | append $builder_gas_values)
@@ -1399,6 +1423,12 @@ def generate-summary [
     let f_builder_invalid_tx_skips = if ($feature_builder_invalid_tx_skips | length) > 0 { $feature_builder_invalid_tx_skips | math sum | math round --precision 0 } else { 0.0 }
     let b_builder_nonce_too_low_skips = if ($baseline_builder_nonce_too_low_skips | length) > 0 { $baseline_builder_nonce_too_low_skips | math sum | math round --precision 0 } else { 0.0 }
     let f_builder_nonce_too_low_skips = if ($feature_builder_nonce_too_low_skips | length) > 0 { $feature_builder_nonce_too_low_skips | math sum | math round --precision 0 } else { 0.0 }
+    let b_builder_stop_rlp_size = if ($baseline_builder_stop_rlp_size | length) > 0 { $baseline_builder_stop_rlp_size | math sum | math round --precision 0 } else { 0.0 }
+    let f_builder_stop_rlp_size = if ($feature_builder_stop_rlp_size | length) > 0 { $feature_builder_stop_rlp_size | math sum | math round --precision 0 } else { 0.0 }
+    let b_builder_stop_pool_empty = if ($baseline_builder_stop_pool_empty | length) > 0 { $baseline_builder_stop_pool_empty | math sum | math round --precision 0 } else { 0.0 }
+    let f_builder_stop_pool_empty = if ($feature_builder_stop_pool_empty | length) > 0 { $feature_builder_stop_pool_empty | math sum | math round --precision 0 } else { 0.0 }
+    let b_builder_stop_build_budget = if ($baseline_builder_stop_build_budget | length) > 0 { $baseline_builder_stop_build_budget | math sum | math round --precision 0 } else { 0.0 }
+    let f_builder_stop_build_budget = if ($feature_builder_stop_build_budget | length) > 0 { $feature_builder_stop_build_budget | math sum | math round --precision 0 } else { 0.0 }
     let b_builder_fill_idle = do $compute_value_stats $baseline_builder_fill_idle_samples
     let f_builder_fill_idle = do $compute_value_stats $feature_builder_fill_idle_samples
     let b_validation = do $compute_value_stats $baseline_validation_latency_values
@@ -1637,6 +1667,9 @@ def generate-summary [
                 builder_reverted_txs: $b_builder_reverted_txs
                 builder_invalid_tx_skips: $b_builder_invalid_tx_skips
                 builder_nonce_too_low_skips: $b_builder_nonce_too_low_skips
+                builder_stop_rlp_size: $b_builder_stop_rlp_size
+                builder_stop_pool_empty: $b_builder_stop_pool_empty
+                builder_stop_build_budget: $b_builder_stop_build_budget
                 builder_fill_idle_p50: $b_builder_fill_idle.p50
                 builder_fill_idle_p90: $b_builder_fill_idle.p90
                 builder_fill_idle_p99: $b_builder_fill_idle.p99
@@ -1675,6 +1708,9 @@ def generate-summary [
                 builder_reverted_txs: $f_builder_reverted_txs
                 builder_invalid_tx_skips: $f_builder_invalid_tx_skips
                 builder_nonce_too_low_skips: $f_builder_nonce_too_low_skips
+                builder_stop_rlp_size: $f_builder_stop_rlp_size
+                builder_stop_pool_empty: $f_builder_stop_pool_empty
+                builder_stop_build_budget: $f_builder_stop_build_budget
                 builder_fill_idle_p50: $f_builder_fill_idle.p50
                 builder_fill_idle_p90: $f_builder_fill_idle.p90
                 builder_fill_idle_p99: $f_builder_fill_idle.p99
@@ -1713,6 +1749,9 @@ def generate-summary [
                 builder_reverted_txs: (do $delta $b_builder_reverted_txs $f_builder_reverted_txs)
                 builder_invalid_tx_skips: (do $delta $b_builder_invalid_tx_skips $f_builder_invalid_tx_skips)
                 builder_nonce_too_low_skips: (do $delta $b_builder_nonce_too_low_skips $f_builder_nonce_too_low_skips)
+                builder_stop_rlp_size: (do $delta $b_builder_stop_rlp_size $f_builder_stop_rlp_size)
+                builder_stop_pool_empty: (do $delta $b_builder_stop_pool_empty $f_builder_stop_pool_empty)
+                builder_stop_build_budget: (do $delta $b_builder_stop_build_budget $f_builder_stop_build_budget)
                 builder_fill_idle_p50: (do $delta $b_builder_fill_idle.p50 $f_builder_fill_idle.p50)
                 builder_fill_idle_p90: (do $delta $b_builder_fill_idle.p90 $f_builder_fill_idle.p90)
                 builder_fill_idle_p99: (do $delta $b_builder_fill_idle.p99 $f_builder_fill_idle.p99)

--- a/tempo.nu
+++ b/tempo.nu
@@ -957,6 +957,8 @@ def generate-summary [
     mut feature_builder_nonce_too_low_skips = []
     mut baseline_builder_stop_rlp_size = []
     mut feature_builder_stop_rlp_size = []
+    mut baseline_builder_stop_gas_limit = []
+    mut feature_builder_stop_gas_limit = []
     mut baseline_builder_stop_pool_empty = []
     mut feature_builder_stop_pool_empty = []
     mut baseline_builder_stop_build_budget = []
@@ -1274,6 +1276,7 @@ def generate-summary [
             do $counter_delta_total $samples "reth_tempo_payload_builder_block_build_stop_total"
         }
         let builder_stop_rlp_size = do $builder_stops_for_reason "rlp_block_size_limit"
+        let builder_stop_gas_limit = do $builder_stops_for_reason "gas_limit"
         let builder_stop_pool_empty = do $builder_stops_for_reason "tx_pool_empty"
         let builder_stop_build_budget = do $builder_stops_for_reason "build_budget"
         let builder_fill_idle_samples = (do $optional_counter_metric_values "reth_tempo_payload_builder_normal_transaction_fill_idle_duration_seconds" 1000.0)
@@ -1298,6 +1301,7 @@ def generate-summary [
             $baseline_builder_invalid_tx_skips = ($baseline_builder_invalid_tx_skips | append $builder_invalid_tx_skips)
             $baseline_builder_nonce_too_low_skips = ($baseline_builder_nonce_too_low_skips | append $builder_nonce_too_low_skips)
             $baseline_builder_stop_rlp_size = ($baseline_builder_stop_rlp_size | append $builder_stop_rlp_size)
+            $baseline_builder_stop_gas_limit = ($baseline_builder_stop_gas_limit | append $builder_stop_gas_limit)
             $baseline_builder_stop_pool_empty = ($baseline_builder_stop_pool_empty | append $builder_stop_pool_empty)
             $baseline_builder_stop_build_budget = ($baseline_builder_stop_build_budget | append $builder_stop_build_budget)
             $baseline_builder_fill_idle_samples = ($baseline_builder_fill_idle_samples | append $builder_fill_idle_samples)
@@ -1317,6 +1321,7 @@ def generate-summary [
             $feature_builder_invalid_tx_skips = ($feature_builder_invalid_tx_skips | append $builder_invalid_tx_skips)
             $feature_builder_nonce_too_low_skips = ($feature_builder_nonce_too_low_skips | append $builder_nonce_too_low_skips)
             $feature_builder_stop_rlp_size = ($feature_builder_stop_rlp_size | append $builder_stop_rlp_size)
+            $feature_builder_stop_gas_limit = ($feature_builder_stop_gas_limit | append $builder_stop_gas_limit)
             $feature_builder_stop_pool_empty = ($feature_builder_stop_pool_empty | append $builder_stop_pool_empty)
             $feature_builder_stop_build_budget = ($feature_builder_stop_build_budget | append $builder_stop_build_budget)
             $feature_builder_fill_idle_samples = ($feature_builder_fill_idle_samples | append $builder_fill_idle_samples)
@@ -1425,6 +1430,8 @@ def generate-summary [
     let f_builder_nonce_too_low_skips = if ($feature_builder_nonce_too_low_skips | length) > 0 { $feature_builder_nonce_too_low_skips | math sum | math round --precision 0 } else { 0.0 }
     let b_builder_stop_rlp_size = if ($baseline_builder_stop_rlp_size | length) > 0 { $baseline_builder_stop_rlp_size | math sum | math round --precision 0 } else { 0.0 }
     let f_builder_stop_rlp_size = if ($feature_builder_stop_rlp_size | length) > 0 { $feature_builder_stop_rlp_size | math sum | math round --precision 0 } else { 0.0 }
+    let b_builder_stop_gas_limit = if ($baseline_builder_stop_gas_limit | length) > 0 { $baseline_builder_stop_gas_limit | math sum | math round --precision 0 } else { 0.0 }
+    let f_builder_stop_gas_limit = if ($feature_builder_stop_gas_limit | length) > 0 { $feature_builder_stop_gas_limit | math sum | math round --precision 0 } else { 0.0 }
     let b_builder_stop_pool_empty = if ($baseline_builder_stop_pool_empty | length) > 0 { $baseline_builder_stop_pool_empty | math sum | math round --precision 0 } else { 0.0 }
     let f_builder_stop_pool_empty = if ($feature_builder_stop_pool_empty | length) > 0 { $feature_builder_stop_pool_empty | math sum | math round --precision 0 } else { 0.0 }
     let b_builder_stop_build_budget = if ($baseline_builder_stop_build_budget | length) > 0 { $baseline_builder_stop_build_budget | math sum | math round --precision 0 } else { 0.0 }
@@ -1668,6 +1675,7 @@ def generate-summary [
                 builder_invalid_tx_skips: $b_builder_invalid_tx_skips
                 builder_nonce_too_low_skips: $b_builder_nonce_too_low_skips
                 builder_stop_rlp_size: $b_builder_stop_rlp_size
+                builder_stop_gas_limit: $b_builder_stop_gas_limit
                 builder_stop_pool_empty: $b_builder_stop_pool_empty
                 builder_stop_build_budget: $b_builder_stop_build_budget
                 builder_fill_idle_p50: $b_builder_fill_idle.p50
@@ -1709,6 +1717,7 @@ def generate-summary [
                 builder_invalid_tx_skips: $f_builder_invalid_tx_skips
                 builder_nonce_too_low_skips: $f_builder_nonce_too_low_skips
                 builder_stop_rlp_size: $f_builder_stop_rlp_size
+                builder_stop_gas_limit: $f_builder_stop_gas_limit
                 builder_stop_pool_empty: $f_builder_stop_pool_empty
                 builder_stop_build_budget: $f_builder_stop_build_budget
                 builder_fill_idle_p50: $f_builder_fill_idle.p50
@@ -1750,6 +1759,7 @@ def generate-summary [
                 builder_invalid_tx_skips: (do $delta $b_builder_invalid_tx_skips $f_builder_invalid_tx_skips)
                 builder_nonce_too_low_skips: (do $delta $b_builder_nonce_too_low_skips $f_builder_nonce_too_low_skips)
                 builder_stop_rlp_size: (do $delta $b_builder_stop_rlp_size $f_builder_stop_rlp_size)
+                builder_stop_gas_limit: (do $delta $b_builder_stop_gas_limit $f_builder_stop_gas_limit)
                 builder_stop_pool_empty: (do $delta $b_builder_stop_pool_empty $f_builder_stop_pool_empty)
                 builder_stop_build_budget: (do $delta $b_builder_stop_build_budget $f_builder_stop_build_budget)
                 builder_fill_idle_p50: (do $delta $b_builder_fill_idle.p50 $f_builder_fill_idle.p50)


### PR DESCRIPTION
## Summary
- collect payload-builder stop counters for gas limit, RLP size, empty pool, and build budget
- show the stop-reason breakdown in Builder details, omitting rows when both sides are empty
- also omit both-empty rows for included tx execution, invalid tx execution, invalid tx attempts, reverted transactions, invalid tx skips, nonce-too-low skips, and fill overhead

## Validation
- `nu --commands 'source tempo.nu'`
- `node --check .github/scripts/bench-e2e-classify.js`
- focused Builder details render assertions
- `git diff --check`

Prompted by: @shekhirin