### PR TITLE
docs(tip-0001): include aa_authorization_list and key_authorization in signing-hash preimages

### DIFF
--- a/tips/tip-0001.md
+++ b/tips/tip-0001.md
@@ -348,7 +348,9 @@ sender_hash = keccak256(0x76 || rlp([
     valid_before,
     valid_after,
     0x80,  // fee_token encoded as EMPTY (skipped)
-    0x00   // placeholder byte for fee_payer_signature
+    0x00,  // placeholder byte for fee_payer_signature
+    aa_authorization_list,
+    key_authorization?  // Only encoded if present (backwards compatible)
 ]))
 
 // When no fee_payer_signature:
@@ -364,7 +366,9 @@ sender_hash = keccak256(0x76 || rlp([
     valid_before,
     valid_after,
     fee_token,  // fee_token is INCLUDED
-    0x80        // empty for no fee_payer_signature
+    0x80,       // empty for no fee_payer_signature
+    aa_authorization_list,
+    key_authorization?  // Only encoded if present (backwards compatible)
 ]))
 ```
 
@@ -392,7 +396,8 @@ fee_payer_hash = keccak256(0x78 || rlp([  // Note: 0x78 magic byte
     valid_after,
     fee_token,      // fee_token ALWAYS included
     sender_address, // 20-byte sender address
-    key_authorization,
+    aa_authorization_list,
+    key_authorization?  // Only encoded if present (backwards compatible)
 ]))
 ```
 


### PR DESCRIPTION
## Summary

The signing-hash preimage listings in `tips/tip-0001.md` are incomplete: both **sender-hash** blocks (`keccak256(0x76 || rlp([...]))`) stop at the `fee_payer_signature` placeholder (field 12), and the **fee-payer-hash** block (`keccak256(0x78 || rlp([...]))`) jumps from `sender_address` straight to `key_authorization`. In the actual protocol, `aa_authorization_list` (and, when present, `key_authorization`) are part of **both** preimages. An implementation written from the spec as published produces signatures the chain rejects.

This PR appends `aa_authorization_list` + optional `key_authorization` to both sender-hash blocks, and inserts `aa_authorization_list` before `key_authorization` in the fee-payer block (also marking it optional, matching the envelope listing's `key_authorization?` convention). No other changes.

## Ground truth (three independent confirmations)

**1. This repo's own encoder** — `crates/primitives/src/transaction/tempo_transaction.rs`. Both `SignableTransaction::encode_for_signing` (sender domain, type byte `0x76`) and `fee_payer_signature_hash` (magic byte `0x78`) delegate to the shared `rlp_encode_fields`, which ends:

```rust
        encode_signature(&self.fee_payer_signature, out);

        // Encode authorization_list
        self.tempo_authorization_list.encode(out);

        // Encode key_authorization (truly optional - only encoded if present)
        if let Some(key_auth) = &self.key_authorization {
            key_auth.encode(out);
        }
        // No bytes at all when None - maintains backwards compatibility
```

For the fee-payer domain, `fee_payer_signature_hash(&self, sender: Address)` passes a closure that writes the sender address into the `fee_payer_signature` slot and then encodes the same trailing fields:

```rust
        self.rlp_encode_fields(
            &mut buf,
            |_, out| {
                // Encode sender address instead of fee_payer_signature
                sender.encode(out);
            },
            false, // skip_fee_token = FALSE - fee payer commits to fee_token!
        );
```

So the authorization list is unconditionally in both preimages, and `key_authorization` is encoded in both when present.

**2. wevm/ox** — `src/tempo/TxEnvelopeTempo.ts` `serialize()` builds one field list for both signing domains, with `authorizationTupleList` always present between the fee-payer slot and the optional key authorization.

**3. Live networks** — the [localharness](https://github.com/compusophy/localharness) Rust implementation (`src/tempo_tx.rs`, an independent from-scratch encoder) only produced signatures accepted by Moderato testnet and Tempo mainnet once the authorization list was included in both preimages. The omission was originally discovered by diffing ox's serialization, because the spec text alone was insufficient to build a working encoder.

## Notes

- A companion PR against tempoxyz/docs (which mirrors this text on the public docs site) is being filed simultaneously.
- Related prior report in this area: tempoxyz/docs#111 (fee-payer placeholder wire format vs signing payload encoding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
