### PR TITLE
docs(tip-1091): permission initial zone creation

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -54,10 +54,10 @@ canonical Zones implementation: monotonically increasing zone IDs, `zones`,
 
 For the initial permissioned launch, the activation hardfork MUST configure a
 nonzero factory `owner`. `createZone` MUST reject calls from any other account.
-The owner MAY nominate another nonzero account, which MUST accept before the
-ownership transfer takes effect. This gate is temporary: the hardfork that
-enables open zone creation MUST remove the caller restriction, after which any
-account may call `createZone` subject to its normal validation rules.
+The owner MAY atomically transfer this authority to another nonzero account.
+This gate is temporary: the hardfork that enables open zone creation MUST remove
+the caller restriction, after which any account may call `createZone` subject to
+its normal validation rules.
 
 Each zone portal is installed at:
 

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -52,6 +52,13 @@ canonical Zones implementation: monotonically increasing zone IDs, `zones`,
 `zoneCount`, `isZonePortal`, `isValidVerifier`, `verifier`, `messenger`, and
 `ZoneCreated`.
 
+For the initial permissioned launch, the activation hardfork MUST configure a
+nonzero factory `owner`. `createZone` MUST reject calls from any other account.
+The owner MAY nominate another nonzero account, which MUST accept before the
+ownership transfer takes effect. This gate is temporary: the hardfork that
+enables open zone creation MUST remove the caller restriction, after which any
+account may call `createZone` subject to its normal validation rules.
+
 Each zone portal is installed at:
 
 ```text

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -409,6 +409,9 @@ interface IVerifier {
 /// @notice Interface for creating zones
 interface IZoneFactory {
 
+    event OwnershipTransferStarted(address indexed currentOwner, address indexed pendingOwner);
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
     struct CreateZoneParams {
         address initialToken; // first TIP-20 to enable (sequencer can enable more later)
         address admin;
@@ -431,11 +434,26 @@ interface IZoneFactory {
     );
 
     error InvalidToken();
+    error InvalidOwner();
+    error NotOwner();
+    error NotPendingOwner();
     error InvalidAdmin();
     error InvalidSequencer();
     error InvalidVerifier();
     error InsufficientGas();
     error ZoneIdOverflow();
+
+    /// @notice Returns the account authorized to create zones.
+    function owner() external view returns (address);
+
+    /// @notice Returns the account nominated to become the owner.
+    function pendingOwner() external view returns (address);
+
+    /// @notice Nominates `newOwner` to receive zone-creation authority.
+    function transferOwnership(address newOwner) external;
+
+    /// @notice Accepts a pending ownership transfer.
+    function acceptOwnership() external;
 
     /// @notice Returns whether a verifier contract is approved for zone creation.
     /// @param verifier The verifier contract address to check.

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -409,7 +409,6 @@ interface IVerifier {
 /// @notice Interface for creating zones
 interface IZoneFactory {
 
-    event OwnershipTransferStarted(address indexed currentOwner, address indexed pendingOwner);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     struct CreateZoneParams {
@@ -436,7 +435,6 @@ interface IZoneFactory {
     error InvalidToken();
     error InvalidOwner();
     error NotOwner();
-    error NotPendingOwner();
     error InvalidAdmin();
     error InvalidSequencer();
     error InvalidVerifier();
@@ -446,14 +444,8 @@ interface IZoneFactory {
     /// @notice Returns the account authorized to create zones.
     function owner() external view returns (address);
 
-    /// @notice Returns the account nominated to become the owner.
-    function pendingOwner() external view returns (address);
-
-    /// @notice Nominates `newOwner` to receive zone-creation authority.
+    /// @notice Transfers zone-creation authority to `newOwner`.
     function transferOwnership(address newOwner) external;
-
-    /// @notice Accepts a pending ownership transfer.
-    function acceptOwnership() external;
 
     /// @notice Returns whether a verifier contract is approved for zone creation.
     /// @param verifier The verifier contract address to check.

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -45,15 +45,20 @@ abstract contract ZoneFactory is IZoneFactory {
     mapping(address => bool) internal _validVerifiers;
     address internal _verifier;
     address internal _messenger;
+    address internal _owner;
+    address internal _pendingOwner;
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    constructor(address initialVerifier, address sharedMessenger) {
+    constructor(address initialOwner, address initialVerifier, address sharedMessenger) {
+        if (initialOwner == address(0)) revert InvalidOwner();
         if (initialVerifier == address(0)) revert InvalidVerifier();
         require(sharedMessenger != address(0), "invalid messenger");
 
+        _owner = initialOwner;
+        emit OwnershipTransferred(address(0), initialOwner);
         _validVerifiers[initialVerifier] = true;
         _verifier = initialVerifier;
         _messenger = sharedMessenger;
@@ -67,6 +72,8 @@ abstract contract ZoneFactory is IZoneFactory {
         external
         returns (uint32 zoneId, address portal)
     {
+        if (msg.sender != _owner) revert NotOwner();
+
         if (!ITIP20Factory(StdPrecompiles.TIP20_FACTORY_ADDRESS).isTIP20(params.initialToken)) {
             revert InvalidToken();
         }
@@ -138,6 +145,25 @@ abstract contract ZoneFactory is IZoneFactory {
         );
     }
 
+    /// @inheritdoc IZoneFactory
+    function transferOwnership(address newOwner) external {
+        if (msg.sender != _owner) revert NotOwner();
+        if (newOwner == address(0)) revert InvalidOwner();
+
+        _pendingOwner = newOwner;
+        emit OwnershipTransferStarted(_owner, newOwner);
+    }
+
+    /// @inheritdoc IZoneFactory
+    function acceptOwnership() external {
+        if (msg.sender != _pendingOwner) revert NotPendingOwner();
+
+        address previousOwner = _owner;
+        _owner = msg.sender;
+        _pendingOwner = address(0);
+        emit OwnershipTransferred(previousOwner, msg.sender);
+    }
+
     /// @notice Returns the deterministic portal vanity address for a zone ID.
     function portalAddress(uint32 zoneId) public pure returns (address) {
         uint160 prefix = uint160(bytes20(ZONE_PORTAL_PREFIX));
@@ -159,6 +185,14 @@ abstract contract ZoneFactory is IZoneFactory {
     /// @notice Returns the number of zones created, excluding reserved zone 0.
     function zoneCount() external view returns (uint32) {
         return _nextZoneId - 1;
+    }
+
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    function pendingOwner() external view returns (address) {
+        return _pendingOwner;
     }
 
     function zones(uint32 zoneId) external view returns (ZoneInfo memory) {

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -46,7 +46,6 @@ abstract contract ZoneFactory is IZoneFactory {
     address internal _verifier;
     address internal _messenger;
     address internal _owner;
-    address internal _pendingOwner;
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -150,18 +149,9 @@ abstract contract ZoneFactory is IZoneFactory {
         if (msg.sender != _owner) revert NotOwner();
         if (newOwner == address(0)) revert InvalidOwner();
 
-        _pendingOwner = newOwner;
-        emit OwnershipTransferStarted(_owner, newOwner);
-    }
-
-    /// @inheritdoc IZoneFactory
-    function acceptOwnership() external {
-        if (msg.sender != _pendingOwner) revert NotPendingOwner();
-
         address previousOwner = _owner;
-        _owner = msg.sender;
-        _pendingOwner = address(0);
-        emit OwnershipTransferred(previousOwner, msg.sender);
+        _owner = newOwner;
+        emit OwnershipTransferred(previousOwner, newOwner);
     }
 
     /// @notice Returns the deterministic portal vanity address for a zone ID.
@@ -189,10 +179,6 @@ abstract contract ZoneFactory is IZoneFactory {
 
     function owner() external view returns (address) {
         return _owner;
-    }
-
-    function pendingOwner() external view returns (address) {
-        return _pendingOwner;
     }
 
     function zones(uint32 zoneId) external view returns (ZoneInfo memory) {

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -45,7 +45,7 @@ abstract contract ZoneFactory is IZoneFactory {
     mapping(address => bool) internal _validVerifiers;
     address internal _verifier;
     address internal _messenger;
-    address internal _owner;
+    address public owner;
 
     /*//////////////////////////////////////////////////////////////
                               CONSTRUCTOR
@@ -56,7 +56,7 @@ abstract contract ZoneFactory is IZoneFactory {
         if (initialVerifier == address(0)) revert InvalidVerifier();
         require(sharedMessenger != address(0), "invalid messenger");
 
-        _owner = initialOwner;
+        owner = initialOwner;
         emit OwnershipTransferred(address(0), initialOwner);
         _validVerifiers[initialVerifier] = true;
         _verifier = initialVerifier;
@@ -71,7 +71,7 @@ abstract contract ZoneFactory is IZoneFactory {
         external
         returns (uint32 zoneId, address portal)
     {
-        if (msg.sender != _owner) revert NotOwner();
+        if (msg.sender != owner) revert NotOwner();
 
         if (!ITIP20Factory(StdPrecompiles.TIP20_FACTORY_ADDRESS).isTIP20(params.initialToken)) {
             revert InvalidToken();
@@ -146,11 +146,11 @@ abstract contract ZoneFactory is IZoneFactory {
 
     /// @inheritdoc IZoneFactory
     function transferOwnership(address newOwner) external {
-        if (msg.sender != _owner) revert NotOwner();
+        if (msg.sender != owner) revert NotOwner();
         if (newOwner == address(0)) revert InvalidOwner();
 
-        address previousOwner = _owner;
-        _owner = newOwner;
+        address previousOwner = owner;
+        owner = newOwner;
         emit OwnershipTransferred(previousOwner, newOwner);
     }
 
@@ -175,10 +175,6 @@ abstract contract ZoneFactory is IZoneFactory {
     /// @notice Returns the number of zones created, excluding reserved zone 0.
     function zoneCount() external view returns (uint32) {
         return _nextZoneId - 1;
-    }
-
-    function owner() external view returns (address) {
-        return _owner;
     }
 
     function zones(uint32 zoneId) external view returns (ZoneInfo memory) {


### PR DESCRIPTION
## Summary

- specify an owner-only `createZone` gate for the initial permissioned launch
- define atomic owner-only ownership transfer for operational key rotation
- state that the later open-zone hardfork removes the caller restriction
- mirror the behavior in the TIP-1091 verification interface and factory artifact

## Why

The initial Deel launch should prevent arbitrary zone deployment while the team focuses on deploying and operating the launch zone. The restriction is explicitly temporary and does not change the intended open version of zones.

Context: https://tempoxyz.slack.com/archives/C0AC9PZN01M/p1784053221500469

Companion Zones implementation: https://github.com/tempoxyz/zones/pull/660

## Impact

The TIP-1091 activation configures a nonzero factory owner. Only that owner may create zones or atomically transfer ownership until a later hardfork opens creation to all callers.

## Validation

- `FOUNDRY_HARDFORK=cancun forge build --sizes`
- `FOUNDRY_HARDFORK=cancun forge fmt --check`
