### PR TITLE
fix(consensus): preserve finalized DKG dealer logs

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -1078,9 +1078,13 @@ where
                     if let Some(block) =
                         storage.get_notarized_reduced_block(&round.epoch(), &digest)
                     {
-                        // The ancestry walk is newest-to-oldest, so older logs replace
-                        // newer ancestry duplicates.
-                        notarized_logs.extend(block.log.clone());
+                        if let Some((dealer, log)) = block.log.clone()
+                            && !finalized_logs.contains_key(&dealer)
+                        {
+                            // The ancestry walk is newest-to-oldest, so older logs replace
+                            // newer ancestry duplicates while finalized logs stay authoritative.
+                            notarized_logs.insert(dealer, log);
+                        }
                         height = if let Some(height) = block.height.previous() {
                             height
                         } else {
@@ -1092,7 +1096,6 @@ where
                     }
                 }
                 for (dealer, log) in notarized_logs {
-                    // Finalized logs stay authoritative over ancestry logs.
                     finalized_logs.entry(dealer).or_insert(log);
                 }
             }

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    num::NonZeroU32,
-    task::Poll,
-};
+use std::{collections::BTreeMap, num::NonZeroU32, task::Poll};
 
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::B256;
@@ -1056,14 +1052,13 @@ where
         {
             output
         } else {
-            let mut raw_logs = storage
+            let mut finalized_logs = storage
                 .logs_for_epoch(round.epoch())
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect::<BTreeMap<_, _>>();
-            let finalized_dealers = raw_logs.keys().cloned().collect::<BTreeSet<_>>();
 
             'ensure_enough_logs: {
-                if raw_logs.len() == round.dealers().len() {
+                if finalized_logs.len() == round.dealers().len() {
                     info!("collected as many logs as there are dealers; concluding DKG");
                     break 'ensure_enough_logs;
                 }
@@ -1072,6 +1067,7 @@ where
                     "did not have all dealer logs yet; will try to extend with \
                     logs read from notarized blocks and concluding DKG that way",
                 );
+                let mut notarized_logs = BTreeMap::new();
                 let (mut height, mut digest) = (request.height, request.digest);
                 while height >= epoch_info.first()
                     && Some(height)
@@ -1083,26 +1079,29 @@ where
                         storage.get_notarized_reduced_block(&round.epoch(), &digest)
                     {
                         if let Some((dealer, log)) = block.log.clone()
-                            && !finalized_dealers.contains(&dealer)
+                            && !finalized_logs.contains_key(&dealer)
                         {
                             // The ancestry walk is newest-to-oldest, so older logs replace
                             // newer ancestry duplicates while finalized logs stay authoritative.
-                            raw_logs.insert(dealer, log);
+                            notarized_logs.insert(dealer, log);
                         }
                         height = if let Some(height) = block.height.previous() {
                             height
                         } else {
-                            break 'ensure_enough_logs;
+                            break;
                         };
                         digest = block.parent;
                     } else {
                         return Ok(Some((digest, request)));
                     }
                 }
+                for (dealer, log) in notarized_logs {
+                    finalized_logs.entry(dealer).or_insert(log);
+                }
             }
 
             let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
-            for (k, v) in raw_logs {
+            for (k, v) in finalized_logs {
                 logs.record(k, v);
             }
 

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -1078,13 +1078,9 @@ where
                     if let Some(block) =
                         storage.get_notarized_reduced_block(&round.epoch(), &digest)
                     {
-                        if let Some((dealer, log)) = block.log.clone()
-                            && !finalized_logs.contains_key(&dealer)
-                        {
-                            // The ancestry walk is newest-to-oldest, so older logs replace
-                            // newer ancestry duplicates while finalized logs stay authoritative.
-                            notarized_logs.insert(dealer, log);
-                        }
+                        // The ancestry walk is newest-to-oldest, so older logs replace
+                        // newer ancestry duplicates.
+                        notarized_logs.extend(block.log.clone());
                         height = if let Some(height) = block.height.previous() {
                             height
                         } else {
@@ -1096,6 +1092,7 @@ where
                     }
                 }
                 for (dealer, log) in notarized_logs {
+                    // Finalized logs stay authoritative over ancestry logs.
                     finalized_logs.entry(dealer).or_insert(log);
                 }
             }

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, num::NonZeroU32, task::Poll};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU32,
+    task::Poll,
+};
 
 use alloy_consensus::BlockHeader as _;
 use alloy_primitives::B256;
@@ -1056,6 +1060,7 @@ where
                 .logs_for_epoch(round.epoch())
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect::<BTreeMap<_, _>>();
+            let finalized_dealers = raw_logs.keys().cloned().collect::<BTreeSet<_>>();
 
             'ensure_enough_logs: {
                 if raw_logs.len() == round.dealers().len() {
@@ -1077,7 +1082,13 @@ where
                     if let Some(block) =
                         storage.get_notarized_reduced_block(&round.epoch(), &digest)
                     {
-                        raw_logs.extend(block.log.clone());
+                        if let Some((dealer, log)) = block.log.clone()
+                            && !finalized_dealers.contains(&dealer)
+                        {
+                            // The ancestry walk is newest-to-oldest, so older logs replace
+                            // newer ancestry duplicates while finalized logs stay authoritative.
+                            raw_logs.insert(dealer, log);
+                        }
                         height = if let Some(height) = block.height.previous() {
                             height
                         } else {


### PR DESCRIPTION
Preserve first-write-wins dealer logs when filling an incomplete DKG cache from notarized ancestry. This keeps validators on the same DKG input regardless of finalized-cache progress.