### PR TITLE
chore(precompiles): drop `std` usage in `dispatch!` macro

### DIFF
--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -161,18 +161,12 @@ macro_rules! dispatch {
         paste::paste! {{
             #[cfg(debug_assertions)]
             {
-                // Check for duplicate selectors without using `std` deps.
-                let mut unique_selectors = true;
-                let mut selectors = core::iter::empty::<[u8; 4]>()
-                    $(.chain(<$iface::$calls as alloy::sol_types::SolInterface>::selectors()))*;
-                // PERF: Cloning the selectors iterator only copies its current index and marker data.
-                while let Some(selector) = selectors.next() {
-                    if selectors.clone().any(|other| selector == other) {
-                        unique_selectors = false;
-                        break;
-                    }
-                }
-                assert!(unique_selectors, "duplicate precompile selector in dispatch! macro");
+                extern crate alloc as __alloc;
+                let mut selectors = __alloc::collections::BTreeSet::new();
+                $(assert!(
+                    <$iface::$calls as alloy::sol_types::SolInterface>::selectors().all(|s| selectors.insert(s)),
+                    "duplicate precompile selector in dispatch! macro",
+                );)*
             }
 
             if let Some(selector) = $crate::dispatch::selector_from_calldata($calldata) {

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -161,11 +161,18 @@ macro_rules! dispatch {
         paste::paste! {{
             #[cfg(debug_assertions)]
             {
-                let mut selectors = std::collections::BTreeSet::new();
-                $(assert!(
-                    <$iface::$calls as alloy::sol_types::SolInterface>::selectors().all(|s| selectors.insert(s)),
-                    "duplicate precompile selector in dispatch! macro",
-                );)*
+                // Check for duplicate selectors without using `std` deps.
+                let mut unique_selectors = true;
+                let mut selectors = core::iter::empty::<[u8; 4]>()
+                    $(.chain(<$iface::$calls as alloy::sol_types::SolInterface>::selectors()))*;
+                // PERF: Cloning the selectors iterator only copies its current index and marker data.
+                while let Some(selector) = selectors.next() {
+                    if selectors.clone().any(|other| selector == other) {
+                        unique_selectors = false;
+                        break;
+                    }
+                }
+                assert!(unique_selectors, "duplicate precompile selector in dispatch! macro");
             }
 
             if let Some(selector) = $crate::dispatch::selector_from_calldata($calldata) {


### PR DESCRIPTION
this PR drops `std` usage in the `dispatch!` macro so that it can be used in `no-std` consumers like zones