### PR TITLE
fix(engine): validate payload-attribute timestamp at millisecond resolution

### DIFF
--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -36,8 +36,15 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
         attr: &TempoPayloadAttributes,
         header: &TempoHeader,
     ) -> Result<(), InvalidPayloadAttributesError> {
-        // Ensure that payload attributes timestamp is not in the past
-        if attr.timestamp < header.timestamp() {
+        // Ensure the payload attributes strictly advance time at millisecond resolution.
+        //
+        // Tempo blocks are sub-second, so a header carries whole seconds in `timestamp`
+        // plus a `timestamp_millis_part`. Comparing only whole seconds here would accept
+        // attributes that move *backwards* within the same second (e.g. parent at 100.900s,
+        // attributes at 100.100s), which the authoritative consensus check
+        // (`TempoConsensus::validate_header_against_parent`) then rejects — a wasted build.
+        // Match that rule: block time must strictly increase in milliseconds.
+        if attr.timestamp_millis() <= header.timestamp_millis() {
             return Err(InvalidPayloadAttributesError::InvalidTimestamp);
         }
         Ok(())


### PR DESCRIPTION
## Summary

`TempoEngineValidator::validate_payload_attributes_against_header` compared payload
attribute timestamps against the parent header using **whole-second** precision:

```rust
if attr.timestamp < header.timestamp() {
    return Err(InvalidPayloadAttributesError::InvalidTimestamp);
}
```

Tempo runs sub-second blocks. A header's time is `timestamp` (seconds) plus
`timestamp_millis_part`, and the authoritative rule in
`TempoConsensus::validate_header_against_parent` is:

```rust
if header.timestamp_millis() <= parent.timestamp_millis() {
    return Err(ConsensusError::TimestampIsInPast { .. });
}
```

## The gap

Because the engine check only looked at whole seconds (and used `<` rather than `<=`), a
parent at `100.900s` with payload attributes at `100.100s` passed the engine check
(`100 < 100` is false) even though the attributes move backwards in time. The builder
would then build a block that consensus rejects.

State is never corrupted — consensus catches it downstream — so this is a
defense-in-depth / wasted-work fix, not a safety fix.

## Change

Both `TempoPayloadAttributes` and `TempoHeader` expose `timestamp_millis()`, so the check
now mirrors consensus exactly (strictly increasing at millisecond resolution):

```rust
if attr.timestamp_millis() <= header.timestamp_millis() {
    return Err(InvalidPayloadAttributesError::InvalidTimestamp);
}
```