### PR TITLE
fix: honor disabled multi-region OTLP input

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -251,7 +251,7 @@ jobs:
       BENCH_INPUT_TXGEN_REF: ${{ inputs['txgen-ref'] || '' }}
       BENCH_INPUT_TOKEN_COUNT: ${{ inputs['token-count'] || '4' }}
       BENCH_INPUT_PROFILING: ${{ inputs.profiling || 'off' }}
-      BENCH_INPUT_OTLP: ${{ github.event_name == 'workflow_dispatch' && (inputs.otlp == false || inputs.otlp == 'false') && 'false' || 'true' }}
+      BENCH_INPUT_OTLP: ${{ format('{0}', github.event_name != 'workflow_dispatch' || inputs.otlp) }}
       BENCH_INPUT_VALSCOPE: ${{ github.event_name == 'workflow_dispatch' && (inputs.valscope == true || inputs.valscope == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BASELINE_ARGS: ${{ inputs['baseline-args'] || '' }}
       BENCH_INPUT_FEATURE_ARGS: ${{ inputs['feature-args'] || '' }}


### PR DESCRIPTION
## Summary

Mirror the multi-region workflow boolean fix so a manual `otlp=false` dispatch reaches the AWS benchmark harness as `false`. Non-dispatch callers retain the default-enabled behavior.

## Evidence

Run https://github.com/tempoxyz/tempo/actions/runs/29459069611 was dispatched with `otlp=false`, but both phase artifacts recorded `enabled: true` and the validator command included `--tracing-otlp`.

## Validation

- `git diff --check`
- `actionlint` (with the custom Depot runner label ignored)
- a fresh `bench-e2e-multi-region` smoke will verify disabled OTLP after merge