### PR TITLE
fix(tip-1092): clear legacy policy storage

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -209,6 +209,11 @@ impl TIP20Token {
         self.transfer_policy_id.read()
     }
 
+    /// Clears the legacy TIP-20 policy slot after its value has moved to TIP-403.
+    pub(crate) fn delete_legacy_transfer_policy_id(&mut self) -> Result<()> {
+        self.transfer_policy_id.delete()
+    }
+
     /// Returns the PAUSE_ROLE constant
     ///
     /// This role identifier grants permission to pause the token contract.
@@ -271,7 +276,10 @@ impl TIP20Token {
         }
 
         let mut registry = TIP403Registry::new();
-        if StorageCtx.spec().is_t9() && registry.has_token_transfer_policy_for(self.address)? {
+        if StorageCtx.spec().is_t9() {
+            if !registry.has_token_transfer_policy_for(self.address)? {
+                self.delete_legacy_transfer_policy_id()?;
+            }
             registry.set_token_transfer_policy(self.address, call.newPolicyId)?;
         } else {
             self.transfer_policy_id.write(call.newPolicyId)?;

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -3688,6 +3688,33 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_change_transfer_policy_id_migrates_and_clears_legacy_policy() -> eyre::Result<()> {
+        let admin = Address::random();
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::path_usd(admin).apply()?;
+            assert_eq!(token.legacy_transfer_policy_id()?, ALLOW_ALL_POLICY_ID);
+
+            StorageCtx.set_spec(TempoHardfork::T9);
+
+            token.change_transfer_policy_id(
+                admin,
+                ITIP20::changeTransferPolicyIdCall {
+                    newPolicyId: REJECT_ALL_POLICY_ID,
+                },
+            )?;
+
+            let registry = TIP403Registry::new();
+            assert!(registry.has_token_transfer_policy_for(token.address)?);
+            assert_eq!(token.transfer_policy_id()?, REJECT_ALL_POLICY_ID);
+            assert_eq!(token.legacy_transfer_policy_id()?, 0);
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_new_t9_token_registers_transfer_policy() -> eyre::Result<()> {
         let admin = Address::random();
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -3653,6 +3653,7 @@ pub(crate) mod tests {
                 U256::ZERO
             );
             assert!(registry.has_token_transfer_policy_for(token.address)?);
+            assert_eq!(token.legacy_transfer_policy_id()?, 0);
             token.approve(
                 Address::random(),
                 ITIP20::approveCall {
@@ -3669,7 +3670,7 @@ pub(crate) mod tests {
                 },
             )?;
             assert_eq!(token.transfer_policy_id()?, REJECT_ALL_POLICY_ID);
-            assert_eq!(token.legacy_transfer_policy_id()?, ALLOW_ALL_POLICY_ID);
+            assert_eq!(token.legacy_transfer_policy_id()?, 0);
 
             // An existing registry binding is skipped and cannot be overwritten.
             assert_eq!(

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -306,8 +306,10 @@ impl TIP403Registry {
                 continue;
             }
 
-            let policy_id = TIP20Token::from_address(token)?.legacy_transfer_policy_id()?;
+            let mut token_contract = TIP20Token::from_address(token)?;
+            let policy_id = token_contract.legacy_transfer_policy_id()?;
             self.set_token_transfer_policy(token, policy_id)?;
+            token_contract.delete_legacy_transfer_policy_id()?;
             migrated += U256::ONE;
         }
 

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -68,7 +68,7 @@ Zone and provable-contract flows must require `hasTokenTransferPolicy(token) == 
 After activation:
 
 - `transferPolicyId()` returns the effective policy ID: the TIP-403 registry binding if one exists, otherwise the token-local policy ID.
-- `changeTransferPolicyId(uint64 newPolicyId)` validates that `newPolicyId` exists in TIP-403 and updates the TIP-403 binding. If no binding exists, it deletes the token-local policy ID and creates the binding with `newPolicyId` atomically.
+- `changeTransferPolicyId(uint64 newPolicyId)` MUST update TIP-403. If no binding exists, it MUST delete the local TIP-20 policy slot and set the TIP-403 binding to `newPolicyId` atomically; it need not copy the old value first.
 - TIP-20 authorization paths use the effective policy ID.
 
 ## Token Creation
@@ -83,7 +83,7 @@ TIP-403 exposes a batch migration path:
 function migrateTransferPolicyIds(address[] calldata tokens) external returns (uint256 migrated);
 ```
 
-For each valid TIP-20 token without a registry binding, the function copies its legacy local policy ID into TIP-403, then deletes the local policy ID. Invalid and already registered token addresses are skipped without reading local state. The function is callable by any account.
+`migrateTransferPolicyIds(tokens)` MUST, for each valid TIP-20 token without a TIP-403 binding, copy the local policy ID into TIP-403, then delete the local TIP-20 policy slot. It MUST skip an existing TIP-403 binding without reading local state. Invalid token addresses are skipped. The function is callable by any account.
 
 Operators manually migrate existing tokens that are enabled on, or about to be enabled on, a running zone. A zone enablement path may call this migration function itself before accepting the token. An admin policy update also creates the binding for an otherwise unmigrated token, but does not copy the prior local policy ID because `newPolicyId` replaces it.
 

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP lets TIP-403 store the active transfer policy ID for a TIP-20 token. New TIP-20 tokens write this binding during creation. Existing TIP-20 tokens are migrated manually when zones or provable-contract flows need the binding in TIP-403.
+This TIP lets TIP-403 store the active transfer policy ID for a TIP-20 token. New TIP-20 tokens write this binding during creation. Existing TIP-20 tokens receive it when they are migrated for zone/provable-contract use or when an admin first changes their policy after activation.
 
 Unmigrated existing tokens keep working by falling back to the token-local policy ID. Zone and provable-contract flows must use the TIP-403 binding and cannot rely on that fallback.
 
@@ -25,7 +25,7 @@ Storing the binding in TIP-403 gives zones a direct registry lookup for a token'
 ## Assumptions
 
 - TIP-403 is available to zones and provable-contract flows.
-- Existing TIP-20 tokens can remain unmigrated unless a zone or provable-contract flow needs the TIP-403 binding.
+- Existing TIP-20 tokens can remain unmigrated until a zone/provable-contract flow needs the TIP-403 binding or an admin changes their policy after activation.
 
 ---
 
@@ -85,7 +85,7 @@ function migrateTransferPolicyIds(address[] calldata tokens) external returns (u
 
 For each valid TIP-20 token without a registry binding, the function copies its legacy local policy ID into TIP-403, then deletes the local policy ID. Invalid and already registered token addresses are skipped without reading local state. The function is callable by any account.
 
-Operators manually migrate existing tokens that are enabled on, or about to be enabled on, a running zone. A zone enablement path may call this migration function itself before accepting the token.
+Operators manually migrate existing tokens that are enabled on, or about to be enabled on, a running zone. A zone enablement path may call this migration function itself before accepting the token. An admin policy update also creates the binding for an otherwise unmigrated token, but does not copy the prior local policy ID because `newPolicyId` replaces it.
 
 As of July 10, 2026, chain scans found:
 
@@ -94,11 +94,11 @@ As of July 10, 2026, chain scans found:
 | Presto mainnet | 29,189,230 | 4,355 |
 | Moderato testnet | 25,830,853 | 15,291,992 |
 
-The testnet count makes full automatic migration impractical because each migrated token creates a new TIP-403 registry slot. This TIP therefore does not require a hardfork-time batch migration, a system transaction, or migration of every historical token before activation.
+The testnet count makes full automatic migration impractical because each migrated token creates a new TIP-403 registry slot. This TIP therefore does not require a hardfork-time batch migration, a system transaction, or migration of every historical token before activation; bindings are created only by targeted migration, token creation, or a post-activation policy update.
 
 ## Threat Model
 
-- This TIP does not change token-admin authority. The migration path is permissionless because it can only copy the token's current local policy ID into TIP-403 and delete that local value; it cannot choose a different policy ID.
+- This TIP does not change token-admin authority. The migration path is permissionless because it can only copy the token's current local policy ID into TIP-403 and delete that local value; it cannot choose a different policy ID. Only the existing token admin can create a binding with a different value through `changeTransferPolicyId`.
 - The actor or script calling `migrateTransferPolicyIds()` cannot change a policy ID, move it back from TIP-403 to a TIP-20 contract, or block any TIP-20 operation.
 
 # Tooling
@@ -114,5 +114,5 @@ This TIP does not change policy-update events. The existing TIP-20 `TransferPoli
 # Invariants
 
 - Unset registry state remains distinguishable from policy ID `0`.
-- Migration copies the token's current local policy ID into TIP-403 and deletes the local policy ID.
+- Migration copies the token's current local policy ID into TIP-403 and deletes the local policy ID; a first post-activation policy update instead deletes the local policy ID and writes `newPolicyId` directly to TIP-403.
 - Once a TIP-403 binding exists, the token-local policy slot is not read or written.

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -68,7 +68,7 @@ Zone and provable-contract flows must require `hasTokenTransferPolicy(token) == 
 After activation:
 
 - `transferPolicyId()` returns the effective policy ID: the TIP-403 registry binding if one exists, otherwise the token-local policy ID.
-- `changeTransferPolicyId(uint64 newPolicyId)` validates that `newPolicyId` exists in TIP-403. If the token has a TIP-403 registry binding, it updates that binding. Otherwise, it updates the token-local policy ID.
+- `changeTransferPolicyId(uint64 newPolicyId)` validates that `newPolicyId` exists in TIP-403 and updates the TIP-403 binding. If no binding exists, it deletes the token-local policy ID and creates the binding with `newPolicyId` atomically.
 - TIP-20 authorization paths use the effective policy ID.
 
 ## Token Creation
@@ -83,7 +83,7 @@ TIP-403 exposes a batch migration path:
 function migrateTransferPolicyIds(address[] calldata tokens) external returns (uint256 migrated);
 ```
 
-For each valid TIP-20 token without a registry binding, the function copies its legacy local policy ID into TIP-403. Invalid and already registered token addresses are skipped. The function is callable by any account.
+For each valid TIP-20 token without a registry binding, the function copies its legacy local policy ID into TIP-403, then deletes the local policy ID. Invalid and already registered token addresses are skipped without reading local state. The function is callable by any account.
 
 Operators manually migrate existing tokens that are enabled on, or about to be enabled on, a running zone. A zone enablement path may call this migration function itself before accepting the token.
 
@@ -98,7 +98,7 @@ The testnet count makes full automatic migration impractical because each migrat
 
 ## Threat Model
 
-- This TIP does not change token-admin authority. The migration path is permissionless because it only copies the token's current local policy ID into TIP-403 and cannot choose a different policy ID.
+- This TIP does not change token-admin authority. The migration path is permissionless because it can only copy the token's current local policy ID into TIP-403 and delete that local value; it cannot choose a different policy ID.
 - The actor or script calling `migrateTransferPolicyIds()` cannot change a policy ID, move it back from TIP-403 to a TIP-20 contract, or block any TIP-20 operation.
 
 # Tooling
@@ -114,4 +114,5 @@ This TIP does not change policy-update events. The existing TIP-20 `TransferPoli
 # Invariants
 
 - Unset registry state remains distinguishable from policy ID `0`.
-- Migration can only copy the token's current local policy ID into TIP-403.
+- Migration copies the token's current local policy ID into TIP-403 and deletes the local policy ID.
+- Once a TIP-403 binding exists, the token-local policy slot is not read or written.


### PR DESCRIPTION
Make TIP-403 the sole policy location after T9:

- migration copies the legacy TIP-20 policy ID, then deletes the legacy slot
- a first post-T9 policy update deletes the legacy slot and writes `newPolicyId` directly to TIP-403
- migration skips existing TIP-403 bindings without reading legacy state

Includes regression coverage for migration-first and change-first paths.

Prompted by: @0xalpharush