### PR TITLE
fix: terminate eyre bail invocations

### DIFF
--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -105,7 +105,9 @@ async fn load_consensus_manifest(
     manifest_path: Option<PathBuf>,
 ) -> eyre::Result<LoadedConsensusManifest> {
     let (manifest_bytes, source) = match (manifest_path, manifest_url) {
-        (None, None) => bail!("--manifest-url or --manifest-path must be set"),
+        (None, None) => {
+            bail!("--manifest-url or --manifest-path must be set");
+        }
         (Some(path), _) => (
             fs::read(&path).wrap_err("failed to read manifest file")?,
             ManifestSource::Path(path),
@@ -164,7 +166,9 @@ async fn fetch_manifest_bytes_from_source(
                 let bytes = fs::read(&path).wrap_err("failed to read manifest file")?;
                 Ok((bytes, ManifestSource::Path(path)))
             }
-            scheme => bail!("unsupported manifest URL scheme: {scheme}"),
+            scheme => {
+                bail!("unsupported manifest URL scheme: {scheme}");
+            }
         };
     }
 
@@ -218,7 +222,9 @@ fn resolve_consensus_archive_source(
                     path.pop();
                     Ok(ConsensusArchiveSource::Path(path.join(archive_file)))
                 }
-                scheme => bail!("unsupported manifest URL scheme: {scheme}"),
+                scheme => {
+                    bail!("unsupported manifest URL scheme: {scheme}");
+                }
             }
         }
         ManifestSource::Path(manifest_path) => {
@@ -237,7 +243,9 @@ fn archive_source_from_url(url: Url) -> eyre::Result<ConsensusArchiveSource> {
             url.to_file_path()
                 .map_err(|_| eyre::eyre!("invalid file:// archive URL"))?,
         )),
-        scheme => bail!("unsupported consensus archive URL scheme: {scheme}"),
+        scheme => {
+            bail!("unsupported consensus archive URL scheme: {scheme}");
+        }
     }
 }
 

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -428,7 +428,7 @@ impl WalletArgs {
 
             Ok(EthereumWallet::new(signer))
         } else {
-            bail!("no wallet provided")
+            bail!("no wallet provided");
         }
     }
 }
@@ -477,7 +477,7 @@ impl ValidatorTransactionArgs {
             std::io::stdin().read_line(&mut input)?;
 
             if !matches!(input.trim(), "y" | "Y" | "yes" | "YES") {
-                bail!("transaction cancelled by user")
+                bail!("transaction cancelled by user");
             }
         }
 

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -1041,14 +1041,14 @@ async fn verify_block<TContext: Pacer>(
             bail!(
                 "failed validating block because payload was accepted, meaning \
                 that this was not actually executed by the execution layer for some reason"
-            )
+            );
         }
         PayloadStatusEnum::Syncing => {
             bail!(
                 "failed validating block because payload is still syncing, \
                 this means the parent block was available to the consensus \
                 layer but not the execution layer"
-            )
+            );
         }
     }
 }

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -967,7 +967,9 @@ impl Dealer {
                     .await
                     .wrap_err("unable to append ack to journal")?;
             }
-            None => bail!("dealer was already finalized, dropping ack of player `{player}`"),
+            None => {
+                bail!("dealer was already finalized, dropping ack of player `{player}`");
+            }
         }
         Ok(())
     }

--- a/crates/consensus/src/follow/driver.rs
+++ b/crates/consensus/src/follow/driver.rs
@@ -340,10 +340,12 @@ where
         let scheme = match self.config.scheme_provider.scoped(finalization_epoch) {
             Some(scheme) => scheme,
             None if can_use_network_identity_fallback => self.network_scheme.clone(),
-            None => bail!(
-                "finalization epoch `{finalization_epoch}` behind network identity starting epoch `{}`",
-                self.config.network_identity.from_epoch,
-            ),
+            None => {
+                bail!(
+                    "finalization epoch `{finalization_epoch}` behind network identity starting epoch `{}`",
+                    self.config.network_identity.from_epoch,
+                );
+            }
         };
 
         let identity = scheme.identity();

--- a/crates/node/tests/it/gas/helpers.rs
+++ b/crates/node/tests/it/gas/helpers.rs
@@ -307,7 +307,7 @@ impl TempoCalls {
             }
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
-        eyre::bail!("timed out waiting for tempo calls receipt {tx_hash}")
+        eyre::bail!("timed out waiting for tempo calls receipt {tx_hash}");
     }
 }
 

--- a/crates/node/tests/it/gas/tip1016_storage.rs
+++ b/crates/node/tests/it/gas/tip1016_storage.rs
@@ -51,7 +51,7 @@ async fn get_createx_deployed_address<P: Provider>(
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    eyre::bail!("timed out waiting for deploy receipts at block {block_number}")
+    eyre::bail!("timed out waiting for deploy receipts at block {block_number}");
 }
 
 /// Returns the total gas_used from all receipts in a block, polling until the RPC catches up.
@@ -66,7 +66,7 @@ async fn total_receipt_gas_for_block<P: Provider>(
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    eyre::bail!("timed out waiting for receipts at block {block_number}")
+    eyre::bail!("timed out waiting for receipts at block {block_number}");
 }
 
 /// Happy path: deploying a contract via CreateX creates new storage (account creation +

--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -58,7 +58,7 @@ async fn wait_for_latest_beneficiary<P: Provider>(
         .ok_or_else(|| eyre::eyre!("latest block missing"))?
         .header
         .beneficiary;
-    eyre::bail!("latest beneficiary {beneficiary:?} did not become {expected:?}")
+    eyre::bail!("latest beneficiary {beneficiary:?} did not become {expected:?}");
 }
 
 fn transfer_blocked(


### PR DESCRIPTION
## Summary
- terminate every `eyre::bail!` invocation used in expression position
- fix the workspace-wide `semicolon_in_expressions_from_macros` errors introduced by the latest nightly toolchain

## Validation
- `cargo +nightly-2026-07-16 fmt --all -- --check`
- verified every `bail!` invocation in the repository is explicitly terminated
- full local Clippy was blocked because the sandbox credential proxy returned 401 while fetching the public `commonwarexyz/monorepo` Git dependency; CI runs the workspace checks

Prompted by: @shekhirin