### PR TITLE
docs(tip-1091): hide withdrawal fallback recipients

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -99,6 +99,12 @@ The initialized portal MUST use the shared messenger returned by
 `ZoneFactory.messenger()`. Withdrawal callback behavior MUST match the canonical
 `ZonePortal.sol` reference.
 
+User withdrawals MUST expose only a nonzero `uint64 fallbackNonce` on Tempo.
+The zone outbox assigns this nonce monotonically and stores its mapping to the
+private zone fallback recipient; a withdrawal bounce-back carries the nonce back
+to the zone, where the inbox resolves and consumes the mapping. This keeps the
+recipient out of L1-visible data while preserving deterministic execution.
+
 Replacing the central portal logic implementation is a Tempo protocol upgrade.
 
 ## Out Of Scope

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -278,7 +278,7 @@ struct Withdrawal {
     uint128 fee; // processing fee for sequencer (calculated at request time)
     bytes32 memo; // user-provided context
     uint64 gasLimit; // max gas for IWithdrawalReceiver callback (0 = no callback)
-    address fallbackRecipient; // zone address for bounce-back if call fails
+    uint64 fallbackNonce; // resolves to the zone bounce-back recipient in ZoneOutbox
     bytes callbackData; // calldata for IWithdrawalReceiver (if gasLimit > 0)
     bytes encryptedSender; // optional encrypted (sender, txHash) reveal payload
 }
@@ -292,7 +292,7 @@ struct PendingWithdrawal {
     uint128 fee; // processing fee for sequencer (calculated at request time)
     bytes32 memo; // user-provided context
     uint64 gasLimit; // max gas for IWithdrawalReceiver callback (0 = no callback)
-    address fallbackRecipient; // zone address for bounce-back if call fails
+    uint64 fallbackNonce; // resolves to the zone bounce-back recipient in ZoneOutbox
     bytes callbackData; // calldata for IWithdrawalReceiver (if gasLimit > 0)
     bytes revealTo; // optional compressed secp256k1 pubkey for sender reveal encryption
 }
@@ -513,7 +513,7 @@ interface IZonePortal {
 
     event WithdrawalBounceBack(
         bytes32 indexed newCurrentDepositQueueHash,
-        address indexed fallbackRecipient,
+        uint64 indexed fallbackNonce,
         address token,
         uint128 amount,
         uint64 depositNumber
@@ -1051,7 +1051,7 @@ interface IZoneOutbox {
         uint128 fee,
         bytes32 memo,
         uint64 gasLimit,
-        address fallbackRecipient,
+        uint64 fallbackNonce,
         bytes data,
         bytes revealTo
     );
@@ -1073,6 +1073,12 @@ interface IZoneOutbox {
 
     /// @notice Next withdrawal index (monotonically increasing)
     function nextWithdrawalIndex() external view returns (uint64);
+
+    /// @notice Last nonce assigned to a user withdrawal fallback recipient
+    function lastFallbackNonce() external view returns (uint64);
+
+    /// @notice Resolve and delete a fallback recipient. Only callable by ZoneInbox.
+    function consumeFallbackRecipient(uint64 fallbackNonce) external returns (address recipient);
 
     /// @notice Current withdrawal batch index (monotonically increasing)
     function withdrawalBatchIndex() external view returns (uint64);

--- a/tips/verify/src/zones/tempo/ZonePortal.sol
+++ b/tips/verify/src/zones/tempo/ZonePortal.sol
@@ -708,7 +708,7 @@ contract ZonePortal is IZonePortal {
 
         address _token = withdrawal.token;
 
-        if (withdrawal.fallbackRecipient == address(0)) {
+        if (withdrawal.fallbackNonce == 0) {
             _processDepositBounceBack(withdrawal);
             return;
         }
@@ -721,7 +721,7 @@ contract ZonePortal is IZonePortal {
         }
 
         if (withdrawal.gasLimit > MAX_WITHDRAWAL_GAS_LIMIT) {
-            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackNonce);
             emit WithdrawalProcessed(
                 withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, false
             );
@@ -748,7 +748,7 @@ contract ZonePortal is IZonePortal {
 
         if (!success) {
             // Callback failed: bounce back to zone (only amount, not fee)
-            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackRecipient);
+            _enqueueBounceBack(_token, withdrawal.amount, withdrawal.fallbackNonce);
         }
         emit WithdrawalProcessed(
             withdrawal.to, withdrawal.senderTag, _token, withdrawal.amount, success
@@ -837,18 +837,12 @@ contract ZonePortal is IZonePortal {
     /// @notice Enqueue a bounce-back deposit for failed callback
     /// @param _token The token from the failed withdrawal
     /// @param amount The amount to bounce back
-    /// @param fallbackRecipient The zone address to receive the bounce-back
-    function _enqueueBounceBack(
-        address _token,
-        uint128 amount,
-        address fallbackRecipient
-    )
-        internal
-    {
+    /// @param fallbackNonce The nonce resolving to the zone bounce-back recipient
+    function _enqueueBounceBack(address _token, uint128 amount, uint64 fallbackNonce) internal {
         Deposit memory depositData = Deposit({
             token: _token,
             sender: address(this),
-            to: fallbackRecipient,
+            to: address(uint160(fallbackNonce)),
             amount: amount,
             bouncebackRecipient: address(0),
             memo: bytes32(0)
@@ -860,7 +854,7 @@ contract ZonePortal is IZonePortal {
         uint64 thisDeposit = ++depositCount;
 
         emit WithdrawalBounceBack(
-            newCurrentDepositQueueHash, fallbackRecipient, _token, amount, thisDeposit
+            newCurrentDepositQueueHash, fallbackNonce, _token, amount, thisDeposit
         );
     }
 


### PR DESCRIPTION
## Summary

Stacked directly on #6787 (`tip/1091`).

- changes the L1-facing withdrawal wire field from `fallbackRecipient` to `uint64 fallbackNonce`
- makes withdrawal bounce-back deposits and events carry only that nonce
- documents that the zone outbox owns the private nonce-to-recipient mapping and the inbox consumes it on bounce-back
- updates the TIP-1091 reference artifacts to match the canonical Zones change in tempoxyz/zones#638

## Why

A plaintext fallback recipient leaks a private zone address into Tempo-visible withdrawal data. A monotonic nonce keeps the recipient in zone state while remaining deterministic under canonical multi-sequencer execution.

## Validation

- `FOUNDRY_HARDFORK=cancun forge fmt --check`
- `FOUNDRY_HARDFORK=cancun forge build --force`
- `FOUNDRY_HARDFORK=cancun forge test`
- `git diff --check`