### PR TITLE
fix(consensus): don't panic on undecodable epoch-boundary DKG outcome

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -763,7 +763,7 @@ where
 
         let onchain_outcome =
             tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
-                .expect("the last block of an epoch must contain the DKG outcome");
+                .wrap_err("the last block of an epoch must contain the DKG outcome")?;
 
         info!("reading validator from contract");
 


### PR DESCRIPTION
# Return an error instead of panicking on an undecodable epoch-boundary DKG outcome

In `handle_finalized_header`, the DKG outcome embedded in the last block of an epoch was
decoded with `.expect(...)`:

    let onchain_outcome =
        OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
            .expect("the last block of an epoch must contain the DKG outcome");

Every *other* call site treats `OnchainDkgOutcome::read` as fallible and propagates the
error with `wrap_err(...)?`:

- `consensus/application/actor.rs`
- `dkg/manager/actor/mod.rs` (`read_outcome_from_boundary`)
- `follow/driver.rs`
- `epoch/manager/actor.rs`

`handle_finalized_header` already returns `eyre::Result<...>` (the line just above this one
uses `wrap_err(...)?`), so the `.expect` is the lone inconsistency. If a boundary block's
`extra_data` ever fails to decode under this node's codec — for example an older node
during a hardfork/codec skew, where upgraded validators finalize a block it can't parse —
the node panics instead of degrading gracefully like the rest of the DKG code path.

Note this is a robustness/consistency fix, not an attacker vector: the DKG outcome lives
inside the header, `Block::digest()` covers `extra_data`, and decode recomputes the hash,
so an untrusted upstream can't forge one without breaking the threshold signature.

The fix swaps `.expect(...)` for `.wrap_err(...)?`, matching the surrounding code.
