### PR TITLE
fix(pool): derive fee_token_cost from gas spending directly

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -102,10 +102,14 @@ impl TempoPooledTransaction {
     ) -> Self {
         let is_payment = transaction.is_payment_v2();
         let value = transaction.value();
-        let cost =
-            calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas())
-                .saturating_add(value);
-        let fee_token_cost = cost - value;
+        // Derive fee_token_cost (gas spending in the fee token) directly, then add value to
+        // get the total cost. Recovering it as `cost - value` was wrong when `cost` saturated:
+        // if gas_spending + value overflows U256, `cost` clamps to U256::MAX and `cost - value`
+        // collapses far below the real gas spending, letting a transaction be admitted/ordered
+        // as though its gas cost were ~0.
+        let fee_token_cost =
+            calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas());
+        let cost = fee_token_cost.saturating_add(value);
         Self {
             inner: EthPooledTransaction {
                 cost,


### PR DESCRIPTION
# fix(pool): compute `fee_token_cost` from gas spending, not `cost - value`

## Problem

`TempoPooledTransaction::new_with` computed:

```rust
let cost = calc_gas_balance_spending(gas_limit, max_fee_per_gas).saturating_add(value);
let fee_token_cost = cost - value;
```

`cost` is a **saturating** add of gas spending and transfer value. `fee_token_cost` (the
gas cost denominated in the fee token) was then recovered by subtracting `value` back out.

That inverse only holds while the add doesn't saturate. Once `gas_spending + value`
exceeds `U256::MAX`, `cost` clamps to `U256::MAX` and:

```
fee_token_cost = U256::MAX - value   // << actual gas spending
```

So a transaction carrying a very large `value` (an AA transaction sums its per-call
values, which is attacker-controlled) drives `fee_token_cost` toward zero. The pool then
treats the transaction as if its gas were nearly free for admission/ordering purposes.

## Fix

Compute `fee_token_cost` from the gas spending directly, and derive `cost` from it:

```rust
let fee_token_cost = calc_gas_balance_spending(gas_limit, max_fee_per_gas);
let cost = fee_token_cost.saturating_add(value);
```

`fee_token_cost` is now always the true gas cost regardless of `value`, and `cost` keeps
its existing saturating semantics.