### PR TITLE
docs(primitives): document core protocol types

### DIFF
--- a/crates/primitives/src/header.rs
+++ b/crates/primitives/src/header.rs
@@ -15,9 +15,13 @@ use crate::ed25519::PublicKey;
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 #[cfg_attr(test, reth_codecs::add_arbitrary_tests(compact))]
 pub struct TempoConsensusContext {
+    /// Consensus epoch this block belongs to.
     pub epoch: u64,
+    /// Consensus view (round) in which this block was proposed.
     pub view: u64,
+    /// Consensus view of the parent block.
     pub parent_view: u64,
+    /// Ed25519 public key of the block's proposer.
     pub proposer: PublicKey,
 }
 

--- a/crates/primitives/src/subblock.rs
+++ b/crates/primitives/src/subblock.rs
@@ -28,6 +28,7 @@ impl PartialValidatorKey {
     }
 }
 
+/// Version tag identifying the subblock encoding format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub enum SubBlockVersion {
@@ -70,6 +71,9 @@ impl Decodable for SubBlockVersion {
     }
 }
 
+/// A validator-submitted batch of transactions to be appended on top of a specific parent
+/// block, carrying its encoding version, the required parent hash, the fee recipient, and the
+/// included transactions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
 pub struct SubBlock {

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -25,7 +25,10 @@ pub const FEE_PAYER_SIGNATURE_MARKER: Signature = Signature::new(U256::ZERO, U25
 
 /// Signature type constants
 pub const SECP256K1_SIGNATURE_LENGTH: usize = 65;
+/// Encoded byte length of a P256 signature: 32 (r) + 32 (s) + 32 (pub_key_x) + 32 (pub_key_y)
+/// + 1 (pre-hash flag).
 pub const P256_SIGNATURE_LENGTH: usize = 129;
+/// Maximum accepted byte length of a WebAuthn signature payload (2 KiB).
 pub const MAX_WEBAUTHN_SIGNATURE_LENGTH: usize = 2048; // 2KB max
 
 /// Nonce key marking an expiring nonce transaction (uses tx hash for replay protection).


### PR DESCRIPTION
Adds accurate doc comments to public items that lacked them across the primitives crate:

- `SubBlockVersion` (enum) — the subblock encoding-format version tag.
- `SubBlock` (struct) — a validator-submitted batch appended on top of a specific parent
  block; summarizes the version / parent-hash / fee-recipient / transactions it carries.
- `TempoConsensusContext` fields (`epoch`, `view`, `parent_view`, `proposer`) — each field's
  role in identifying the consensus round and proposer.
- `P256_SIGNATURE_LENGTH` / `MAX_WEBAUTHN_SIGNATURE_LENGTH` — the byte-layout the P256 length
  represents (r/s/x/y + pre-hash flag) and the 2 KiB WebAuthn cap.