### PR TITLE
Fix and update links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The blockchain for payments at scale.
 
 [Tempo](https://docs.tempo.xyz/) is a blockchain designed specifically for stablecoin payments. Its architecture focuses on high throughput, low cost, and features that financial institutions, payment service providers, and fintech platforms expect from modern payment infrastructure.
 
-You can get started today by integrating with the [Tempo testnet](https://docs.tempo.xyz/quickstart/integrate-tempo), [building on Tempo](https://docs.tempo.xyz/guide/use-accounts), [running a Tempo node](https://docs.tempo.xyz/guide/node), reading the [Tempo protocol specs](https://docs.tempo.xyz/protocol) or by [building with Tempo SDKs](https://docs.tempo.xyz/sdk).
+You can get started today by integrating with the [Tempo testnet](https://docs.tempo.xyz/quickstart/integrate-tempo), [building on Tempo](https://tempo.xyz/developers/docs/build), [running a Tempo node](https://docs.tempo.xyz/guide/node), reading the [Tempo protocol specs](https://docs.tempo.xyz/protocol) or by [building with Tempo SDKs](https://docs.tempo.xyz/sdk).
 
 ## What makes Tempo different
 

--- a/README.md
+++ b/README.md
@@ -88,20 +88,20 @@ cast rpc tempo_fundAddress <ADDRESS> --rpc-url https://rpc.moderato.tempo.xyz
 
 We provide three different installation paths: installing a pre-built binary, building from source or using our provided Docker image.
 
-- [Pre-built Binary](https://docs.tempo.xyz/guide/node/installation#pre-built-binary)
-- [Build from Source](https://docs.tempo.xyz/guide/node/installation#build-from-source)
-- [Docker](https://docs.tempo.xyz/guide/node/installation#docker)
+- [Pre-built Binary](https://tempo.xyz/developers/docs/guide/node/installation#pre-built-binary)
+- [Build from Source](https://tempo.xyz/developers/docs/guide/node/installation#build-from-source)
+- [Docker](https://tempo.xyz/developers/docs/guide/node/installation#docker)
 
-See the [Tempo documentation](https://docs.tempo.xyz/guide/node) for instructions on how to install and run Tempo.
+See the [Tempo documentation](https://tempo.xyz/developers/docs/guide/node) for instructions on how to install and run Tempo.
 
 ### As a developer
 
 Tempo has several SDKs to help you get started building on Tempo:
 
-- [TypeScript](https://docs.tempo.xyz/sdk/typescript)
-- [Rust](https://docs.tempo.xyz/sdk/rust)
-- [Go](https://docs.tempo.xyz/sdk/go)
-- [Foundry](https://docs.tempo.xyz/sdk/foundry)
+- [TypeScript](https://tempo.xyz/developers/docs/sdk/typescript)
+- [Rust](https://tempo.xyz/developers/docs/sdk/rust)
+- [Go](https://tempo.xyz/developers/docs/sdk/go)
+- [Foundry](https://tempo.xyz/developers/docs/sdk/foundry)
 
 Want to contribute?
 

--- a/README.md
+++ b/README.md
@@ -21,22 +21,22 @@ The blockchain for payments at scale.
 
 [Tempo](https://docs.tempo.xyz/) is a blockchain designed specifically for stablecoin payments. Its architecture focuses on high throughput, low cost, and features that financial institutions, payment service providers, and fintech platforms expect from modern payment infrastructure.
 
-You can get started today by integrating with the [Tempo testnet](https://docs.tempo.xyz/quickstart/integrate-tempo), [building on Tempo](https://tempo.xyz/developers/docs/build), [running a Tempo node](https://docs.tempo.xyz/guide/node), reading the [Tempo protocol specs](https://docs.tempo.xyz/protocol) or by [building with Tempo SDKs](https://docs.tempo.xyz/sdk).
+You can get started today by integrating with the [Tempo testnet](https://tempo.xyz/developers/docs/quickstart/integrate-tempo), [building on Tempo](https://tempo.xyz/developers/docs/build), [running a Tempo node](https://tempo.xyz/developers/docs/guide/node), reading the [Tempo protocol specs](https://tempo.xyz/developers/docs/protocol) or by [building with Tempo SDKs](https://tempo.xyz/developers/docs/sdk).
 
 ## What makes Tempo different
 
-- [TIP‑20 token standard](https://docs.tempo.xyz/protocol/tip20/overview) (enshrined ERC‑20 extensions)
+- [TIP‑20 token standard](https://tempo.xyz/developers/docs/protocol/tip20/overview) (enshrined ERC‑20 extensions)
 
   - Predictable payment throughput via dedicated payment lanes reserved for TIP‑20 transfers (eliminates noisy‑neighbor contention).
   - Native reconciliation with on‑transfer memos and commitment patterns (hash/locator) for off‑chain PII and large data.
-  - Built‑in compliance through [TIP‑403 Policy Registry](https://docs.tempo.xyz/protocol/tip403/overview): single policy shared across multiple tokens, updated once and enforced everywhere.
+  - Built‑in compliance through [TIP‑403 Policy Registry](https://tempo.xyz/developers/docs/protocol/tip403/overview): single policy shared across multiple tokens, updated once and enforced everywhere.
 
-- Low, predictable fees in [stablecoins](https://docs.tempo.xyz/learn/stablecoins)
+- Low, predictable fees in [stablecoins](https://tempo.xyz/learn/what-are-stablecoins/)
 
-  - Users pay gas directly in USD-stablecoins at launch; the [Fee AMM](https://docs.tempo.xyz/protocol/fees/fee-amm#fee-amm-overview) automatically converts to the validator’s preferred stablecoin.
+  - Users pay gas directly in USD-stablecoins at launch; the [Fee AMM](https://tempo.xyz/developers/docs/protocol/fees/fee-amm#fee-amm-overview) automatically converts to the validator’s preferred stablecoin.
   - TIP‑20 transfers target sub‑millidollar costs (<$0.001).
 
-- [Tempo Transactions](https://docs.tempo.xyz/guide/tempo-transaction) (native “smart accounts”)
+- [Tempo Transactions](https://tempo.xyz/developers/docs/guide/tempo-transaction) (native “smart accounts”)
 
   - Batched payments: atomic multi‑operation payouts (payroll, settlements, refunds).
   - Fee sponsorship: apps can pay users' gas to streamline onboarding and flows.
@@ -59,7 +59,7 @@ You can get started today by integrating with the [Tempo testnet](https://docs.t
 - Deploy and interact with smart contracts using the same tools, languages, and frameworks used on Ethereum, such as Solidity, Foundry, and Hardhat.
 - All Ethereum JSON-RPC methods work out of the box.
 
-While the execution environment mirrors Ethereum's, Tempo introduces some differences optimized for payments, described [here](https://docs.tempo.xyz/quickstart/evm-compatibility).
+While the execution environment mirrors Ethereum's, Tempo introduces some differences optimized for payments, described [here](https://tempo.xyz/developers/docs/quickstart/evm-compatibility).
 
 ## Getting Started
 
@@ -76,7 +76,7 @@ You can connect to Tempo's public testnet using the following details:
 | **WebSocket URL**  | `wss://rpc.moderato.tempo.xyz`     |
 | **Block Explorer** | `https://explore.tempo.xyz`        |
 
-Next, grab some stablecoins to test with from Tempo's [Faucet](https://docs.tempo.xyz/quickstart/faucet#faucet).
+Next, grab some stablecoins to test with from Tempo's [Faucet](https://tempo.xyz/developers/docs/quickstart/faucet#faucet).
 
 Alternatively, use [`cast`](https://github.com/foundry-rs/foundry):
 


### PR DESCRIPTION
The link to building on tempo ([https://docs.tempo.xyz/guide/use-accounts](https://docs.tempo.xyz/guide/use-accounts)) is broken.
Also, the other links that point to the documentation are using ```docs.temp.xyz```, which redirects to  ```tempo.xyz/developers/docs```. I believe it is a better idea to point directly to it to minimise redirects.