### PR TITLE
test: add T8 live-network feature checks

### DIFF
--- a/scripts/t8/README.md
+++ b/scripts/t8/README.md
@@ -1,0 +1,37 @@
+# T8 network checks
+
+These scripts exercise the externally observable behavior of TIP-1042,
+TIP-1062/TIP-1087, TIP-1070, and TIP-1075 against a live Tempo RPC. They mutate
+chain state and should be run with a disposable funded key.
+
+```bash
+export RPC_URL=https://rpc-nextfork.devnet.tempo.xyz
+export PRIVATE_KEY=0x...
+scripts/t8/run-all.sh
+```
+
+`USE_FAUCET=1` (the default) calls `tempo_fundAddress`. Set it to `0` when the
+key is already funded. The TIP-1070 check reads the current committee; set
+`WAIT_FOR_EPOCH=1` to keep polling until the onchain committee epoch advances.
+
+## DEX transition and gas comparison
+
+Run setup before T8 activation and verification after activation with the same
+key and state file:
+
+```bash
+T8_DEX_STATE_FILE=t8-moderato.json scripts/t8/test-tip-1062-1087.sh setup
+# activate T8
+T8_DEX_STATE_FILE=t8-moderato.json scripts/t8/test-tip-1062-1087.sh verify
+```
+
+The setup phase places a legacy order and records its receipt gas. Verification
+confirms that the legacy order remains readable, assigns the saved book index,
+places a new order on the indexed book, cancels the legacy order, and requires
+the indexed placement to use less gas. On a network where T8 is already active,
+`post-only` verifies new indexed orderbook lookup plus order placement/cancel.
+
+The public DEX ABI intentionally hides the physical order version. The test
+therefore proves V2 eligibility by checking the persisted book index and then
+exercising the write/read/cancel path whose T8 implementation selects V2 for an
+indexed book; exact storage layout remains covered by the Rust unit tests.

--- a/scripts/t8/common.sh
+++ b/scripts/t8/common.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+readonly TIP20_FACTORY="0x20FC000000000000000000000000000000000000"
+readonly TIP_FEE_MANAGER="0xfeec000000000000000000000000000000000000"
+readonly TIP403_REGISTRY="0x403C000000000000000000000000000000000000"
+readonly STABLECOIN_DEX="0xdec0000000000000000000000000000000000000"
+readonly CURRENT_COMMITTEE="0xC077E00000000000000000000000000000000000"
+readonly PATH_USD="0x20C0000000000000000000000000000000000000"
+
+require_env() {
+  local name
+  for name in "$@"; do
+    if [[ -z "${!name:-}" ]]; then
+      echo "missing required environment variable: $name" >&2
+      exit 2
+    fi
+  done
+}
+
+require_tools() {
+  local tool
+  for tool in cast jq; do
+    command -v "$tool" >/dev/null || { echo "required tool not found: $tool" >&2; exit 2; }
+  done
+}
+
+require_t8() {
+  local schedule
+  schedule=$(rpc tempo_forkSchedule)
+  if ! jq -e '.schedule[] | select(.name == "T8" and .active == true)' \
+    >/dev/null <<<"$schedule"; then
+    echo "T8 is not active on $RPC_URL" >&2
+    exit 2
+  fi
+}
+
+rpc() { cast rpc --rpc-url "$RPC_URL" "$@"; }
+call() { cast call --rpc-url "$RPC_URL" "$@"; }
+scalar() { call "$@" | awk 'NR == 1 { print $1 }'; }
+
+send() {
+  cast send --rpc-url "$RPC_URL" --private-key "$PRIVATE_KEY" --json "$@"
+}
+
+tx_hash() { jq -er '.transactionHash'; }
+
+assert_eq() {
+  local expected="$1" actual="$2" message="$3"
+  if [[ "${expected,,}" != "${actual,,}" ]]; then
+    echo "FAIL: $message (expected=$expected actual=$actual)" >&2
+    exit 1
+  fi
+}
+
+assert_ne() {
+  local unexpected="$1" actual="$2" message="$3"
+  if [[ "${unexpected,,}" == "${actual,,}" ]]; then
+    echo "FAIL: $message (unexpected=$unexpected)" >&2
+    exit 1
+  fi
+}
+
+receipt_field() {
+  local hash="$1" field="$2"
+  cast receipt --rpc-url "$RPC_URL" "$hash" --json | jq -er ".$field"
+}
+
+send_hash() {
+  send "$@" | tx_hash
+}
+
+send_ok() {
+  local hash status
+  hash=$(send_hash "$@")
+  status=$(receipt_field "$hash" status)
+  assert_eq "0x1" "$status" "transaction $hash reverted"
+  echo "$hash"
+}
+
+fund_address() {
+  local address="$1"
+  if [[ "${USE_FAUCET:-1}" == "1" ]]; then
+    rpc tempo_fundAddress "$address" >/dev/null
+  fi
+}
+
+new_salt() {
+  cast keccak "t8-network-test:$1:$(date +%s%N):$$"
+}
+
+create_tip20() {
+  local label="$1" admin="$2" salt token issuer_role
+  salt=$(new_salt "$label")
+  token=$(call "$TIP20_FACTORY" \
+    "getTokenAddress(address,bytes32)(address)" "$admin" "$salt")
+  send_ok "$TIP20_FACTORY" \
+    "createToken(string,string,string,address,address,bytes32)(address)" \
+    "T8 $label" "T8${label:0:3}" "USD" "$PATH_USD" "$admin" "$salt" >/dev/null
+  issuer_role=$(cast keccak "ISSUER_ROLE")
+  send_ok "$token" "grantRole(bytes32,address)" "$issuer_role" "$admin" >/dev/null
+  echo "$token"
+}
+
+account_address() {
+  cast wallet address --private-key "$PRIVATE_KEY"
+}
+
+gas_used_decimal() {
+  local hash="$1" gas
+  gas=$(receipt_field "$hash" gasUsed)
+  cast to-dec "$gas"
+}
+
+print_pass() { echo "PASS: $*"; }

--- a/scripts/t8/run-all.sh
+++ b/scripts/t8/run-all.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+dir=$(cd "$(dirname "$0")" && pwd)
+
+"$dir/test-tip-1042.sh"
+"$dir/test-tip-1062-1087.sh" "${DEX_MODE:-post-only}"
+"$dir/test-tip-1070.sh"
+"$dir/test-tip-1075.sh"
+
+echo "PASS: all requested T8 network checks completed"

--- a/scripts/t8/test-tip-1042.sh
+++ b/scripts/t8/test-tip-1042.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+require_tools
+require_env RPC_URL PRIVATE_KEY
+require_t8
+
+admin=$(account_address)
+fund_address "$admin"
+beneficiary=$(cast block --rpc-url "$RPC_URL" latest --json | jq -er '.miner')
+validator_token=$(call "$TIP_FEE_MANAGER" "validatorTokens(address)(address)" "$beneficiary")
+if [[ "${validator_token,,}" == "0x0000000000000000000000000000000000000000" ]]; then
+  validator_token="$PATH_USD"
+fi
+
+fee_token=$(create_tip20 "fee" "$admin")
+mint_amount=1000000000000
+send_ok "$fee_token" "mint(address,uint256)" "$admin" "$mint_amount" >/dev/null
+
+# Seed the pool while FeeManager is authorized, then make FeeManager explicitly
+# unauthorized. TIP-1042 must exempt only protocol fee collection, not public AMM calls.
+send_ok "$fee_token" "approve(address,uint256)(bool)" "$TIP_FEE_MANAGER" "$mint_amount" >/dev/null
+send_ok "$validator_token" "approve(address,uint256)(bool)" "$TIP_FEE_MANAGER" "$mint_amount" >/dev/null
+send_ok "$TIP_FEE_MANAGER" "mint(address,address,uint256,address)(uint256)" \
+  "$fee_token" "$validator_token" 1000000 "$admin" >/dev/null
+send_ok "$TIP_FEE_MANAGER" "setUserToken(address)" "$fee_token" >/dev/null
+
+policy_before=$(scalar "$TIP403_REGISTRY" "policyIdCounter()(uint64)")
+send_ok "$TIP403_REGISTRY" "createPolicy(address,uint8)(uint64)" "$admin" 1 >/dev/null
+policy_after=$(scalar "$TIP403_REGISTRY" "policyIdCounter()(uint64)")
+assert_ne "$policy_before" "$policy_after" "blacklist policy was not created"
+policy_id="$policy_before"
+
+send_ok "$TIP403_REGISTRY" "modifyPolicyBlacklist(uint64,address,bool)" \
+  "$policy_id" "$TIP_FEE_MANAGER" true >/dev/null
+send_ok "$fee_token" "changeTransferPolicyId(uint64)" "$policy_id" >/dev/null
+
+authorized=$(scalar "$TIP403_REGISTRY" "isAuthorizedRecipient(uint64,address)(bool)" \
+  "$policy_id" "$TIP_FEE_MANAGER")
+assert_eq "false" "$authorized" "FeeManager must be blacklisted for this test"
+
+balance_before=$(scalar "$fee_token" "balanceOf(address)(uint256)" "$admin")
+recipient=$(cast wallet new --json | jq -er '.[0].address')
+hash=$(send_ok "$PATH_USD" "transfer(address,uint256)(bool)" "$recipient" 1)
+balance_after=$(scalar "$fee_token" "balanceOf(address)(uint256)" "$admin")
+if (( balance_after >= balance_before )); then
+  echo "FAIL: fee-token balance did not decrease ($balance_before -> $balance_after)" >&2
+  exit 1
+fi
+
+print_pass "TIP-1042 paid transaction $hash with $fee_token while FeeManager was blacklisted"

--- a/scripts/t8/test-tip-1062-1087.sh
+++ b/scripts/t8/test-tip-1062-1087.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+require_tools
+require_env RPC_URL PRIVATE_KEY
+
+mode=${1:-post-only}
+state_file=${T8_DEX_STATE_FILE:-.t8-dex-state.json}
+admin=$(account_address)
+
+if [[ "$mode" != "setup" ]]; then
+  require_t8
+fi
+
+place_order() {
+  local token="$1" order_id hash gas order
+  order_id=$(scalar "$STABLECOIN_DEX" "nextOrderId()(uint128)")
+  hash=$(send_ok "$STABLECOIN_DEX" "place(address,uint128,bool,int16)(uint128)" \
+    "$token" "$(scalar "$STABLECOIN_DEX" "MIN_ORDER_AMOUNT()(uint128)")" false 0)
+  gas=$(gas_used_decimal "$hash")
+  order=$(call "$STABLECOIN_DEX" \
+    "getOrder(uint128)((uint128,address,bytes32,bool,int16,uint128,uint128,uint128,uint128,bool,int16))" \
+    "$order_id")
+  [[ -n "$order" ]] || { echo "FAIL: order $order_id is not readable" >&2; exit 1; }
+  printf '%s %s %s\n' "$order_id" "$hash" "$gas"
+}
+
+setup_pair() {
+  local token key
+  fund_address "$admin"
+  token=$(create_tip20 "dex" "$admin")
+  send_ok "$token" "mint(address,uint256)" "$admin" 1000000000000 >/dev/null
+  send_ok "$token" "approve(address,uint256)(bool)" "$STABLECOIN_DEX" \
+    0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff >/dev/null
+  key=$(call "$STABLECOIN_DEX" "pairKey(address,address)(bytes32)" "$token" "$PATH_USD")
+  send_ok "$STABLECOIN_DEX" "createPair(address)(bytes32)" "$token" >/dev/null
+  printf '%s %s\n' "$token" "$key"
+}
+
+find_book_index() {
+  local wanted="${1,,}" max=${BOOK_INDEX_SCAN_LIMIT:-10000} i key
+  for ((i=0; i<max; i++)); do
+    if ! key=$(call "$STABLECOIN_DEX" "bookKeyForIndex(uint32)(bytes32)" "$i" 2>/dev/null); then
+      break
+    fi
+    if [[ "${key,,}" == "$wanted" ]]; then echo "$i"; return 0; fi
+  done
+  echo "book key $1 not found within first $max entries" >&2
+  return 1
+}
+
+case "$mode" in
+  setup)
+    read -r token key < <(setup_pair)
+    read -r order_id hash gas < <(place_order "$token")
+    jq -n --arg token "$token" --arg bookKey "$key" --arg orderId "$order_id" \
+      --arg txHash "$hash" --argjson gas "$gas" \
+      '{token:$token,bookKey:$bookKey,legacyOrderId:$orderId,legacyTxHash:$txHash,legacyGas:$gas}' \
+      >"$state_file"
+    chmod 600 "$state_file"
+    print_pass "TIP-1062 pre-fork fixture saved to $state_file (order $order_id, gas $gas)"
+    ;;
+  verify)
+    [[ -f "$state_file" ]] || { echo "missing setup state: $state_file" >&2; exit 2; }
+    token=$(jq -er '.token' "$state_file")
+    key=$(jq -er '.bookKey' "$state_file")
+    legacy_order=$(jq -er '.legacyOrderId' "$state_file")
+    legacy_gas=$(jq -er '.legacyGas' "$state_file")
+    call "$STABLECOIN_DEX" \
+      "getOrder(uint128)((uint128,address,bytes32,bool,int16,uint128,uint128,uint128,uint128,bool,int16))" \
+      "$legacy_order" >/dev/null
+    index=$(find_book_index "$key")
+    send_ok "$STABLECOIN_DEX" "setBookIndex(uint32)" "$index" >/dev/null
+    indexed=$(call "$STABLECOIN_DEX" "bookIndexForKey(bytes32)(bool,uint32)" "$key" --json)
+    assert_eq "true" "$(jq -er '.[0]' <<<"$indexed")" "orderbook index was not persisted"
+    read -r v2_order hash v2_gas < <(place_order "$token")
+    send_ok "$STABLECOIN_DEX" "cancel(uint128)" "$legacy_order" >/dev/null
+    if (( v2_gas >= legacy_gas )); then
+      echo "FAIL: indexed V2 placement did not reduce gas ($legacy_gas -> $v2_gas)" >&2
+      exit 1
+    fi
+    print_pass "TIP-1062/1087 migrated legacy order $legacy_order, placed indexed V2 order $v2_order, gas $legacy_gas -> $v2_gas"
+    ;;
+  post-only)
+    read -r token key < <(setup_pair)
+    indexed=$(call "$STABLECOIN_DEX" "bookIndexForKey(bytes32)(bool,uint32)" "$key" --json)
+    assert_eq "true" "$(jq -er '.[0]' <<<"$indexed")" "new T8 orderbook has no saved index"
+    index=$(jq -er '.[1]' <<<"$indexed")
+    resolved=$(call "$STABLECOIN_DEX" "bookKeyForIndex(uint32)(bytes32)" "$index")
+    assert_eq "$key" "$resolved" "saved index resolves to the wrong orderbook"
+    read -r order_id hash gas < <(place_order "$token")
+    send_ok "$STABLECOIN_DEX" "cancel(uint128)" "$order_id" >/dev/null
+    print_pass "TIP-1062/1087 placed and cancelled indexed V2-eligible order $order_id (gas $gas)"
+    ;;
+  *)
+    echo "usage: $0 setup|verify|post-only" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/t8/test-tip-1070.sh
+++ b/scripts/t8/test-tip-1070.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+require_tools
+require_env RPC_URL
+require_t8
+
+read_committee() {
+  call "$CURRENT_COMMITTEE" "getCommitteeMembers()(uint64,bytes32[])" --json
+}
+
+committee=$(read_committee)
+epoch=$(jq -er '.[0]' <<<"$committee")
+members=$(jq -er '.[1] | length' <<<"$committee")
+if (( members == 0 )); then
+  echo "FAIL: onchain committee is empty at epoch $epoch" >&2
+  exit 1
+fi
+print_pass "TIP-1070 exposes $members committee members for epoch $epoch"
+
+if [[ "${WAIT_FOR_EPOCH:-0}" != "1" ]]; then
+  exit 0
+fi
+
+deadline=$((SECONDS + ${EPOCH_TIMEOUT_SECONDS:-7200}))
+interval=${EPOCH_POLL_SECONDS:-15}
+while (( SECONDS < deadline )); do
+  sleep "$interval"
+  next=$(read_committee)
+  next_epoch=$(jq -er '.[0]' <<<"$next")
+  if (( next_epoch > epoch )); then
+    next_members=$(jq -er '.[1] | length' <<<"$next")
+    (( next_members > 0 )) || { echo "FAIL: committee became empty at epoch $next_epoch" >&2; exit 1; }
+    print_pass "TIP-1070 committee advanced from epoch $epoch to $next_epoch ($next_members members)"
+    exit 0
+  fi
+done
+
+echo "FAIL: committee epoch did not advance from $epoch within ${EPOCH_TIMEOUT_SECONDS:-7200}s" >&2
+exit 1

--- a/scripts/t8/test-tip-1075.sh
+++ b/scripts/t8/test-tip-1075.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+require_tools
+require_env RPC_URL PRIVATE_KEY
+require_t8
+
+admin=$(account_address)
+fund_address "$admin"
+token=$(create_tip20 "rewards" "$admin")
+recipient=$(cast wallet new --json | jq -er '.[0].address')
+
+send_ok "$token" "mint(address,uint256)" "$admin" 1000000000 >/dev/null
+
+snapshot() {
+  jq -nc \
+    --arg opted "$(call "$token" "optedInSupply()(uint128)")" \
+    --arg global "$(call "$token" "globalRewardPerToken()(uint256)")" \
+    --arg info "$(call "$token" "userRewardInfo(address)((address,uint256,uint256))" "$admin")" \
+    '{optedInSupply:$opted,globalRewardPerToken:$global,userRewardInfo:$info}'
+}
+
+before=$(snapshot)
+send_ok "$token" "setRewardRecipient(address)" "$recipient" >/dev/null
+send_ok "$token" "distributeReward(uint256)" 1000000 >/dev/null
+send_ok "$token" "transfer(address,uint256)(bool)" "$recipient" 1 >/dev/null
+send_ok "$token" "mint(address,uint256)" "$admin" 1 >/dev/null
+send_ok "$token" "burn(uint256)" 1 >/dev/null
+after_paths=$(snapshot)
+assert_eq "$before" "$after_paths" "T8 reward state changed through deprecated or balance paths"
+
+claimed=$(scalar "$token" "claimRewards()(uint256)" --from "$admin")
+assert_eq "0" "$claimed" "fresh T8 account unexpectedly has claimable rewards"
+send_ok "$token" "claimRewards()(uint256)" >/dev/null
+after_claim=$(snapshot)
+assert_eq "$before" "$after_claim" "claimRewards mutated fresh T8 reward state"
+
+print_pass "TIP-1075 reward APIs and transfer/mint/burn paths left reward state unchanged"


### PR DESCRIPTION
Adds reusable live-network checks for the requested T8 TIPs:

- TIP-1042: pays fees in a custom token while FeeManager is explicitly blacklisted
- TIP-1062/1087: supports pre/post activation migration testing, indexed V2-eligible placement, legacy-order compatibility, and receipt-gas comparison
- TIP-1070: reads the effective committee and optionally waits for an epoch transition
- TIP-1075: verifies deprecated APIs and balance-changing paths leave reward state unchanged

Includes a combined runner and usage documentation for nextfork and Moderato.

Validation:
- `bash -n scripts/t8/*.sh`
- `git diff --cached --check`
- ABI calldata encoding checks with `cast calldata`
- missing-environment guard smoke test

Not run: `cargo test -p tempo-precompiles test_t8 --lib` could not fetch the pinned Commonware Git dependency because the dependency endpoint returned HTTP 401. Live scripts were not executed because that would mutate a network.

Prompted by: @klkvr