### PR TITLE
fix(ci): repair reth-bump image workflow

### DIFF
--- a/.github/workflows/build-reth-bump-image.yml
+++ b/.github/workflows/build-reth-bump-image.yml
@@ -3,6 +3,7 @@ name: Build reth-bump image
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - reth-auto-bump

--- a/.github/workflows/build-reth-bump-image.yml
+++ b/.github/workflows/build-reth-bump-image.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     name: Build candidate images
     permissions:
+      actions: read
       contents: read
       packages: write
       id-token: write


### PR DESCRIPTION
## Summary

- grant `actions: read` to the reusable Docker workflow caller, fixing the startup validation failure
- add `workflow_dispatch` so reth-bump image builds can be started manually

Fixes the startup failure in https://github.com/tempoxyz/tempo/actions/runs/29346798851

Prompted by: @shekhirin