### PR TITLE
fix(consensus): exit follow driver cleanly on mailbox close

### DIFF
--- a/crates/consensus/src/follow/driver.rs
+++ b/crates/consensus/src/follow/driver.rs
@@ -218,7 +218,14 @@ where
             select!(
                 biased;
 
-                Some(message) = self.mailbox.recv() => {
+                message = self.mailbox.recv() => {
+                    let Some(message) = message else {
+                        // All senders (marshal reporter, upstream event reporter) dropped:
+                        // the driver is shutting down. Exit cleanly. Binding the full Option
+                        // (rather than `Some(message)`) keeps this branch always-enabled, so
+                        // select! never panics with "all branches disabled and no else branch".
+                        break;
+                    };
                     match message {
                         Message::Event(event) => {
                             // Emits an event on error.


### PR DESCRIPTION
fix(consensus): exit the follow driver cleanly when its mailbox closes

The follow driver's main loop drives a single-branch `tokio::select!`:

```rust
loop {
    select!(
        biased;
        Some(message) = self.mailbox.recv() => { ... }
    );
}
```

When every sender is dropped — the marshal's `MarshalReporter` and the upstream
`EventReporter` — `mailbox.recv()` yields `None`. The `Some(message)` pattern then fails to
match, and a `tokio::select!` with only one branch and no `else` arm **panics** ("all
branches are disabled and there is no else branch"). So a normal teardown race turns into a
panic.

The sibling actor in `epoch/manager/actor.rs` gets this right: it matches the full `Option`
and `break`s on `None`.

The fix binds the whole `Option` (keeping the branch always-enabled so `select!` can't hit
the disabled-branch panic) and breaks out of the loop on `None`, giving a clean shutdown.
Behaviour is otherwise unchanged.