### PR TITLE
docs(tip-1091): define proxy-safe portal storage

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -86,14 +86,17 @@ MUST NOT rely on nonce-based address prediction. Instead, the native factory:
 3. computes the portal vanity address;
 4. verifies that account has no existing code, storage, or EIP-7702 delegation;
 5. etches `portal_proxy_runtime` at that address;
-6. initializes the portal's storage-backed state with the `createZone`
-   parameters;
+6. calls the portal's factory-only initializer with the `createZone` parameters;
 7. records the zone metadata, marks the portal in `isZonePortal`, and emits
    `ZoneCreated`.
 
 The portal account MUST NOT contain a full copy of `ZonePortal` runtime
 bytecode. It MUST route to one protocol-managed portal logic implementation,
 while each portal keeps independent observable state.
+
+Only `ZONE_FACTORY_ADDRESS` MAY call a portal initializer, and initialization
+MUST succeed at most once. The factory MUST initialize a newly etched portal in
+the same `createZone` operation before the portal becomes externally usable.
 
 The initialized portal MUST use the shared messenger returned by
 `ZoneFactory.messenger()`. Withdrawal callback behavior MUST match the canonical

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -86,8 +86,8 @@ MUST NOT rely on nonce-based address prediction. Instead, the native factory:
 3. computes the portal vanity address;
 4. verifies that account has no existing code, storage, or EIP-7702 delegation;
 5. etches `portal_proxy_runtime` at that address;
-6. initializes portal state as if the `ZonePortal.sol` constructor ran with the
-   `createZone` parameters;
+6. initializes the portal's storage-backed state with the `createZone`
+   parameters;
 7. records the zone metadata, marks the portal in `isZonePortal`, and emits
    `ZoneCreated`.
 
@@ -105,7 +105,21 @@ private zone fallback recipient; a withdrawal bounce-back carries the nonce back
 to the zone, where the inbox resolves and consumes the mapping. This keeps the
 recipient out of L1-visible data while preserving deterministic execution.
 
-Replacing the central portal logic implementation is a Tempo protocol upgrade.
+The activation hardfork MUST etch the initial `ZonePortal` runtime at
+`ZONE_PORTAL_LOGIC_ADDRESS`. A later hardfork MAY replace the runtime at that
+same address. Because every portal proxy delegates to the fixed logic address,
+the replacement upgrades all existing portals without changing their proxy
+bytecode or per-portal storage. Replacement implementations MUST preserve the
+existing storage layout or the hardfork MUST migrate affected portal state.
+
+Once native precompiles can perform the external EVM calls required by the
+portal flow, a later hardfork MAY register the `ZONE_PORTAL_PREFIX` address
+family for native dispatch. The native implementation MUST operate on the
+called portal account's existing storage and preserve the `IZonePortal` ABI,
+events, and authorization behavior. The migration MUST NOT change portal
+addresses or require per-zone state migration solely because execution becomes
+native; the existing proxy runtime MAY remain as observable account code while
+native dispatch takes precedence.
 
 ## Out Of Scope
 

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -97,6 +97,8 @@ while each portal keeps independent observable state.
 Only `ZONE_FACTORY_ADDRESS` MAY call a portal initializer, and initialization
 MUST succeed at most once. The factory MUST initialize a newly etched portal in
 the same `createZone` operation before the portal becomes externally usable.
+`ZONE_FACTORY_ADDRESS` MUST remain constant across portal logic deployments and
+upgrades; it MUST NOT be derived from the address that deploys the logic.
 
 The initialized portal MUST use the shared messenger returned by
 `ZoneFactory.messenger()`. Withdrawal callback behavior MUST match the canonical

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -329,7 +329,7 @@ interface IZoneTxContext {
                 ZONE PORTAL STORAGE SLOT CONSTANTS
 //////////////////////////////////////////////////////////////*/
 
-// ZonePortal storage layout (non-immutable variables only):
+// ZonePortal storage layout:
 //   slot 0: sequencer (address)
 //   slot 1: admin (address)
 //   slot 2: pendingSequencer (address)
@@ -346,6 +346,9 @@ interface IZoneTxContext {
 //   slot 13: _withdrawalQueue.slots (mapping(uint256 => bytes32))
 //   slot 14: rpcUrl (string)
 //   slot 15: pendingAdmin (address)
+//   slot 16: _withdrawalReentrancyStatus (uint256)
+//   slot 17: zoneId (uint32) + messenger (address) [packed]
+//   slot 18: verifier (address) + genesisTempoBlockNumber (uint64) [packed]
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -623,7 +623,8 @@ interface IZonePortal {
         bytes32 genesisBlockHash,
         uint64 genesisTempoBlockNumber,
         string calldata rpcUrl
-    ) external;
+    )
+        external;
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -348,7 +348,7 @@ interface IZoneTxContext {
 //   slot 15: pendingAdmin (address)
 //   slot 16: _withdrawalReentrancyStatus (uint256)
 //   slot 17: zoneId (uint32) + messenger (address) [packed]
-//   slot 18: verifier (address) + genesisTempoBlockNumber (uint64) [packed]
+//   slot 18: verifier (address) + genesisTempoBlockNumber (uint64) + _initialized (bool) [packed]
 //
 // These constants are the single source of truth for cross-domain reads.
 // ZoneConfig and ZoneInbox use them to read portal state via
@@ -588,6 +588,8 @@ interface IZonePortal {
 
     error NotSequencer();
     error NotAdmin();
+    error NotFactory();
+    error AlreadyInitialized();
     error NotPendingSequencer();
     error NotPendingAdmin();
     error InvalidProof();
@@ -610,6 +612,18 @@ interface IZonePortal {
     error TokenAlreadyEnabled();
     error InvalidBouncebackRecipient();
     error InvalidDepositTransition();
+
+    function initialize(
+        uint32 zoneId,
+        address initialToken,
+        address messenger,
+        address admin,
+        address sequencer,
+        address verifier,
+        bytes32 genesisBlockHash,
+        uint64 genesisTempoBlockNumber,
+        string calldata rpcUrl
+    ) external;
 
     /// @notice Fixed gas value for deposit fee calculation (100,000 gas)
     function FIXED_DEPOSIT_GAS() external view returns (uint64);

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -97,17 +97,18 @@ abstract contract ZoneFactory is IZoneFactory {
         // precompile, represented by abstract hooks here so this artifact documents
         // the required behavior without pretending it is ordinary Solidity.
         _nativeEtchPortalProxy(portal, portalProxyRuntime());
-        ZonePortal(portal).initialize(
-            zoneId,
-            params.initialToken,
-            _messenger,
-            params.admin,
-            params.sequencer,
-            params.verifier,
-            params.zoneParams.genesisBlockHash,
-            params.zoneParams.genesisTempoBlockNumber,
-            params.rpcUrl
-        );
+        ZonePortal(portal)
+            .initialize(
+                zoneId,
+                params.initialToken,
+                _messenger,
+                params.admin,
+                params.sequencer,
+                params.verifier,
+                params.zoneParams.genesisBlockHash,
+                params.zoneParams.genesisTempoBlockNumber,
+                params.rpcUrl
+            );
 
         _zones[zoneId] = ZoneInfo({
             zoneId: zoneId,

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -88,10 +88,9 @@ abstract contract ZoneFactory is IZoneFactory {
         //    the `portal` account. The runtime delegatecalls into
         //    ZONE_PORTAL_LOGIC_ADDRESS, the single protocol-managed ZonePortal logic
         //    implementation.
-        // 3. The protocol initializes the portal account's storage/immutable
-        //    equivalents with the same values the ZonePortal constructor would have
-        //    received: zone ID, initial token, shared messenger, admin, sequencer,
-        //    verifier, genesis block hash, genesis Tempo block number, and RPC URL.
+        // 3. The protocol initializes the portal account's storage with the zone ID,
+        //    initial token, shared messenger, admin, sequencer, verifier, genesis block
+        //    hash, genesis Tempo block number, and RPC URL.
         //
         // The exact host operations are implementation details of the Tempo
         // precompile, represented by abstract hooks here so this artifact documents
@@ -141,7 +140,7 @@ abstract contract ZoneFactory is IZoneFactory {
     /// @dev Native host hook: etch proxy/caller runtime bytecode at `portal`.
     function _nativeEtchPortalProxy(address portal, bytes memory runtime) internal virtual;
 
-    /// @dev Native host hook: initialize state equivalent to the ZonePortal constructor.
+    /// @dev Native host hook: initialize the portal's storage-backed state.
     function _nativeInitializePortal(
         address portal,
         uint32 zoneId,

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import { IZoneFactory, ZoneInfo } from "../interfaces/IZone.sol";
+import { ZonePortal } from "./ZonePortal.sol";
 import { StdPrecompiles } from "tempo-std/StdPrecompiles.sol";
 import { ITIP20Factory } from "tempo-std/interfaces/ITIP20Factory.sol";
 
@@ -88,7 +89,7 @@ abstract contract ZoneFactory is IZoneFactory {
         //    the `portal` account. The runtime delegatecalls into
         //    ZONE_PORTAL_LOGIC_ADDRESS, the single protocol-managed ZonePortal logic
         //    implementation.
-        // 3. The protocol initializes the portal account's storage with the zone ID,
+        // 3. This factory calls the portal's one-time initializer with the zone ID,
         //    initial token, shared messenger, admin, sequencer, verifier, genesis block
         //    hash, genesis Tempo block number, and RPC URL.
         //
@@ -96,7 +97,17 @@ abstract contract ZoneFactory is IZoneFactory {
         // precompile, represented by abstract hooks here so this artifact documents
         // the required behavior without pretending it is ordinary Solidity.
         _nativeEtchPortalProxy(portal, portalProxyRuntime());
-        _nativeInitializePortal(portal, zoneId, params);
+        ZonePortal(portal).initialize(
+            zoneId,
+            params.initialToken,
+            _messenger,
+            params.admin,
+            params.sequencer,
+            params.verifier,
+            params.zoneParams.genesisBlockHash,
+            params.zoneParams.genesisTempoBlockNumber,
+            params.rpcUrl
+        );
 
         _zones[zoneId] = ZoneInfo({
             zoneId: zoneId,
@@ -139,15 +150,6 @@ abstract contract ZoneFactory is IZoneFactory {
 
     /// @dev Native host hook: etch proxy/caller runtime bytecode at `portal`.
     function _nativeEtchPortalProxy(address portal, bytes memory runtime) internal virtual;
-
-    /// @dev Native host hook: initialize the portal's storage-backed state.
-    function _nativeInitializePortal(
-        address portal,
-        uint32 zoneId,
-        CreateZoneParams calldata params
-    )
-        internal
-        virtual;
 
     /*//////////////////////////////////////////////////////////////
                                  VIEWS

--- a/tips/verify/src/zones/tempo/ZonePortal.sol
+++ b/tips/verify/src/zones/tempo/ZonePortal.sol
@@ -68,11 +68,6 @@ contract ZonePortal is IZonePortal {
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
 
-    uint32 public immutable zoneId;
-    address public immutable verifier;
-    address public immutable messenger;
-    uint64 public immutable genesisTempoBlockNumber;
-
     /// @notice Current sequencer address
     address public sequencer;
 
@@ -132,6 +127,14 @@ contract ZonePortal is IZonePortal {
 
     /// @notice Reentrancy guard for withdrawal delivery.
     uint256 internal _withdrawalReentrancyStatus;
+
+    /// @notice Zone metadata stored after the cross-domain layout.
+    /// @dev These values must remain in account storage so each delegatecall proxy observes its
+    ///      own metadata. Keep them after the established slots read directly by zone contracts.
+    uint32 public zoneId;
+    address public messenger;
+    address public verifier;
+    uint64 public genesisTempoBlockNumber;
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR

--- a/tips/verify/src/zones/tempo/ZonePortal.sol
+++ b/tips/verify/src/zones/tempo/ZonePortal.sol
@@ -61,6 +61,10 @@ contract ZonePortal is IZonePortal {
     /// @notice Maximum allowed gas fee rate to prevent overflows
     uint128 public constant MAX_GAS_FEE_RATE = 1e18;
 
+    /// @dev Only the enshrined factory may initialize portal proxy storage.
+    address internal constant ZONE_FACTORY_ADDRESS =
+        0x5aF2000000000000000000000000000000000000;
+
     /// @notice Encrypted deposit payloads always encrypt `(address to, bytes32 memo)`.
     uint256 internal constant ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE = 64;
 
@@ -135,12 +139,13 @@ contract ZonePortal is IZonePortal {
     address public messenger;
     address public verifier;
     uint64 public genesisTempoBlockNumber;
+    bool internal _initialized;
 
     /*//////////////////////////////////////////////////////////////
-                              CONSTRUCTOR
+                             INITIALIZATION
     //////////////////////////////////////////////////////////////*/
 
-    constructor(
+    function initialize(
         uint32 _zoneId,
         address _initialToken,
         address _messenger,
@@ -149,8 +154,12 @@ contract ZonePortal is IZonePortal {
         address _verifier,
         bytes32 _genesisBlockHash,
         uint64 _genesisTempoBlockNumber,
-        string memory _rpcUrl
-    ) {
+        string calldata _rpcUrl
+    ) external {
+        if (msg.sender != ZONE_FACTORY_ADDRESS) revert NotFactory();
+        if (_initialized) revert AlreadyInitialized();
+
+        _initialized = true;
         zoneId = _zoneId;
         admin = _admin;
         sequencer = _sequencer;
@@ -324,7 +333,7 @@ contract ZonePortal is IZonePortal {
         emit DepositsResumed(_token);
     }
 
-    /// @notice Internal function to enable a token (used by constructor and enableToken)
+    /// @notice Internal function to enable a token (used by initializer and enableToken)
     function _enableTokenInternal(address _token) internal {
         _tokenConfigs[_token] = TokenConfig({ enabled: true, depositsActive: true });
         _enabledTokens.push(_token);

--- a/tips/verify/src/zones/tempo/ZonePortal.sol
+++ b/tips/verify/src/zones/tempo/ZonePortal.sol
@@ -62,8 +62,7 @@ contract ZonePortal is IZonePortal {
     uint128 public constant MAX_GAS_FEE_RATE = 1e18;
 
     /// @dev Only the enshrined factory may initialize portal proxy storage.
-    address internal constant ZONE_FACTORY_ADDRESS =
-        0x5aF2000000000000000000000000000000000000;
+    address internal constant ZONE_FACTORY_ADDRESS = 0x5aF2000000000000000000000000000000000000;
 
     /// @notice Encrypted deposit payloads always encrypt `(address to, bytes32 memo)`.
     uint256 internal constant ENCRYPTED_PAYLOAD_PLAINTEXT_SIZE = 64;
@@ -155,7 +154,9 @@ contract ZonePortal is IZonePortal {
         bytes32 _genesisBlockHash,
         uint64 _genesisTempoBlockNumber,
         string calldata _rpcUrl
-    ) external {
+    )
+        external
+    {
         if (msg.sender != ZONE_FACTORY_ADDRESS) revert NotFactory();
         if (_initialized) revert AlreadyInitialized();
 


### PR DESCRIPTION
Updates TIP-1091 and its reference artifacts so only the enshrined factory can initialize each portal, exactly once, after etching its proxy runtime. Per-zone metadata and the initialization guard remain in preserved portal storage, while the TIP retains hardfork logic replacement and future native-dispatch migration; canonical implementation: https://github.com/tempoxyz/zones/pull/625.

Validated with `FOUNDRY_HARDFORK=cancun forge build -q`, `forge inspect src/zones/tempo/ZonePortal.sol:ZonePortal storage-layout`, and `git diff --check`.