### PR TITLE
fix: allow scheduled multi-region benchmarks

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -262,6 +262,7 @@ jobs:
 
     steps:
       - name: Check org membership
+        if: github.event_name != 'schedule'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -598,7 +598,7 @@ jobs:
         continue-on-error: true
 
       - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 


### PR DESCRIPTION
Skip the org membership lookup for trusted `schedule` events so the nightly multi-region benchmark can run when GitHub assigns `github-merge-queue[bot]` as the actor. Manual and PR-triggered runs continue to require org membership.

Fixes the failure in https://github.com/tempoxyz/tempo/actions/runs/29302822720/job/86990021166.

---

Also while here, fix a tag annotation causing an unrelated failure in the **Scan GitHub Actions** workflow so that CI passes.