### PR TITLE
fix(ci): allow reth-bump image builds to start

### DIFF
--- a/.github/workflows/build-reth-bump-image.yml
+++ b/.github/workflows/build-reth-bump-image.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     name: Build candidate images
     permissions:
+      actions: read
       contents: read
       packages: write
       id-token: write


### PR DESCRIPTION
This PR fixes reth-bump candidate builds failing before the reusable Docker workflow starts, as seen in [run 29346798851](https://github.com/tempoxyz/tempo/actions/runs/29346798851). It:

1. grants the build caller `actions: read`, matching the permission required by `docker.yml`
2. allows pushes to `reth-auto-bump` to produce the normal immutable candidate image