### PR TITLE
perf(tip-1092): use direct token policy slots

### DIFF
--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -63,9 +63,6 @@ pub struct TIP403Registry {
     policy_set: Mapping<u64, Mapping<Address, bool>>,
     /// Account receive policy configuration.
     receive_policies: Mapping<Address, ReceivePolicy>,
-    /// TIP-1092 token-to-policy bindings. Unset entries fall back to the policy ID stored on the
-    /// TIP-20 token.
-    token_transfer_policies: Mapping<Address, TokenTransferPolicy>,
 }
 
 /// Packed TIP-1092 token-to-policy binding.
@@ -75,6 +72,19 @@ struct TokenTransferPolicy {
     policy_id: u64,
     /// Distinguishes an unset binding from the valid reject-all policy ID `0`.
     is_set: bool,
+}
+
+impl TokenTransferPolicy {
+    /// Returns the handler for a token's non-standard direct-address storage slot.
+    ///
+    /// TIP-20 addresses occupy the reserved `0x20C0...` namespace, so their zero-padded address
+    /// values cannot collide with TIP-403's sequential Solidity storage slots.
+    fn at(token: Address) -> TokenTransferPolicyHandler {
+        TokenTransferPolicyHandler::new(
+            U256::from_be_slice(token.as_slice()),
+            TIP403_REGISTRY_ADDRESS,
+        )
+    }
 }
 
 /// Per-account TIP-1028 receive policy configuration.
@@ -276,7 +286,7 @@ impl TIP403Registry {
         &self,
         token: Address,
     ) -> Result<Option<u64>> {
-        let binding = self.token_transfer_policies[token].read()?;
+        let binding = TokenTransferPolicy::at(token).read()?;
         Ok(binding.is_set.then_some(binding.policy_id))
     }
 
@@ -286,7 +296,7 @@ impl TIP403Registry {
         token: Address,
         policy_id: u64,
     ) -> Result<()> {
-        self.token_transfer_policies[token].write(TokenTransferPolicy {
+        TokenTransferPolicy::at(token).write(TokenTransferPolicy {
             policy_id,
             is_set: true,
         })
@@ -1040,7 +1050,7 @@ mod tests {
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
     };
     use alloy::{
-        primitives::{Address, Log},
+        primitives::{Address, Log, address},
         sol_types::SolEvent,
     };
     use rand_08::Rng;
@@ -1048,6 +1058,36 @@ mod tests {
         PATH_USD_ADDRESS, SYSTEM_PRECOMPILES, TIP403_REGISTRY_ADDRESS,
     };
     use tempo_primitives::{MasterId, TempoAddressExt, UserTag};
+
+    #[test]
+    fn test_token_transfer_policy_uses_token_address_as_slot() -> eyre::Result<()> {
+        let token = address!("20c0000000000000000000000000000000001234");
+        let token_slot = U256::from_be_slice(token.as_slice());
+        let mut storage = HashMapStorageProvider::new(1);
+
+        StorageCtx::enter(&mut storage, || {
+            let mut registry = TIP403Registry::new();
+            registry.set_token_transfer_policy(token, 42)?;
+
+            assert_eq!(
+                registry.registered_token_transfer_policy_id(token)?,
+                Some(42)
+            );
+            Ok::<(), TempoPrecompileError>(())
+        })?;
+
+        let entries = storage.into_storage().collect::<Vec<_>>();
+        assert_eq!(
+            entries,
+            vec![(
+                TIP403_REGISTRY_ADDRESS,
+                token_slot,
+                U256::from(42) | (U256::ONE << 64),
+            )]
+        );
+
+        Ok(())
+    }
 
     #[test]
     fn test_create_policy() -> eyre::Result<()> {

--- a/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
+++ b/crates/precompiles/tests/storage_tests/solidity/precompiles.rs
@@ -21,8 +21,7 @@ fn test_tip403_registry_layout() {
         policy_id_counter,
         policy_records,
         policy_set,
-        receive_policies,
-        token_transfer_policies
+        receive_policies
     );
     if let Err(errors) = compare_layouts(&solc_layout, &rust_layout) {
         panic_layout_mismatch("Layout", errors, &sol_path);
@@ -60,17 +59,6 @@ fn test_tip403_registry_layout() {
             compare_nested_struct_type(&solc_layout, "CompoundPolicyData", &rust_compound)
         {
             panic_layout_mismatch("CompoundPolicyData struct layout", errors, &sol_path);
-        }
-    }
-
-    // Verify `TokenTransferPolicy` packs the ID and set bit into one slot.
-    {
-        use tempo_precompiles::tip403_registry::__packing_token_transfer_policy::*;
-        let rust_binding = struct_fields!(slots::TOKEN_TRANSFER_POLICIES, policy_id, is_set);
-        if let Err(errors) =
-            compare_nested_struct_type(&solc_layout, "TokenTransferPolicy", &rust_binding)
-        {
-            panic_layout_mismatch("TokenTransferPolicy struct layout", errors, &sol_path);
         }
     }
 }

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.layout.json
@@ -4,7 +4,7 @@
       "storage-layout": {
         "storage": [
           {
-            "astId": 48,
+            "astId": 43,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policyIdCounter",
             "offset": 0,
@@ -12,7 +12,7 @@
             "type": "t_uint64"
           },
           {
-            "astId": 54,
+            "astId": 49,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policyRecords",
             "offset": 0,
@@ -20,7 +20,7 @@
             "type": "t_mapping(t_uint64,t_struct(PolicyRecord)21_storage)"
           },
           {
-            "astId": 61,
+            "astId": 56,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "policySet",
             "offset": 0,
@@ -28,20 +28,12 @@
             "type": "t_mapping(t_uint64,t_mapping(t_address,t_bool))"
           },
           {
-            "astId": 67,
+            "astId": 62,
             "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
             "label": "receivePolicies",
             "offset": 0,
             "slot": "3",
             "type": "t_mapping(t_address,t_struct(ReceivePolicy)40_storage)"
-          },
-          {
-            "astId": 73,
-            "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-            "label": "tokenTransferPolicies",
-            "offset": 0,
-            "slot": "4",
-            "type": "t_mapping(t_address,t_struct(TokenTransferPolicy)45_storage)"
           }
         ],
         "types": {
@@ -68,13 +60,6 @@
             "label": "mapping(address => struct TIP403Registry.ReceivePolicy)",
             "numberOfBytes": "32",
             "value": "t_struct(ReceivePolicy)40_storage"
-          },
-          "t_mapping(t_address,t_struct(TokenTransferPolicy)45_storage)": {
-            "encoding": "mapping",
-            "key": "t_address",
-            "label": "mapping(address => struct TIP403Registry.TokenTransferPolicy)",
-            "numberOfBytes": "32",
-            "value": "t_struct(TokenTransferPolicy)45_storage"
           },
           "t_mapping(t_uint64,t_mapping(t_address,t_bool))": {
             "encoding": "mapping",
@@ -241,29 +226,6 @@
                 "offset": 19,
                 "slot": "0",
                 "type": "t_uint8"
-              }
-            ],
-            "numberOfBytes": "32"
-          },
-          "t_struct(TokenTransferPolicy)45_storage": {
-            "encoding": "inplace",
-            "label": "struct TIP403Registry.TokenTransferPolicy",
-            "members": [
-              {
-                "astId": 42,
-                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-                "label": "policyId",
-                "offset": 0,
-                "slot": "0",
-                "type": "t_uint64"
-              },
-              {
-                "astId": 44,
-                "contract": "tests/storage_tests/solidity/testdata/tip403_registry.sol:TIP403Registry",
-                "label": "isSet",
-                "offset": 8,
-                "slot": "0",
-                "type": "t_bool"
               }
             ],
             "numberOfBytes": "32"

--- a/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
+++ b/crates/precompiles/tests/storage_tests/solidity/testdata/tip403_registry.sol
@@ -36,11 +36,6 @@ contract TIP403Registry {
         address recoveryAddress;
     }
 
-    struct TokenTransferPolicy {
-        uint64 policyId;
-        bool isSet;
-    }
-
     // ========== Storage ==========
 
     /// Counter for policy IDs
@@ -55,7 +50,4 @@ contract TIP403Registry {
 
     /// Account receive policy configuration
     mapping(address => ReceivePolicy) internal receivePolicies;
-
-    /// TIP-1092 token-to-policy bindings
-    mapping(address => TokenTransferPolicy) internal tokenTransferPolicies;
 }

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -35,13 +35,20 @@ Storing the binding in TIP-403 gives zones a direct registry lookup for a token'
 
 TIP-403 stores one registry-owned transfer-policy binding per migrated or newly created TIP-20 token:
 
+For a token address `token`, TIP-403 stores the packed binding directly in storage slot
+`uint256(uint160(token))`. This is intentionally not Solidity's standard mapping layout and avoids
+hashing the token address with a mapping base slot during policy lookup.
+
 ```text
-token_transfer_policy: mapping(address token => uint256 packed)
+storage[uint256(uint160(token))]
 
 bits 0..63: policy_id
 bit 64: is_set
 bits 65..255: reserved
 ```
+
+TIP-20 addresses use the reserved `0x20C0...` namespace, so these slots do not overlap TIP-403's
+sequential Solidity storage slots.
 
 The `is_set` bit is required because policy ID `0` is a valid built-in reject-all policy. A packed value of zero means unset. A packed value with `is_set == 1` and `policy_id == 0` means the token is explicitly registered to policy `0`.
 


### PR DESCRIPTION
Stores each TIP-20 policy binding in TIP-403 at `uint256(uint160(token))` instead of a Solidity mapping slot, removing the mapping keccak from policy lookup while keeping the packed policy ID and set bit.

Updates TIP-1092 and the storage-layout fixtures, with a raw-storage regression test for the direct slot. Validated with the full `tempo-precompiles` unit and storage test suites.