### PR TITLE
docs(e2e): fix grammar in `metric_prefix` panic note

### DIFF
--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -153,7 +153,7 @@ where
     /// Get the metric prefix used by the most recently started instance.
     ///
     /// # Panics
-    /// Panics if the node has was never started.
+    /// Panics if the node was never started.
     pub fn metric_prefix(&self) -> String {
         assert!(self.n_starts > 0, "node has never been started");
         format!("{}_{}", self.uid, self.n_starts - 1)


### PR DESCRIPTION
# docs(e2e): fix grammar in `metric_prefix` panic note

The `# Panics` doc line read "Panics if the node has was never started." — "has was" is a
grammatical slip. Corrected to "Panics if the node was never started.", which also matches
the actual assertion message a couple of lines below (`"node has never been started"`).