### PR TITLE
ci: wire telemetry secret to multi-region benchmark

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -54,6 +54,8 @@ on:
     secrets:
       BENCH_LOGS_PUSH_URL:
         required: false
+      TEMPO_TELEMETRY_URL:
+        required: false
       BENCH_METRICS_PUSH_URL:
         required: false
       DEREK_BENCH_TOKEN:
@@ -431,7 +433,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type c6id.8xlarge \
             --metrics-push-url "${{ secrets.BENCH_METRICS_PUSH_URL }}" \
-            --logs-push-url "${{ secrets.BENCH_LOGS_PUSH_URL }}" \
+            --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
 
@@ -484,7 +486,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type c6id.8xlarge \
             --metrics-push-url "${{ secrets.BENCH_METRICS_PUSH_URL }}" \
-            --logs-push-url "${{ secrets.BENCH_LOGS_PUSH_URL }}" \
+            --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
 
@@ -527,7 +529,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type c6id.8xlarge \
             --metrics-push-url "${{ secrets.BENCH_METRICS_PUSH_URL }}" \
-            --logs-push-url "${{ secrets.BENCH_LOGS_PUSH_URL }}" \
+            --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
 
@@ -570,7 +572,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type c6id.8xlarge \
             --metrics-push-url "${{ secrets.BENCH_METRICS_PUSH_URL }}" \
-            --logs-push-url "${{ secrets.BENCH_LOGS_PUSH_URL }}" \
+            --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
 


### PR DESCRIPTION
The multi-region benchmark scripts now support OTLP export, but the active workflow only passes `BENCH_LOGS_PUSH_URL`, which is not configured in this repository. Wire the existing `TEMPO_TELEMETRY_URL` secret through the existing argument, retaining the old secret as fallback.