### PR TITLE
fix(primitives): saturate AASigned::value() to match TempoTransaction

### DIFF
--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -348,11 +348,13 @@ impl Transaction for AASigned {
 
     #[inline]
     fn value(&self) -> U256 {
-        // Return sum of all call values
+        // Return sum of all call values, saturating to U256::MAX on overflow to match
+        // TempoTransaction::value(). alloy's U256 `+` wraps rather than panics, so a plain
+        // fold would silently report a small wrapped value for a call set summing past 2^256.
         self.tx
             .calls
             .iter()
-            .fold(U256::ZERO, |acc, call| acc + call.value)
+            .fold(U256::ZERO, |acc, call| acc.saturating_add(call.value))
     }
 
     #[inline]


### PR DESCRIPTION
# fix(primitives): saturate `AASigned::value()` sum

Sum the per-call values with `saturating_add` instead of `+`, matching the canonical
`TempoTransaction::value()`.

`AASigned` is the transaction behind `TempoTxEnvelope::AA`, so `envelope.value()` for an
AA transaction dispatches to this impl. alloy's `U256` implements `Add` via `wrapping_add`
(ruint `impl_bin_op!(Add, add, …, wrapping_add)`), so the previous `acc + call.value`
did **not** panic on overflow — it silently wrapped. A multi-call AA transaction whose
call values sum past `2^256` (e.g. two calls of `U256::MAX`) therefore reported a small
wrapped `value()`, while the identical transaction expressed as a bare `TempoTransaction`
reported `U256::MAX`. The saturating behaviour is deliberate and pinned by
`test_value_saturates_on_overflow`; this brings the AA copy in line.

Any consumer keying off `Transaction::value()` (pool cost accounting, RPC) now gets a
consistent, non-wrapped value for such transactions.