### PR TITLE
ci(bench): remove target TPS from scenario names

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1128,8 +1128,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
         $tracy_capture_started = true
     }
 
-    let tps_k = ($ctx.tps // 1000)
-    let scenario = $"($ctx.preset)-($tps_k)k"
+    let scenario = (txgen-benchmark-scenario-name $ctx.preset $ctx.tps)
     let phase_clickhouse_url = if $ctx.clickhouse_url != "" and ($ctx.clickhouse_run == "" or $ctx.clickhouse_run == $phase) {
         $ctx.clickhouse_url
     } else {

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1128,7 +1128,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
         $tracy_capture_started = true
     }
 
-    let scenario = (txgen-benchmark-scenario-name $ctx.preset $ctx.tps)
+    let scenario = $ctx.preset
     let phase_clickhouse_url = if $ctx.clickhouse_url != "" and ($ctx.clickhouse_run == "" or $ctx.clickhouse_run == $phase) {
         $ctx.clickhouse_url
     } else {

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -247,7 +247,7 @@ def "main run" [
     let resolved_scenario = if $scenario != "" {
         $scenario
     } else {
-        txgen-benchmark-scenario-name $preset $tps
+        $preset
     }
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
         error make { msg: "--baseline and --feature must both be provided for txgen comparison mode" }

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -247,8 +247,7 @@ def "main run" [
     let resolved_scenario = if $scenario != "" {
         $scenario
     } else {
-        let tps_k = ($tps // 1000)
-        $"($preset)-($tps_k)k"
+        txgen-benchmark-scenario-name $preset $tps
     }
     if ($baseline != "" and $feature == "") or ($baseline == "" and $feature != "") {
         error make { msg: "--baseline and --feature must both be provided for txgen comparison mode" }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -132,15 +132,6 @@ def txgen-scenario-file-stem [scenario_id: string] {
         | str replace -a "/" "-"
 }
 
-def txgen-benchmark-scenario-name [preset: string, tps: int] {
-    if $preset == "default" {
-        "default"
-    } else {
-        let tps_k = ($tps // 1000)
-        $"($preset)-($tps_k)k"
-    }
-}
-
 def txgen-tip20-uses-fee-amm [scenario: record] {
     $scenario.fee_token == "any_tip20"
 }

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -132,6 +132,15 @@ def txgen-scenario-file-stem [scenario_id: string] {
         | str replace -a "/" "-"
 }
 
+def txgen-benchmark-scenario-name [preset: string, tps: int] {
+    if $preset == "default" {
+        "default"
+    } else {
+        let tps_k = ($tps // 1000)
+        $"($preset)-($tps_k)k"
+    }
+}
+
 def txgen-tip20-uses-fee-amm [scenario: record] {
     $scenario.fee_token == "any_tip20"
 }


### PR DESCRIPTION
## Summary
- report benchmark scenarios using only their preset/scenario identifier
- remove the target-TPS suffix from all automatically generated benchmark names
- preserve explicit `--scenario` overrides
- apply the naming consistently across both txgen benchmark entry paths

## Validation
- sourced `bench-e2e.nu` and `contrib/bench/bench-txgen.nu` with Nushell
- confirmed no target-TPS scenario-name construction remains in either entry path
- `git diff --check`

Prompted by: @shekhirin