### PR TITLE
docs(tip-1091): derive zone genesis in protocol

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -46,6 +46,8 @@ the `deployedBytecode.object` from the `ZonePortal` Foundry artifact generated
 from the canonical Zones revision selected for activation, and the activation
 configuration MUST record that revision and the runtime bytecode hash.
 
+T9 MUST define the canonical zone genesis used by the native factory.
+
 ## Specification
 
 Tempo adds a `ZoneFactory` precompile at:
@@ -106,16 +108,32 @@ The native factory MUST start with zone ID `1`. Its initial owner is configured
 by T9 and remains TBD. The shared messenger at `ZONE_MESSENGER_ADDRESS` MUST
 authorize `ZONE_FACTORY_ADDRESS`.
 
+### Canonical Zone Genesis
+
+`createZone` MUST NOT accept a caller-supplied zone genesis hash or Tempo genesis
+anchor. After assigning the zone ID and portal address, the native factory MUST:
+
+1. use the parent Tempo block as the zone's Tempo genesis anchor;
+2. build the canonical zone genesis from the zone ID, portal, initial token,
+   admin, sequencer, and parent Tempo header; and
+3. compute `genesisBlockHash` from the resulting block-zero header.
+
+`genesisTempoBlockHash` and `genesisTempoBlockNumber` MUST be the hash and number
+of the parent Tempo block. The factory MUST store these values and
+`genesisBlockHash` in `ZoneInfo`, emit them in `ZoneCreated`, and pass the
+genesis block hash and Tempo block number to the portal initializer.
+
 `createZone` MUST NOT deploy the portal with EVM `CREATE` or `CREATE2`, and
 MUST NOT rely on nonce-based address prediction. Instead, the native factory:
 
 1. validates the request as the canonical factory would;
 2. assigns the next zone ID;
 3. computes the portal vanity address;
-4. etches `portal_proxy_runtime` at that address;
-5. calls the portal's factory-only initializer with the `createZone` parameters
-   and the protocol-managed verifier and messenger addresses;
-6. records the zone metadata and emits `ZoneCreated`.
+4. builds the canonical zone genesis using the parent Tempo block;
+5. etches `portal_proxy_runtime` at that address;
+6. calls the portal's factory-only initializer with the computed genesis
+   commitment and the protocol-managed verifier and messenger addresses;
+7. records the zone metadata and emits `ZoneCreated`.
 
 The portal account MUST NOT contain a full copy of `ZonePortal` runtime
 bytecode. It MUST route to one protocol-managed portal logic implementation,

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -14,13 +14,6 @@ struct ZoneInfo {
     string rpcUrl;
 }
 
-/// @notice Zone genesis parameters supplied during creation.
-struct ZoneParams {
-    bytes32 genesisBlockHash;
-    bytes32 genesisTempoBlockHash;
-    uint64 genesisTempoBlockNumber;
-}
-
 /// @notice Minimal initializer interface required by the native factory.
 interface IZonePortalInitializer {
 
@@ -47,7 +40,6 @@ interface IZoneFactory {
         address initialToken;
         address admin;
         address sequencer;
-        ZoneParams zoneParams;
         string rpcUrl;
     }
 

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -73,6 +73,10 @@ abstract contract ZoneFactory is IZoneFactory {
 
         portal = portalAddress(zoneId);
 
+        (bytes32 genesisBlockHash, bytes32 genesisTempoBlockHash, uint64 genesisTempoBlockNumber) = _nativeBuildZoneGenesis(
+            zoneId, portal, params.initialToken, params.admin, params.sequencer
+        );
+
         // Native precompile operation, not EVM CREATE or CREATE2:
         //
         // 1. The protocol etches minimal portal proxy/caller bytecode directly into
@@ -95,8 +99,8 @@ abstract contract ZoneFactory is IZoneFactory {
                 params.admin,
                 params.sequencer,
                 ZONE_VERIFIER_ADDRESS,
-                params.zoneParams.genesisBlockHash,
-                params.zoneParams.genesisTempoBlockNumber,
+                genesisBlockHash,
+                genesisTempoBlockNumber,
                 params.rpcUrl
             );
 
@@ -106,9 +110,9 @@ abstract contract ZoneFactory is IZoneFactory {
             initialToken: params.initialToken,
             admin: params.admin,
             sequencer: params.sequencer,
-            genesisBlockHash: params.zoneParams.genesisBlockHash,
-            genesisTempoBlockHash: params.zoneParams.genesisTempoBlockHash,
-            genesisTempoBlockNumber: params.zoneParams.genesisTempoBlockNumber,
+            genesisBlockHash: genesisBlockHash,
+            genesisTempoBlockHash: genesisTempoBlockHash,
+            genesisTempoBlockNumber: genesisTempoBlockNumber,
             rpcUrl: params.rpcUrl
         });
 
@@ -119,9 +123,9 @@ abstract contract ZoneFactory is IZoneFactory {
             params.admin,
             params.sequencer,
             ZONE_VERIFIER_ADDRESS,
-            params.zoneParams.genesisBlockHash,
-            params.zoneParams.genesisTempoBlockHash,
-            params.zoneParams.genesisTempoBlockNumber
+            genesisBlockHash,
+            genesisTempoBlockHash,
+            genesisTempoBlockNumber
         );
     }
 
@@ -148,6 +152,23 @@ abstract contract ZoneFactory is IZoneFactory {
 
     /// @dev Native host hook: etch proxy/caller runtime bytecode at `portal`.
     function _nativeEtchPortalProxy(address portal, bytes memory runtime) internal virtual;
+
+    /// @dev Native host hook that builds the canonical zone genesis using the parent Tempo block.
+    function _nativeBuildZoneGenesis(
+        uint32 zoneId,
+        address portal,
+        address initialToken,
+        address admin,
+        address sequencer
+    )
+        internal
+        view
+        virtual
+        returns (
+            bytes32 genesisBlockHash,
+            bytes32 genesisTempoBlockHash,
+            uint64 genesisTempoBlockNumber
+        );
 
     /*//////////////////////////////////////////////////////////////
                                  VIEWS


### PR DESCRIPTION
Removes caller-supplied genesis fields from `createZone` and specifies that the native factory builds the canonical zone genesis using the parent Tempo block.

The protocol computes the block-zero hash after assigning the zone ID and portal address, then initializes the portal and records the resulting commitment.

Validation:
- `git diff --check`
- `FOUNDRY_HARDFORK=cancun forge fmt --check src/zones/interfaces/IZone.sol src/zones/tempo/ZoneFactory.sol`
- `FOUNDRY_HARDFORK=cancun forge build -q`
- `FOUNDRY_HARDFORK=cancun forge test -q`
- ASCII source scan