### PR TITLE
feat(payload): add txpool prewarming hit rate metric

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1243,6 +1243,11 @@ where
         } else {
             pool_transactions_included as f64 / pool_transactions_yielded as f64
         };
+        let txpool_prewarming_hit_rate = if total_transactions == 0 {
+            0.0
+        } else {
+            txpool_prewarmed_transactions as f64 / total_transactions as f64
+        };
         self.metrics
             .pool_transactions_yielded
             .record(pool_transactions_yielded as f64);
@@ -1261,6 +1266,12 @@ where
         self.metrics
             .parallel_transactions_executed_last
             .set(parallel_transactions_executed as f64);
+        self.metrics
+            .txpool_prewarming_hit_rate
+            .record(txpool_prewarming_hit_rate);
+        self.metrics
+            .txpool_prewarming_hit_rate_last
+            .set(txpool_prewarming_hit_rate);
         self.metrics
             .invalid_pool_transaction_execution_attempts
             .record(invalid_pool_transaction_execution_attempts as f64);
@@ -1318,6 +1329,7 @@ where
             pool_transactions_included,
             parallel_transactions_executed,
             txpool_prewarmed_transactions,
+            txpool_prewarming_hit_rate,
             invalid_pool_transaction_execution_attempts,
             pool_transactions_inclusion_ratio,
             subblock_transactions,

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -41,6 +41,10 @@ pub(crate) struct TempoPayloadBuilderMetrics {
     pub(crate) parallel_transactions_executed: Histogram,
     /// Number of pool transactions committed through parallel storage-action replay in the last payload.
     pub(crate) parallel_transactions_executed_last: Gauge,
+    /// Ratio of block transactions that were prewarmed through the transaction pool.
+    pub(crate) txpool_prewarming_hit_rate: Histogram,
+    /// Ratio of block transactions that were prewarmed through the transaction pool in the last payload.
+    pub(crate) txpool_prewarming_hit_rate_last: Gauge,
     /// Number of pool transaction execution attempts rejected as invalid.
     pub(crate) invalid_pool_transaction_execution_attempts: Histogram,
     /// Ratio of yielded pool transactions that were included in the payload.


### PR DESCRIPTION
## Summary
- record the share of all block transactions prewarmed through the txpool
- expose both a histogram and a last-payload gauge
- include the hit rate in the built-payload log

## Testing
- `cargo +nightly fmt --check`
- `cargo check -p tempo-payload-builder` *(blocked: fetching pinned Commonware git dependency returned HTTP 401)*

Prompted by: @shekhirin