### PR TITLE
refactor(alloy): extract RPC tx env conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12945,7 +12945,6 @@ dependencies = [
  "reth-primitives-traits",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
- "revm",
  "serde",
  "serde_json",
  "tempo-chainspec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12945,6 +12945,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
+ "revm",
  "serde",
  "serde_json",
  "tempo-chainspec",

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -36,6 +36,7 @@ alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
 alloy-json-rpc.workspace = true
 alloy-transport.workspace = true
+revm = { workspace = true, optional = true }
 
 reth-evm = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
@@ -63,9 +64,10 @@ tokio.workspace = true
 
 [features]
 default = []
+revm = ["dep:revm", "dep:tempo-revm"]
 reth = [
+    "revm",
     "dep:tempo-evm",
-    "dep:tempo-revm",
     "dep:reth-evm",
     "dep:reth-primitives-traits",
     "dep:reth-rpc-convert",

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -36,7 +36,6 @@ alloy-signer-local.workspace = true
 alloy-sol-types.workspace = true
 alloy-json-rpc.workspace = true
 alloy-transport.workspace = true
-revm = { workspace = true, optional = true }
 
 reth-evm = { workspace = true, optional = true }
 reth-primitives-traits = { workspace = true, optional = true }
@@ -64,7 +63,7 @@ tokio.workspace = true
 
 [features]
 default = []
-revm = ["dep:revm", "dep:tempo-revm"]
+revm = ["dep:tempo-revm"]
 reth = [
     "revm",
     "dep:tempo-evm",

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -260,14 +260,17 @@ impl TempoTransactionRequest {
         self
     }
 
-    /// Converts this request into a Tempo transaction environment for RPC simulation.
+    /// Applies this request's Tempo-specific fields to a transaction environment for RPC
+    /// simulation.
     ///
-    /// Set `force_aa` when the original RPC request explicitly selected Tempo AA semantics in a
-    /// way that is not retained after deserialization, such as an explicitly empty `calls` list.
+    /// The caller must construct `env` from this request's inner Ethereum transaction using its
+    /// host-specific RPC conversion. Set `force_aa` when the original RPC request explicitly
+    /// selected Tempo AA semantics in a way that is not retained after deserialization, such as an
+    /// explicitly empty `calls` list.
     #[cfg(feature = "revm")]
-    pub fn into_tempo_tx_env(
+    pub fn apply_to_tempo_tx_env(
         self,
-        inner: revm::context::TxEnv,
+        mut env: TempoTxEnv,
         is_t1c: bool,
         force_aa: bool,
     ) -> Result<TempoTxEnv, ValueError<Self>> {
@@ -280,7 +283,7 @@ impl TempoTransactionRequest {
             self.clone()
                 .build_aa()
                 .ok()
-                .and_then(|tx| tx.recover_fee_payer(inner.caller).ok())
+                .and_then(|tx| tx.recover_fee_payer(env.inner.caller).ok())
         });
 
         let Self {
@@ -306,38 +309,36 @@ impl TempoTransactionRequest {
             });
         }
 
-        Ok(TempoTxEnv {
-            fee_token,
-            is_system_tx: false,
-            unique_tx_identifier: Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER),
-            fee_payer,
-            tempo_tx_env: is_aa.then(|| {
-                Box::new(TempoBatchCallEnv {
-                    aa_calls: calls,
-                    signature: create_mock_tempo_signature(
-                        key_type.unwrap_or(SignatureType::Secp256k1),
-                        key_data,
-                        key_id,
-                        inner.caller,
-                        is_t1c,
-                    ),
-                    tempo_authorization_list: tempo_authorization_list
-                        .into_iter()
-                        .map(RecoveredTempoAuthorization::new)
-                        .collect(),
-                    nonce_key: nonce_key.unwrap_or_default(),
-                    key_authorization,
-                    signature_hash: alloy_primitives::B256::ZERO,
-                    tx_hash: alloy_primitives::B256::ZERO,
-                    valid_before: valid_before.map(NonZeroU64::get),
-                    valid_after: valid_after.map(NonZeroU64::get),
-                    subblock_transaction: false,
-                    override_key_id: key_id,
-                    expiring_nonce_idx: None,
-                })
-            }),
-            inner,
-        })
+        env.fee_token = fee_token;
+        env.is_system_tx = false;
+        env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
+        env.fee_payer = fee_payer;
+        env.tempo_tx_env = is_aa.then(|| {
+            Box::new(TempoBatchCallEnv {
+                aa_calls: calls,
+                signature: create_mock_tempo_signature(
+                    key_type.unwrap_or(SignatureType::Secp256k1),
+                    key_data,
+                    key_id,
+                    env.inner.caller,
+                    is_t1c,
+                ),
+                tempo_authorization_list: tempo_authorization_list
+                    .into_iter()
+                    .map(RecoveredTempoAuthorization::new)
+                    .collect(),
+                nonce_key: nonce_key.unwrap_or_default(),
+                key_authorization,
+                signature_hash: alloy_primitives::B256::ZERO,
+                tx_hash: alloy_primitives::B256::ZERO,
+                valid_before: valid_before.map(NonZeroU64::get),
+                valid_after: valid_after.map(NonZeroU64::get),
+                subblock_transaction: false,
+                override_key_id: key_id,
+                expiring_nonce_idx: None,
+            })
+        });
+        Ok(env)
     }
 
     /// Attempts to build a [`TempoTransaction`] with the configured fields.
@@ -728,7 +729,7 @@ mod tests {
 
     #[cfg(feature = "revm")]
     #[test]
-    fn test_into_tempo_tx_env_preserves_request_calls() {
+    fn test_apply_to_tempo_tx_env_preserves_request_calls() {
         let calls = vec![Call {
             to: address!("0x1111111111111111111111111111111111111111").into(),
             value: U256::ONE,
@@ -748,7 +749,7 @@ mod tests {
         };
 
         let env = request
-            .into_tempo_tx_env(revm::context::TxEnv::default(), false, false)
+            .apply_to_tempo_tx_env(TempoTxEnv::default(), false, false)
             .expect("valid Tempo simulation environment");
         let calls = env.tempo_tx_env.expect("AA environment").aa_calls;
 
@@ -765,7 +766,23 @@ mod tests {
 
     #[cfg(feature = "revm")]
     #[test]
-    fn test_into_tempo_tx_env_can_force_aa_semantics() {
+    fn test_apply_to_tempo_tx_env_preserves_base_environment() {
+        let mut base_env = TempoTxEnv::default();
+        base_env.inner.caller = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        base_env.inner.gas_limit = 123_456;
+        base_env.inner.chain_id = Some(4242);
+        let inner = base_env.inner.clone();
+
+        let env = TempoTransactionRequest::default()
+            .apply_to_tempo_tx_env(base_env, false, false)
+            .expect("valid Tempo simulation environment");
+
+        assert_eq!(env.inner, inner);
+    }
+
+    #[cfg(feature = "revm")]
+    #[test]
+    fn test_apply_to_tempo_tx_env_can_force_aa_semantics() {
         let to = address!("0x2222222222222222222222222222222222222222");
         let request = TempoTransactionRequest {
             inner: TransactionRequest {
@@ -776,7 +793,7 @@ mod tests {
         };
 
         let env = request
-            .into_tempo_tx_env(revm::context::TxEnv::default(), false, true)
+            .apply_to_tempo_tx_env(TempoTxEnv::default(), false, true)
             .expect("valid Tempo simulation environment");
         let calls = env.tempo_tx_env.expect("forced AA environment").aa_calls;
 
@@ -786,9 +803,9 @@ mod tests {
 
     #[cfg(feature = "revm")]
     #[test]
-    fn test_into_tempo_tx_env_rejects_forced_aa_without_calls() {
+    fn test_apply_to_tempo_tx_env_rejects_forced_aa_without_calls() {
         let err = TempoTransactionRequest::default()
-            .into_tempo_tx_env(revm::context::TxEnv::default(), false, true)
+            .apply_to_tempo_tx_env(TempoTxEnv::default(), false, true)
             .expect_err("forced AA request without calls should fail");
 
         assert_eq!(err.to_string(), "empty calls list");
@@ -796,7 +813,7 @@ mod tests {
 
     #[cfg(feature = "revm")]
     #[test]
-    fn test_into_tempo_tx_env_uses_execution_caller_for_keychain_signature() {
+    fn test_apply_to_tempo_tx_env_uses_execution_caller_for_keychain_signature() {
         let request = TempoTransactionRequest {
             inner: TransactionRequest {
                 from: Some(address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
@@ -807,13 +824,11 @@ mod tests {
             ..Default::default()
         };
         let caller = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-        let inner = revm::context::TxEnv {
-            caller,
-            ..Default::default()
-        };
+        let mut env = TempoTxEnv::default();
+        env.inner.caller = caller;
 
         let env = request
-            .into_tempo_tx_env(inner, false, false)
+            .apply_to_tempo_tx_env(env, false, false)
             .expect("valid Tempo simulation environment");
         let aa_env = env.tempo_tx_env.expect("AA environment");
         let TempoSignature::Keychain(signature) = aa_env.signature else {

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -13,8 +13,25 @@ use tempo_primitives::{
         key_authorization::serde_nonzero_quantity_opt,
     },
 };
+#[cfg(feature = "revm")]
+use tempo_primitives::{
+    TempoSignature,
+    transaction::{
+        RecoveredTempoAuthorization,
+        tt_signature::{
+            KeychainSignature, P256SignatureWithPreHash, PrimitiveSignature, WebAuthnSignature,
+        },
+    },
+};
+#[cfg(feature = "revm")]
+use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
 
 use crate::TempoNetwork;
+
+/// Non-zero transaction identifier used only for RPC simulations.
+#[cfg(feature = "revm")]
+pub(super) const RPC_SIMULATION_UNIQUE_TX_IDENTIFIER: alloy_primitives::B256 =
+    alloy_primitives::B256::new(*b"TEMPO_RPC_SIMULATION_MPP_CONTEXT");
 
 /// An Ethereum [`TransactionRequest`] extended with Tempo-specific fields.
 #[derive(
@@ -243,6 +260,87 @@ impl TempoTransactionRequest {
         self
     }
 
+    /// Converts this request into a Tempo transaction environment for RPC simulation.
+    ///
+    /// Set `force_aa` when the original RPC request explicitly selected Tempo AA semantics in a
+    /// way that is not retained after deserialization, such as an explicitly empty `calls` list.
+    #[cfg(feature = "revm")]
+    pub fn into_tempo_tx_env(
+        self,
+        inner: revm::context::TxEnv,
+        is_t1c: bool,
+        force_aa: bool,
+    ) -> Result<TempoTxEnv, ValueError<Self>> {
+        let caller = self.inner.from.unwrap_or_default();
+        let is_aa = force_aa || self.has_aa_fields();
+        if is_aa && self.calls.is_empty() && self.inner.to.is_none() {
+            return Err(ValueError::new_static(self, "empty calls list"));
+        }
+
+        let fee_payer = self.fee_payer_signature.is_some().then(|| {
+            self.clone()
+                .build_aa()
+                .ok()
+                .and_then(|tx| tx.recover_fee_payer(caller).ok())
+        });
+
+        let Self {
+            inner: request,
+            fee_token,
+            nonce_key,
+            mut calls,
+            key_type,
+            key_data,
+            key_id,
+            tempo_authorization_list,
+            key_authorization,
+            valid_before,
+            valid_after,
+            fee_payer_signature: _,
+        } = self;
+
+        if let Some(to) = request.to {
+            calls.push(Call {
+                to,
+                value: request.value.unwrap_or_default(),
+                input: request.input.into_input().unwrap_or_default(),
+            });
+        }
+
+        Ok(TempoTxEnv {
+            fee_token,
+            is_system_tx: false,
+            unique_tx_identifier: Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER),
+            fee_payer,
+            tempo_tx_env: is_aa.then(|| {
+                Box::new(TempoBatchCallEnv {
+                    aa_calls: calls,
+                    signature: create_mock_tempo_signature(
+                        key_type.unwrap_or(SignatureType::Secp256k1),
+                        key_data,
+                        key_id,
+                        caller,
+                        is_t1c,
+                    ),
+                    tempo_authorization_list: tempo_authorization_list
+                        .into_iter()
+                        .map(RecoveredTempoAuthorization::new)
+                        .collect(),
+                    nonce_key: nonce_key.unwrap_or_default(),
+                    key_authorization,
+                    signature_hash: alloy_primitives::B256::ZERO,
+                    tx_hash: alloy_primitives::B256::ZERO,
+                    valid_before: valid_before.map(NonZeroU64::get),
+                    valid_after: valid_after.map(NonZeroU64::get),
+                    subblock_transaction: false,
+                    override_key_id: key_id,
+                    expiring_nonce_idx: None,
+                })
+            }),
+            inner,
+        })
+    }
+
     /// Attempts to build a [`TempoTransaction`] with the configured fields.
     pub fn build_aa(self) -> Result<TempoTransaction, ValueError<Self>> {
         if self.calls.is_empty() && self.inner.to.is_none() {
@@ -302,6 +400,79 @@ impl TempoTransactionRequest {
             nonce_key: self.nonce_key.unwrap_or_default(),
             key_authorization: self.key_authorization,
         })
+    }
+}
+
+#[cfg(feature = "revm")]
+fn create_mock_tempo_signature(
+    key_type: SignatureType,
+    key_data: Option<Bytes>,
+    key_id: Option<Address>,
+    caller: Address,
+    is_t1c: bool,
+) -> TempoSignature {
+    let signature = create_mock_primitive_signature(&key_type, key_data);
+    if key_id.is_some() {
+        let signature = if is_t1c {
+            KeychainSignature::new(caller, signature)
+        } else {
+            KeychainSignature::new_v1(caller, signature)
+        };
+        TempoSignature::Keychain(signature)
+    } else {
+        TempoSignature::Primitive(signature)
+    }
+}
+
+#[cfg(feature = "revm")]
+pub(super) fn create_mock_primitive_signature(
+    key_type: &SignatureType,
+    key_data: Option<Bytes>,
+) -> PrimitiveSignature {
+    match key_type {
+        SignatureType::Secp256k1 => PrimitiveSignature::Secp256k1(
+            alloy_primitives::Signature::new(U256::ZERO, U256::ZERO, false),
+        ),
+        SignatureType::P256 => PrimitiveSignature::P256(P256SignatureWithPreHash {
+            r: alloy_primitives::B256::ZERO,
+            s: alloy_primitives::B256::ZERO,
+            pub_key_x: alloy_primitives::B256::ZERO,
+            pub_key_y: alloy_primitives::B256::ZERO,
+            pre_hash: false,
+        }),
+        SignatureType::WebAuthn => {
+            const CLIENT_JSON: &str = r#"{"type":"webauthn.get","challenge":"","origin":""}"#;
+            const AUTH_DATA_SIZE: usize = 37;
+            const MIN_SIZE: usize = AUTH_DATA_SIZE + CLIENT_JSON.len();
+            const DEFAULT_SIZE: usize = 800;
+            const MAX_SIZE: usize = 8192;
+
+            let size = key_data
+                .as_deref()
+                .and_then(|data| match data.len() {
+                    1 => Some(data[0] as usize),
+                    2 => Some(u16::from_be_bytes([data[0], data[1]]) as usize),
+                    4 => Some(u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize),
+                    _ => None,
+                })
+                .unwrap_or(DEFAULT_SIZE)
+                .clamp(MIN_SIZE, MAX_SIZE);
+
+            let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
+            webauthn_data[32] = 0x01;
+            let padding = "x".repeat(size - MIN_SIZE);
+            let client_json =
+                format!(r#"{{"type":"webauthn.get","challenge":"","origin":"{padding}"}}"#);
+            webauthn_data.extend_from_slice(client_json.as_bytes());
+
+            PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                webauthn_data: webauthn_data.into(),
+                r: alloy_primitives::B256::ZERO,
+                s: alloy_primitives::B256::ZERO,
+                pub_key_x: alloy_primitives::B256::ZERO,
+                pub_key_y: alloy_primitives::B256::ZERO,
+            })
+        }
     }
 }
 
@@ -541,6 +712,74 @@ mod tests {
 
     fn nz(value: u64) -> NonZeroU64 {
         NonZeroU64::new(value).expect("test timestamp must be non-zero")
+    }
+
+    #[cfg(feature = "revm")]
+    #[test]
+    fn test_into_tempo_tx_env_preserves_request_calls() {
+        let calls = vec![Call {
+            to: address!("0x1111111111111111111111111111111111111111").into(),
+            value: U256::ONE,
+            input: Bytes::from_static(&[0xaa]),
+        }];
+        let request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                to: Some(address!("0x2222222222222222222222222222222222222222").into()),
+                value: Some(U256::from(2)),
+                input: alloy_rpc_types_eth::TransactionInput::new(Bytes::from_static(&[0xbb])),
+                ..Default::default()
+            },
+            calls,
+            nonce_key: Some(U256::ZERO),
+            ..Default::default()
+        };
+
+        let env = request
+            .into_tempo_tx_env(revm::context::TxEnv::default(), false, false)
+            .expect("valid Tempo simulation environment");
+        let calls = env.tempo_tx_env.expect("AA environment").aa_calls;
+
+        assert_eq!(calls.len(), 2);
+        assert_eq!(
+            calls[0].to,
+            address!("0x1111111111111111111111111111111111111111").into()
+        );
+        assert_eq!(
+            calls[1].to,
+            address!("0x2222222222222222222222222222222222222222").into()
+        );
+    }
+
+    #[cfg(feature = "revm")]
+    #[test]
+    fn test_into_tempo_tx_env_can_force_aa_semantics() {
+        let to = address!("0x2222222222222222222222222222222222222222");
+        let request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                to: Some(to.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let env = request
+            .into_tempo_tx_env(revm::context::TxEnv::default(), false, true)
+            .expect("valid Tempo simulation environment");
+        let calls = env.tempo_tx_env.expect("forced AA environment").aa_calls;
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].to, to.into());
+    }
+
+    #[cfg(feature = "revm")]
+    #[test]
+    fn test_into_tempo_tx_env_rejects_forced_aa_without_calls() {
+        let err = TempoTransactionRequest::default()
+            .into_tempo_tx_env(revm::context::TxEnv::default(), false, true)
+            .expect_err("forced AA request without calls should fail");
+
+        assert_eq!(err.to_string(), "empty calls list");
     }
 
     #[test]

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -271,7 +271,6 @@ impl TempoTransactionRequest {
         is_t1c: bool,
         force_aa: bool,
     ) -> Result<TempoTxEnv, ValueError<Self>> {
-        let caller = self.inner.from.unwrap_or_default();
         let is_aa = force_aa || self.has_aa_fields();
         if is_aa && self.calls.is_empty() && self.inner.to.is_none() {
             return Err(ValueError::new_static(self, "empty calls list"));
@@ -281,7 +280,7 @@ impl TempoTransactionRequest {
             self.clone()
                 .build_aa()
                 .ok()
-                .and_then(|tx| tx.recover_fee_payer(caller).ok())
+                .and_then(|tx| tx.recover_fee_payer(inner.caller).ok())
         });
 
         let Self {
@@ -319,7 +318,7 @@ impl TempoTransactionRequest {
                         key_type.unwrap_or(SignatureType::Secp256k1),
                         key_data,
                         key_id,
-                        caller,
+                        inner.caller,
                         is_t1c,
                     ),
                     tempo_authorization_list: tempo_authorization_list
@@ -780,6 +779,35 @@ mod tests {
             .expect_err("forced AA request without calls should fail");
 
         assert_eq!(err.to_string(), "empty calls list");
+    }
+
+    #[cfg(feature = "revm")]
+    #[test]
+    fn test_into_tempo_tx_env_uses_execution_caller_for_keychain_signature() {
+        let request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")),
+                to: Some(address!("0x1111111111111111111111111111111111111111").into()),
+                ..Default::default()
+            },
+            key_id: Some(address!("0x2222222222222222222222222222222222222222")),
+            ..Default::default()
+        };
+        let caller = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let inner = revm::context::TxEnv {
+            caller,
+            ..Default::default()
+        };
+
+        let env = request
+            .into_tempo_tx_env(inner, false, false)
+            .expect("valid Tempo simulation environment");
+        let aa_env = env.tempo_tx_env.expect("AA environment");
+        let TempoSignature::Keychain(signature) = aa_env.signature else {
+            panic!("expected keychain signature");
+        };
+
+        assert_eq!(signature.user_address, caller);
     }
 
     #[test]

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -403,6 +403,10 @@ impl TempoTransactionRequest {
 }
 
 #[cfg(feature = "revm")]
+/// Creates a mock AA signature for RPC simulation based on key type hints.
+///
+/// If `key_id` is set, wraps the primitive signature in a keychain signature using `caller` as
+/// the account owner. `is_t1c` selects the keychain signature version.
 fn create_mock_tempo_signature(
     key_type: SignatureType,
     key_data: Option<Bytes>,
@@ -424,6 +428,7 @@ fn create_mock_tempo_signature(
 }
 
 #[cfg(feature = "revm")]
+/// Creates a mock primitive signature for RPC simulation.
 pub(super) fn create_mock_primitive_signature(
     key_type: &SignatureType,
     key_data: Option<Bytes>,
@@ -440,12 +445,18 @@ pub(super) fn create_mock_primitive_signature(
             pre_hash: false,
         }),
         SignatureType::WebAuthn => {
+            // `key_data` encodes the desired total WebAuthn data size. It excludes the 128 bytes
+            // occupied by the public key coordinates and defaults to 800 bytes when absent.
             const CLIENT_JSON: &str = r#"{"type":"webauthn.get","challenge":"","origin":""}"#;
+            // Authenticator data contains a 32-byte rpIdHash, one byte of flags, and a four-byte
+            // signature counter. The client JSON template makes the minimum total 87 bytes.
             const AUTH_DATA_SIZE: usize = 37;
             const MIN_SIZE: usize = AUTH_DATA_SIZE + CLIENT_JSON.len();
             const DEFAULT_SIZE: usize = 800;
             const MAX_SIZE: usize = 8192;
 
+            // Accept one-, two-, or four-byte big-endian size hints and clamp the result to avoid
+            // unbounded allocations from RPC input.
             let size = key_data
                 .as_deref()
                 .and_then(|data| match data.len() {
@@ -457,8 +468,10 @@ pub(super) fn create_mock_primitive_signature(
                 .unwrap_or(DEFAULT_SIZE)
                 .clamp(MIN_SIZE, MAX_SIZE);
 
+            // Set the user-presence flag in otherwise empty authenticator data.
             let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
             webauthn_data[32] = 0x01;
+            // Pad the origin field so the serialized WebAuthn data reaches the requested size.
             let padding = "x".repeat(size - MIN_SIZE);
             let client_json =
                 format!(r#"{{"type":"webauthn.get","challenge":"","origin":"{padding}"}}"#);

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -1,8 +1,7 @@
 use crate::rpc::{TempoHeaderResponse, TempoTransactionRequest};
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844, error::ValueError};
 use alloy_network::{NetworkTransactionBuilder, TxSigner};
-use alloy_primitives::{Address, B256, Bytes, Signature};
-use core::num::NonZeroU64;
+use alloy_primitives::Signature;
 use reth_evm::EvmEnv;
 use reth_primitives_traits::SealedHeader;
 use reth_rpc_convert::{
@@ -11,18 +10,8 @@ use reth_rpc_convert::{
 use reth_rpc_eth_types::EthApiError;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
-use tempo_primitives::{
-    SignatureType, TempoHeader, TempoSignature, TempoTxEnvelope, TempoTxType,
-    transaction::{Call, RecoveredTempoAuthorization},
-};
-use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
-
-/// Non-zero transaction identifier used only for RPC simulations.
-///
-/// RPC requests are not final signed transactions, so gas filling and other request normalization
-/// can make a simulated signing payload differ from the eventual submitted transaction. Use a
-/// fixed sentinel instead of deriving a misleading future channel id from the simulated payload.
-const RPC_SIMULATION_UNIQUE_TX_IDENTIFIER: B256 = B256::new(*b"TEMPO_RPC_SIMULATION_MPP_CONTEXT");
+use tempo_primitives::{TempoHeader, TempoSignature, TempoTxEnvelope, TempoTxType};
+use tempo_revm::TempoTxEnv;
 
 impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
     fn try_into_sim_tx(self) -> Result<TempoTxEnvelope, ValueError<Self>> {
@@ -105,207 +94,9 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
         self,
         evm_env: &EvmEnv<TempoHardfork, TempoBlockEnv>,
     ) -> Result<TempoTxEnv, Self::Err> {
-        let caller_addr = self.inner.from.unwrap_or_default();
-        let is_aa = self.has_aa_fields();
-
-        let fee_payer = if self.fee_payer_signature.is_some() {
-            // Try to recover the fee payer address from the signature.
-            // If recovery fails (e.g. dummy signature during gas estimation / fill),
-            // keep it unresolved so estimation/fill can continue with sender-paid semantics.
-            let recovered = self
-                .clone()
-                .build_aa()
-                .ok()
-                .and_then(|tx| tx.recover_fee_payer(caller_addr).ok());
-            Some(recovered)
-        } else {
-            None
-        };
-
-        let Self {
-            inner,
-            fee_token,
-            calls,
-            key_type,
-            key_data,
-            key_id,
-            tempo_authorization_list,
-            nonce_key,
-            key_authorization,
-            valid_before,
-            valid_after,
-            fee_payer_signature: _,
-        } = self;
-
-        Ok(TempoTxEnv {
-            fee_token,
-            is_system_tx: false,
-            unique_tx_identifier: Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER),
-            fee_payer,
-            tempo_tx_env: if is_aa {
-                // Create mock signature for gas estimation
-                // If key_type is not provided, default to secp256k1
-                // For Keychain signatures, use the caller's address as the root key address
-                let key_type = key_type.unwrap_or(SignatureType::Secp256k1);
-                let mock_signature = create_mock_tempo_sig(
-                    &key_type,
-                    key_data.as_ref(),
-                    key_id,
-                    caller_addr,
-                    evm_env.spec_id().is_t1c(),
-                );
-
-                let mut calls = calls;
-                if let Some(to) = &inner.to {
-                    calls.push(Call {
-                        to: *to,
-                        value: inner.value.unwrap_or_default(),
-                        input: inner.input.clone().into_input().unwrap_or_default(),
-                    });
-                }
-                if calls.is_empty() {
-                    return Err(EthApiError::InvalidParams("empty calls list".to_string()));
-                }
-
-                Some(Box::new(TempoBatchCallEnv {
-                    aa_calls: calls,
-                    signature: mock_signature,
-                    tempo_authorization_list: tempo_authorization_list
-                        .into_iter()
-                        .map(RecoveredTempoAuthorization::new)
-                        .collect(),
-                    nonce_key: nonce_key.unwrap_or_default(),
-                    key_authorization,
-                    signature_hash: B256::ZERO,
-                    tx_hash: B256::ZERO,
-                    valid_before: valid_before.map(NonZeroU64::get),
-                    valid_after: valid_after.map(NonZeroU64::get),
-                    subblock_transaction: false,
-                    override_key_id: key_id,
-                    expiring_nonce_idx: None,
-                }))
-            } else {
-                None
-            },
-            inner: inner.try_into_tx_env(evm_env)?,
-        })
-    }
-}
-
-/// Creates a mock AA signature for gas estimation based on key type hints
-///
-/// - `key_type`: The primitive signature type (secp256k1, P256, WebAuthn)
-/// - `key_data`: Type-specific data (e.g., WebAuthn size)
-/// - `key_id`: If Some, wraps the signature in a Keychain wrapper (+3,000 gas for key validation)
-/// - `caller_addr`: The transaction caller address (used as root key address for Keychain)
-/// - `is_t1c`: Whether T1C is active — determines keychain signature version (V1 pre-T1C, V2 post-T1C)
-fn create_mock_tempo_sig(
-    key_type: &SignatureType,
-    key_data: Option<&Bytes>,
-    key_id: Option<Address>,
-    caller_addr: alloy_primitives::Address,
-    is_t1c: bool,
-) -> TempoSignature {
-    use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
-
-    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
-
-    if key_id.is_some() {
-        // For Keychain signatures, the root_key_address is the caller (account owner).
-        let keychain_sig = if is_t1c {
-            KeychainSignature::new(caller_addr, inner_sig)
-        } else {
-            KeychainSignature::new_v1(caller_addr, inner_sig)
-        };
-        TempoSignature::Keychain(keychain_sig)
-    } else {
-        TempoSignature::Primitive(inner_sig)
-    }
-}
-
-/// Creates a mock primitive signature for gas estimation
-fn create_mock_primitive_signature(
-    sig_type: &SignatureType,
-    key_data: Option<Bytes>,
-) -> tempo_primitives::transaction::tt_signature::PrimitiveSignature {
-    use tempo_primitives::transaction::tt_signature::{
-        P256SignatureWithPreHash, PrimitiveSignature, WebAuthnSignature,
-    };
-
-    match sig_type {
-        SignatureType::Secp256k1 => {
-            // Create a dummy secp256k1 signature (65 bytes)
-            PrimitiveSignature::Secp256k1(Signature::new(
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::ZERO,
-                false,
-            ))
-        }
-        SignatureType::P256 => {
-            // Create a dummy P256 signature
-            PrimitiveSignature::P256(P256SignatureWithPreHash {
-                r: alloy_primitives::B256::ZERO,
-                s: alloy_primitives::B256::ZERO,
-                pub_key_x: alloy_primitives::B256::ZERO,
-                pub_key_y: alloy_primitives::B256::ZERO,
-                pre_hash: false,
-            })
-        }
-        SignatureType::WebAuthn => {
-            // Create a dummy WebAuthn signature with the specified size
-            // key_data contains the total size of webauthn_data (excluding 128 bytes for public keys)
-            // Default: 800 bytes if no key_data provided
-
-            // Base clientDataJSON template (50 bytes): {"type":"webauthn.get","challenge":"","origin":""}
-            // Authenticator data (37 bytes): 32 rpIdHash + 1 flags + 4 signCount
-            // Minimum total: 87 bytes
-            const BASE_CLIENT_JSON: &str = r#"{"type":"webauthn.get","challenge":"","origin":""}"#;
-            const AUTH_DATA_SIZE: usize = 37;
-            const MIN_WEBAUTHN_SIZE: usize = AUTH_DATA_SIZE + BASE_CLIENT_JSON.len(); // 87 bytes
-            const DEFAULT_WEBAUTHN_SIZE: usize = 800; // Default when no key_data provided
-            const MAX_WEBAUTHN_SIZE: usize = 8192; // Maximum realistic WebAuthn signature size
-
-            // Parse size from key_data, or use default
-            let size = if let Some(data) = key_data.as_ref() {
-                match data.len() {
-                    1 => data[0] as usize,
-                    2 => u16::from_be_bytes([data[0], data[1]]) as usize,
-                    4 => u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize,
-                    _ => DEFAULT_WEBAUTHN_SIZE, // Fallback default
-                }
-            } else {
-                DEFAULT_WEBAUTHN_SIZE // Default size when no key_data provided
-            };
-
-            // Clamp size to safe bounds to prevent DoS via unbounded allocation
-            let size = size.clamp(MIN_WEBAUTHN_SIZE, MAX_WEBAUTHN_SIZE);
-
-            // Construct authenticatorData (37 bytes)
-            let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
-            webauthn_data[32] = 0x01; // UP flag set
-
-            // Construct clientDataJSON with padding in origin field if needed
-            let additional_bytes = size - MIN_WEBAUTHN_SIZE;
-            let client_json = if additional_bytes > 0 {
-                // Add padding bytes to origin field
-                // {"type":"webauthn.get","challenge":"","origin":"XXXXX"}
-                let padding = "x".repeat(additional_bytes);
-                format!(r#"{{"type":"webauthn.get","challenge":"","origin":"{padding}"}}"#,)
-            } else {
-                BASE_CLIENT_JSON.to_string()
-            };
-
-            webauthn_data.extend_from_slice(client_json.as_bytes());
-            let webauthn_data = Bytes::from(webauthn_data);
-
-            PrimitiveSignature::WebAuthn(WebAuthnSignature {
-                webauthn_data,
-                r: alloy_primitives::B256::ZERO,
-                s: alloy_primitives::B256::ZERO,
-                pub_key_x: alloy_primitives::B256::ZERO,
-                pub_key_y: alloy_primitives::B256::ZERO,
-            })
-        }
+        let inner = self.inner.clone().try_into_tx_env(evm_env)?;
+        self.into_tempo_tx_env(inner, evm_env.spec_id().is_t1c(), false)
+            .map_err(|err| EthApiError::InvalidParams(err.to_string()))
     }
 }
 
@@ -338,13 +129,16 @@ impl FromConsensusHeader<TempoHeader> for TempoHeaderResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{TxKind, address};
+    use crate::rpc::request::{
+        RPC_SIMULATION_UNIQUE_TX_IDENTIFIER, create_mock_primitive_signature,
+    };
+    use alloy_primitives::{Address, B256, Bytes, TxKind, address};
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use reth_rpc_convert::TryIntoTxEnv;
     use tempo_primitives::{
-        TempoTransaction,
+        SignatureType, TempoTransaction,
         transaction::{Call, FEE_PAYER_SIGNATURE_MARKER, tt_signature::PrimitiveSignature},
     };
 

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -95,7 +95,7 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
         evm_env: &EvmEnv<TempoHardfork, TempoBlockEnv>,
     ) -> Result<TempoTxEnv, Self::Err> {
         let inner = self.inner.clone().try_into_tx_env(evm_env)?;
-        self.into_tempo_tx_env(inner, evm_env.spec_id().is_t1c(), false)
+        self.apply_to_tempo_tx_env(inner.into(), evm_env.spec_id().is_t1c(), false)
             .map_err(|err| EthApiError::InvalidParams(err.to_string()))
     }
 }

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -396,8 +396,8 @@ def main():
         internal_deps = ws_path_deps - publish_keep
         text = strip_dep_lines(text, lambda n: n in internal_deps)
 
-        # Strip the `reth` feature block
-        text = strip_feature_blocks(text, ['reth'])
+        # Strip feature blocks backed by non-publishable internal dependencies
+        text = strip_feature_blocks(text, ['revm', 'reth'])
 
         # Strip "rpc" from tempo-primitives features (rpc feature is stripped during publish)
         text = re.sub(r', "rpc"', '', text)


### PR DESCRIPTION
Moves Tempo RPC simulation environment construction behind a lightweight `revm` feature and makes the Reth conversion trait delegate to it. This lets non-Reth RPC consumers reuse the canonical request mapping and mock-signature logic without enabling the full `tempo-alloy/reth` feature.