### PR TITLE
feat(precompiles): add stateless benchmark pipeline

### DIFF
--- a/.github/workflows/bench-stateless-precompiles.yml
+++ b/.github/workflows/bench-stateless-precompiles.yml
@@ -1,0 +1,271 @@
+name: Stateless precompile benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      warmup_seconds:
+        description: "Criterion warm-up time per case"
+        required: true
+        default: "3"
+        type: string
+      measurement_seconds:
+        description: "Criterion measurement time per case"
+        required: true
+        default: "10"
+        type: string
+      sample_size:
+        description: "Criterion sample count per case (minimum 10)"
+        required: true
+        default: "100"
+        type: string
+      cpu_set:
+        description: "Pinned taskset CPU list for the benchmark runner"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      warmup_seconds:
+        description: "Criterion warm-up time per case"
+        required: false
+        default: "3"
+        type: string
+      measurement_seconds:
+        description: "Criterion measurement time per case"
+        required: false
+        default: "10"
+        type: string
+      sample_size:
+        description: "Criterion sample count per case (minimum 10)"
+        required: false
+        default: "100"
+        type: string
+      cpu_set:
+        description: "Pinned taskset CPU list for the benchmark runner"
+        required: true
+        type: string
+    secrets:
+      CLICKHOUSE_URL:
+        required: false
+      CLICKHOUSE_USER:
+        required: false
+      CLICKHOUSE_PASSWORD:
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: stateless-precompiles-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  native:
+    name: Native stateless precompile benchmarks
+    if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' && github.event_name != 'pull_request_target' && github.event_name != 'merge_group' }}
+    runs-on: [self-hosted, Linux, X64, bare-metal-dual-schelk]
+    timeout-minutes: 90
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: full
+      RUSTC_WRAPPER: sccache
+      RUSTFLAGS: -C target-cpu=native
+      CRITERION_HOME: ${{ github.workspace }}/bench-results/stateless-precompiles/criterion
+      TEMPO_BENCH_MANIFEST: ${{ github.workspace }}/bench-results/stateless-precompiles/cases.json
+      TEMPO_BENCH_MACHINE_ID: bare-metal-dual-schelk
+      TEMPO_BENCH_CPU_SET: ${{ inputs.cpu_set }}
+      TEMPO_BENCH_RUN_ID: stateless-precompiles-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      # This workflow is intentionally not triggered by pull_request. Native code
+      # from untrusted PRs must not execute on the self-hosted benchmark runner.
+      - name: Reset workspace directory
+        run: |
+          sudo rm -rf "$GITHUB_WORKSPACE"
+          sudo -u actions-runner mkdir -p "$GITHUB_WORKSPACE"
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+        continue-on-error: true
+
+      - name: Validate benchmark configuration
+        env:
+          WARMUP_SECONDS: ${{ inputs.warmup_seconds || '3' }}
+          MEASUREMENT_SECONDS: ${{ inputs.measurement_seconds || '10' }}
+          SAMPLE_SIZE: ${{ inputs.sample_size || '100' }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$WARMUP_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::warmup_seconds must be a positive integer"
+            exit 1
+          fi
+          if ! [[ "$MEASUREMENT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::measurement_seconds must be a positive integer"
+            exit 1
+          fi
+          if ! [[ "$SAMPLE_SIZE" =~ ^[0-9]+$ ]] || [ "$SAMPLE_SIZE" -lt 10 ]; then
+            echo "::error::sample_size must be an integer greater than or equal to 10"
+            exit 1
+          fi
+          if [ -z "$TEMPO_BENCH_CPU_SET" ] || ! [[ "$TEMPO_BENCH_CPU_SET" =~ ^[0-9,-]+$ ]]; then
+            echo "::error::cpu_set must be non-empty and contain only CPU numbers, commas, and ranges"
+            exit 1
+          fi
+          {
+            echo "TEMPO_BENCH_WARMUP_SECONDS=$WARMUP_SECONDS"
+            echo "TEMPO_BENCH_MEASUREMENT_SECONDS=$MEASUREMENT_SECONDS"
+            echo "TEMPO_BENCH_SAMPLE_SIZE=$SAMPLE_SIZE"
+          } >> "$GITHUB_ENV"
+
+      - name: Validate benchmark host
+        run: |
+          set -euo pipefail
+          if ! taskset --cpu-list "$TEMPO_BENCH_CPU_SET" true; then
+            echo "::error::cpu_set is not available to the benchmark runner"
+            exit 1
+          fi
+
+          mapfile -t governors < <(
+            for path in /sys/devices/system/cpu/cpu*/cpufreq/scaling_governor; do
+              [ -f "$path" ] && cat "$path"
+            done | sort -u
+          )
+          if [ "${#governors[@]}" -eq 0 ]; then
+            echo "::error::no CPU governor metadata is available"
+            exit 1
+          fi
+          for governor in "${governors[@]}"; do
+            if [ "$governor" != "performance" ]; then
+              echo "::error::every CPU governor must be performance; observed $governor"
+              exit 1
+            fi
+          done
+
+          if [ -f /sys/devices/system/cpu/intel_pstate/no_turbo ] && \
+             [ "$(cat /sys/devices/system/cpu/intel_pstate/no_turbo)" != "1" ]; then
+            echo "::error::Intel turbo boost must be disabled"
+            exit 1
+          fi
+          if [ -f /sys/devices/system/cpu/cpufreq/boost ] && \
+             [ "$(cat /sys/devices/system/cpu/cpufreq/boost)" != "0" ]; then
+            echo "::error::AMD turbo boost must be disabled"
+            exit 1
+          fi
+
+      - name: Test benchmark exporter
+        run: python3 -m unittest discover -s contrib/bench/tests -p 'test_*.py'
+
+      - name: Build native benchmark target
+        run: |
+          cargo bench \
+            -p tempo-precompiles \
+            --features test-utils \
+            --bench stateless_precompiles \
+            --no-run
+
+      - name: Run native benchmarks
+        run: |
+          set -euo pipefail
+          rm -rf "$CRITERION_HOME"
+          mkdir -p "$(dirname "$TEMPO_BENCH_MANIFEST")"
+          echo "TEMPO_BENCH_STARTED_AT=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
+
+          command=(
+            cargo bench
+            -p tempo-precompiles
+            --features test-utils
+            --bench stateless_precompiles
+            --
+            --warm-up-time "$TEMPO_BENCH_WARMUP_SECONDS"
+            --measurement-time "$TEMPO_BENCH_MEASUREMENT_SECONDS"
+            --sample-size "$TEMPO_BENCH_SAMPLE_SIZE"
+            --noplot
+          )
+          taskset --cpu-list "$TEMPO_BENCH_CPU_SET" "${command[@]}" \
+            2>&1 | tee bench-results/stateless-precompiles/benchmark.log
+
+      - name: Export canonical report
+        run: |
+          python3 contrib/bench/export-stateless-precompiles.py \
+            --manifest "$TEMPO_BENCH_MANIFEST" \
+            --criterion-dir "$CRITERION_HOME" \
+            --output bench-results/stateless-precompiles/report.json \
+            --rows-output bench-results/stateless-precompiles/clickhouse-rows.jsonl \
+            --profile bench \
+            --features tempo-precompiles/test-utils \
+            --allocator tikv-jemallocator/0.6.1 \
+            --warmup-seconds "$TEMPO_BENCH_WARMUP_SECONDS" \
+            --measurement-seconds "$TEMPO_BENCH_MEASUREMENT_SECONDS" \
+            --sample-size "$TEMPO_BENCH_SAMPLE_SIZE"
+
+      - name: Add benchmark summary
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          report = json.loads(Path("bench-results/stateless-precompiles/report.json").read_text())
+          lines = [
+              "## Native stateless precompile benchmarks",
+              "",
+              f"Run: `{report['run']['id']}` on `{report['host']['machine_id']}`",
+              "",
+              "| Case | Time (ns) | Gas | Mgas/s | Conservative Mgas/s |",
+              "| --- | ---: | ---: | ---: | ---: |",
+          ]
+          for result in report["results"]:
+              case = result["case"]
+              measurement = result["measurement"]["typical"]
+              metrics = result["metrics"]
+              lines.append(
+                  f"| `{case['case_id']}` | {measurement['point_estimate_ns']:.2f} "
+                  f"| {case['gas_used']} | {metrics['mgas_per_second']:.3f} "
+                  f"| {metrics['conservative_mgas_per_second']:.3f} |"
+              )
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as summary:
+              summary.write("\n".join(lines) + "\n")
+          PY
+
+      - name: Upload benchmark results
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: stateless-precompile-bench-${{ github.run_id }}-${{ github.run_attempt }}
+          path: bench-results/stateless-precompiles/
+          if-no-files-found: warn
+
+  publish:
+    name: Publish stateless precompile results
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: native
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Download benchmark results
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: stateless-precompile-bench-${{ github.run_id }}-${{ github.run_attempt }}
+          path: bench-results/stateless-precompiles
+
+      - name: Publish results to ClickHouse
+        env:
+          CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
+          CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
+          CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+          CLICKHOUSE_DATABASE: ${{ vars.CLICKHOUSE_DATABASE || 'default' }}
+        run: |
+          if [ -n "$CLICKHOUSE_URL" ]; then echo "::add-mask::$CLICKHOUSE_URL"; fi
+          if [ -n "$CLICKHOUSE_USER" ]; then echo "::add-mask::$CLICKHOUSE_USER"; fi
+          if [ -n "$CLICKHOUSE_PASSWORD" ]; then echo "::add-mask::$CLICKHOUSE_PASSWORD"; fi
+          bash contrib/bench/upload-execution-microbench-results.sh \
+            bench-results/stateless-precompiles/clickhouse-rows.jsonl

--- a/.github/workflows/bench-stateless-precompiles.yml
+++ b/.github/workflows/bench-stateless-precompiles.yml
@@ -262,7 +262,7 @@ jobs:
           CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
           CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
-          CLICKHOUSE_DATABASE: ${{ vars.CLICKHOUSE_DATABASE || 'default' }}
+          CLICKHOUSE_DATABASE: ${{ vars.CLICKHOUSE_DATABASE || 'tempo_repricing' }}
         run: |
           if [ -n "$CLICKHOUSE_URL" ]; then echo "::add-mask::$CLICKHOUSE_URL"; fi
           if [ -n "$CLICKHOUSE_USER" ]; then echo "::add-mask::$CLICKHOUSE_USER"; fi

--- a/.github/workflows/bench-stateless-precompiles.yml
+++ b/.github/workflows/bench-stateless-precompiles.yml
@@ -86,8 +86,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
         continue-on-error: true
 

--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -33,12 +33,12 @@ on:
       packages:
         description: "Cargo package(s) containing benchmark targets, separated by spaces"
         required: true
-        default: "tempo-evm"
+        default: "tempo-evm tempo-precompiles"
         type: string
       benchmarks:
         description: "Cargo bench target(s), separated by spaces; leave empty for every bench in the package(s)"
         required: false
-        default: "tip20_execution dex_execution"
+        default: "tip20_execution dex_execution stateless_precompiles"
         type: string
       filters:
         description: "Optional benchmark name filter passed to cargo codspeed run"
@@ -81,8 +81,8 @@ jobs:
       - name: Resolve cargo codspeed arguments
         id: args
         env:
-          INPUT_PACKAGES: ${{ inputs.packages || 'tempo-evm' }}
-          INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution dex_execution' }}
+          INPUT_PACKAGES: ${{ inputs.packages || 'tempo-evm tempo-precompiles' }}
+          INPUT_BENCHMARKS: ${{ inputs.benchmarks || 'tip20_execution dex_execution stateless_precompiles' }}
           INPUT_FILTERS: ${{ inputs.filters }}
           INPUT_MEASUREMENT_MODES: ${{ inputs.measurement_modes || 'simulation' }}
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13374,6 +13374,7 @@ dependencies = [
  "tempo-primitives",
  "tempo-revm",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tracing",
 ]
 

--- a/contrib/bench/clickhouse/001_execution_microbench_results.sql
+++ b/contrib/bench/clickhouse/001_execution_microbench_results.sql
@@ -1,0 +1,86 @@
+-- Native execution microbenchmarks. A run uses a stable (run_id, case_id)
+-- identity, and ReplacingMergeTree makes retried inserts idempotent after merge.
+-- Queries that must observe deduplication immediately should use FINAL.
+CREATE TABLE IF NOT EXISTS tempo_execution_microbench_results
+(
+    schema_version UInt16,
+    run_id String,
+    started_at DateTime64(3, 'UTC'),
+    repository Nullable(String),
+    git_sha Nullable(String),
+    git_ref Nullable(String),
+    workflow_url Nullable(String),
+    workflow_run_attempt Nullable(UInt32),
+
+    suite_id LowCardinality(String),
+    suite_version UInt16,
+    benchmark_layer LowCardinality(String),
+    measurement_mode LowCardinality(String),
+    warmup_seconds Float64,
+    measurement_seconds Float64,
+    requested_sample_size UInt32,
+
+    case_id String,
+    criterion_id String,
+    precompile LowCardinality(String),
+    precompile_address String,
+    precompile_registry_id LowCardinality(String),
+    tempo_hardfork LowCardinality(String),
+    precompile_spec LowCardinality(String),
+    input_kind LowCardinality(String),
+    input_length UInt64,
+    state_gas_reservoir UInt64,
+    gas_limit UInt64,
+    gas_used UInt64,
+    state_gas_used UInt64,
+    gas_refunded Int64,
+    expected_status LowCardinality(String),
+    expected_output_length UInt64,
+    state_gas_reservoir_remaining UInt64,
+    provenance_source Nullable(String),
+    provenance_reference Nullable(String),
+
+    typical_statistic LowCardinality(String),
+    estimate_ns Float64,
+    estimate_standard_error_ns Float64,
+    estimate_confidence_level Float64,
+    estimate_lower_bound_ns Float64,
+    estimate_upper_bound_ns Float64,
+    median_ns Float64,
+    std_dev_ns Float64,
+    sample_count UInt32,
+    sampling_mode Nullable(String),
+    mgas_per_second Float64,
+    conservative_mgas_per_second Float64,
+    nanoseconds_per_gas Float64,
+    gibibytes_per_second Nullable(Float64),
+
+    profile LowCardinality(String),
+    features String,
+    allocator LowCardinality(String),
+    rustc Nullable(String),
+    cargo Nullable(String),
+    target Nullable(String),
+    rustflags Nullable(String),
+    revm_version Nullable(String),
+    revm_precompile_version Nullable(String),
+    criterion_compat_version Nullable(String),
+
+    machine_id LowCardinality(String),
+    runner_name Nullable(String),
+    os Nullable(String),
+    architecture Nullable(String),
+    cpu_model Nullable(String),
+    microcode Nullable(String),
+    logical_cpu_count Nullable(UInt32),
+    cpu_set Nullable(String),
+    kernel Nullable(String),
+    cpu_governors Nullable(String),
+    turbo_control_json Nullable(String),
+    case_metadata_json String,
+
+    ingested_at DateTime64(3, 'UTC') DEFAULT now64(3)
+)
+ENGINE = ReplacingMergeTree(ingested_at)
+PARTITION BY toYYYYMM(started_at)
+ORDER BY (run_id, case_id);

--- a/contrib/bench/clickhouse/001_execution_microbench_results.sql
+++ b/contrib/bench/clickhouse/001_execution_microbench_results.sql
@@ -1,7 +1,9 @@
 -- Native execution microbenchmarks. A run uses a stable (run_id, case_id)
 -- identity, and ReplacingMergeTree makes retried inserts idempotent after merge.
 -- Queries that must observe deduplication immediately should use FINAL.
-CREATE TABLE IF NOT EXISTS tempo_execution_microbench_results
+CREATE DATABASE IF NOT EXISTS tempo_repricing;
+
+CREATE TABLE IF NOT EXISTS tempo_repricing.tempo_execution_microbench_results
 (
     schema_version UInt16,
     run_id String,

--- a/contrib/bench/export-stateless-precompiles.py
+++ b/contrib/bench/export-stateless-precompiles.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Export native Criterion measurements using Tempo's benchmark report schema.
+
+The benchmark target owns case semantics and writes a manifest. This exporter owns
+the result envelope and joins that manifest to Criterion's native wall-time output
+by the full Criterion benchmark ID. It deliberately does not infer case metadata
+from Criterion directory names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover - the benchmark runner uses Python 3.11+
+    tomllib = None
+
+
+SCHEMA_VERSION = 1
+
+
+class ExportError(RuntimeError):
+    """A benchmark result cannot be exported without losing integrity."""
+
+
+def read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ExportError(f"missing required file: {path}") from error
+    except json.JSONDecodeError as error:
+        raise ExportError(f"invalid JSON in {path}: {error}") from error
+
+
+def command_output(*command: str) -> str | None:
+    try:
+        return subprocess.run(
+            command,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+
+def env_or_command(name: str, *command: str) -> str | None:
+    value = os.environ.get(name)
+    return value or command_output(*command)
+
+
+def first_prefixed_line(text: str | None, prefix: str) -> str | None:
+    if not text:
+        return None
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return line.removeprefix(prefix).strip()
+    return None
+
+
+def first_file_entry(paths: list[Path]) -> dict[str, str] | None:
+    for path in paths:
+        try:
+            value = path.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if value:
+            return {"path": str(path), "value": value}
+    return None
+
+
+def cpu_info() -> tuple[str | None, str | None]:
+    model = None
+    microcode = None
+    try:
+        lines = Path("/proc/cpuinfo").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return model, microcode
+
+    for line in lines:
+        key, separator, value = line.partition(":")
+        if not separator:
+            continue
+        if model is None and key.strip() in {"model name", "Hardware"}:
+            model = value.strip()
+        elif microcode is None and key.strip() == "microcode":
+            microcode = value.strip()
+        if model is not None and microcode is not None:
+            break
+    return model, microcode
+
+
+def os_release() -> str | None:
+    try:
+        values = {}
+        for line in Path("/etc/os-release").read_text(encoding="utf-8").splitlines():
+            key, separator, value = line.partition("=")
+            if separator:
+                values[key] = value.strip().strip('"')
+        return values.get("PRETTY_NAME")
+    except OSError:
+        return None
+
+
+def host_metadata(machine_id: str | None, cpu_set: str | None) -> dict[str, Any]:
+    cpu_model, microcode = cpu_info()
+    governors = []
+    for path in sorted(Path("/sys/devices/system/cpu").glob("cpu*/cpufreq/scaling_governor")):
+        try:
+            governors.append(path.read_text(encoding="utf-8").strip())
+        except OSError:
+            pass
+
+    turbo = first_file_entry(
+        [
+            Path("/sys/devices/system/cpu/intel_pstate/no_turbo"),
+            Path("/sys/devices/system/cpu/cpufreq/boost"),
+        ]
+    )
+    return without_none(
+        {
+            "machine_id": machine_id,
+            "runner_name": os.environ.get("RUNNER_NAME"),
+            "os": os_release() or platform.platform(),
+            "kernel": platform.release(),
+            "architecture": platform.machine(),
+            "cpu_model": cpu_model or platform.processor() or None,
+            "microcode": microcode,
+            "logical_cpu_count": os.cpu_count(),
+            "cpu_set": cpu_set,
+            "cpu_governors": sorted(set(governors)) or None,
+            "turbo_control": turbo,
+        }
+    )
+
+
+def without_none(value: dict[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if item is not None}
+
+
+def integer_or_none(value: str | None) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        return None
+
+
+def dependency_versions(lockfile: Path = Path("Cargo.lock")) -> dict[str, dict[str, str]] | None:
+    if tomllib is None:
+        return None
+    try:
+        cargo_lock = tomllib.loads(lockfile.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+    wanted = {"codspeed-criterion-compat", "revm", "revm-precompile", "tikv-jemallocator"}
+    versions = {}
+    for package in cargo_lock.get("package", []):
+        name = package.get("name")
+        if name in wanted:
+            versions[name] = without_none(
+                {
+                    "version": package.get("version"),
+                    "source": package.get("source"),
+                }
+            )
+    return versions or None
+
+
+def validate_manifest(manifest: Any, path: Path) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    if not isinstance(manifest, dict):
+        raise ExportError(f"manifest root must be an object: {path}")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise ExportError(
+            f"unsupported manifest schema_version {manifest.get('schema_version')!r}; "
+            f"expected {SCHEMA_VERSION}"
+        )
+    suite = manifest.get("suite")
+    if not isinstance(suite, dict) or not isinstance(suite.get("id"), str):
+        raise ExportError("manifest suite must be an object with a string id")
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ExportError("manifest cases must be a non-empty array")
+
+    case_ids: set[str] = set()
+    criterion_ids: set[str] = set()
+    for index, case in enumerate(cases):
+        if not isinstance(case, dict):
+            raise ExportError(f"manifest case {index} must be an object")
+        case_id = case.get("case_id")
+        criterion_id = case.get("criterion_id")
+        if not isinstance(case_id, str) or not case_id:
+            raise ExportError(f"manifest case {index} has no case_id")
+        if not isinstance(criterion_id, str) or not criterion_id:
+            raise ExportError(f"manifest case {case_id!r} has no criterion_id")
+        if case_id in case_ids:
+            raise ExportError(f"duplicate case_id in manifest: {case_id}")
+        if criterion_id in criterion_ids:
+            raise ExportError(f"duplicate criterion_id in manifest: {criterion_id}")
+        if not isinstance(case.get("gas_used"), int) or case["gas_used"] < 0:
+            raise ExportError(f"manifest case {case_id!r} has invalid gas_used")
+        case_ids.add(case_id)
+        criterion_ids.add(criterion_id)
+
+    return suite, cases
+
+
+def load_criterion_results(root: Path) -> dict[str, dict[str, Any]]:
+    results: dict[str, dict[str, Any]] = {}
+    for benchmark_path in sorted(root.glob("**/new/benchmark.json")):
+        benchmark = read_json(benchmark_path)
+        if not isinstance(benchmark, dict):
+            raise ExportError(f"Criterion benchmark metadata must be an object: {benchmark_path}")
+        criterion_id = benchmark.get("full_id")
+        if not isinstance(criterion_id, str) or not criterion_id:
+            raise ExportError(f"Criterion benchmark has no full_id: {benchmark_path}")
+        if criterion_id in results:
+            raise ExportError(f"duplicate Criterion benchmark ID: {criterion_id}")
+
+        directory = benchmark_path.parent
+        estimates = read_json(directory / "estimates.json")
+        sample = read_json(directory / "sample.json")
+        if not isinstance(estimates, dict) or not isinstance(sample, dict):
+            raise ExportError(f"invalid Criterion result for {criterion_id}")
+        results[criterion_id] = {
+            "benchmark": benchmark,
+            "estimates": estimates,
+            "sample": sample,
+        }
+
+    if not results:
+        raise ExportError(f"no Criterion native results found below {root}")
+    return results
+
+
+def normalized_estimate(estimate: Any, name: str, criterion_id: str) -> dict[str, Any]:
+    if not isinstance(estimate, dict):
+        raise ExportError(f"Criterion {name} estimate missing for {criterion_id}")
+    interval = estimate.get("confidence_interval")
+    if not isinstance(interval, dict):
+        raise ExportError(f"Criterion {name} confidence interval missing for {criterion_id}")
+    try:
+        return {
+            "point_estimate_ns": float(estimate["point_estimate"]),
+            "standard_error_ns": float(estimate["standard_error"]),
+            "confidence_interval": {
+                "confidence_level": float(interval["confidence_level"]),
+                "lower_bound_ns": float(interval["lower_bound"]),
+                "upper_bound_ns": float(interval["upper_bound"]),
+            },
+        }
+    except (KeyError, TypeError, ValueError) as error:
+        raise ExportError(f"invalid Criterion {name} estimate for {criterion_id}") from error
+
+
+def measurement_for(result: dict[str, Any], criterion_id: str) -> dict[str, Any]:
+    estimates = result["estimates"]
+    typical_name = "slope" if estimates.get("slope") is not None else "mean"
+    typical = normalized_estimate(estimates.get(typical_name), typical_name, criterion_id)
+    median = normalized_estimate(estimates.get("median"), "median", criterion_id)
+    std_dev = normalized_estimate(estimates.get("std_dev"), "std_dev", criterion_id)
+    sample = result["sample"]
+    iterations = sample.get("iters")
+    times = sample.get("times")
+    if not isinstance(iterations, list) or not isinstance(times, list) or len(iterations) != len(times):
+        raise ExportError(f"invalid Criterion samples for {criterion_id}")
+
+    return {
+        "unit": "nanoseconds",
+        "typical_statistic": typical_name,
+        "typical": typical,
+        "median": median,
+        "std_dev": std_dev,
+        "sample_count": len(iterations),
+        "sampling_mode": sample.get("sampling_mode"),
+    }
+
+
+def metrics_for(case: dict[str, Any], measurement: dict[str, Any]) -> dict[str, float]:
+    gas_used = case["gas_used"]
+    estimate_ns = measurement["typical"]["point_estimate_ns"]
+    upper_bound_ns = measurement["typical"]["confidence_interval"]["upper_bound_ns"]
+    if estimate_ns <= 0 or upper_bound_ns <= 0:
+        raise ExportError(f"non-positive timing estimate for {case['case_id']}")
+
+    metrics = {
+        "mgas_per_second": gas_used * 1_000.0 / estimate_ns,
+        "conservative_mgas_per_second": gas_used * 1_000.0 / upper_bound_ns,
+        "nanoseconds_per_gas": estimate_ns / gas_used if gas_used else 0.0,
+    }
+    input_length = case.get("input", {}).get("length")
+    if isinstance(input_length, int) and input_length >= 0:
+        metrics["gibibytes_per_second"] = input_length / estimate_ns * (1e9 / 2**30)
+    return metrics
+
+
+def build_metadata(args: argparse.Namespace) -> dict[str, Any]:
+    rustc_verbose = command_output("rustc", "-Vv")
+    workflow_url = args.workflow_url
+    if workflow_url is None and os.environ.get("GITHUB_SERVER_URL") and os.environ.get("GITHUB_REPOSITORY") and os.environ.get("GITHUB_RUN_ID"):
+        workflow_url = (
+            f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}"
+            f"/actions/runs/{os.environ['GITHUB_RUN_ID']}"
+        )
+
+    return {
+        "run": without_none(
+            {
+                "id": args.run_id or os.environ.get("TEMPO_BENCH_RUN_ID") or str(uuid.uuid4()),
+                "started_at": args.started_at
+                or os.environ.get("TEMPO_BENCH_STARTED_AT")
+                or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "repository": args.repository or os.environ.get("GITHUB_REPOSITORY"),
+                "git_sha": args.git_sha or env_or_command("GITHUB_SHA", "git", "rev-parse", "HEAD"),
+                "git_ref": args.git_ref
+                or os.environ.get("GITHUB_REF_NAME")
+                or os.environ.get("GITHUB_REF"),
+                "workflow_url": workflow_url,
+                "workflow_run_attempt": integer_or_none(os.environ.get("GITHUB_RUN_ATTEMPT")),
+            }
+        ),
+        "build": without_none(
+            {
+                "profile": args.profile,
+                "features": sorted(args.features),
+                "allocator": args.allocator,
+                "rustc": first_prefixed_line(rustc_verbose, "release: ")
+                or first_prefixed_line(rustc_verbose, "rustc ")
+                or command_output("rustc", "--version"),
+                "rustc_verbose": rustc_verbose,
+                "cargo": command_output("cargo", "--version"),
+                "target": first_prefixed_line(rustc_verbose, "host: "),
+                "rustflags": os.environ.get("RUSTFLAGS"),
+                "rustc_wrapper": os.environ.get("RUSTC_WRAPPER"),
+                "dependencies": dependency_versions(),
+            }
+        ),
+        "host": host_metadata(
+            args.machine_id or os.environ.get("TEMPO_BENCH_MACHINE_ID"),
+            args.cpu_set or os.environ.get("TEMPO_BENCH_CPU_SET"),
+        ),
+        "configuration": {
+            "measurement_mode": "wall_time",
+            "warmup_seconds": args.warmup_seconds,
+            "measurement_seconds": args.measurement_seconds,
+            "requested_sample_size": args.sample_size,
+        },
+    }
+
+
+def build_report(
+    manifest: dict[str, Any],
+    criterion_results: dict[str, dict[str, Any]],
+    metadata: dict[str, Any],
+) -> dict[str, Any]:
+    suite, cases = validate_manifest(manifest, Path("<manifest>"))
+    results = []
+    for case in cases:
+        criterion_id = case["criterion_id"]
+        criterion_result = criterion_results.get(criterion_id)
+        if criterion_result is None:
+            raise ExportError(f"missing Criterion result for manifest case {criterion_id}")
+        measurement = measurement_for(criterion_result, criterion_id)
+        results.append(
+            {
+                "case": case,
+                "measurement": measurement,
+                "metrics": metrics_for(case, measurement),
+            }
+        )
+
+    manifest_ids = {case["criterion_id"] for case in cases}
+    unexpected = sorted(set(criterion_results) - manifest_ids)
+    if unexpected:
+        raise ExportError(
+            "Criterion emitted results absent from the benchmark manifest: " + ", ".join(unexpected)
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        **metadata,
+        "suite": suite,
+        "results": results,
+    }
+
+
+def row_for(report: dict[str, Any], result: dict[str, Any]) -> dict[str, Any]:
+    run = report["run"]
+    build = report["build"]
+    host = report["host"]
+    suite = report["suite"]
+    configuration = report["configuration"]
+    case = result["case"]
+    measurement = result["measurement"]
+    typical = measurement["typical"]
+    interval = typical["confidence_interval"]
+    precompile = case.get("precompile", {})
+    protocol = case.get("protocol", {})
+    input_spec = case.get("input", {})
+    expected = case.get("expected", {})
+    provenance = case.get("provenance") or {}
+    dependencies = build.get("dependencies", {})
+
+    # Keep the row shape stable. Optional values are represented as null rather
+    # than omitted so a JSONEachRow consumer can validate one explicit schema.
+    return {
+        "schema_version": report["schema_version"],
+        "run_id": run.get("id"),
+        "started_at": run.get("started_at"),
+        "repository": run.get("repository"),
+        "git_sha": run.get("git_sha"),
+        "git_ref": run.get("git_ref"),
+        "workflow_url": run.get("workflow_url"),
+        "workflow_run_attempt": run.get("workflow_run_attempt"),
+        "suite_id": suite.get("id"),
+        "suite_version": suite.get("version"),
+        "benchmark_layer": suite.get("benchmark_layer"),
+        "measurement_mode": configuration.get("measurement_mode"),
+        "warmup_seconds": configuration.get("warmup_seconds"),
+        "measurement_seconds": configuration.get("measurement_seconds"),
+        "requested_sample_size": configuration.get("requested_sample_size"),
+        "case_id": case.get("case_id"),
+        "criterion_id": case.get("criterion_id"),
+        "precompile": precompile.get("name"),
+        "precompile_address": precompile.get("address"),
+        "precompile_registry_id": precompile.get("registry_id"),
+        "tempo_hardfork": protocol.get("hardfork"),
+        "precompile_spec": protocol.get("precompile_spec"),
+        "input_kind": input_spec.get("kind"),
+        "input_length": input_spec.get("length"),
+        "state_gas_reservoir": case.get("state_gas_reservoir"),
+        "gas_limit": case.get("gas_limit"),
+        "gas_used": case.get("gas_used"),
+        "state_gas_used": case.get("state_gas_used"),
+        "gas_refunded": case.get("gas_refunded"),
+        "expected_status": expected.get("status"),
+        "expected_output_length": expected.get("output_length"),
+        "state_gas_reservoir_remaining": expected.get("state_gas_reservoir_remaining"),
+        "provenance_source": provenance.get("source"),
+        "provenance_reference": provenance.get("reference"),
+        "typical_statistic": measurement.get("typical_statistic"),
+        "estimate_ns": typical.get("point_estimate_ns"),
+        "estimate_standard_error_ns": typical.get("standard_error_ns"),
+        "estimate_confidence_level": interval.get("confidence_level"),
+        "estimate_lower_bound_ns": interval.get("lower_bound_ns"),
+        "estimate_upper_bound_ns": interval.get("upper_bound_ns"),
+        "median_ns": measurement.get("median", {}).get("point_estimate_ns"),
+        "std_dev_ns": measurement.get("std_dev", {}).get("point_estimate_ns"),
+        "sample_count": measurement.get("sample_count"),
+        "sampling_mode": measurement.get("sampling_mode"),
+        "mgas_per_second": result["metrics"].get("mgas_per_second"),
+        "conservative_mgas_per_second": result["metrics"].get(
+            "conservative_mgas_per_second"
+        ),
+        "nanoseconds_per_gas": result["metrics"].get("nanoseconds_per_gas"),
+        "gibibytes_per_second": result["metrics"].get("gibibytes_per_second"),
+        "profile": build.get("profile"),
+        "features": ",".join(build.get("features", [])),
+        "allocator": build.get("allocator"),
+        "rustc": build.get("rustc"),
+        "cargo": build.get("cargo"),
+        "target": build.get("target"),
+        "rustflags": build.get("rustflags"),
+        "revm_version": dependencies.get("revm", {}).get("version"),
+        "revm_precompile_version": dependencies.get("revm-precompile", {}).get("version"),
+        "criterion_compat_version": dependencies.get("codspeed-criterion-compat", {}).get(
+            "version"
+        ),
+        "machine_id": host.get("machine_id"),
+        "runner_name": host.get("runner_name"),
+        "os": host.get("os"),
+        "architecture": host.get("architecture"),
+        "cpu_model": host.get("cpu_model"),
+        "microcode": host.get("microcode"),
+        "logical_cpu_count": host.get("logical_cpu_count"),
+        "cpu_set": host.get("cpu_set"),
+        "kernel": host.get("kernel"),
+        "cpu_governors": ",".join(host["cpu_governors"])
+        if host.get("cpu_governors")
+        else None,
+        "turbo_control_json": json.dumps(
+            host.get("turbo_control"), sort_keys=True, separators=(",", ":")
+        )
+        if host.get("turbo_control")
+        else None,
+        "case_metadata_json": json.dumps(case, sort_keys=True, separators=(",", ":")),
+    }
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_rows(path: Path, report: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rows = [row_for(report, result) for result in report["results"]]
+    path.write_text(
+        "".join(json.dumps(row, sort_keys=True, separators=(",", ":")) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--criterion-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--rows-output", type=Path)
+    parser.add_argument("--run-id")
+    parser.add_argument("--started-at")
+    parser.add_argument("--repository")
+    parser.add_argument("--git-sha")
+    parser.add_argument("--git-ref")
+    parser.add_argument("--workflow-url")
+    parser.add_argument("--machine-id")
+    parser.add_argument("--cpu-set")
+    parser.add_argument("--profile", default="bench")
+    parser.add_argument("--features", action="append", default=[])
+    parser.add_argument("--allocator", required=True)
+    parser.add_argument("--warmup-seconds", type=float, required=True)
+    parser.add_argument("--measurement-seconds", type=float, required=True)
+    parser.add_argument("--sample-size", type=int, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.warmup_seconds <= 0 or args.measurement_seconds <= 0:
+            raise ExportError("warm-up and measurement times must be positive")
+        if args.sample_size < 10:
+            raise ExportError("sample size must be at least 10")
+        manifest = read_json(args.manifest)
+        # Validate with the real filename before collecting other metadata.
+        validate_manifest(manifest, args.manifest)
+        criterion_results = load_criterion_results(args.criterion_dir)
+        report = build_report(manifest, criterion_results, build_metadata(args))
+        write_json(args.output, report)
+        if args.rows_output:
+            write_rows(args.rows_output, report)
+    except ExportError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Wrote {len(report['results'])} benchmark result(s) to {args.output}")
+    if args.rows_output:
+        print(f"Wrote ClickHouse JSONEachRow data to {args.rows_output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/bench/stateless-precompiles.md
+++ b/contrib/bench/stateless-precompiles.md
@@ -136,7 +136,6 @@ account, for example:
 
 ```bash
 clickhouse-client \
-  --database "${CLICKHOUSE_DATABASE:-default}" \
   --queries-file contrib/bench/clickhouse/001_execution_microbench_results.sql
 ```
 
@@ -145,7 +144,7 @@ on `tempo_execution_microbench_results`: `INSERT` publishes the batch and `SELEC
 deduplicated row count. With `CLICKHOUSE_URL`,
 `CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD` configured, it publishes rows through
 `contrib/bench/upload-execution-microbench-results.sh`; `CLICKHOUSE_DATABASE` is a repository
-variable and defaults to `default`. ClickHouse credentials are scoped only to the publication
+variable and defaults to `tempo_repricing`. ClickHouse credentials are scoped only to the publication
 step in a separate GitHub-hosted job. The credential-free self-hosted job uploads its artifact;
 the hosted job downloads, validates, and publishes it. Publication runs only from
 `refs/heads/main`; dispatch the workflow on `main` to seed or update dashboard data. The

--- a/contrib/bench/stateless-precompiles.md
+++ b/contrib/bench/stateless-precompiles.md
@@ -1,0 +1,167 @@
+# Stateless precompile benchmark results
+
+The `stateless_precompiles` target measures precompiles directly through Tempo's resolved
+`revm` registry. It does not include EVM call overhead, transaction execution, block
+validation, or state-root work. Keep results from those future benchmark layers separate.
+
+CodSpeed runs this target on pull requests and `main` to detect relative performance
+regressions. Absolute wall-time results come from the manually dispatched or reusable
+`Stateless precompile benchmarks` workflow on `bare-metal-dual-schelk`. Do not use CodSpeed
+simulation measurements as absolute gas-per-second results.
+
+## Case and resolver boundaries
+
+Tempo's materialized `StatelessPrecompileCase` is the canonical runner input. The Identity cases
+are native Rust definitions with deterministic zero-filled input; this PR needs no general input,
+transaction, or payload generator. The `0`, `32`, `256`, and `1024` byte cases carry provenance
+for the pinned EEST benchmark release, but neither the model nor the benchmark has a runtime
+dependency on EEST's fixture format. Future EEST adapters and Tempo-native generators should
+translate their outputs into the same materialized case model.
+
+The current direct resolver uses `EthPrecompiles` with the Ethereum precompile spec selected for
+the explicit Tempo hardfork. More Ethereum built-ins therefore require only new cases. A future
+Tempo-native custom stateless precompile, such as a zones proof verifier, will also require a
+resolver adapter; adding its cases alone will not make it resolvable through `EthPrecompiles`.
+
+## Native run
+
+The workflow runs the equivalent of:
+
+```bash
+export RUSTFLAGS='-C target-cpu=native'
+export CRITERION_HOME="$PWD/bench-results/stateless-precompiles/criterion"
+export TEMPO_BENCH_MANIFEST="$PWD/bench-results/stateless-precompiles/cases.json"
+
+cargo bench \
+  -p tempo-precompiles \
+  --features test-utils \
+  --bench stateless_precompiles
+
+python3 contrib/bench/export-stateless-precompiles.py \
+  --manifest "$TEMPO_BENCH_MANIFEST" \
+  --criterion-dir "$CRITERION_HOME" \
+  --output bench-results/stateless-precompiles/report.json \
+  --rows-output bench-results/stateless-precompiles/clickhouse-rows.jsonl \
+  --profile bench \
+  --features tempo-precompiles/test-utils \
+  --allocator tikv-jemallocator/0.6.1 \
+  --warmup-seconds 3 \
+  --measurement-seconds 10 \
+  --sample-size 100
+```
+
+Set `TEMPO_BENCH_MACHINE_ID` to a stable identifier when results may be published. Set
+`TEMPO_BENCH_CPU_SET` and invoke the benchmark through `taskset` if a runner has an assigned
+benchmark CPU. Both values are recorded in the report. Do not guess a CPU: coordinate an
+isolated CPU set for the runner. Local artifact-only runs may omit it; the GitHub workflow
+requires an explicit CPU set for every native run.
+
+The workflow deletes its Criterion result directory before every run. This is important:
+the exporter rejects measurements not declared by the current benchmark manifest and rejects
+manifest cases without a measurement.
+
+## Artifact contract
+
+Each workflow artifact contains:
+
+- `cases.json`: benchmark-owned case semantics emitted after correctness preflight.
+- `criterion/`: raw native Criterion estimates and samples.
+- `report.json`: canonical, self-contained Tempo report.
+- `clickhouse-rows.jsonl`: deterministic one-result-per-line projection for ClickHouse
+  `JSONEachRow` ingestion.
+
+`report.json` is the source of truth. JSON stores run and host metadata once and keeps the
+case/result relationship explicit. The JSONL file is only a transport projection; it can be
+regenerated from the report and should not become a second benchmark schema.
+
+### `report.json` schema version 1
+
+The top-level object contains:
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Version of the report and JSONEachRow projection. Bump for incompatible changes. |
+| `run` | Run ID, start time, repository, git SHA/ref, workflow URL, and workflow attempt. |
+| `build` | Cargo profile, enabled features, allocator, Rust/Cargo versions, target, `RUSTFLAGS`, wrapper, and relevant locked dependency versions. |
+| `host` | Stable machine ID plus runner, OS, kernel, CPU, microcode, CPU set, governor, and raw turbo-control state. |
+| `configuration` | Measurement mode (`wall_time`) plus requested Criterion warm-up time, measurement time, and sample size. |
+| `suite` | Benchmark-owned suite ID/version and benchmark layer. |
+| `results` | One entry for every case declared by the benchmark manifest. |
+
+Each `results[]` entry contains:
+
+| Field | Meaning |
+| --- | --- |
+| `case` | Tempo-owned case definition: stable IDs, precompile, protocol context, input parameters, gas, expected outcome, and optional provenance. |
+| `measurement.unit` | `nanoseconds`; Criterion's estimates are time per benchmark iteration. |
+| `measurement.typical_statistic` | `slope` for Criterion linear sampling, otherwise `mean`. |
+| `measurement.typical` | Point estimate, standard error, confidence level, and lower/upper confidence bounds. |
+| `measurement.median` | Median time estimate and confidence interval. |
+| `measurement.std_dev` | Standard-deviation estimate and confidence interval. |
+| `measurement.sample_count` | Number of Criterion samples, not the number of timed iterations. |
+| `measurement.sampling_mode` | Criterion sampling mode used for the case. |
+| `metrics.mgas_per_second` | `gas_used * 1000 / estimate_ns`. |
+| `metrics.conservative_mgas_per_second` | `gas_used * 1000 / upper_confidence_bound_ns`. |
+| `metrics.nanoseconds_per_gas` | Typical estimate divided by charged gas. |
+| `metrics.gibibytes_per_second` | Input bytes processed per second, expressed as GiB/s. |
+
+Time and charged gas are both retained because changing gas prices changes gas/s without
+changing execution time. A dashboard should graph `estimate_ns` as well as gas-derived metrics.
+There is no mandatory input digest: native/generated cases are identified by the versioned case
+ID and their parameters. External fixture adapters may include an artifact checksum in case
+metadata when integrity requires it.
+
+### ClickHouse handoff
+
+`clickhouse-rows.jsonl` repeats run, build, and host dimensions on every result and flattens the
+stable fields required for filtering and charting. Optional fields are emitted as JSON `null`,
+not omitted. The complete case is also retained in `case_metadata_json` so a supplemental input
+source can add metadata without requiring an immediate table migration.
+
+The projected columns are grouped as follows:
+
+- Run: `run_id`, `started_at`, `repository`, `git_sha`, `git_ref`, `workflow_url`,
+  `workflow_run_attempt`.
+- Suite/case: `suite_id`, `suite_version`, `benchmark_layer`, `measurement_mode`, `case_id`, `criterion_id`,
+  run configuration, precompile address/name/registry ID, hardfork/spec, input kind/length, charged,
+  state, and refunded gas fields, expected outcome, and provenance.
+- Measurement: typical estimate and confidence interval, median, standard deviation, sample
+  count/mode, and derived gas/byte rates.
+- Build/host: profile, features, allocator, tool/dependency versions, target/Rust flags, machine,
+  CPU, microcode, CPU set/governor/turbo state, OS, and kernel.
+
+The versioned table DDL is
+`contrib/bench/clickhouse/001_execution_microbench_results.sql`. Apply it once with an administrative
+account, for example:
+
+```bash
+clickhouse-client \
+  --database "${CLICKHOUSE_DATABASE:-default}" \
+  --queries-file contrib/bench/clickhouse/001_execution_microbench_results.sql
+```
+
+The benchmark workflow never runs DDL. Its narrowly scoped account needs `INSERT` and `SELECT`
+on `tempo_execution_microbench_results`: `INSERT` publishes the batch and `SELECT` verifies the
+deduplicated row count. With `CLICKHOUSE_URL`,
+`CLICKHOUSE_USER`, and `CLICKHOUSE_PASSWORD` configured, it publishes rows through
+`contrib/bench/upload-execution-microbench-results.sh`; `CLICKHOUSE_DATABASE` is a repository
+variable and defaults to `default`. ClickHouse credentials are scoped only to the publication
+step in a separate GitHub-hosted job. The credential-free self-hosted job uploads its artifact;
+the hosted job downloads, validates, and publishes it. Publication runs only from
+`refs/heads/main`; dispatch the workflow on `main` to seed or update dashboard data. The
+self-hosted native job does not execute feature-branch or PR code, and CodSpeed remains the
+feature-branch regression signal. Local native runs can still produce an artifact without
+ClickHouse credentials.
+
+`CLICKHOUSE_URL` must use HTTPS. Plain HTTP is rejected except for an explicit loopback address
+used in local testing; credentials are never exposed to feature-branch benchmark code.
+
+The uploader refuses publication unless a CPU set was explicitly selected, every observed CPU
+governor is `performance`, and any detected Intel or AMD turbo control shows turbo disabled.
+Artifact-only runs remain permissive. The table's `ReplacingMergeTree` key is
+`(run_id, case_id)`; dashboard queries that must deduplicate retries immediately should use
+`FINAL` or an equivalent `argMax` query.
+
+These rows do not match the existing block/TPS benchmark tables. Comparisons must filter to the
+same `benchmark_layer`, machine, hardfork, precompile spec, allocator, build profile, and CPU
+controls.

--- a/contrib/bench/tests/test_export_stateless_precompiles.py
+++ b/contrib/bench/tests/test_export_stateless_precompiles.py
@@ -1,0 +1,247 @@
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+EXPORTER = REPOSITORY_ROOT / "contrib/bench/export-stateless-precompiles.py"
+CLICKHOUSE_DDL = (
+    REPOSITORY_ROOT / "contrib/bench/clickhouse/001_execution_microbench_results.sql"
+)
+
+
+def estimate(point: float, lower: float, upper: float) -> dict:
+    return {
+        "confidence_interval": {
+            "confidence_level": 0.95,
+            "lower_bound": lower,
+            "upper_bound": upper,
+        },
+        "point_estimate": point,
+        "standard_error": 1.25,
+    }
+
+
+class ExportStatelessPrecompilesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.manifest_path = self.root / "cases.json"
+        self.criterion_dir = self.root / "criterion"
+        self.output = self.root / "report.json"
+        self.rows_output = self.root / "rows.jsonl"
+        self.case = {
+            "case_id": "identity/32-bytes",
+            "criterion_id": "stateless_precompiles/direct/identity/32-bytes",
+            "precompile": {
+                "name": "identity",
+                "address": "0x0000000000000000000000000000000000000004",
+                "registry_id": "ID",
+            },
+            "protocol": {"hardfork": "T7", "precompile_spec": "OSAKA"},
+            "input": {"kind": "repeat", "length": 32, "byte": 0},
+            "state_gas_reservoir": 1000,
+            "gas_limit": 18,
+            "gas_used": 18,
+            "state_gas_used": 0,
+            "gas_refunded": 0,
+            "expected": {
+                "status": "success",
+                "output_length": 32,
+                "state_gas_reservoir_remaining": 1000,
+            },
+        }
+        self.write_manifest([self.case])
+        self.write_criterion_result(self.case["criterion_id"])
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_manifest(self, cases: list[dict]) -> None:
+        self.manifest_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "suite": {
+                        "id": "stateless-precompiles",
+                        "version": 1,
+                        "benchmark_layer": "direct",
+                    },
+                    "cases": cases,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def write_criterion_result(self, criterion_id: str, directory: str = "sanitized-name") -> None:
+        result_dir = self.criterion_dir / directory / "new"
+        result_dir.mkdir(parents=True, exist_ok=True)
+        (result_dir / "benchmark.json").write_text(
+            json.dumps(
+                {
+                    "group_id": "stateless_precompiles",
+                    "function_id": "direct/identity",
+                    "value_str": "32-bytes",
+                    "throughput": {"Bytes": 32},
+                    "full_id": criterion_id,
+                    "directory_name": "sanitized-name",
+                    "title": criterion_id,
+                }
+            ),
+            encoding="utf-8",
+        )
+        (result_dir / "estimates.json").write_text(
+            json.dumps(
+                {
+                    "mean": estimate(102.0, 100.0, 105.0),
+                    "median": estimate(101.0, 99.0, 104.0),
+                    "median_abs_dev": estimate(2.0, 1.0, 3.0),
+                    "slope": estimate(100.0, 98.0, 103.0),
+                    "std_dev": estimate(4.0, 3.0, 5.0),
+                }
+            ),
+            encoding="utf-8",
+        )
+        (result_dir / "sample.json").write_text(
+            json.dumps(
+                {
+                    "sampling_mode": "Linear",
+                    "iters": [1.0, 2.0, 3.0],
+                    "times": [100.0, 200.0, 300.0],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def run_exporter(self) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(EXPORTER),
+                "--manifest",
+                str(self.manifest_path),
+                "--criterion-dir",
+                str(self.criterion_dir),
+                "--output",
+                str(self.output),
+                "--rows-output",
+                str(self.rows_output),
+                "--run-id",
+                "test-run",
+                "--started-at",
+                "2026-07-13T00:00:00Z",
+                "--git-sha",
+                "abc123",
+                "--machine-id",
+                "test-machine",
+                "--features",
+                "tempo-precompiles/test-utils",
+                "--allocator",
+                "system",
+                "--warmup-seconds",
+                "1",
+                "--measurement-seconds",
+                "2",
+                "--sample-size",
+                "10",
+            ],
+            cwd=REPOSITORY_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_exports_report_and_clickhouse_row(self) -> None:
+        result = self.run_exporter()
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        report = json.loads(self.output.read_text(encoding="utf-8"))
+        self.assertEqual(report["schema_version"], 1)
+        self.assertEqual(report["run"]["id"], "test-run")
+        self.assertEqual(report["suite"]["benchmark_layer"], "direct")
+        self.assertEqual(report["build"]["allocator"], "system")
+        self.assertEqual(report["configuration"]["measurement_seconds"], 2.0)
+        self.assertEqual(report["configuration"]["measurement_mode"], "wall_time")
+        self.assertEqual(len(report["results"]), 1)
+        exported = report["results"][0]
+        self.assertEqual(exported["case"]["case_id"], "identity/32-bytes")
+        self.assertEqual(exported["measurement"]["typical_statistic"], "slope")
+        self.assertEqual(exported["measurement"]["sample_count"], 3)
+        self.assertAlmostEqual(exported["metrics"]["mgas_per_second"], 180.0)
+        self.assertAlmostEqual(
+            exported["metrics"]["conservative_mgas_per_second"],
+            18_000.0 / 103.0,
+        )
+
+        rows = [json.loads(line) for line in self.rows_output.read_text(encoding="utf-8").splitlines()]
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["case_id"], "identity/32-bytes")
+        self.assertEqual(rows[0]["precompile_registry_id"], "ID")
+        self.assertEqual(rows[0]["machine_id"], "test-machine")
+        self.assertEqual(rows[0]["estimate_ns"], 100.0)
+        self.assertEqual(rows[0]["measurement_mode"], "wall_time")
+        self.assertEqual(rows[0]["gas_refunded"], 0)
+        self.assertEqual(rows[0]["state_gas_reservoir"], 1000)
+        self.assertEqual(rows[0]["state_gas_reservoir_remaining"], 1000)
+        self.assertNotIn("hostname", rows[0])
+        self.assertIsInstance(rows[0]["case_metadata_json"], str)
+
+        ddl_columns = {
+            match.group(1)
+            for line in CLICKHOUSE_DDL.read_text(encoding="utf-8").splitlines()
+            if (match := re.match(r"^    ([a-z][a-z0-9_]*)\s+", line))
+        }
+        ddl_columns.remove("ingested_at")
+        self.assertEqual(set(rows[0]), ddl_columns)
+
+    def test_rejects_missing_criterion_case(self) -> None:
+        missing = {**self.case, "case_id": "identity/missing", "criterion_id": "missing/id"}
+        self.write_manifest([self.case, missing])
+        result = self.run_exporter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing Criterion result for manifest case missing/id", result.stderr)
+
+    def test_rejects_unmanifested_criterion_result(self) -> None:
+        self.write_criterion_result(
+            "stateless_precompiles/direct/identity/extra",
+            directory="extra-sanitized-name",
+        )
+        result = self.run_exporter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("absent from the benchmark manifest", result.stderr)
+
+    def test_rejects_duplicate_case_ids(self) -> None:
+        duplicate = {**self.case, "criterion_id": "different/criterion/id"}
+        self.write_manifest([self.case, duplicate])
+        result = self.run_exporter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("duplicate case_id", result.stderr)
+
+    def test_uses_mean_when_slope_is_absent(self) -> None:
+        estimates_path = self.criterion_dir / "sanitized-name/new/estimates.json"
+        estimates = json.loads(estimates_path.read_text(encoding="utf-8"))
+        estimates["slope"] = None
+        estimates_path.write_text(json.dumps(estimates), encoding="utf-8")
+
+        result = self.run_exporter()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(self.output.read_text(encoding="utf-8"))
+        measurement = report["results"][0]["measurement"]
+        self.assertEqual(measurement["typical_statistic"], "mean")
+        self.assertEqual(measurement["typical"]["point_estimate_ns"], 102.0)
+
+    def test_rejects_unsupported_manifest_schema(self) -> None:
+        manifest = json.loads(self.manifest_path.read_text(encoding="utf-8"))
+        manifest["schema_version"] = 2
+        self.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+        result = self.run_exporter()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsupported manifest schema_version", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/bench/tests/test_upload_execution_microbench_results.py
+++ b/contrib/bench/tests/test_upload_execution_microbench_results.py
@@ -1,0 +1,137 @@
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+UPLOADER = REPOSITORY_ROOT / "contrib/bench/upload-execution-microbench-results.sh"
+
+
+class UploadExecutionMicrobenchResultsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        self.rows = self.root / "rows.jsonl"
+        self.curl_log = self.root / "curl-args.jsonl"
+        self.write_rows()
+
+        fake_curl = self.root / "curl"
+        fake_curl.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+
+with open(os.environ["CURL_LOG"], "a", encoding="utf-8") as log:
+    log.write(json.dumps({
+        "argv": sys.argv[1:],
+        "has_password": "CLICKHOUSE_PASSWORD" in os.environ,
+        "has_user": "CLICKHOUSE_USER" in os.environ,
+    }) + "\\n")
+if "--get" in sys.argv:
+    print(os.environ.get("FAKE_CLICKHOUSE_COUNT", "1"))
+""",
+            encoding="utf-8",
+        )
+        fake_curl.chmod(0o755)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_rows(
+        self,
+        *,
+        cpu_set: str | None = "2",
+        governors: str | None = "performance",
+        turbo: str | None = None,
+    ) -> None:
+        row = {
+            "schema_version": 1,
+            "run_id": "test-run-1",
+            "case_id": "identity/empty",
+            "measurement_mode": "wall_time",
+            "machine_id": "test-runner",
+            "cpu_set": cpu_set,
+            "cpu_governors": governors,
+            "turbo_control_json": turbo,
+        }
+        self.rows.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+    def run_uploader(self, **environment: str) -> subprocess.CompletedProcess[str]:
+        env = {
+            **os.environ,
+            "PATH": f"{self.root}:{os.environ['PATH']}",
+            "CURL_LOG": str(self.curl_log),
+            "FAKE_CLICKHOUSE_COUNT": "1",
+            "CLICKHOUSE_URL": "https://clickhouse.invalid",
+            "CLICKHOUSE_USER": "benchmark-user",
+            "CLICKHOUSE_PASSWORD": "secret-password",
+            "CLICKHOUSE_DATABASE": "bench",
+            **environment,
+        }
+        return subprocess.run(
+            ["bash", str(UPLOADER), str(self.rows)],
+            cwd=REPOSITORY_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_inserts_and_verifies_without_credentials_in_argv(self) -> None:
+        result = self.run_uploader()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Uploaded and verified 1 result(s)", result.stdout)
+
+        calls = [json.loads(line) for line in self.curl_log.read_text().splitlines()]
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(any("--data-binary" in call["argv"] for call in calls))
+        self.assertTrue(any("--get" in call["argv"] for call in calls))
+        self.assertTrue(all(not call["has_password"] for call in calls))
+        self.assertTrue(all(not call["has_user"] for call in calls))
+        self.assertNotIn("secret-password", json.dumps(calls))
+
+    def test_rejects_unpinned_publication(self) -> None:
+        self.write_rows(cpu_set=None)
+        result = self.run_uploader()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("non-empty cpu_set", result.stderr)
+        self.assertFalse(self.curl_log.exists())
+
+    def test_rejects_partially_configured_credentials(self) -> None:
+        result = self.run_uploader(CLICKHOUSE_PASSWORD="")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("partially configured", result.stderr)
+        self.assertFalse(self.curl_log.exists())
+
+    def test_rejects_non_loopback_http(self) -> None:
+        result = self.run_uploader(CLICKHOUSE_URL="http://clickhouse.invalid")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must use HTTPS", result.stderr)
+        self.assertFalse(self.curl_log.exists())
+
+    def test_rejects_non_performance_governor(self) -> None:
+        self.write_rows(governors="performance,powersave")
+        result = self.run_uploader()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("governor must be performance", result.stderr)
+
+    def test_validates_detected_turbo_control(self) -> None:
+        self.write_rows(
+            turbo=json.dumps(
+                {
+                    "path": "/sys/devices/system/cpu/cpufreq/boost",
+                    "value": "1",
+                },
+                separators=(",", ":"),
+            )
+        )
+        result = self.run_uploader()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("turbo boost is enabled", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/bench/upload-execution-microbench-results.sh
+++ b/contrib/bench/upload-execution-microbench-results.sh
@@ -8,7 +8,7 @@
 #   CLICKHOUSE_URL       ClickHouse HTTP endpoint (for example, https://host:8443)
 #   CLICKHOUSE_USER      Benchmark user with INSERT and SELECT on the result table
 #   CLICKHOUSE_PASSWORD  Benchmark user password
-#   CLICKHOUSE_DATABASE  Database name (default: default)
+#   CLICKHOUSE_DATABASE  Database name (default: tempo_repricing)
 #
 # Usage: upload-execution-microbench-results.sh <clickhouse-rows.jsonl>
 
@@ -16,7 +16,7 @@ set -euo pipefail
 
 TABLE="tempo_execution_microbench_results"
 ROWS_PATH="${1:-}"
-DATABASE="${CLICKHOUSE_DATABASE:-default}"
+DATABASE="${CLICKHOUSE_DATABASE:-tempo_repricing}"
 
 credential_count=0
 [ -n "${CLICKHOUSE_URL:-}" ] && credential_count=$((credential_count + 1))

--- a/contrib/bench/upload-execution-microbench-results.sh
+++ b/contrib/bench/upload-execution-microbench-results.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Insert native execution microbenchmark JSONEachRow data into ClickHouse.
+#
+# This runner intentionally has no DDL path. Apply the versioned table DDL with
+# an administrative account before configuring the benchmark workflow.
+#
+# Environment:
+#   CLICKHOUSE_URL       ClickHouse HTTP endpoint (for example, https://host:8443)
+#   CLICKHOUSE_USER      Benchmark user with INSERT and SELECT on the result table
+#   CLICKHOUSE_PASSWORD  Benchmark user password
+#   CLICKHOUSE_DATABASE  Database name (default: default)
+#
+# Usage: upload-execution-microbench-results.sh <clickhouse-rows.jsonl>
+
+set -euo pipefail
+
+TABLE="tempo_execution_microbench_results"
+ROWS_PATH="${1:-}"
+DATABASE="${CLICKHOUSE_DATABASE:-default}"
+
+credential_count=0
+[ -n "${CLICKHOUSE_URL:-}" ] && credential_count=$((credential_count + 1))
+[ -n "${CLICKHOUSE_USER:-}" ] && credential_count=$((credential_count + 1))
+[ -n "${CLICKHOUSE_PASSWORD:-}" ] && credential_count=$((credential_count + 1))
+if [ "$credential_count" -eq 0 ]; then
+  echo "Skipping ClickHouse upload: CLICKHOUSE_URL, CLICKHOUSE_USER, or CLICKHOUSE_PASSWORD not set"
+  exit 0
+fi
+if [ "$credential_count" -ne 3 ]; then
+  echo "error: ClickHouse credentials are partially configured; URL, user, and password are all required" >&2
+  exit 1
+fi
+
+if [[ "$CLICKHOUSE_URL" == https://* ]]; then
+  CURL_PROTOCOL="=https"
+elif [[ "$CLICKHOUSE_URL" =~ ^http://(localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?(/.*)?$ ]]; then
+  CURL_PROTOCOL="=http"
+else
+  echo "error: CLICKHOUSE_URL must use HTTPS; HTTP is allowed only for an explicit loopback address" >&2
+  exit 1
+fi
+
+if [ -z "$ROWS_PATH" ] || [ ! -f "$ROWS_PATH" ]; then
+  echo "error: JSONEachRow input file not found: ${ROWS_PATH:-<missing>}" >&2
+  exit 1
+fi
+if ! [[ "$DATABASE" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+  echo "error: CLICKHOUSE_DATABASE is not a valid unquoted database identifier" >&2
+  exit 1
+fi
+if [[ "$CLICKHOUSE_USER" == *$'\n'* || "$CLICKHOUSE_USER" == *$'\r'* || "$CLICKHOUSE_PASSWORD" == *$'\n'* || "$CLICKHOUSE_PASSWORD" == *$'\r'* ]]; then
+  echo "error: ClickHouse credentials must not contain line breaks" >&2
+  exit 1
+fi
+
+# Validate the complete batch before sending any bytes. This catches truncated
+# artifacts, duplicate cases, and accidental simulation results locally.
+VALIDATION_RESULT="$(env -u CLICKHOUSE_USER -u CLICKHOUSE_PASSWORD python3 - "$ROWS_PATH" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+rows = []
+for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+    if not line.strip():
+        continue
+    try:
+        row = json.loads(line)
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"error: invalid JSONEachRow line {line_number}: {error}")
+    if not isinstance(row, dict):
+        raise SystemExit(f"error: JSONEachRow line {line_number} is not an object")
+    rows.append(row)
+
+if not rows:
+    raise SystemExit("error: JSONEachRow input contains no results")
+
+run_ids = {row.get("run_id") for row in rows}
+if len(run_ids) != 1 or None in run_ids or "" in run_ids:
+    raise SystemExit("error: every row must have the same non-empty run_id")
+run_id = next(iter(run_ids))
+if not re.fullmatch(r"[A-Za-z0-9._:-]+", run_id):
+    raise SystemExit("error: run_id contains unsupported characters")
+case_ids = [row.get("case_id") for row in rows]
+if any(not isinstance(case_id, str) or not case_id for case_id in case_ids):
+    raise SystemExit("error: every row must have a non-empty case_id")
+if len(case_ids) != len(set(case_ids)):
+    raise SystemExit("error: duplicate case_id in JSONEachRow input")
+if any(row.get("schema_version") != 1 for row in rows):
+    raise SystemExit("error: unsupported JSONEachRow schema_version")
+if any(row.get("measurement_mode") != "wall_time" for row in rows):
+    raise SystemExit("error: only wall_time measurements may be published")
+if any("hostname" in row for row in rows):
+    raise SystemExit("error: hostname must not be persisted in benchmark rows")
+
+cpu_sets = {row.get("cpu_set") for row in rows}
+if len(cpu_sets) != 1 or None in cpu_sets or "" in cpu_sets:
+    raise SystemExit("error: published runs require one non-empty cpu_set")
+machine_ids = {row.get("machine_id") for row in rows}
+if len(machine_ids) != 1 or None in machine_ids or "" in machine_ids:
+    raise SystemExit("error: published runs require one non-empty machine_id")
+governor_sets = {row.get("cpu_governors") for row in rows}
+if len(governor_sets) != 1 or None in governor_sets or "" in governor_sets:
+    raise SystemExit("error: published runs require observed CPU governor metadata")
+governors = next(iter(governor_sets)).split(",")
+if any(governor != "performance" for governor in governors):
+    raise SystemExit("error: every observed CPU governor must be performance")
+
+turbo_values = {row.get("turbo_control_json") for row in rows}
+if len(turbo_values) != 1:
+    raise SystemExit("error: inconsistent turbo-control metadata")
+turbo_json = next(iter(turbo_values))
+if turbo_json is not None:
+    try:
+        turbo = json.loads(turbo_json)
+    except (TypeError, json.JSONDecodeError) as error:
+        raise SystemExit(f"error: invalid turbo-control metadata: {error}")
+    path = turbo.get("path", "")
+    value = turbo.get("value")
+    if path.endswith("/intel_pstate/no_turbo"):
+        expected = "1"
+    elif path.endswith("/cpufreq/boost"):
+        expected = "0"
+    else:
+        raise SystemExit(f"error: unknown turbo-control path: {path}")
+    if value != expected:
+        raise SystemExit(f"error: turbo boost is enabled according to {path}")
+
+print(f"{run_id}\t{len(rows)}")
+PY
+)"
+IFS=$'\t' read -r RUN_ID EXPECTED_COUNT <<< "$VALIDATION_RESULT"
+echo "Validated ${EXPECTED_COUNT} result(s) for run ${RUN_ID}"
+
+# Keep credentials out of argv and command output. Curl reads the temporary
+# mode-0600 config, and the trap removes it on success or failure.
+AUTH_CONFIG="$(mktemp)"
+trap 'rm -f "$AUTH_CONFIG"' EXIT
+chmod 600 "$AUTH_CONFIG"
+escaped_user="${CLICKHOUSE_USER//\\/\\\\}"
+escaped_user="${escaped_user//\"/\\\"}"
+escaped_password="${CLICKHOUSE_PASSWORD//\\/\\\\}"
+escaped_password="${escaped_password//\"/\\\"}"
+printf 'user = "%s:%s"\n' "$escaped_user" "$escaped_password" > "$AUTH_CONFIG"
+unset CLICKHOUSE_USER CLICKHOUSE_PASSWORD escaped_user escaped_password
+
+endpoint="${CLICKHOUSE_URL%/}/?database=${DATABASE}&date_time_input_format=best_effort&input_format_defaults_for_omitted_fields=1&query=INSERT%20INTO%20${TABLE}%20FORMAT%20JSONEachRow"
+curl \
+  --config "$AUTH_CONFIG" \
+  --proto "$CURL_PROTOCOL" \
+  --proto-redir "$CURL_PROTOCOL" \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --data-binary "@$ROWS_PATH" \
+  "$endpoint"
+
+observed_count="$(curl \
+  --config "$AUTH_CONFIG" \
+  --proto "$CURL_PROTOCOL" \
+  --proto-redir "$CURL_PROTOCOL" \
+  --fail-with-body \
+  --silent \
+  --show-error \
+  --get \
+  --data-urlencode "database=$DATABASE" \
+  --data-urlencode "param_run_id=$RUN_ID" \
+  --data-urlencode "query=SELECT count() FROM $TABLE FINAL WHERE run_id = {run_id:String} FORMAT TabSeparatedRaw" \
+  "${CLICKHOUSE_URL%/}/")"
+observed_count="${observed_count//[[:space:]]/}"
+if ! [[ "$observed_count" =~ ^[0-9]+$ ]]; then
+  echo "error: ClickHouse verification returned an invalid count" >&2
+  exit 1
+fi
+if [ "$observed_count" -ne "$EXPECTED_COUNT" ]; then
+  echo "error: ClickHouse verification found $observed_count row(s), expected $EXPECTED_COUNT" >&2
+  exit 1
+fi
+
+echo "Uploaded and verified ${EXPECTED_COUNT} result(s) in ${DATABASE}.${TABLE}"

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -50,6 +50,7 @@ serde_json.workspace = true
 tempo-evm = { workspace = true, features = ["engine"] }
 tempo-alloy.workspace = true
 tempo-revm.workspace = true
+tikv-jemallocator = "0.6.1"
 
 [features]
 default = ["rpc"]
@@ -62,5 +63,10 @@ required-features = ["test-utils"]
 
 [[bench]]
 name = "tempo_precompiles"
+harness = false
+required-features = ["test-utils"]
+
+[[bench]]
+name = "stateless_precompiles"
 harness = false
 required-features = ["test-utils"]

--- a/crates/precompiles/benches/stateless_precompiles.rs
+++ b/crates/precompiles/benches/stateless_precompiles.rs
@@ -1,0 +1,258 @@
+//! Direct stateless precompile microbenchmarks.
+//!
+//! This target measures only the resolved precompile implementation. Transaction decoding, EVM
+//! call machinery, block validation, and state-root work belong to separate benchmark layers.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use revm::{
+    handler::EthPrecompiles,
+    precompile::{Precompile as RevmPrecompile, PrecompileSpecId, PrecompileStatus},
+};
+use serde::Serialize;
+use std::{env, fs, hint::black_box, path::PathBuf};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_precompiles::{
+    benchmark::{BenchmarkProvenance, StatelessPrecompileCase, identity_benchmark_cases},
+    ethereum_precompile_spec,
+};
+
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+const BENCHMARK_GROUP: &str = "stateless_precompiles/direct";
+const MANIFEST_ENV: &str = "TEMPO_BENCH_MANIFEST";
+const TARGET_HARDFORK: TempoHardfork = TempoHardfork::T7;
+
+fn stateless_precompiles(c: &mut Criterion) {
+    let cases = identity_benchmark_cases(TARGET_HARDFORK);
+
+    preflight(&cases);
+    write_manifest_if_requested(&cases);
+
+    let mut group = c.benchmark_group(BENCHMARK_GROUP);
+    for case in &cases {
+        let precompile = resolve_precompile(case);
+        let case_name = case_name(case);
+
+        // One element represents one unit of charged regular gas.
+        group.throughput(Throughput::Elements(case.expected.gas_used));
+        group.bench_with_input(
+            BenchmarkId::new(case.precompile.name.as_str(), case_name),
+            case,
+            |b, case| {
+                b.iter(|| {
+                    // The returned Bytes and Result are consumed and dropped inside the timed
+                    // closure. This intentionally includes output allocation, copying, and
+                    // deallocation using the same jemalloc configuration as the EVM benches.
+                    black_box(precompile.execute(
+                        black_box(case.input.as_ref()),
+                        black_box(case.gas_limit),
+                        black_box(case.state_gas_reservoir),
+                    ))
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn resolve_precompile(case: &StatelessPrecompileCase) -> &'static RevmPrecompile {
+    let spec = ethereum_precompile_spec(case.hardfork);
+    EthPrecompiles::new(spec)
+        .precompiles
+        .get(&case.precompile.address)
+        .unwrap_or_else(|| {
+            panic!(
+                "{} is not registered at {} for {:?}",
+                case.precompile.name, case.precompile.address, case.hardfork
+            )
+        })
+}
+
+fn preflight(cases: &[StatelessPrecompileCase]) {
+    for case in cases {
+        let precompile = resolve_precompile(case);
+        assert_eq!(
+            precompile.id(),
+            &case.precompile.registry_id,
+            "{} resolved registry ID {:?}, expected {:?}",
+            case.id,
+            precompile.id(),
+            case.precompile.registry_id,
+        );
+
+        let result = precompile.execute(
+            case.input.as_ref(),
+            case.gas_limit,
+            case.state_gas_reservoir,
+        );
+        case.validate_result(&result)
+            .unwrap_or_else(|error| panic!("preflight failed: {error}"));
+    }
+}
+
+fn case_name(case: &StatelessPrecompileCase) -> &str {
+    let (namespace, name) = case
+        .id
+        .split_once('/')
+        .unwrap_or_else(|| panic!("benchmark case ID {} has no namespace", case.id));
+    assert_eq!(
+        namespace, case.precompile.name,
+        "benchmark case ID {} does not use the {} namespace",
+        case.id, case.precompile.name
+    );
+    name
+}
+
+fn criterion_id(case: &StatelessPrecompileCase) -> String {
+    format!("{BENCHMARK_GROUP}/{}", case.id)
+}
+
+fn write_manifest_if_requested(cases: &[StatelessPrecompileCase]) {
+    let Some(path) = env::var_os(MANIFEST_ENV).map(PathBuf::from) else {
+        return;
+    };
+
+    let manifest = CaseManifest {
+        schema_version: 1,
+        suite: SuiteManifest {
+            id: "stateless-precompiles",
+            version: 1,
+            benchmark_layer: "direct",
+        },
+        cases: cases.iter().map(CaseManifestEntry::from).collect(),
+    };
+    let mut json = serde_json::to_string_pretty(&manifest).expect("serialize benchmark manifest");
+    json.push('\n');
+
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).unwrap_or_else(|error| {
+            panic!(
+                "create benchmark manifest directory {}: {error}",
+                parent.display()
+            )
+        });
+    }
+    fs::write(&path, json)
+        .unwrap_or_else(|error| panic!("write benchmark manifest {}: {error}", path.display()));
+}
+
+#[derive(Serialize)]
+struct CaseManifest {
+    schema_version: u32,
+    suite: SuiteManifest,
+    cases: Vec<CaseManifestEntry>,
+}
+
+#[derive(Serialize)]
+struct SuiteManifest {
+    id: &'static str,
+    version: u32,
+    benchmark_layer: &'static str,
+}
+
+#[derive(Serialize)]
+struct CaseManifestEntry {
+    case_id: String,
+    criterion_id: String,
+    precompile: PrecompileManifest,
+    protocol: ProtocolManifest,
+    input: InputManifest,
+    gas_limit: u64,
+    state_gas_reservoir: u64,
+    gas_used: u64,
+    gas_refunded: i64,
+    state_gas_used: u64,
+    expected: ExpectedManifest,
+    provenance: Option<ProvenanceManifest>,
+}
+
+impl From<&StatelessPrecompileCase> for CaseManifestEntry {
+    fn from(case: &StatelessPrecompileCase) -> Self {
+        let precompile_spec =
+            PrecompileSpecId::from_spec_id(ethereum_precompile_spec(case.hardfork));
+        Self {
+            case_id: case.id.clone(),
+            criterion_id: criterion_id(case),
+            precompile: PrecompileManifest {
+                name: case.precompile.name.clone(),
+                registry_id: case.precompile.registry_id.name().into(),
+                address: format!("{:#x}", case.precompile.address),
+            },
+            protocol: ProtocolManifest {
+                hardfork: case.hardfork.to_string(),
+                precompile_spec: format!("{precompile_spec:?}"),
+            },
+            input: InputManifest {
+                kind: case.input.kind.clone(),
+                length: case.input.len(),
+            },
+            gas_limit: case.gas_limit,
+            state_gas_reservoir: case.state_gas_reservoir,
+            gas_used: case.expected.gas_used,
+            gas_refunded: case.expected.gas_refunded,
+            state_gas_used: case.expected.state_gas_used,
+            expected: ExpectedManifest {
+                status: status_name(&case.expected.status),
+                output_length: case.expected.output.len(case.input.as_ref()),
+                state_gas_reservoir_remaining: case.expected.state_gas_reservoir_remaining,
+            },
+            provenance: case.provenance.as_ref().map(ProvenanceManifest::from),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct PrecompileManifest {
+    name: String,
+    registry_id: String,
+    address: String,
+}
+
+#[derive(Serialize)]
+struct ProtocolManifest {
+    hardfork: String,
+    precompile_spec: String,
+}
+
+#[derive(Serialize)]
+struct InputManifest {
+    kind: String,
+    length: usize,
+}
+
+#[derive(Serialize)]
+struct ExpectedManifest {
+    status: &'static str,
+    output_length: usize,
+    state_gas_reservoir_remaining: u64,
+}
+
+#[derive(Serialize)]
+struct ProvenanceManifest {
+    source: String,
+    reference: String,
+}
+
+impl From<&BenchmarkProvenance> for ProvenanceManifest {
+    fn from(provenance: &BenchmarkProvenance) -> Self {
+        Self {
+            source: provenance.source.clone(),
+            reference: provenance.reference.clone(),
+        }
+    }
+}
+
+fn status_name(status: &PrecompileStatus) -> &'static str {
+    match status {
+        PrecompileStatus::Success => "success",
+        PrecompileStatus::Revert => "revert",
+        PrecompileStatus::Halt(_) => "halt",
+    }
+}
+
+criterion_group!(benches, stateless_precompiles);
+criterion_main!(benches);

--- a/crates/precompiles/src/benchmark.rs
+++ b/crates/precompiles/src/benchmark.rs
@@ -1,0 +1,441 @@
+//! Shared models for direct precompile benchmarks.
+//!
+//! Benchmark case definitions are Tempo-owned. External suites such as EEST can be translated
+//! into this model, but do not define its storage or execution format.
+
+use alloy::primitives::{Address, Bytes};
+use revm::precompile::{PrecompileId, PrecompileResult, PrecompileStatus, u64_to_address};
+use tempo_chainspec::hardfork::TempoHardfork;
+
+/// Describes the precompile selected by a benchmark case.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BenchmarkPrecompile {
+    /// Stable human-readable precompile name.
+    pub name: String,
+    /// Expected identifier of the implementation resolved from the registry.
+    pub registry_id: PrecompileId,
+    /// Address used to resolve the implementation from the production precompile registry.
+    pub address: Address,
+}
+
+/// Describes where a benchmark case originated.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BenchmarkProvenance {
+    /// Source suite or project, for example `tempo` or `eest`.
+    pub source: String,
+    /// Stable source identifier such as an issue or pinned upstream case.
+    pub reference: String,
+}
+
+/// Materialized benchmark input and a stable description of how it was produced.
+///
+/// `kind` is deliberately Tempo-owned rather than tied to an external fixture format. Examples
+/// include `zero-filled`, `inline`, or a future Tempo-specific proof generator name.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BenchmarkInput {
+    /// Stable input source or materialization kind.
+    pub kind: String,
+    /// Bytes passed directly to the precompile.
+    pub bytes: Bytes,
+}
+
+impl BenchmarkInput {
+    /// Returns the materialized input length.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    /// Returns `true` when the materialized input is empty.
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+impl AsRef<[u8]> for BenchmarkInput {
+    fn as_ref(&self) -> &[u8] {
+        self.bytes.as_ref()
+    }
+}
+
+/// Expected bytes for a successful, reverted, or halted precompile result.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ExpectedOutput {
+    /// The output must be byte-for-byte equal to the input.
+    SameAsInput,
+    /// The output must equal these exact bytes.
+    Exact(Bytes),
+}
+
+impl ExpectedOutput {
+    /// Returns the expected output length for `input`.
+    pub fn len(&self, input: &[u8]) -> usize {
+        match self {
+            Self::SameAsInput => input.len(),
+            Self::Exact(bytes) => bytes.len(),
+        }
+    }
+
+    fn as_bytes<'a>(&'a self, input: &'a [u8]) -> &'a [u8] {
+        match self {
+            Self::SameAsInput => input,
+            Self::Exact(bytes) => bytes,
+        }
+    }
+}
+
+/// Correctness expectations checked before a case is benchmarked.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ExpectedPrecompileResult {
+    /// Expected execution status.
+    pub status: PrecompileStatus,
+    /// Expected regular gas charged by the precompile.
+    pub gas_used: u64,
+    /// Expected regular gas refund.
+    pub gas_refunded: i64,
+    /// Expected state gas charged by the precompile.
+    pub state_gas_used: u64,
+    /// Expected state-gas reservoir returned after execution.
+    pub state_gas_reservoir_remaining: u64,
+    /// Expected output bytes.
+    pub output: ExpectedOutput,
+}
+
+/// A materialized, fixture-format-independent stateless precompile benchmark case.
+///
+/// Input generation and external fixture formats intentionally sit outside this type. Generators
+/// and adapters only need to produce this materialized representation for the direct runner.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StatelessPrecompileCase {
+    /// Stable case identifier, namespaced by precompile (for example `identity/32-bytes`).
+    pub id: String,
+    /// Precompile to resolve and execute.
+    pub precompile: BenchmarkPrecompile,
+    /// Explicit Tempo hardfork under which the case runs.
+    pub hardfork: TempoHardfork,
+    /// Materialized precompile input and its Tempo-owned kind.
+    pub input: BenchmarkInput,
+    /// Regular gas supplied to the precompile.
+    pub gas_limit: u64,
+    /// State-gas reservoir supplied to the precompile.
+    pub state_gas_reservoir: u64,
+    /// Correctness expectations checked outside the timed region.
+    pub expected: ExpectedPrecompileResult,
+    /// Optional source attribution for supplemental cases.
+    pub provenance: Option<BenchmarkProvenance>,
+}
+
+impl StatelessPrecompileCase {
+    /// Validates a direct precompile result against this case's expectations.
+    pub fn validate_result(
+        &self,
+        result: &PrecompileResult,
+    ) -> Result<(), PrecompileCaseValidationError> {
+        let output = result
+            .as_ref()
+            .map_err(|error| PrecompileCaseValidationError::Fatal {
+                case_id: self.id.clone(),
+                error: error.to_string(),
+            })?;
+
+        if output.status != self.expected.status {
+            return Err(PrecompileCaseValidationError::Status {
+                case_id: self.id.clone(),
+                expected: self.expected.status.clone(),
+                actual: output.status.clone(),
+            });
+        }
+        if output.gas_used != self.expected.gas_used {
+            return Err(PrecompileCaseValidationError::GasUsed {
+                case_id: self.id.clone(),
+                expected: self.expected.gas_used,
+                actual: output.gas_used,
+            });
+        }
+        if output.gas_refunded != self.expected.gas_refunded {
+            return Err(PrecompileCaseValidationError::GasRefunded {
+                case_id: self.id.clone(),
+                expected: self.expected.gas_refunded,
+                actual: output.gas_refunded,
+            });
+        }
+        if output.state_gas_used != self.expected.state_gas_used {
+            return Err(PrecompileCaseValidationError::StateGasUsed {
+                case_id: self.id.clone(),
+                expected: self.expected.state_gas_used,
+                actual: output.state_gas_used,
+            });
+        }
+        if output.reservoir != self.expected.state_gas_reservoir_remaining {
+            return Err(PrecompileCaseValidationError::StateGasReservoirRemaining {
+                case_id: self.id.clone(),
+                expected: self.expected.state_gas_reservoir_remaining,
+                actual: output.reservoir,
+            });
+        }
+
+        let expected = self.expected.output.as_bytes(self.input.as_ref());
+        if output.bytes.as_ref() != expected {
+            return Err(PrecompileCaseValidationError::Output {
+                case_id: self.id.clone(),
+                expected_len: expected.len(),
+                actual_len: output.bytes.len(),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+/// Failure returned when a benchmark case does not execute as declared.
+#[derive(Debug, thiserror::Error)]
+pub enum PrecompileCaseValidationError {
+    /// The precompile returned a fatal provider error.
+    #[error("benchmark case {case_id} returned a fatal precompile error: {error}")]
+    Fatal {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Provider error text.
+        error: String,
+    },
+    /// The returned precompile status differed from the expected status.
+    #[error("benchmark case {case_id} returned status {actual:?}, expected {expected:?}")]
+    Status {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Expected status.
+        expected: PrecompileStatus,
+        /// Actual status.
+        actual: PrecompileStatus,
+    },
+    /// The regular gas charge differed from the expected charge.
+    #[error("benchmark case {case_id} used {actual} gas, expected {expected}")]
+    GasUsed {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Expected gas charge.
+        expected: u64,
+        /// Actual gas charge.
+        actual: u64,
+    },
+    /// The regular gas refund differed from the expected refund.
+    #[error("benchmark case {case_id} refunded {actual} gas, expected {expected}")]
+    GasRefunded {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Expected gas refund.
+        expected: i64,
+        /// Actual gas refund.
+        actual: i64,
+    },
+    /// The state gas charge differed from the expected charge.
+    #[error("benchmark case {case_id} used {actual} state gas, expected {expected}")]
+    StateGasUsed {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Expected state gas charge.
+        expected: u64,
+        /// Actual state gas charge.
+        actual: u64,
+    },
+    /// The returned state-gas reservoir differed from the expected remainder.
+    #[error("benchmark case {case_id} returned state-gas reservoir {actual}, expected {expected}")]
+    StateGasReservoirRemaining {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Expected remaining reservoir.
+        expected: u64,
+        /// Actual remaining reservoir.
+        actual: u64,
+    },
+    /// The output differed from the expected bytes.
+    #[error(
+        "benchmark case {case_id} returned incorrect output ({actual_len} bytes, expected {expected_len})"
+    )]
+    Output {
+        /// Stable benchmark case ID.
+        case_id: String,
+        /// Expected output length.
+        expected_len: usize,
+        /// Actual output length.
+        actual_len: usize,
+    },
+}
+
+/// Returns the direct Identity benchmark cases for an explicit Tempo hardfork.
+///
+/// Cases around 32-byte word boundaries are Tempo-native. The fixed 0/32/256/1024-byte sizes
+/// overlap the pinned EEST benchmark suite and carry that supplemental provenance. Inputs are
+/// materialized here because Identity only needs deterministic zero-filled byte strings; a general
+/// workload generator is intentionally outside the scope of this direct benchmark.
+pub fn identity_benchmark_cases(hardfork: TempoHardfork) -> Vec<StatelessPrecompileCase> {
+    const EEST_REFERENCE: &str = concat!(
+        "execution-specs/tests-benchmark@v0.0.9/",
+        "tests/benchmark/compute/precompile/test_identity.py::test_identity_fixed_size"
+    );
+
+    [
+        ("empty", 0, Some(EEST_REFERENCE)),
+        ("1-byte", 1, None),
+        ("31-bytes", 31, None),
+        ("32-bytes", 32, Some(EEST_REFERENCE)),
+        ("33-bytes", 33, None),
+        ("256-bytes", 256, Some(EEST_REFERENCE)),
+        ("1024-bytes", 1_024, Some(EEST_REFERENCE)),
+        ("128-kib", 128 * 1_024, None),
+    ]
+    .into_iter()
+    .map(|(name, input_len, eest_reference)| {
+        let gas_used = identity_gas(input_len);
+        let provenance = eest_reference.map_or_else(
+            || BenchmarkProvenance {
+                source: "tempo".into(),
+                reference: "RETH-1014".into(),
+            },
+            |reference| BenchmarkProvenance {
+                source: "eest".into(),
+                reference: reference.into(),
+            },
+        );
+
+        StatelessPrecompileCase {
+            id: format!("identity/{name}"),
+            precompile: BenchmarkPrecompile {
+                name: "identity".into(),
+                registry_id: PrecompileId::Identity,
+                address: u64_to_address(4),
+            },
+            hardfork,
+            input: BenchmarkInput {
+                kind: "zero-filled".into(),
+                bytes: Bytes::from(vec![0_u8; input_len]),
+            },
+            // Use the exact schedule charge so the case validates the successful boundary without
+            // emitting an unbounded sentinel into downstream JSON consumers.
+            gas_limit: gas_used,
+            state_gas_reservoir: 0,
+            expected: ExpectedPrecompileResult {
+                status: PrecompileStatus::Success,
+                gas_used,
+                gas_refunded: 0,
+                state_gas_used: 0,
+                state_gas_reservoir_remaining: 0,
+                output: ExpectedOutput::SameAsInput,
+            },
+            provenance: Some(provenance),
+        }
+    })
+    .collect()
+}
+
+const fn identity_gas(input_len: usize) -> u64 {
+    const BASE_GAS: u64 = 15;
+    const GAS_PER_WORD: u64 = 3;
+    let words = (input_len as u64).div_ceil(32);
+    BASE_GAS + GAS_PER_WORD * words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ethereum_precompile_spec;
+    use revm::{precompile::PrecompileOutput, primitives::hardfork::SpecId};
+
+    fn case() -> StatelessPrecompileCase {
+        StatelessPrecompileCase {
+            id: "identity/test".into(),
+            precompile: BenchmarkPrecompile {
+                name: "identity".into(),
+                registry_id: PrecompileId::Identity,
+                address: Address::from([0_u8; 20]),
+            },
+            hardfork: TempoHardfork::T7,
+            input: BenchmarkInput {
+                kind: "inline".into(),
+                bytes: Bytes::from_static(b"tempo"),
+            },
+            gas_limit: 18,
+            state_gas_reservoir: 7,
+            expected: ExpectedPrecompileResult {
+                status: PrecompileStatus::Success,
+                gas_used: 18,
+                gas_refunded: 0,
+                state_gas_used: 0,
+                state_gas_reservoir_remaining: 7,
+                output: ExpectedOutput::SameAsInput,
+            },
+            provenance: None,
+        }
+    }
+
+    #[test]
+    fn validates_expected_result() {
+        let case = case();
+        let result = Ok(PrecompileOutput::new(18, case.input.bytes.clone(), 7));
+        assert!(case.validate_result(&result).is_ok());
+    }
+
+    #[test]
+    fn rejects_wrong_gas_and_output() {
+        let case = case();
+
+        let wrong_gas = Ok(PrecompileOutput::new(19, case.input.bytes.clone(), 7));
+        assert!(matches!(
+            case.validate_result(&wrong_gas),
+            Err(PrecompileCaseValidationError::GasUsed { .. })
+        ));
+
+        let wrong_output = Ok(PrecompileOutput::new(18, Bytes::from_static(b"wrong"), 7));
+        assert!(matches!(
+            case.validate_result(&wrong_output),
+            Err(PrecompileCaseValidationError::Output { .. })
+        ));
+
+        let wrong_reservoir = Ok(PrecompileOutput::new(18, case.input.bytes.clone(), 6));
+        assert!(matches!(
+            case.validate_result(&wrong_reservoir),
+            Err(PrecompileCaseValidationError::StateGasReservoirRemaining { .. })
+        ));
+    }
+
+    #[test]
+    fn identity_cases_have_stable_ids_and_gas() {
+        let cases = identity_benchmark_cases(TempoHardfork::T7);
+
+        assert_eq!(
+            cases
+                .iter()
+                .map(|case| case.id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "identity/empty",
+                "identity/1-byte",
+                "identity/31-bytes",
+                "identity/32-bytes",
+                "identity/33-bytes",
+                "identity/256-bytes",
+                "identity/1024-bytes",
+                "identity/128-kib",
+            ]
+        );
+        assert_eq!(
+            cases
+                .iter()
+                .map(|case| case.expected.gas_used)
+                .collect::<Vec<_>>(),
+            [15, 18, 18, 18, 21, 39, 111, 12_303]
+        );
+        assert!(cases.iter().all(|case| case.hardfork == TempoHardfork::T7));
+        assert!(cases.iter().all(|case| case.input.kind == "zero-filled"));
+        assert!(cases.iter().all(|case| {
+            case.precompile.registry_id == PrecompileId::Identity
+                && case.gas_limit == case.expected.gas_used
+        }));
+    }
+
+    #[test]
+    fn tempo_precompile_spec_boundary_is_explicit() {
+        assert_eq!(ethereum_precompile_spec(TempoHardfork::T1B), SpecId::PRAGUE);
+        assert_eq!(ethereum_precompile_spec(TempoHardfork::T1C), SpecId::OSAKA);
+        assert_eq!(ethereum_precompile_spec(TempoHardfork::T7), SpecId::OSAKA);
+    }
+}

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -10,6 +10,9 @@ pub mod storage;
 pub mod dispatch;
 pub use dispatch::*;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod benchmark;
+
 pub(crate) mod ip_validation;
 
 pub mod account_keychain;
@@ -149,14 +152,23 @@ pub fn tempo_precompiles(
     actions: StorageActions,
     non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
 ) -> PrecompilesMap {
-    let spec = if cfg.spec.is_t1c() {
-        cfg.spec.into()
-    } else {
-        SpecId::PRAGUE
-    };
+    let spec = ethereum_precompile_spec(cfg.spec);
     let mut precompiles = PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles);
     extend_tempo_precompiles(&mut precompiles, cfg, actions, non_creditable_slots);
     precompiles
+}
+
+/// Returns the Ethereum precompile specification used by Tempo at `hardfork`.
+///
+/// Tempo launched with Prague precompiles and adopted the Osaka set at T1C. Keeping this mapping
+/// separate from `From<TempoHardfork> for SpecId` is intentional: Tempo's EVM opcode rules use
+/// Osaka throughout, while the built-in precompile set has this additional compatibility boundary.
+pub fn ethereum_precompile_spec(hardfork: TempoHardfork) -> SpecId {
+    if hardfork.is_t1c() {
+        hardfork.into()
+    } else {
+        SpecId::PRAGUE
+    }
 }
 
 /// Registers Tempo-specific precompiles into an existing [`PrecompilesMap`] by installing a


### PR DESCRIPTION
Implements [RETH-1014](https://linear.app/tempoxyz/issue/RETH-1014/implement-identity-benchmark). Adds an identity-precompile benchmark template that validates expected gas and output, then exports Criterion results as a versioned report and ClickHouse `JSONEachRow` rows.

Adds a main-only bare-metal workflow with CPU, governor, and turbo checks, artifact handoff to a GitHub-hosted publisher, and a schema and uploader targeting `tempo_repricing`. The stateless target is also included in the existing CodSpeed microbenchmark workflow.

Native publication activates after merge: dispatch the workflow on `main`; feature branches use CodSpeed and cannot execute on the self-hosted runner.