### PR TITLE
ci: validate v1.11.0 release tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12827,7 +12827,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -12983,7 +12983,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13046,7 +13046,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13076,7 +13076,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13090,7 +13090,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13141,7 +13141,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13193,7 +13193,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13212,7 +13212,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13220,7 +13220,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13245,7 +13245,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13317,7 +13317,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13355,7 +13355,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13375,7 +13375,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13409,7 +13409,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13458,7 +13458,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13491,7 +13491,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13516,7 +13516,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13525,7 +13525,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13568,7 +13568,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -13580,7 +13580,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.10.2"
+version = "1.11.0"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.10.2"
+version = "1.11.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Temporary validation PR for the protected `release/v1.11.0` ref. The tip starts from the latest successful nightly build and applies #6866, #6871, and #6814.

Prompted by: @klkvr