### PR TITLE
feat(revm): support custom `StorageCtx` in `ProtocolFeeManager` trait

### DIFF
--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -48,8 +48,8 @@ use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params_with_amsterdam};
 
 pub use tempo_revm::{
-    ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoHaltReason, TempoInvalidTransaction,
-    TempoStateAccess,
+    ProtocolFeeContext, ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoHaltReason,
+    TempoInvalidTransaction, TempoStateAccess,
 };
 
 #[cfg(test)]

--- a/crates/evm/tests/reexports.rs
+++ b/crates/evm/tests/reexports.rs
@@ -1,0 +1,12 @@
+use tempo_evm::{ProtocolFeeContext, ProtocolFeeManager};
+
+#[test]
+fn protocol_fee_context_is_available_to_consumers() {
+    fn assert_reexports<DB: revm::Database>(
+        _ctx: Option<ProtocolFeeContext<'_, DB>>,
+        _manager: Option<&dyn ProtocolFeeManager<DB>>,
+    ) {
+    }
+
+    assert_reexports::<revm::database::EmptyDB>(None, None);
+}

--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -1,11 +1,46 @@
-use crate::{TempoStateAccess, TempoTxEnv};
+use crate::{TempoBlockEnv, TempoStateAccess, TempoTxEnv};
 use alloy_primitives::{Address, U256};
 use core::fmt::Debug;
-use revm::{Database, context::Journal};
+use revm::{
+    Database,
+    context::{CfgEnv, Journal},
+};
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_precompiles::{
-    error::Result as TempoResult, storage::StorageActions, tip_fee_manager::TipFeeManager,
+    error::Result as TempoResult,
+    storage::{StorageActions, StorageCtx},
+    tip_fee_manager::TipFeeManager,
 };
+
+/// EVM state needed to install storage for an internal protocol fee hook.
+pub struct ProtocolFeeContext<'a, DB: Database> {
+    /// Active transaction journal.
+    pub journal: &'a mut Journal<DB>,
+    /// Active block environment.
+    pub block_env: &'a TempoBlockEnv,
+    /// Active EVM configuration.
+    pub cfg: &'a CfgEnv<TempoHardfork>,
+    /// Active transaction environment.
+    pub tx_env: &'a TempoTxEnv,
+    /// Storage-action recorder shared with transaction execution.
+    pub actions: StorageActions,
+}
+
+impl<DB: alloy_evm::Database> ProtocolFeeContext<'_, DB> {
+    /// Installs Tempo's ordinary protocol storage context and executes `f`.
+    ///
+    /// TIP-1060 accounting is disabled because protocol fee storage is charged externally.
+    pub fn enter<R>(self, f: impl FnOnce() -> R) -> R {
+        StorageCtx::enter_evm_without_tip1060_accounting(
+            self.journal,
+            self.block_env,
+            self.cfg,
+            self.tx_env,
+            self.actions,
+            f,
+        )
+    }
+}
 
 /// Internal protocol fee hooks, separate from the public FeeManager precompile.
 pub trait ProtocolFeeManager<DB: Database>: Debug {
@@ -34,9 +69,15 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
         })
     }
 
-    /// Collects the maximum possible fee before transaction execution.
+    /// Installs protocol storage and collects the maximum possible fee before execution.
+    ///
+    /// Implementations must preserve the handler's externally charged storage and checkpoint
+    /// semantics. [`ProtocolFeeContext::enter`] installs Tempo's ordinary storage provider;
+    /// downstream EVMs may install a custom provider instead.
+    #[allow(clippy::too_many_arguments)]
     fn collect_fee_pre_tx(
         &self,
+        ctx: ProtocolFeeContext<'_, DB>,
         fee_payer: Address,
         user_token: Address,
         max_amount: U256,
@@ -44,9 +85,15 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
         skip_liquidity_check: bool,
     ) -> TempoResult<Address>;
 
-    /// Settles the final fee after transaction execution.
+    /// Installs protocol storage and settles the final fee after execution.
+    ///
+    /// Implementations must preserve the handler's externally charged storage semantics.
+    /// [`ProtocolFeeContext::enter`] installs Tempo's ordinary storage provider;
+    /// downstream EVMs may install a custom provider instead.
+    #[allow(clippy::too_many_arguments)]
     fn collect_fee_post_tx(
         &self,
+        ctx: ProtocolFeeContext<'_, DB>,
         fee_payer: Address,
         actual_spending: U256,
         refund_amount: U256,
@@ -66,38 +113,44 @@ impl TempoFeeManager {
     }
 }
 
-impl<DB: Database> ProtocolFeeManager<DB> for TempoFeeManager {
+impl<DB: alloy_evm::Database> ProtocolFeeManager<DB> for TempoFeeManager {
     fn collect_fee_pre_tx(
         &self,
+        ctx: ProtocolFeeContext<'_, DB>,
         fee_payer: Address,
         user_token: Address,
         max_amount: U256,
         beneficiary: Address,
         skip_liquidity_check: bool,
     ) -> TempoResult<Address> {
-        TipFeeManager::new().collect_fee_pre_tx(
-            fee_payer,
-            user_token,
-            max_amount,
-            beneficiary,
-            skip_liquidity_check,
-        )
+        ctx.enter(|| {
+            TipFeeManager::new().collect_fee_pre_tx(
+                fee_payer,
+                user_token,
+                max_amount,
+                beneficiary,
+                skip_liquidity_check,
+            )
+        })
     }
 
     fn collect_fee_post_tx(
         &self,
+        ctx: ProtocolFeeContext<'_, DB>,
         fee_payer: Address,
         actual_spending: U256,
         refund_amount: U256,
         fee_token: Address,
         beneficiary: Address,
     ) -> TempoResult<U256> {
-        TipFeeManager::new().collect_fee_post_tx(
-            fee_payer,
-            actual_spending,
-            refund_amount,
-            fee_token,
-            beneficiary,
-        )
+        ctx.enter(|| {
+            TipFeeManager::new().collect_fee_post_tx(
+                fee_payer,
+                actual_spending,
+                refund_amount,
+                fee_token,
+                beneficiary,
+            )
+        })
     }
 }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -64,7 +64,7 @@ use tempo_primitives::{
 };
 
 use crate::{
-    TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction, TempoTxEnv,
+    ProtocolFeeContext, TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction, TempoTxEnv,
     common::TempoStateAccess,
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
@@ -1381,21 +1381,19 @@ where
             let checkpoint = journal.checkpoint();
 
             let skip_liquidity_check = evm.skip_liquidity_check;
-            let result = StorageCtx::enter_evm_without_tip1060_accounting(
-                journal,
-                block,
-                cfg,
-                tx,
-                actions.clone(),
-                || {
-                    fee_manager.collect_fee_pre_tx(
-                        fee_payer,
-                        fee_token,
-                        gas_balance_spending,
-                        block.beneficiary(),
-                        skip_liquidity_check,
-                    )
+            let result = fee_manager.collect_fee_pre_tx(
+                ProtocolFeeContext {
+                    journal,
+                    block_env: block,
+                    cfg,
+                    tx_env: tx,
+                    actions: actions.clone(),
                 },
+                fee_payer,
+                fee_token,
+                gas_balance_spending,
+                block.beneficiary(),
+                skip_liquidity_check,
             );
 
             if let Err(err) = result {
@@ -1693,32 +1691,30 @@ where
         let (journal, block, tx) = (&mut context.journaled_state, &context.block, &context.tx);
         let beneficiary = context.block.beneficiary();
 
-        let credited = StorageCtx::enter_evm_without_tip1060_accounting(
-            &mut *journal,
-            block,
-            &context.cfg,
-            tx,
-            actions,
-            || {
-                if !actual_spending.is_zero() || !refund_amount.is_zero() {
-                    let fee_payer = tx.fee_payer().expect("pre-validated in `validate_env`");
-                    let fee_token = evm
-                        .fee_token
-                        .expect("set in `validate_against_state_and_deduct_caller`");
-                    fee_manager
-                        .collect_fee_post_tx(
-                            fee_payer,
-                            actual_spending,
-                            refund_amount,
-                            fee_token,
-                            beneficiary,
-                        )
-                        .map_err(|e| EVMError::Custom(format!("{e:?}")))
-                } else {
-                    Ok(U256::ZERO)
-                }
-            },
-        )?;
+        let credited = if !actual_spending.is_zero() || !refund_amount.is_zero() {
+            let fee_payer = tx.fee_payer().expect("pre-validated in `validate_env`");
+            let fee_token = evm
+                .fee_token
+                .expect("set in `validate_against_state_and_deduct_caller`");
+            fee_manager
+                .collect_fee_post_tx(
+                    ProtocolFeeContext {
+                        journal,
+                        block_env: block,
+                        cfg: &context.cfg,
+                        tx_env: tx,
+                        actions,
+                    },
+                    fee_payer,
+                    actual_spending,
+                    refund_amount,
+                    fee_token,
+                    beneficiary,
+                )
+                .map_err(|e| EVMError::Custom(format!("{e:?}")))?
+        } else {
+            U256::ZERO
+        };
 
         // Stash the per-tx credit so `TempoBlockExecutor` can surface it on `TempoTxResult`
         // for payload scoring. Reset to zero on every tx entry below in `validate_env`.
@@ -2697,6 +2693,7 @@ mod tests {
 
         fn collect_fee_pre_tx(
             &self,
+            _ctx: ProtocolFeeContext<'_, DB>,
             _fee_payer: Address,
             _user_token: Address,
             _max_amount: U256,
@@ -2710,6 +2707,7 @@ mod tests {
 
         fn collect_fee_post_tx(
             &self,
+            _ctx: ProtocolFeeContext<'_, DB>,
             _fee_payer: Address,
             _actual_spending: U256,
             _refund_amount: U256,

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,7 +21,7 @@ mod tx;
 
 pub use error::{TempoHaltReason, TempoInvalidTransaction};
 pub use evm::TempoEvm;
-pub use fee_manager::{ProtocolFeeManager, TempoFeeManager};
+pub use fee_manager::{ProtocolFeeContext, ProtocolFeeManager, TempoFeeManager};
 pub use handler::{ValidationContext, calculate_aa_batch_intrinsic_gas};
 pub use revm::interpreter::instructions::utility::IntoAddress;
 pub use tempo_primitives::TempoBlockEnv;


### PR DESCRIPTION
## Motivation

`ProtocolFeeManager` fee hooks currently run after the handler installs the default `StorageCtx`, preventing downstream EVMs from selecting a custom storage provider without duplicating handler logic or nesting storage contexts.

## Solution

Add context-aware pre- and post-fee methods that receive the journal and EVM environment. Their default implementations preserve Tempo’s existing storage behavior, while downstream fee managers can override them to install a custom `StorageCtx`.