### PR TITLE
refactor(consensus): use Alloy for follower websocket

### DIFF
--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -52,7 +52,6 @@ commonware-utils.workspace = true
 eyre.workspace = true
 futures.workspace = true
 governor.workspace = true
-jsonrpsee = { workspace = true, features = ["http-client", "ws-client"] }
 indexmap.workspace = true
 jiff = { workspace = true, features = ["std"] }
 parking_lot.workspace = true

--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -1,27 +1,15 @@
-use std::{sync::Arc, time::Duration};
+use std::{pin::Pin, sync::Arc, time::Duration};
 
+use alloy_primitives::B256;
+use alloy_rpc_client::{ClientBuilder, RpcClient, WsConnect};
 use alloy_rpc_types_eth::{Block as RpcBlock, Transaction};
 use commonware_consensus::{Reporter, types::Height};
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner, spawn_cell};
 use eyre::{Report, WrapErr as _, ensure};
-use futures::{
-    FutureExt as _, StreamExt as _,
-    future::{BoxFuture, Either},
-    stream::{self, Fuse, FusedStream},
-};
-use jsonrpsee::{
-    core::{
-        client,
-        client::{ClientT as _, Subscription},
-    },
-    rpc_params,
-    ws_client::{PingConfig, WsClient, WsClientBuilder},
-};
-use rand_08::Rng as _;
+use futures::{FutureExt as _, Stream, StreamExt as _, future::BoxFuture, stream};
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
-use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query, TempoConsensusApiClient};
+use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query};
 use tempo_primitives::{TempoHeader, TempoTxEnvelope};
-use tempo_telemetry_util::display_duration;
 use tokio::{
     select,
     sync::{mpsc, oneshot},
@@ -34,37 +22,32 @@ use crate::{
     utils::OptionFuture,
 };
 
-pub(super) type EventStream =
-    Either<stream::Empty<Result<Event, serde_json::Error>>, Fuse<Subscription<Event>>>;
+type EventStream = Pin<Box<dyn Stream<Item = Event> + Send>>;
 
-const RECONNECT_BACKOFF_FACTOR: u64 = 2;
-const RECONNECT_MAX_BACKOFF: Duration = Duration::from_secs(20);
-const RECONNECT_JITTER: Duration = Duration::from_secs(1);
+/// Alloy sends a ping after this period without outbound traffic. If the peer
+/// does not pong before the next interval, Alloy closes and reconnects the
+/// transport, then replays pending requests and active subscriptions.
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+const RECONNECT_RETRY_INTERVAL: Duration = Duration::from_secs(2);
 
-/// How often websocket pings are sent to keep the connection to the upstream
-/// node alive (and to detect dead connections, triggering a reconnect).
-const PING_INTERVAL: Duration = Duration::from_secs(5);
-/// How long the connection may stay inactive (no pongs or other messages)
-/// before it is considered dead and closed.
-const PING_INACTIVE_LIMIT: Duration = Duration::from_secs(10);
-/// How many times the connection may exceed the inactivity limit before it is
-/// closed.
-const PING_MAX_FAILURES: usize = 1;
+struct Connected {
+    client: Arc<RpcClient>,
+    events: EventStream,
+}
 
-/// Manages the connection to the upstream node.
+/// Manages communication with the upstream node.
 ///
-/// This actor holds the websocket connection to the upstream node, reconnecting
-/// it if necessary.
+/// Alloy owns websocket keepalive, reconnects, pending-request replay, and
+/// resubscription. This actor only establishes the initial client and forwards
+/// requests and subscription events.
 pub(crate) struct Actor<TContext> {
     pub(super) context: ContextCell<TContext>,
-    pub(super) connection: Option<Arc<WsClient>>,
+    client: Option<Arc<RpcClient>>,
     pub(super) mailbox: mpsc::UnboundedReceiver<super::ingress::Message>,
-    pub(super) url: &'static Url,
-    pub(super) pending_connect: OptionFuture<BoxFuture<'static, (u64, eyre::Result<WsClient>)>>,
-    pub(super) pending_stream:
-        OptionFuture<BoxFuture<'static, Result<Subscription<Event>, client::Error>>>,
-    pub(super) event_stream: EventStream,
-    /// Requests waiting for the actor to establish a connection.
+    pub(super) url: Url,
+    pending_connect: OptionFuture<BoxFuture<'static, eyre::Result<Connected>>>,
+    event_stream: EventStream,
+    /// Requests waiting for the initial connection.
     pub(super) waiters: Vec<super::ingress::Message>,
 }
 
@@ -72,6 +55,22 @@ impl<TContext> Actor<TContext>
 where
     TContext: Clock + Metrics + Spawner,
 {
+    pub(crate) fn new(
+        context: ContextCell<TContext>,
+        mailbox: mpsc::UnboundedReceiver<super::ingress::Message>,
+        url: Url,
+    ) -> Self {
+        Self {
+            context,
+            client: None,
+            mailbox,
+            url,
+            pending_connect: OptionFuture::none(),
+            event_stream: inactive_event_stream(),
+            waiters: Vec::new(),
+        }
+    }
+
     pub(crate) fn start(
         mut self,
         reporter: impl Reporter<Activity = Event>,
@@ -81,77 +80,41 @@ where
 
     async fn run(mut self, mut reporter: impl Reporter<Activity = Event>) {
         loop {
-            self.reconnect_or_resubscribe();
+            self.ensure_connected();
             self.drain_waiters();
 
             select!(
                 biased;
 
-                (attempts, client) = &mut self.pending_connect => {
-                    match client {
-                        Ok(client) => {
-                            let client = Arc::new(client);
-                            self.connection.replace(client);
+                connected = &mut self.pending_connect => {
+                    match connected {
+                        Ok(connected) => {
+                            debug_span!("consensus_event_subscription")
+                                .in_scope(|| debug!("connected and subscribed to upstream node"));
+                            self.client = Some(connected.client);
+                            self.event_stream = connected.events;
                         }
                         Err(reason) => {
-                            let reconnect_in = reconnect_delay(attempts);
-                            warn_span!("reconnect").in_scope(|| warn!(
+                            warn_span!("connect").in_scope(|| warn!(
                                 %reason,
-                                attempts,
-                                reconnect_in = %display_duration(reconnect_in),
                                 url = %self.url,
                                 "connecting to upstream node failed, attempting again",
                             ));
-                            self.pending_connect.replace({
-                                let context = self.context.clone();
-                                let url = self.url;
-                                async move {
-                                    context.sleep(reconnect_in).await;
-                                    connect(url, attempts.saturating_add(1)).await
-                                }.boxed()
-                            });
                         }
                     }
                 }
 
-                stream = &mut self.pending_stream => {
-                    match stream {
-                        Ok(stream) => {
-                        debug_span!("consensus_event_subscription")
-                            .in_scope(|| debug!("subscription for consensus events established"));
-                            self.event_stream = active_event_stream(stream);
-                        }
-                        Err(error) => {
-                            warn_span!("event_subscription").in_scope(|| warn!(
-                                reason = %Report::new(error),
-                                "failed subscribing to events; reconnecting to upstream node"
-                            ));
-                            self.connection.take();
-                            self.event_stream = inactive_event_stream();
-                        }
-                    }
-                }
-
-                event = self.event_stream.next(), if !self.event_stream.is_terminated() => {
+                event = self.event_stream.next() => {
                     match event {
-                        Some(Ok(event)) => {
+                        Some(event) => {
                             debug_span!("consensus_event").in_scope(|| debug!(
                                 ?event, "received consensus event, forwarding to reporter"
                             ));
                             reporter.report(event).await;
                         }
-                        Some(Err(error)) => {
-                            warn_span!("event").in_scope(|| warn!(
-                                %error,
-                                "event stream encountered an error",
-                            ));
-                            self.event_stream = inactive_event_stream();
-                        }
                         None => {
-                            warn_span!("event_subscription").in_scope(|| warn!(
-                                url = %self.url,
-                                "event stream terminated",
-                            ));
+                            warn!(url = %self.url, "upstream subscription terminated");
+                            self.client = None;
                             self.event_stream = inactive_event_stream();
                         }
                     }
@@ -164,47 +127,33 @@ where
         }
     }
 
-    #[instrument(skip_all)]
-    fn reconnect_or_resubscribe(&mut self) {
-        if self.pending_connect.is_some() || self.pending_stream.is_some() {
+    fn ensure_connected(&mut self) {
+        if self.client.is_some() || self.pending_connect.is_some() {
             return;
         }
 
-        let Some(client) = self.connection.clone() else {
-            self.pending_connect.replace(connect(self.url, 1));
-            return;
-        };
-
-        if !self.event_stream.is_terminated() {
-            return;
-        }
-
-        if client.is_connected() {
-            self.pending_stream.replace(subscribe(client));
-        } else {
-            warn!(url = %self.url, "upstream client disconnected, reconnecting");
-            self.connection.take();
-            self.pending_connect.replace(connect(self.url, 1));
-        }
+        let url = self.url.clone();
+        let context = self.context.clone();
+        self.pending_connect.replace(
+            async move {
+                loop {
+                    match connect(url.clone()).await {
+                        Ok(connected) => return Ok(connected),
+                        Err(error) => {
+                            warn!(%error, %url, "initial upstream connection failed; retrying");
+                            context.sleep(RECONNECT_RETRY_INTERVAL).await;
+                        }
+                    }
+                }
+            }
+            .boxed(),
+        );
     }
 
-    /// Drains the waiters by fetching the data they are waiting for.
-    ///
-    /// Only executes if a client is present and connected.
     fn drain_waiters(&mut self) {
-        if self.pending_connect.is_some()
-            || self.pending_stream.is_some()
-            || self.event_stream.is_terminated()
-        {
-            return;
-        }
-
-        let Some(client) = &self.connection else {
+        let Some(client) = &self.client else {
             return;
         };
-        if !client.is_connected() {
-            return;
-        }
 
         for request in self.waiters.drain(..) {
             match request {
@@ -225,65 +174,41 @@ where
     }
 }
 
-fn connect(url: &'static Url, attempts: u64) -> BoxFuture<'static, (u64, eyre::Result<WsClient>)> {
-    async move {
-        (
-            attempts,
-            WsClientBuilder::default()
-                .enable_ws_ping(
-                    PingConfig::new()
-                        .ping_interval(PING_INTERVAL)
-                        .inactive_limit(PING_INACTIVE_LIMIT)
-                        .max_failures(PING_MAX_FAILURES),
-                )
-                .build(url)
-                .await
-                .map_err(Report::new),
-        )
-    }
-    .boxed()
+async fn connect(url: Url) -> eyre::Result<Connected> {
+    let connector = WsConnect::new(url.to_string())
+        .with_keepalive_interval(KEEPALIVE_INTERVAL)
+        .with_retry_interval(RECONNECT_RETRY_INTERVAL)
+        .with_max_retries(u32::MAX);
+    let client = Arc::new(
+        ClientBuilder::default()
+            .ws(connector)
+            .await
+            .map_err(Report::new)?,
+    );
+
+    let mut call = client.request_noparams::<B256>("consensus_subscribe");
+    call.set_is_subscription();
+    let subscription_id = call.await.map_err(Report::new)?;
+    let subscription = client.get_subscription::<Event>(subscription_id).await;
+
+    Ok(Connected {
+        client,
+        events: Box::pin(subscription.into_stream()),
+    })
 }
 
-fn subscribe(
-    client: Arc<WsClient>,
-) -> BoxFuture<'static, Result<Subscription<Event>, client::Error>> {
-    async move { client.subscribe_events().await }.boxed()
-}
-
-pub(super) fn inactive_event_stream() -> EventStream {
-    Either::Left(stream::empty())
-}
-
-fn active_event_stream(stream: Subscription<Event>) -> EventStream {
-    Either::Right(stream.fuse())
-}
-
-fn reconnect_delay(attempts: u64) -> Duration {
-    reconnect_backoff(attempts) + random_jitter()
-}
-
-fn reconnect_backoff(attempts: u64) -> Duration {
-    let backoff_secs = attempts.saturating_mul(RECONNECT_BACKOFF_FACTOR);
-    let backoff = Duration::from_secs(backoff_secs);
-
-    backoff.min(RECONNECT_MAX_BACKOFF)
-}
-
-fn random_jitter() -> Duration {
-    let max_jitter_millis = RECONNECT_JITTER.as_millis() as u64;
-    Duration::from_millis(rand_08::thread_rng().gen_range(0..=max_jitter_millis))
+fn inactive_event_stream() -> EventStream {
+    Box::pin(stream::pending())
 }
 
 #[instrument(skip_all, fields(%height), err)]
 async fn get_finalization(
-    client: Arc<WsClient>,
+    client: Arc<RpcClient>,
     height: Height,
     response: oneshot::Sender<Option<CertifiedBlock>>,
 ) -> eyre::Result<()> {
-    // TODO: right now, the response channel would just drop and an error
-    // emitted here. Should this failure be propagated upstream?
     let finalization = client
-        .get_finalization(Query::Height(height.get()))
+        .request("consensus_getFinalization", (Query::Height(height.get()),))
         .await
         .wrap_err("failed getting finalization")?;
     response
@@ -294,14 +219,14 @@ async fn get_finalization(
 /// Fetches a full consensus block from the upstream node.
 #[instrument(skip_all, fields(%digest), err)]
 async fn get_block(
-    client: Arc<WsClient>,
+    client: Arc<RpcClient>,
     digest: Digest,
     response: oneshot::Sender<Option<Block>>,
 ) -> eyre::Result<()> {
     let block = client
-        .request::<Option<RpcBlock<Transaction<TempoTxEnvelope>, TempoHeader>>, _>(
+        .request::<_, Option<RpcBlock<Transaction<TempoTxEnvelope>, TempoHeader>>>(
             "eth_getBlockByHash",
-            rpc_params![digest.0, true],
+            (digest.0, true),
         )
         .await
         .wrap_err("failed getting block by hash")?
@@ -323,21 +248,4 @@ async fn get_block(
     response
         .send(block)
         .map_err(|_| eyre::eyre!("receiver went away"))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn reconnect_backoff_linearly_increases_and_caps() {
-        assert_eq!(reconnect_backoff(0), Duration::from_secs(0));
-        assert_eq!(reconnect_backoff(1), Duration::from_secs(2));
-        assert_eq!(reconnect_backoff(2), Duration::from_secs(4));
-        assert_eq!(reconnect_backoff(3), Duration::from_secs(6));
-        assert_eq!(reconnect_backoff(4), Duration::from_secs(8));
-        assert_eq!(reconnect_backoff(5), Duration::from_secs(10));
-        assert_eq!(reconnect_backoff(10), RECONNECT_MAX_BACKOFF);
-        assert_eq!(reconnect_backoff(u64::MAX), RECONNECT_MAX_BACKOFF);
-    }
 }

--- a/crates/consensus/src/follow/upstream/in_process.rs
+++ b/crates/consensus/src/follow/upstream/in_process.rs
@@ -1,5 +1,5 @@
-//! An upstream provider to be used in e2e tests The [`jsonrpsee`] stack used by
-//! the standard websocket based provider requires a tokio runtime, which the tests
+//! An upstream provider to be used in e2e tests. The Alloy stack used by the
+//! standard websocket-based provider requires a Tokio runtime, which the tests
 //! runtime does not provide.
 
 use std::{sync::Arc, time::Duration};

--- a/crates/consensus/src/follow/upstream/mod.rs
+++ b/crates/consensus/src/follow/upstream/mod.rs
@@ -11,8 +11,6 @@ use tempo_node::rpc::consensus::Event;
 use tokio::sync::mpsc;
 use url::Url;
 
-use crate::utils::OptionFuture;
-
 mod actor;
 pub mod in_process;
 mod ingress;
@@ -50,24 +48,13 @@ pub(crate) fn init<TContext>(
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = ingress::Mailbox::new(tx);
 
-    let url = Box::leak(Box::from(
-        parse_upstream_url(&config.upstream_url).wrap_err_with(|| {
-            format!(
-                "failed parsing upstream location as websocket URL: `{}`",
-                config.upstream_url
-            )
-        })?,
-    ));
-    let actor = Actor {
-        context: ContextCell::new(context),
-        connection: None,
-        mailbox: rx,
-        url,
-        pending_connect: OptionFuture::none(),
-        pending_stream: OptionFuture::none(),
-        event_stream: actor::inactive_event_stream(),
-        waiters: Vec::new(),
-    };
+    let url = parse_upstream_url(&config.upstream_url).wrap_err_with(|| {
+        format!(
+            "failed parsing upstream location as websocket URL: `{}`",
+            config.upstream_url
+        )
+    })?;
+    let actor = Actor::new(ContextCell::new(context), rx, url);
 
     Ok((actor, mailbox))
 }


### PR DESCRIPTION
Migrates the follower upstream websocket to Alloy pubsub, which owns keepalive, reconnect backoff, pending-request replay, and resubscription. Removes the duplicate jsonrpsee connection and subscription state machine while retaining initial-connect retry and request/event forwarding.

Prompted by: @klkvr