### PR TITLE
fix(evm): reject empty validator set instead of panicking

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -359,10 +359,11 @@ where
         let Some(validator_set) = &self.validator_set else {
             return Ok(());
         };
-        let gas_per_subblock = self
-            .shared_gas_limit
-            .checked_div(validator_set.len() as u64)
-            .expect("validator set must not be empty");
+        let validator_count = validator_set.len() as u64;
+        if validator_count == 0 {
+            return Err(BlockValidationError::msg("validator set must not be empty"));
+        }
+        let gas_per_subblock = self.shared_gas_limit / validator_count;
 
         let mut incentive_gas = 0;
         let mut seen = HashSet::new();


### PR DESCRIPTION
# Reject an empty validator set instead of panicking

## Context

During subblock incentive-gas validation, the code divides the shared gas limit by the
number of validators:

```rust
let Some(validator_set) = &self.validator_set else {
    return Ok(());
};
let gas_per_subblock = self
    .shared_gas_limit
    .checked_div(validator_set.len() as u64)
    .expect("validator set must not be empty");
```

The guard only checks that `validator_set` is `Some(..)`, not that it is **non-empty**. A
`Some([])` therefore reaches `checked_div(0)`, which returns `None`, and the `.expect(..)`
panics — aborting block validation rather than rejecting the block.

## Change

Check for an empty set explicitly and return a `BlockValidationError` (the same error type
already used throughout this function), then divide with a plain `/` since the divisor is
now known to be non-zero:

```rust
let validator_count = validator_set.len() as u64;
if validator_count == 0 {
    return Err(BlockValidationError::msg("validator set must not be empty"));
}
let gas_per_subblock = self.shared_gas_limit / validator_count;
```

A malformed block now fails validation cleanly instead of panicking the node.
