### PR TITLE
chore: bump reth for shared sender recovery cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8595,7 +8595,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8622,7 +8622,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8655,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8688,7 +8688,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8771,7 +8771,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8781,7 +8781,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8834,7 +8834,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8850,7 +8850,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8864,7 +8864,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8902,7 +8902,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8931,7 +8931,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8957,7 +8957,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8987,7 +8987,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9002,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9027,7 +9027,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9051,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9110,7 +9110,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9167,7 +9167,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9195,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9218,7 +9218,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9299,7 +9299,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9329,7 +9329,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9386,7 +9386,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9397,7 +9397,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "clap",
  "eyre",
@@ -9511,7 +9511,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9527,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9556,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9586,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9635,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9655,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9673,7 +9673,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9686,7 +9686,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9705,7 +9705,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9757,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "serde",
  "serde_json",
@@ -9767,7 +9767,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "bytes",
  "futures",
@@ -9813,7 +9813,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9830,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "bindgen",
  "cc",
@@ -9839,7 +9839,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "futures",
  "metrics",
@@ -9852,7 +9852,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9861,7 +9861,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9875,7 +9875,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9933,7 +9933,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9982,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10011,7 +10011,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10028,7 +10028,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10052,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10120,7 +10120,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10222,7 +10222,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10246,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10270,7 +10270,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "bytes",
  "eyre",
@@ -10299,7 +10299,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10311,7 +10311,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10335,7 +10335,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10347,7 +10347,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10370,7 +10370,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10413,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10461,7 +10461,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10489,7 +10489,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10505,7 +10505,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10520,7 +10520,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10597,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10627,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10670,7 +10670,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10690,7 +10690,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10768,7 +10768,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10819,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10833,7 +10833,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10864,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10915,7 +10915,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10943,7 +10943,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10957,7 +10957,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10977,7 +10977,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10992,7 +10992,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11056,7 +11056,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11072,7 +11072,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11082,7 +11082,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "clap",
  "eyre",
@@ -11102,7 +11102,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11121,7 +11121,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11164,7 +11164,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11216,7 +11216,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11235,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11263,7 +11263,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+source = "git+https://github.com/paradigmxyz/reth?rev=d38ccb3599d0ecd537061747f7426f8a471833e3#d38ccb3599d0ecd537061747f7426f8a471833e3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,68 +146,68 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d38ccb3599d0ecd537061747f7426f8a471833e3", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -473,6 +473,8 @@ async fn run_p2p_network(
             IncomingEthRequest::GetCells { response, .. } => {
                 let _ = response.send(Ok(Default::default()));
             }
+            // The proxy does not serve snap protocol data.
+            IncomingEthRequest::GetSnap { .. } => {}
         }
     }
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -47,8 +47,9 @@ use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
     EthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
-        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, LoadBlock,
-        LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction, SpawnBlocking, Trace,
+        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthSubscriptions, EthTransactions,
+        LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction,
+        SpawnBlocking, Trace,
         bal::GetBlockAccessList,
         estimate::EstimateCall,
         pending_block::{BuildPendingEnv, PendingEnvBuilder},
@@ -376,6 +377,8 @@ where
 }
 
 impl<N> EthFees for TempoEthApi<N> where N: TempoEthApiBounds {}
+
+impl<N> EthSubscriptions for TempoEthApi<N> where N: TempoEthApiBounds {}
 
 impl<N> Trace for TempoEthApi<N> where N: TempoEthApiBounds {}
 

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -370,7 +370,7 @@ where
         let BuildArguments {
             cached_reads,
             execution_cache,
-            mut trie_handle,
+            mut state_root_handle,
             config,
             cancel,
             best_payload,
@@ -539,19 +539,22 @@ where
         maybe_override_fee_recipient(&mut executor, &attributes);
 
         let bal_task_handle = if self.enable_bal {
-            let bal_task_handle =
-                self.spawn_bal_task(trie_handle.as_ref().map(|handle| handle.state_hook()));
+            let bal_task_handle = self.spawn_bal_task(
+                state_root_handle
+                    .as_mut()
+                    .map(|handle| handle.take_state_hook()),
+            );
             executor
                 .evm_mut()
                 .db_mut()
                 .set_state_hook(Some(Box::new(bal_task_handle.state_hook())));
             Some(bal_task_handle)
         } else {
-            if let Some(ref handle) = trie_handle {
+            if let Some(handle) = state_root_handle.as_mut() {
                 executor
                     .evm_mut()
                     .db_mut()
-                    .set_state_hook(Some(Box::new(handle.state_hook())));
+                    .set_state_hook(Some(Box::new(handle.take_state_hook())));
             }
             None
         };
@@ -1019,9 +1022,10 @@ where
         // Drop the BAL task sender to trigger finalization.
         let bal_rx = bal_task_handle.map(|handle| handle.into_bal_rx());
 
-        let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
+        let hashed_state = if let Some(Ok(hashed_state)) = state_root_handle
             .as_mut()
-            .map(|rx| rx.take_hashed_state_rx().recv())
+            .and_then(|handle| handle.try_take_hashed_state_rx())
+            .map(|rx| rx.recv())
         {
             hashed_state
         } else {
@@ -1037,7 +1041,7 @@ where
                     "skipping payload state-root computation"
                 );
                 None
-            } else if let Some(mut handle) = trie_handle {
+            } else if let Some(mut handle) = state_root_handle {
                 let state_root_wait_start = Instant::now();
                 let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
                 match handle.state_root() {


### PR DESCRIPTION
## Summary
- Pin Reth dependencies to `d38ccb3599d0ecd537061747f7426f8a471833e3` from `alexey/shared-sender-recovery-cache`.
- Adapt Tempo to the updated payload state-root handle, RPC subscription helper, and incoming snap request APIs.

## Profile
- This dependency bump shares the sender recovery cache across Reth transaction paths.
- Benchmark evidence will be produced by the default Derek preset.

## Verification
- `cargo check --workspace --all-targets`
- `cargo +nightly fmt --all -- --check`
- `git diff --check`

Prompted by: @shekhirin