### PR TITLE
ci(bench): restore reusable workflow permissions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,10 +15,10 @@ env:
 
 name: bench
 
-permissions: # zizmor: ignore[excessive-permissions] -- reusable workflows require these permissions
+permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  issues: write # zizmor: ignore[excessive-permissions] -- required by reusable workflows
+  pull-requests: write # zizmor: ignore[excessive-permissions] -- required by reusable workflows
 
 jobs:
   tempo-bench-ack:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -17,6 +17,8 @@ name: bench
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   tempo-bench-ack:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,7 +15,7 @@ env:
 
 name: bench
 
-permissions:
+permissions: # zizmor: ignore[excessive-permissions] -- reusable workflows require these permissions
   contents: read
   issues: write
   pull-requests: write


### PR DESCRIPTION
## Summary

- restore `issues: write` and `pull-requests: write` at the bench caller workflow level
- allow the reusable e2e and replay workflows to request their required permissions
- prevent GitHub Actions startup failures before jobs are created

## Validation

- `git diff --check`

Prompted by: @shekhirin