### PR TITLE
refactor(chainspec): generalize Tempo provider bounds

### DIFF
--- a/crates/node/src/rpc/fork_schedule.rs
+++ b/crates/node/src/rpc/fork_schedule.rs
@@ -3,7 +3,7 @@ use reth_chainspec::{EthereumHardfork, ForkCondition, Hardforks, Head};
 use reth_primitives_traits::AlloyBlockHeader as _;
 use reth_provider::{BlockNumReader, ChainSpecProvider, HeaderProvider};
 use serde::{Deserialize, Serialize};
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
+use tempo_chainspec::hardfork::TempoHardforks;
 
 /// Response for `tempo_forkSchedule`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -58,7 +58,7 @@ fn internal_err(msg: impl ToString) -> jsonrpsee::types::ErrorObject<'static> {
 #[async_trait::async_trait]
 impl<P> TempoForkScheduleApiServer for TempoForkScheduleRpc<P>
 where
-    P: ChainSpecProvider<ChainSpec = TempoChainSpec>
+    P: ChainSpecProvider<ChainSpec: Hardforks + TempoHardforks>
         + BlockNumReader
         + HeaderProvider
         + Send

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -31,7 +31,7 @@ pub use token::{TempoToken, TempoTokenApiServer};
 use crate::rpc::error::TempoEthApiError;
 use alloy::primitives::{U256, uint};
 use alloy_evm::{EvmFactory, block::BlockExecutorFactory};
-use reth_chainspec::{EthereumHardforks, Hardforks};
+use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_ethereum::tasks::{
     Runtime,
     pool::{BlockingTaskGuard, BlockingTaskPool},
@@ -528,15 +528,15 @@ where
 /// Converter for Tempo receipts.
 #[derive(Debug, Clone)]
 #[expect(clippy::type_complexity)]
-pub struct TempoReceiptConverter {
+pub struct TempoReceiptConverter<ChainSpec = TempoChainSpec> {
     inner: EthReceiptConverter<
-        TempoChainSpec,
+        ChainSpec,
         fn(TempoReceipt, usize, TransactionMeta) -> ReceiptWithBloom<TempoReceipt<Log>>,
     >,
 }
 
-impl TempoReceiptConverter {
-    pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
+impl<ChainSpec> TempoReceiptConverter<ChainSpec> {
+    pub fn new(chain_spec: Arc<ChainSpec>) -> Self {
         Self {
             inner: EthReceiptConverter::new(chain_spec).with_builder(
                 |receipt: TempoReceipt, next_log_index, meta| {
@@ -563,7 +563,10 @@ impl TempoReceiptConverter {
     }
 }
 
-impl ReceiptConverter<TempoPrimitives> for TempoReceiptConverter {
+impl<ChainSpec> ReceiptConverter<TempoPrimitives> for TempoReceiptConverter<ChainSpec>
+where
+    ChainSpec: EthChainSpec + 'static,
+{
     type RpcReceipt = TempoTransactionReceipt;
     type Error = EthApiError;
 
@@ -630,12 +633,12 @@ impl<N> TempoEthApiBuilder<N> {
 impl<N> EthApiBuilder<N> for TempoEthApiBuilder<N>
 where
     N: FullNodeComponents<
-            Types: NodeTypes<ChainSpec = TempoChainSpec, Primitives = TempoPrimitives>,
+            Types: NodeTypes<Primitives = TempoPrimitives>,
             Pool = <N as RpcNodeCore>::Pool,
             Evm = <N as RpcNodeCore>::Evm,
         > + FullNodeTypes<Provider = <N as RpcNodeCore>::Provider>
         + TempoEthApiBounds,
-    <N as RpcNodeCore>::Provider: ChainSpecProvider<ChainSpec = TempoChainSpec>,
+    <N as RpcNodeCore>::Provider: ChainSpecProvider<ChainSpec = <N::Types as NodeTypes>::ChainSpec>,
     <<N as RpcNodeCore>::Evm as ConfigureEvm>::NextBlockEnvCtx: BuildPendingEnv<TempoHeader>,
     <N::Types as NodeTypes>::ChainSpec: Hardforks + EthereumHardforks,
 {

--- a/crates/transaction-pool/src/amm.rs
+++ b/crates/transaction-pool/src/amm.rs
@@ -7,15 +7,13 @@ use alloy_primitives::{
 };
 use itertools::Itertools;
 use parking_lot::RwLock;
+use reth_chainspec::EthChainSpec;
 use reth_primitives_traits::SealedHeader;
 use reth_provider::{
     ChainSpecProvider, ExecutionOutcome, HeaderProvider, ProviderError, ProviderResult,
     StateProviderFactory,
 };
-use tempo_chainspec::{
-    TempoChainSpec,
-    hardfork::{TempoHardfork, TempoHardforks},
-};
+use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
 use tempo_evm::TempoStateAccess;
 use tempo_precompiles::{
     DEFAULT_FEE_TOKEN, TIP_FEE_MANAGER_ADDRESS,
@@ -45,7 +43,7 @@ impl AmmLiquidityCache {
     where
         Client: StateProviderFactory
             + HeaderProvider<Header = TempoHeader>
-            + ChainSpecProvider<ChainSpec = TempoChainSpec>,
+            + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>,
     {
         let this = Self {
             inner: Default::default(),
@@ -175,7 +173,7 @@ impl AmmLiquidityCache {
     where
         Client: StateProviderFactory
             + HeaderProvider<Header = TempoHeader>
-            + ChainSpecProvider<ChainSpec = TempoChainSpec>,
+            + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>,
     {
         self.clear();
         let tip = client.best_block_number()?;

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{
 use alloy_sol_types::SolEvent;
 use futures::StreamExt;
 use itertools::{Either, Itertools};
-use reth_chainspec::ChainSpecProvider;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives_traits::AlloyBlockHeader;
 use reth_provider::{CanonStateNotification, CanonStateSubscriptions, Chain, HeaderProvider};
 use reth_storage_api::StateProviderFactory;
@@ -22,7 +22,7 @@ use std::{
     collections::{BTreeMap, btree_map::Entry},
     time::Instant,
 };
-use tempo_chainspec::TempoChainSpec;
+use tempo_chainspec::hardfork::TempoHardforks;
 use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
@@ -584,7 +584,7 @@ pub async fn maintain_tempo_pool<Client>(pool: TempoTransactionPool<Client>)
 where
     Client: StateProviderFactory
         + HeaderProvider<Header = TempoHeader>
-        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + CanonStateSubscriptions<Primitives = TempoPrimitives>
         + 'static,
 {

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -13,7 +13,7 @@ use alloy_primitives::{
     map::{AddressMap, AddressSet, Entry, HashMap},
 };
 use parking_lot::RwLock;
-use reth_chainspec::ChainSpecProvider;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_eth_wire_types::HandleMempoolData;
 use reth_provider::{ChangedAccount, StateProviderFactory};
 use reth_storage_api::StateProvider;
@@ -29,7 +29,7 @@ use reth_transaction_pool::{
 };
 use revm::database::BundleAccount;
 use std::{sync::Arc, time::Instant};
-use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardfork};
+use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     account_keychain::AccountKeychain,
@@ -38,7 +38,7 @@ use tempo_precompiles::{
     tip20::TIP20Token,
     tip403_registry::{REJECT_ALL_POLICY_ID, TIP403Registry},
 };
-use tempo_primitives::Block;
+use tempo_primitives::{Block, TempoHeader};
 use tempo_revm::TempoStateAccess;
 
 /// Tempo transaction pool that routes based on nonce_key
@@ -55,7 +55,9 @@ pub struct TempoTransactionPool<Client> {
 
 impl<Client> TempoTransactionPool<Client>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + 'static,
+    Client: StateProviderFactory
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
+        + 'static,
 {
     pub fn new(
         protocol_pool: Pool<
@@ -74,7 +76,9 @@ where
 }
 impl<Client> TempoTransactionPool<Client>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + 'static,
+    Client: StateProviderFactory
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
+        + 'static,
 {
     /// Obtains a clone of the shared [`AmmLiquidityCache`].
     pub fn amm_liquidity_cache(&self) -> AmmLiquidityCache {
@@ -618,7 +622,7 @@ impl<Client> std::fmt::Debug for TempoTransactionPool<Client> {
 impl<Client> TransactionPool for TempoTransactionPool<Client>
 where
     Client: StateProviderFactory
-        + ChainSpecProvider<ChainSpec = TempoChainSpec>
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + Send
         + Sync
         + 'static,
@@ -1225,7 +1229,9 @@ where
 
 impl<Client> TransactionPoolExt for TempoTransactionPool<Client>
 where
-    Client: StateProviderFactory + ChainSpecProvider<ChainSpec = TempoChainSpec> + 'static,
+    Client: StateProviderFactory
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
+        + 'static,
 {
     type Block = Block;
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -8,7 +8,7 @@ use alloy_consensus::constants::KECCAK_EMPTY;
 use alloy_evm::{Database, EvmEnv};
 use alloy_primitives::{Address, B256};
 use parking_lot::RwLock;
-use reth_chainspec::ChainSpecProvider;
+use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{
     Account, Bytecode, SealedBlock, transaction::error::InvalidTransactionError,
@@ -34,10 +34,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicU8, Ordering},
 };
-use tempo_chainspec::{
-    TempoChainSpec,
-    hardfork::{TempoHardfork, TempoHardforks},
-};
+use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
 use tempo_evm::{TempoEvmConfig, evm::TempoEvm};
 use tempo_precompiles::{
     nonce::{INonce, NonceManager},
@@ -116,7 +113,8 @@ pub struct TempoTransactionValidator<Client> {
 
 impl<Client> TempoTransactionValidator<Client>
 where
-    Client: ChainSpecProvider<ChainSpec = TempoChainSpec> + StateProviderFactory,
+    Client: ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
+        + StateProviderFactory,
 {
     pub fn new(
         inner: EthTransactionValidator<Client, TempoPooledTransaction, TempoEvmConfig>,
@@ -670,7 +668,8 @@ where
 
 impl<Client> TransactionValidator for TempoTransactionValidator<Client>
 where
-    Client: ChainSpecProvider<ChainSpec = TempoChainSpec> + StateProviderFactory,
+    Client: ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
+        + StateProviderFactory,
 {
     type Transaction = TempoPooledTransaction;
     type Block = Block;
@@ -812,8 +811,9 @@ mod tests {
         Arc,
         atomic::{AtomicUsize, Ordering},
     };
-    use tempo_chainspec::spec::{
-        MODERATO, TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE, TEMPO_T1_TX_GAS_LIMIT_CAP,
+    use tempo_chainspec::{
+        TempoChainSpec,
+        spec::{MODERATO, TEMPO_T0_BASE_FEE, TEMPO_T1_BASE_FEE, TEMPO_T1_TX_GAS_LIMIT_CAP},
     };
     use tempo_precompiles::{
         PATH_USD_ADDRESS,


### PR DESCRIPTION
This PR  generalizes transaction pool and RPC chainspec bounds so downstream nodes with a custom chainspec can use `TempoTransactionPool`, `TempoEthApiBuilder`, and the fork schedule RPC. 