### PR TITLE
fix(pool): deduplicate live AA 2D replacements

### DIFF
--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -2180,6 +2180,23 @@ impl BestAA2dTransactions {
                             .insert(ExpiringNonceEvictionKey::from_pending_owned(tx));
                     }
                 } else if let Some(id) = tx.transaction.transaction.aa_transaction_id() {
+                    // A live update may replace a transaction that was already in the
+                    // snapshot. Overwrite `by_id` first and remove the returned transaction's
+                    // ordering key so the same ID can never have two independent entries.
+                    let previous = self.by_id.insert(
+                        id,
+                        Arc::new(AA2dInternalTransaction {
+                            inner: AA2dStoredTransaction {
+                                submission_id: tx.submission_id,
+                                transaction: tx.transaction,
+                            },
+                            is_pending: AtomicBool::new(true),
+                        }),
+                    );
+                    if let Some(previous) = previous {
+                        self.independent
+                            .remove(&previous.inner.eviction_key(self.base_fee));
+                    }
                     if process {
                         // Only mark as independent if no ancestor is already tracked
                         if !self.by_id.contains_key(&AA2dTransactionId::new(
@@ -2191,16 +2208,6 @@ impl BestAA2dTransactions {
                             self.independent.insert(key, id);
                         }
                     }
-                    self.by_id.insert(
-                        id,
-                        Arc::new(AA2dInternalTransaction {
-                            inner: AA2dStoredTransaction {
-                                submission_id: tx.submission_id,
-                                transaction: tx.transaction,
-                            },
-                            is_pending: AtomicBool::new(true),
-                        }),
-                    );
                 }
             } else {
                 break;
@@ -7202,6 +7209,84 @@ mod tests {
             !no_updates,
             "new tx should only be yielded when live updates are enabled"
         );
+    }
+
+    #[test_case::test_case(2_000_000_000, true ; "replacement within yielded priority is processed")]
+    #[test_case::test_case(6_000_000_000, false ; "replacement above yielded priority is stashed")]
+    fn best_transactions_live_replacement_has_single_ordering_entry(
+        replacement_priority: u128,
+        replacement_is_yielded: bool,
+    ) {
+        let mut pool = AA2dPool::default();
+        let sender_a = Address::random();
+        let sender_b = Address::random();
+        let sender_c = Address::random();
+
+        let tx_a = TxBuilder::aa(sender_a)
+            .nonce_key(U256::ZERO)
+            .max_priority_fee(5_000_000_000)
+            .max_fee(20_000_000_000)
+            .build();
+        let tx_a_hash = *tx_a.hash();
+        let tx_b = TxBuilder::aa(sender_b)
+            .nonce_key(U256::ZERO)
+            .max_priority_fee(1_000_000_000)
+            .max_fee(20_000_000_000)
+            .build();
+        let tx_c = TxBuilder::aa(sender_c)
+            .nonce_key(U256::ZERO)
+            .max_priority_fee(500_000_000)
+            .max_fee(20_000_000_000)
+            .build();
+        let tx_c_hash = *tx_c.hash();
+
+        for tx in [tx_a, tx_b, tx_c] {
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T1,
+            )
+            .unwrap();
+        }
+
+        let mut best = pool.best_transactions();
+        assert_eq!(*best.next().unwrap().hash(), tx_a_hash);
+
+        let replacement = TxBuilder::aa(sender_b)
+            .nonce_key(U256::ZERO)
+            .max_priority_fee(replacement_priority)
+            .max_fee(60_000_000_000)
+            .build();
+        let replacement_hash = *replacement.hash();
+        pool.add_transaction(
+            Arc::new(wrap_valid_tx(replacement, TransactionOrigin::Local)),
+            0,
+            TempoHardfork::T1,
+        )
+        .unwrap();
+
+        best.add_new_transactions();
+
+        let id_b = AA2dTransactionId::new(AASequenceId::new(sender_b, U256::ZERO), 0);
+        let unique_ids: HashSet<_> = best.independent.values().copied().collect();
+        assert_eq!(
+            best.independent.len(),
+            unique_ids.len(),
+            "each transaction ID must have at most one ordering entry"
+        );
+        assert_eq!(
+            best.independent.values().filter(|id| **id == id_b).count(),
+            usize::from(replacement_is_yielded),
+            "the replacement ID must have at most one ordering entry"
+        );
+
+        let remaining: Vec<_> = best.map(|tx| *tx.hash()).collect();
+        let expected = if replacement_is_yielded {
+            vec![replacement_hash, tx_c_hash]
+        } else {
+            vec![tx_c_hash]
+        };
+        assert_eq!(remaining, expected);
     }
 
     #[test]


### PR DESCRIPTION
Live AA 2D replacements now remove the prior snapshot ordering key before inserting the replacement, preventing duplicate transaction IDs from terminating best-transaction iteration early. Adds regression coverage for both processed and stashed replacements.

Validated with `cargo test -p tempo-transaction-pool` and `cargo clippy -p tempo-transaction-pool --tests -- -D warnings`.