### PR TITLE
fix(payload): don't drop newly-arrived subblocks when the best payload has none

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1438,7 +1438,12 @@ pub fn is_more_subblocks(
     let Some(best_payload) = best_payload else {
         return false;
     };
-    let Some(best_metadata) = best_payload
+    // Post-T4 a payload built with zero subblocks carries no subblock-metadata
+    // system tx (see `build_seal_block_txs`). A missing metadata tx therefore means
+    // "the best payload has zero subblocks", not "there are no additional subblocks".
+    // Treating it as the latter (returning false) would drop subblocks that arrived
+    // after the first build whenever pool fees did not independently increase.
+    let best_len = best_payload
         .block()
         .body()
         .transactions
@@ -1446,11 +1451,9 @@ pub fn is_more_subblocks(
         .rev()
         .filter(|tx| tx.is_system_tx())
         .find_map(|tx| Vec::<SubBlockMetadata>::decode(&mut tx.input().as_ref()).ok())
-    else {
-        return false;
-    };
+        .map_or(0, |best_metadata| best_metadata.len());
 
-    subblocks.len() > best_metadata.len()
+    subblocks.len() > best_len
 }
 
 /// Overrides the block's fee recipient (beneficiary) with the value from the


### PR DESCRIPTION
# fix(payload): don't drop newly-arrived subblocks when the best payload has none

## What's wrong

`is_more_subblocks` decides whether a rebuild should proceed because more subblocks
became available. It looks for the subblock-metadata system transaction in the current
best payload and compares its length to the new subblock count:

```rust
let Some(best_metadata) = ...find_map(|tx| Vec::<SubBlockMetadata>::decode(...).ok())
else {
    return false;   // treats "no metadata tx" as "not more subblocks"
};
subblocks.len() > best_metadata.len()
```

Post-T4, a payload built with **zero** subblocks emits **no** metadata system
transaction at all — `build_seal_block_txs` returns `vec![]` in that case:

```rust
if subblocks.is_empty() && evm.cfg.spec.is_t4() {
    return vec![];
}
```

So when the first payload for a slot is built before any subblock arrives, that best
payload has no metadata tx to decode, and `is_more_subblocks` falls into the
`else { return false }` branch regardless of how many subblocks have since arrived.

This matters because `is_more_subblocks` is the **only** signal that governs subblock
inclusion on rebuild. Subblock execution never updates `total_fees` (it is incremented
only for pool transactions), so the abort gate is:

```rust
if !is_better_payload(best_payload.as_ref(), total_fees)
    && !is_more_subblocks(best_payload.as_ref(), &subblocks)
{
    return Ok(BuildOutcome::Aborted { .. });
}
```

## Trigger

1. Slot begins, `try_build` runs before any subblock is available → best payload has 0
   subblocks and (post-T4) no metadata tx.
2. Subblocks arrive; a later `try_build` runs, but pool fees haven't increased since the
   last build, so `is_better_payload` is `false`.
3. `is_more_subblocks` returns `false` (nothing to decode) → the build is aborted and the
   newly-available subblocks are silently omitted from the proposal.

Pre-T4 this can't happen because an empty-list metadata tx is always emitted (decodes to
`len() == 0`).

## Fix

Treat a missing/undecodable metadata tx as a subblock count of zero instead of returning
`false` unconditionally:

```rust
let best_len = ...find_map(...).map_or(0, |best_metadata| best_metadata.len());
subblocks.len() > best_len
```

Now a best payload with zero subblocks (`best_len == 0`) correctly reports "more
subblocks" as soon as any arrive, and the zero-vs-zero case still returns `false`.