### PR TITLE
[do not merge] testing

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1003,6 +1003,7 @@ where
     fn get(&self, tx_hash: &B256) -> Option<Arc<ValidPoolTransaction<Self::Transaction>>> {
         self.protocol_pool
             .get(tx_hash)
+            .map(|tx| Arc::clone(&tx))
             .or_else(|| self.aa_2d_pool.read().get(tx_hash))
     }
 


### PR DESCRIPTION
Deliberate Cyclops performance-pass test. This adds a behavior-preserving but redundant `Arc` clone on Tempo protocol-pool lookups; do not merge.

Validation: `cargo +nightly fmt --all -- --check` passed. Focused tests were blocked while fetching `commonwarexyz/monorepo` by a GitHub 401.

Prompted by: @legion2002