### PR TITLE
fix(rpc): detect AA transactions by key_type/key_data in gas estimation

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -146,6 +146,8 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
                 || nonce_key.is_some()
                 || key_authorization.is_some()
                 || key_id.is_some()
+                || key_type.is_some()
+                || key_data.is_some()
                 || fee_payer.is_some()
                 || valid_before.is_some()
                 || valid_after.is_some()


### PR DESCRIPTION
fix(rpc): detect AA transactions by key_type / key_data in gas estimation

The transaction-type classifier (`crates/alloy/src/network.rs`) treats a request as an AA
(Tempo) transaction when `key_type` or `key_data` is set:

    || self.key_type.is_some()
    || self.key_data.is_some()

But `TryIntoTxEnv::try_into_tx_env` — the path used by `eth_estimateGas` and `eth_call` —
did not include those two fields in its equivalent predicate. It keyed off `calls`,
`tempo_authorization_list`, `nonce_key`, `key_authorization`, `key_id`, `fee_payer`,
`valid_before`, `valid_after`, but not `key_type` / `key_data`.

Consequence: a request that sets only `key_type` (the field that exists precisely to select
a WebAuthn / P256 signature) was built as a plain, non-AA tx env. That skips the
signature-verification gas that a real submission incurs, so `eth_estimateGas` returned a
value too low and the transaction could hit out-of-gas once submitted.

Fix: add `key_type.is_some()` and `key_data.is_some()` to the `try_into_tx_env` predicate so
the two AA-detection paths agree.