### PR TITLE
feat(deps): bump reth to glamsterdam-devnet-7 and integrate new revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,8 +394,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
+source = "git+https://github.com/alloy-rs/evm?rev=1e540975017acd4e1b59aa27c49939f9b69e201e#1e540975017acd4e1b59aa27c49939f9b69e201e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2255,15 +2254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -5701,7 +5691,6 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "block-padding",
  "generic-array",
 ]
 
@@ -8594,8 +8583,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8621,8 +8610,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8654,8 +8643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8674,8 +8663,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8687,8 +8676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8759,6 +8748,7 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
+ "socket2",
  "tar",
  "tokio",
  "tokio-stream",
@@ -8770,8 +8760,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8780,8 +8770,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8802,8 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8823,8 +8812,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8833,8 +8821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8849,8 +8837,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8863,8 +8851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8876,8 +8864,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8901,8 +8889,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8930,8 +8918,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8956,8 +8944,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8986,8 +8974,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9001,8 +8989,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9026,8 +9014,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9050,8 +9038,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9074,8 +9062,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9109,8 +9097,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9166,13 +9154,12 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "aes",
  "alloy-primitives",
  "alloy-rlp",
- "block-padding",
  "byteorder",
  "cipher",
  "concat-kdf",
@@ -9194,8 +9181,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9217,8 +9204,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9230,10 +9217,12 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
+ "reth-execution-errors",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
+ "reth-storage-api",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.18",
@@ -9242,8 +9231,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9298,8 +9287,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9328,8 +9317,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9346,8 +9335,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9362,8 +9351,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9385,8 +9374,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9396,8 +9385,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9424,8 +9413,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9446,8 +9435,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9487,8 +9476,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "clap",
  "eyre",
@@ -9510,8 +9499,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9526,8 +9515,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9542,8 +9531,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9555,8 +9544,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9585,8 +9574,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9599,8 +9588,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9609,8 +9598,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9634,8 +9623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9654,8 +9643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9672,8 +9661,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9685,8 +9674,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9704,8 +9693,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,8 +9731,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9756,8 +9745,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "serde",
  "serde_json",
@@ -9766,8 +9755,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9792,8 +9781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "bytes",
  "futures",
@@ -9812,8 +9801,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9829,8 +9818,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "bindgen",
  "cc",
@@ -9838,8 +9827,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "futures",
  "metrics",
@@ -9851,8 +9840,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9860,8 +9849,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9874,8 +9863,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9932,8 +9921,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9957,8 +9946,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9981,8 +9970,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9996,8 +9985,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10010,8 +9999,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10027,8 +10016,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10051,8 +10040,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10119,8 +10108,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10174,8 +10163,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10184,6 +10173,7 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "ethereum_ssz",
+ "ethereum_ssz_derive",
  "eyre",
  "http-body-util",
  "jsonrpsee",
@@ -10207,6 +10197,7 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
+ "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
@@ -10221,8 +10212,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10245,8 +10236,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10269,8 +10260,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10298,8 +10289,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10310,8 +10301,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10334,8 +10325,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10346,8 +10337,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10369,8 +10360,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10380,8 +10371,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10412,8 +10402,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10460,14 +10450,13 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
- "rayon",
  "reth-config",
  "reth-db-api",
  "reth-errors",
@@ -10488,8 +10477,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10504,8 +10493,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10519,8 +10508,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10596,8 +10585,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10626,8 +10615,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10669,8 +10658,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10689,8 +10678,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10720,8 +10709,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10767,8 +10756,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10818,8 +10807,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10832,8 +10821,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10848,9 +10837,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
+version = "0.5.2"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -10863,8 +10851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10914,8 +10902,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10942,8 +10930,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10956,8 +10944,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10976,8 +10964,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -10991,8 +10979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11017,8 +11005,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11034,8 +11022,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11055,8 +11043,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11071,8 +11059,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11081,8 +11069,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "clap",
  "eyre",
@@ -11101,8 +11089,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11120,8 +11108,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11163,8 +11151,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11188,8 +11176,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11215,8 +11203,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11234,19 +11222,16 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
  "crossbeam-utils",
- "derive_more",
- "itertools 0.14.0",
  "metrics",
  "rand 0.9.4",
- "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -11262,8 +11247,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.3.0"
-source = "git+https://github.com/paradigmxyz/reth?rev=1bf2384#1bf23842268edad605afcc45908f8bcb6afbc26a"
+version = "2.4.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=4f36452#4f36452cdaa9865fee40496ae4ebd0129829c32e"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11278,14 +11263,14 @@ dependencies = [
  "serde_json",
  "slotmap",
  "smallvec",
+ "strum",
  "tracing",
 ]
 
 [[package]]
 name = "reth-zstd-compressors"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
+source = "git+https://github.com/paradigmxyz/reth-core?rev=8cc57a8c2889bc7d226bfd7a1fdf484354e1a878#8cc57a8c2889bc7d226bfd7a1fdf484354e1a878"
 dependencies = [
  "zstd",
 ]
@@ -11293,8 +11278,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11312,8 +11296,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "bitvec",
  "phf",
@@ -11324,8 +11307,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11341,8 +11323,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11357,8 +11338,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11373,8 +11353,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "either",
@@ -11387,8 +11366,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11406,8 +11384,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "auto_impl",
  "either",
@@ -11423,9 +11400,8 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
+version = "0.41.2"
+source = "git+https://github.com/paradigmxyz/revm-inspectors?rev=1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa#1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11444,8 +11420,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11457,8 +11432,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11483,8 +11457,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11494,8 +11467,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "41.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+source = "git+https://github.com/bluealloy/revm?rev=0c688c6884819c1374a302b3bcb3ce7cd936dbd8#0c688c6884819c1374a302b3bcb3ce7cd936dbd8"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,68 +146,68 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1bf2384", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4f36452", features = [
   "std",
   "optional-checks",
 ] }
@@ -219,7 +219,7 @@ alloy-contract = { version = "2.1.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.1.1", default-features = false }
 alloy-evm = { version = "0.37.1", default-features = false }
-revm-inspectors = "=0.41.0"
+revm-inspectors = "0.41.2"
 alloy-genesis = { version = "2.1.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-abi = { version = "1.6.0", default-features = false }
@@ -407,6 +407,28 @@ vergen-git2 = "10.0.1"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
+
+# Mirror of reth's patch section at rev 4f36452 (glamsterdam-devnet-7) — patches
+# only apply from the workspace root, so tempo must carry them itself.
+revm = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-bytecode = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-context = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-context-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-database = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-handler = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-inspector = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-interpreter = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-precompile = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-state = { git = "https://github.com/bluealloy/revm", rev = "0c688c6884819c1374a302b3bcb3ce7cd936dbd8" }
+revm-inspectors = { git = "https://github.com/paradigmxyz/revm-inspectors", rev = "1f82bd2f7f3ec14a6099aaa30c7ae14b12fa7aaa" }
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "1e540975017acd4e1b59aa27c49939f9b69e201e" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-codecs-derive = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-rpc-traits = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
+reth-zstd-compressors = { git = "https://github.com/paradigmxyz/reth-core", rev = "8cc57a8c2889bc7d226bfd7a1fdf484354e1a878" }
 
 # Commonware at HEAD after PR #3588 was merged
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "2a7dd423f0a241276a5a38db8cc3d05f11de0c03" }

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -473,6 +473,10 @@ async fn run_p2p_network(
             IncomingEthRequest::GetCells { response, .. } => {
                 let _ = response.send(Ok(Default::default()));
             }
+            IncomingEthRequest::GetSnap { .. } => {
+                // The proxy does not serve the snap protocol; dropping the
+                // response channel signals the request as unfulfilled.
+            }
         }
     }
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -47,8 +47,9 @@ use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
     EthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
-        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, LoadBlock,
-        LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction, SpawnBlocking, Trace,
+        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthSubscriptions,
+        EthTransactions, LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState,
+        LoadTransaction, SpawnBlocking, Trace,
         bal::GetBlockAccessList,
         estimate::EstimateCall,
         pending_block::{BuildPendingEnv, PendingEnvBuilder},
@@ -473,6 +474,7 @@ where
 }
 
 impl<N> EstimateCall for TempoEthApi<N> where N: TempoEthApiBounds {}
+impl<N> EthSubscriptions for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> LoadBlock for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> LoadReceipt for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> EthBlocks for TempoEthApi<N> where N: TempoEthApiBounds {}

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -370,7 +370,7 @@ where
         let BuildArguments {
             cached_reads,
             execution_cache,
-            mut trie_handle,
+            state_root_handle: mut trie_handle,
             config,
             cancel,
             best_payload,
@@ -540,18 +540,18 @@ where
 
         let bal_task_handle = if self.enable_bal {
             let bal_task_handle =
-                self.spawn_bal_task(trie_handle.as_ref().map(|handle| handle.state_hook()));
+                self.spawn_bal_task(trie_handle.as_mut().map(|handle| handle.take_state_hook()));
             executor
                 .evm_mut()
                 .db_mut()
                 .set_state_hook(Some(Box::new(bal_task_handle.state_hook())));
             Some(bal_task_handle)
         } else {
-            if let Some(ref handle) = trie_handle {
+            if let Some(handle) = trie_handle.as_mut() {
                 executor
                     .evm_mut()
                     .db_mut()
-                    .set_state_hook(Some(Box::new(handle.state_hook())));
+                    .set_state_hook(Some(Box::new(handle.take_state_hook())));
             }
             None
         };
@@ -1021,11 +1021,12 @@ where
 
         let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
             .as_mut()
-            .map(|rx| rx.take_hashed_state_rx().recv())
+            .and_then(|handle| handle.try_take_hashed_state_rx())
+            .map(|rx| rx.recv())
         {
             hashed_state
         } else {
-            finish_provider.hashed_post_state(&db.bundle_state)
+            Arc::new(finish_provider.hashed_post_state(&db.bundle_state))
         };
 
         let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
@@ -1090,7 +1091,7 @@ where
             )
         } else {
             let (state_root, trie_updates) = finish_provider
-                .state_root_with_updates(hashed_state.clone())
+                .state_root_with_updates((*hashed_state).clone())
                 .map_err(BlockExecutionError::other)?;
 
             (state_root, Arc::new(trie_updates), None)
@@ -1295,7 +1296,7 @@ where
         let executed_block = BuiltPayloadExecutedBlock {
             recovered_block: block,
             execution_output: Arc::new(execution_output),
-            hashed_state: Arc::new(hashed_state),
+            hashed_state,
             trie_updates,
             changed_paths,
         };

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -106,7 +106,7 @@ fn fill_state_gas(output: &mut PrecompileOutput, storage: &StorageCtx) {
         if output.is_success() {
             // On success: parent takes the child's final reservoir.
             output.reservoir = storage.reservoir();
-            output.state_gas_used = storage.state_gas_used();
+            output.state_gas_used = storage.state_gas_used() as i64;
         } else {
             // On revert or halt: state changes are undone, so ALL state gas returns
             // to the parent's reservoir.

--- a/crates/revm/src/gas_params.rs
+++ b/crates/revm/src/gas_params.rs
@@ -131,11 +131,11 @@ fn amsterdam_gas_params() -> GasParams {
         (GasId::code_deposit_state_gas(), T4_CODE_DEPOSIT_STATE),
         // EIP-7702 delegation: 25k regular + 225k state = 250k per auth
         (
-            GasId::tx_eip7702_per_empty_account_cost(),
+            GasId::tx_eip7702_regular_gas(),
             T4_NEW_ACCOUNT_REGULAR,
         ),
         // Auth refund is disabled post-T1.
-        (GasId::tx_eip7702_auth_refund(), 0),
+        (GasId::tx_eip7702_regular_refund(), 0),
         // For each auth revm charges new_account_state_gas + tx_eip7702_state_gas_bytecode state gas
         //
         // Per TIP-1016, we only need 225k unconditional state gas charge (another 250k is charged only
@@ -157,11 +157,11 @@ fn t1_gas_params() -> GasParams {
         (GasId::new_account_cost_for_selfdestruct(), NEW_ACCOUNT_COST),
         (GasId::code_deposit_cost(), CODE_DEPOSIT_COST_T1),
         (
-            GasId::tx_eip7702_per_empty_account_cost(),
+            GasId::tx_eip7702_regular_gas(),
             EIP7702_PER_EMPTY_ACCOUNT_COST_T1,
         ),
         // Auth refund is disabled post-T1.
-        (GasId::tx_eip7702_auth_refund(), 0),
+        (GasId::tx_eip7702_regular_refund(), 0),
     ]);
     gas_params
 }
@@ -338,16 +338,19 @@ mod tests {
         );
         assert_eq!(gas_params.get(GasId::code_deposit_state_gas()), 2_300);
 
-        // EIP-7702 delegation: 25,000 regular + 225,000 state per auth
+        // EIP-7702 delegation: 25,000 regular + 225,000 state per auth.
+        // `tx_eip7702_per_empty_account_cost` returns only the regular
+        // portion; the state portion lives in `new_account_state_gas` (+ the
+        // zeroed bytecode state gas).
         assert_eq!(
-            gas_params.get(GasId::tx_eip7702_per_empty_account_cost()),
+            gas_params.get(GasId::tx_eip7702_regular_gas()),
             25_000,
-            "EIP-7702 per auth total = 25k regular + 225k state per spec"
+            "EIP-7702 per auth regular gas per spec"
         );
         assert_eq!(
             gas_params.tx_eip7702_per_empty_account_cost(),
-            250_000,
-            "EIP-7702 per auth state gas per spec"
+            25_000,
+            "EIP-7702 per auth regular gas per spec"
         );
         assert_eq!(
             gas_params.new_account_state_gas(),
@@ -355,9 +358,11 @@ mod tests {
             "EIP-7702 per auth state gas per spec"
         );
         assert_eq!(
-            gas_params.tx_eip7702_per_empty_account_cost() - gas_params.new_account_state_gas(),
-            25_000,
-            "EIP-7702 per auth regular gas = total - state = 25k"
+            gas_params.tx_eip7702_per_empty_account_cost()
+                + gas_params.new_account_state_gas()
+                + gas_params.tx_eip7702_state_gas_bytecode(),
+            250_000,
+            "EIP-7702 per auth total = 25k regular + 225k state per spec"
         );
         assert_eq!(
             gas_params.tx_eip7702_auth_refund_regular(),
@@ -424,7 +429,9 @@ mod tests {
 
         // EIP-7702: 25,000 regular + 225,000 state = 250,000 per auth
         assert_eq!(
-            t4.tx_eip7702_per_empty_account_cost(),
+            t4.tx_eip7702_per_empty_account_cost()
+                + t4.new_account_state_gas()
+                + t4.tx_eip7702_state_gas_bytecode(),
             250_000,
             "EIP-7702 per auth total must be 250,000"
         );

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
-use alloy_primitives::{Address, TxKind, U256};
+use alloy_primitives::{Address, U256};
 use reth_evm::{EvmError, EvmInternals};
 use revm::{
     Database,
@@ -22,7 +22,7 @@ use revm::{
     },
     handler::{
         EvmTr, FrameResult, FrameTr, Handler, MainnetHandler, post_execution,
-        pre_execution::{self, apply_auth_list, calculate_caller_fee},
+        pre_execution::{self, PreExecutionOutput, apply_auth_list, calculate_caller_fee},
         precompile_output_to_interpreter_result, validation,
     },
     inspector::{Inspector, InspectorHandler},
@@ -67,7 +67,7 @@ use tempo_primitives::{
 };
 
 use crate::{
-    TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction, TempoTxEnv,
+    TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction,
     common::TempoStateAccess,
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
@@ -830,53 +830,55 @@ where
     type Error = EVMError<DB::Error, TempoInvalidTransaction>;
     type HaltReason = TempoHaltReason;
 
-    /// Overridden run flow that inserts Tempo's T0+ intrinsic-gas-limit check
-    /// between pre-execution and execution.
+    /// Overridden transaction-level gas builder that reproduces the pre-T0
+    /// behavior when the initial gas spending exceeds the gas limit.
     ///
-    /// Mirrors the default [`Handler::run_without_catch_error`]; the check
-    /// cannot live in [`Handler::execution`] anymore since it no longer
-    /// receives `init_and_floor_gas`.
+    /// Upstream's [`Handler::tx_gas`] subtracts the intrinsic gas unguarded,
+    /// which would underflow for pre-T0 (Genesis) transactions that pass
+    /// validation with `gas_limit < intrinsic` (nonce gas is added after
+    /// validation). [`TempoEvm::initial_gas_and_reservoir`] falls back to
+    /// `(u64::MAX, 0)` in that case, matching the historic behavior.
     #[inline]
-    fn run_without_catch_error(
-        &mut self,
+    fn tx_gas(&self, evm: &mut Self::Evm, init_and_floor_gas: &InitialAndFloorGas) -> Gas {
+        let tx_gas_limit = evm.ctx_ref().tx().gas_limit();
+        let (remaining, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
+        Gas::new_with_remaining_and_reservoir(tx_gas_limit, remaining, reservoir)
+    }
+
+    /// Overridden pre-execution that rebuilds the transaction-level gas after
+    /// Tempo's state-dependent intrinsic charges are applied.
+    ///
+    /// Mirrors the default [`Handler::pre_execution`], but
+    /// [`Self::validate_against_state_and_deduct_caller`] can add charges to
+    /// `init_and_floor_gas` (e.g. the 2D-nonce CREATE new-account cost) that
+    /// the gas tracker built before pre-execution does not reflect. Rebuilding
+    /// `gas` here keeps the default run flow correct without overriding it.
+    ///
+    /// Tempo keeps the EIP-2780 runtime gas phase disabled, so pre-execution
+    /// never runs out of runtime gas and always returns `Some`.
+    #[inline]
+    fn pre_execution(
+        &self,
         evm: &mut Self::Evm,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        let mut init_and_floor_gas = self.validate(evm)?;
-        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
-        let pre_execution = self.pre_execution(evm, &mut init_and_floor_gas, &mut gas)?;
+        init_and_floor_gas: &mut InitialAndFloorGas,
+        gas: &mut Gas,
+    ) -> Result<Option<PreExecutionOutput>, Self::Error> {
+        self.validate_against_state_and_deduct_caller(evm, init_and_floor_gas)?;
+        self.load_accounts(evm)?;
 
-        // Tempo's `validate_against_state_and_deduct_caller` can add
-        // state-dependent intrinsic charges to `init_and_floor_gas` (e.g. the
-        // 2D-nonce CREATE new-account cost). Rebuild the transaction-level gas
-        // so the frame budget reflects them; with EIP-2780 disabled,
-        // `pre_execution` records nothing on the discarded instance.
-        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+        // Rebuild the transaction-level gas so the frame budget reflects any
+        // state-dependent intrinsic charges added above.
+        *gas = self.tx_gas(evm, init_and_floor_gas);
 
-        let refund = pre_execution.map(|pe| pe.eip7702_refund).unwrap_or(0) as i64;
+        let checkpoint = evm.ctx().journal_mut().checkpoint();
+        let eip7702_refund = self
+            .apply_eip7702_auth_list(evm, gas)?
+            .expect("EIP-2780 is disabled: authorization list never runs out of runtime gas");
 
-        let mut exec_result = None;
-        if let Some(pre_execution) = pre_execution {
-            let spec = evm.ctx_ref().cfg().spec();
-            if let Some(oog) = check_gas_limit(*spec, evm.ctx_ref().tx(), &init_and_floor_gas) {
-                // T0+: a gas limit below the intrinsic cost is included as an
-                // out-of-gas halt instead of entering execution. Commit the
-                // runtime gas phase checkpoint so the applied authorizations
-                // persist, matching the pre-EIP-2780 behavior where no
-                // checkpoint spanned them.
-                evm.ctx().journal_mut().checkpoint_commit();
-                exec_result = Some(oog);
-            } else {
-                exec_result = self.execution(evm, pre_execution.checkpoint, &mut gas)?;
-            }
-        }
-        let mut exec_result = match exec_result {
-            Some(exec_result) => exec_result,
-            None => self.runtime_oog_result(evm, &init_and_floor_gas, &mut gas)?,
-        };
-
-        let result_gas = self.post_execution(evm, &mut exec_result, init_and_floor_gas, refund)?;
-
-        self.execution_result(evm, exec_result, result_gas)
+        Ok(Some(PreExecutionOutput {
+            eip7702_refund,
+            checkpoint,
+        }))
     }
 
     /// Overridden execution method that handles AA vs standard transactions.
@@ -2146,8 +2148,7 @@ where
             // them at the intrinsic phase exactly like revm 41.0.0 did.
             // Pre-T4 gas tables have these at zero.
             init_gas.initial_state_gas += tx.authorization_list_len() as u64
-                * (gas_params.new_account_state_gas()
-                    + gas_params.tx_eip7702_state_gas_bytecode());
+                * (gas_params.new_account_state_gas() + gas_params.tx_eip7702_state_gas_bytecode());
             if tx.kind().is_create() {
                 init_gas.initial_state_gas += gas_params.create_state_gas();
             }
@@ -2527,48 +2528,6 @@ where
 {
     type IT = EthInterpreter;
 
-    /// Overridden inspect run flow that inserts Tempo's T0+ intrinsic-gas-limit
-    /// check between pre-execution and execution.
-    ///
-    /// Mirrors [`Handler::run_without_catch_error`] as overridden above, using
-    /// the inspector-aware execution path.
-    #[inline]
-    fn inspect_run_without_catch_error(
-        &mut self,
-        evm: &mut Self::Evm,
-    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        let mut init_and_floor_gas = self.validate(evm)?;
-        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
-        let pre_execution = self.pre_execution(evm, &mut init_and_floor_gas, &mut gas)?;
-
-        // See `run_without_catch_error`: rebuild the transaction-level gas to
-        // pick up intrinsic charges added during pre-execution.
-        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
-
-        let refund = pre_execution.map(|pe| pe.eip7702_refund).unwrap_or(0) as i64;
-
-        let mut exec_result = None;
-        if let Some(pre_execution) = pre_execution {
-            let spec = evm.ctx_ref().cfg().spec();
-            if let Some(oog) = check_gas_limit(*spec, evm.ctx_ref().tx(), &init_and_floor_gas) {
-                // See `run_without_catch_error`: included as an out-of-gas
-                // halt with the applied authorizations persisted.
-                evm.ctx().journal_mut().checkpoint_commit();
-                exec_result = Some(oog);
-            } else {
-                exec_result = self.inspect_execution(evm, pre_execution.checkpoint, &mut gas)?;
-            }
-        }
-        let mut exec_result = match exec_result {
-            Some(exec_result) => exec_result,
-            None => self.runtime_oog_result(evm, &init_and_floor_gas, &mut gas)?,
-        };
-
-        let result_gas = self.post_execution(evm, &mut exec_result, init_and_floor_gas, refund)?;
-
-        self.execution_result(evm, exec_result, result_gas)
-    }
-
     /// Overridden execution method with inspector support that handles AA vs standard transactions.
     #[inline]
     fn inspect_execution(
@@ -2588,38 +2547,6 @@ where
             self.inspect_execute_single_call(evm, gas).map(Some)
         }
     }
-}
-
-/// Helper function to create a frame result for an out of gas error.
-///
-/// Use native fn when new revm version is released.
-#[inline]
-fn oog_frame_result(kind: TxKind, gas_limit: u64) -> FrameResult {
-    if kind.is_call() {
-        FrameResult::new_call_oog(gas_limit, 0..0, 0)
-    } else {
-        FrameResult::new_create_oog(gas_limit, 0)
-    }
-}
-
-/// Checks if gas limit is sufficient and returns OOG frame result if not.
-///
-/// For T0+, validates gas limit covers intrinsic gas. For pre-T0, skips check
-/// to maintain backward compatibility.
-#[inline]
-fn check_gas_limit(
-    spec: tempo_chainspec::hardfork::TempoHardfork,
-    tx: &TempoTxEnv,
-    adjusted_gas: &InitialAndFloorGas,
-) -> Option<FrameResult> {
-    if spec.is_t0() && tx.gas_limit() < adjusted_gas.initial_total_gas() {
-        let kind = *tx
-            .first_call()
-            .expect("we already checked that there is at least one call in aa tx")
-            .0;
-        return Some(oog_frame_result(kind, tx.gas_limit()));
-    }
-    None
 }
 
 /// Validates time window for AA transactions
@@ -4623,7 +4550,9 @@ mod tests {
                 0..0,
             ));
 
-            handler.refund(&mut evm, &mut frame_result, 0);
+            handler
+                .refund(&mut evm, &mut frame_result, 0)
+                .expect("refund should succeed");
             frame_result.gas().refunded()
         };
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -16,7 +16,10 @@ use revm::{
         result::{EVMError, ExecutionResult, InvalidTransaction, ResultGas},
         transaction::{AccessListItem, AccessListItemTr},
     },
-    context_interface::cfg::{GasId, GasParams},
+    context_interface::{
+        cfg::{GasId, GasParams},
+        journaled_state::JournalCheckpoint,
+    },
     handler::{
         EvmTr, FrameResult, FrameTr, Handler, MainnetHandler, post_execution,
         pre_execution::{self, apply_auth_list, calculate_caller_fee},
@@ -556,8 +559,7 @@ where
     fn execute_single_call_with<F>(
         &mut self,
         evm: &mut TempoEvm<DB, I>,
-        gas_limit: u64,
-        reservoir: u64,
+        gas: &mut Gas,
         mut run_loop: F,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>
     where
@@ -567,14 +569,21 @@ where
             <<TempoEvm<DB, I> as EvmTr>::Frame as FrameTr>::FrameInit,
         ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>,
     {
-        // Create first frame action
-        let first_frame_input = self.first_frame_input(evm, gas_limit, reservoir)?;
+        // Create first frame action. `None` only happens when the EIP-2780
+        // runtime gas phase runs out of gas, which Tempo keeps disabled.
+        let first_frame_input = self.first_frame_input(evm, gas)?.ok_or_else(|| {
+            EVMError::Custom("first frame creation ran out of gas with EIP-2780 disabled".into())
+        })?;
+
+        // All regular gas is forwarded to the first frame; unused gas returns
+        // when `last_frame_result` settles the frame.
+        gas.spend_all();
 
         // Run execution loop (standard or inspector)
         let mut frame_result = run_loop(self, evm, first_frame_input)?;
 
         // Handle last frame result
-        self.last_frame_result(evm, reservoir, &mut frame_result)?;
+        self.last_frame_result(evm, &mut frame_result, gas)?;
 
         Ok(frame_result)
     }
@@ -585,10 +594,9 @@ where
     fn execute_single_call(
         &mut self,
         evm: &mut TempoEvm<DB, I>,
-        gas_limit: u64,
-        reservoir: u64,
+        gas: &mut Gas,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>> {
-        self.execute_single_call_with(evm, gas_limit, reservoir, Self::run_exec_loop)
+        self.execute_single_call_with(evm, gas, Self::run_exec_loop)
     }
 
     /// Generic multi-call execution that works with both standard and inspector exec loops.
@@ -622,8 +630,7 @@ where
         F: FnMut(
             &mut Self,
             &mut TempoEvm<DB, I>,
-            u64,
-            u64,
+            &mut Gas,
         ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>,
     {
         // Create checkpoint for atomic execution - captures state before any calls
@@ -663,7 +670,13 @@ where
             }
 
             // Execute call with NO additional initial gas (already deducted upfront in validation)
-            let frame_result = execute_single(self, evm, remaining_gas, reservoir);
+            //
+            // The per-call transaction-level gas mirrors the pre-call state: the
+            // call's budget is the batch's remaining gas (also its limit, matching
+            // the temporary `tx.gas_limit` above) plus the current reservoir.
+            let mut call_gas =
+                Gas::new_with_remaining_and_reservoir(remaining_gas, remaining_gas, reservoir);
+            let frame_result = execute_single(self, evm, &mut call_gas);
 
             // Restore original TxEnv immediately after execution, even if execution failed
             {
@@ -753,11 +766,16 @@ where
     fn execute_multi_call(
         &mut self,
         evm: &mut TempoEvm<DB, I>,
-        gas_limit: u64,
-        reservoir: u64,
+        gas: &Gas,
         calls: Vec<tempo_primitives::transaction::Call>,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>> {
-        self.execute_multi_call_with(evm, gas_limit, reservoir, calls, Self::execute_single_call)
+        self.execute_multi_call_with(
+            evm,
+            gas.remaining(),
+            gas.reservoir(),
+            calls,
+            Self::execute_single_call,
+        )
     }
 
     /// Executes a standard single-call transaction with inspector support.
@@ -767,13 +785,12 @@ where
     fn inspect_execute_single_call(
         &mut self,
         evm: &mut TempoEvm<DB, I>,
-        gas_limit: u64,
-        reservoir: u64,
+        gas: &mut Gas,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>
     where
         I: Inspector<TempoContext<DB>, EthInterpreter>,
     {
-        self.execute_single_call_with(evm, gas_limit, reservoir, Self::inspect_run_exec_loop)
+        self.execute_single_call_with(evm, gas, Self::inspect_run_exec_loop)
     }
 
     /// Executes a multi-call AA transaction atomically with inspector support.
@@ -783,8 +800,7 @@ where
     fn inspect_execute_multi_call(
         &mut self,
         evm: &mut TempoEvm<DB, I>,
-        gas_limit: u64,
-        reservoir: u64,
+        gas: &Gas,
         calls: Vec<tempo_primitives::transaction::Call>,
     ) -> Result<FrameResult, EVMError<DB::Error, TempoInvalidTransaction>>
     where
@@ -792,8 +808,8 @@ where
     {
         self.execute_multi_call_with(
             evm,
-            gas_limit,
-            reservoir,
+            gas.remaining(),
+            gas.reservoir(),
             calls,
             Self::inspect_execute_single_call,
         )
@@ -814,6 +830,55 @@ where
     type Error = EVMError<DB::Error, TempoInvalidTransaction>;
     type HaltReason = TempoHaltReason;
 
+    /// Overridden run flow that inserts Tempo's T0+ intrinsic-gas-limit check
+    /// between pre-execution and execution.
+    ///
+    /// Mirrors the default [`Handler::run_without_catch_error`]; the check
+    /// cannot live in [`Handler::execution`] anymore since it no longer
+    /// receives `init_and_floor_gas`.
+    #[inline]
+    fn run_without_catch_error(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        let mut init_and_floor_gas = self.validate(evm)?;
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+        let pre_execution = self.pre_execution(evm, &mut init_and_floor_gas, &mut gas)?;
+
+        // Tempo's `validate_against_state_and_deduct_caller` can add
+        // state-dependent intrinsic charges to `init_and_floor_gas` (e.g. the
+        // 2D-nonce CREATE new-account cost). Rebuild the transaction-level gas
+        // so the frame budget reflects them; with EIP-2780 disabled,
+        // `pre_execution` records nothing on the discarded instance.
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+
+        let refund = pre_execution.map(|pe| pe.eip7702_refund).unwrap_or(0) as i64;
+
+        let mut exec_result = None;
+        if let Some(pre_execution) = pre_execution {
+            let spec = evm.ctx_ref().cfg().spec();
+            if let Some(oog) = check_gas_limit(*spec, evm.ctx_ref().tx(), &init_and_floor_gas) {
+                // T0+: a gas limit below the intrinsic cost is included as an
+                // out-of-gas halt instead of entering execution. Commit the
+                // runtime gas phase checkpoint so the applied authorizations
+                // persist, matching the pre-EIP-2780 behavior where no
+                // checkpoint spanned them.
+                evm.ctx().journal_mut().checkpoint_commit();
+                exec_result = Some(oog);
+            } else {
+                exec_result = self.execution(evm, pre_execution.checkpoint, &mut gas)?;
+            }
+        }
+        let mut exec_result = match exec_result {
+            Some(exec_result) => exec_result,
+            None => self.runtime_oog_result(evm, &init_and_floor_gas, &mut gas)?,
+        };
+
+        let result_gas = self.post_execution(evm, &mut exec_result, init_and_floor_gas, refund)?;
+
+        self.execution_result(evm, exec_result, result_gas)
+    }
+
     /// Overridden execution method that handles AA vs standard transactions.
     ///
     /// Dispatches based on transaction type:
@@ -823,22 +888,19 @@ where
     fn execution(
         &mut self,
         evm: &mut Self::Evm,
-        init_and_floor_gas: &InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        let spec = evm.ctx_ref().cfg().spec();
-        let tx = evm.tx();
-
-        if let Some(oog) = check_gas_limit(*spec, tx, init_and_floor_gas) {
-            return Ok(oog);
-        }
-
-        let (gas_limit, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
+        _checkpoint: JournalCheckpoint,
+        gas: &mut Gas,
+    ) -> Result<Option<FrameResult>, Self::Error> {
+        // Tempo keeps the EIP-2780 runtime gas phase disabled: first-frame
+        // creation charges nothing, so the phase checkpoint opened by
+        // `pre_execution` (or `run_system_call`) commits immediately.
+        evm.ctx().journal_mut().checkpoint_commit();
 
         if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
             let calls = tempo_tx_env.aa_calls.clone();
-            self.execute_multi_call(evm, gas_limit, reservoir, calls)
+            self.execute_multi_call(evm, gas, calls).map(Some)
         } else {
-            self.execute_single_call(evm, gas_limit, reservoir)
+            self.execute_single_call(evm, gas).map(Some)
         }
     }
 
@@ -854,7 +916,7 @@ where
         if exec_result.instruction_result().is_ok() {
             gas_credits::apply_refund(evm, exec_result.gas_mut())?;
         }
-        self.refund(evm, exec_result, eip7702_gas_refund);
+        self.refund(evm, exec_result, eip7702_gas_refund)?;
 
         let result_gas = post_execution::build_result_gas(
             exec_result.instruction_result().is_halt(),
@@ -877,16 +939,25 @@ where
     /// regardless of the transaction's gas used. Pre-T7 keeps the standard
     /// capped behavior (`Gas::set_final_refund`).
     #[inline]
-    fn refund(&self, evm: &mut Self::Evm, exec_result: &mut FrameResult, eip7702_refund: i64) {
+    fn refund(
+        &self,
+        evm: &mut Self::Evm,
+        exec_result: &mut FrameResult,
+        eip7702_refund: i64,
+    ) -> Result<(), Self::Error> {
         let spec = evm.ctx.cfg.spec;
-        let gas = exec_result.gas_mut();
         if spec.is_t7() {
             // No cap: leave the accumulated refund counter untouched after
             // recording the EIP-7702 auth refund.
-            gas.record_refund(eip7702_refund);
+            exec_result.gas_mut().record_refund(eip7702_refund);
         } else {
-            post_execution::refund(spec.into(), gas, eip7702_refund);
+            post_execution::refund(
+                evm.ctx.cfg.gas_params(),
+                exec_result.gas_mut(),
+                eip7702_refund,
+            );
         }
+        Ok(())
     }
 
     /// Take logs from the Journal if outcome is Halt Or Revert.
@@ -913,8 +984,8 @@ where
     fn apply_eip7702_auth_list(
         &self,
         evm: &mut Self::Evm,
-        _init_and_floor_gas: &mut InitialAndFloorGas,
-    ) -> Result<u64, Self::Error> {
+        _gas: &mut Gas,
+    ) -> Result<Option<u64>, Self::Error> {
         let ctx = &mut evm.ctx;
         let spec = ctx.cfg.spec;
 
@@ -938,14 +1009,12 @@ where
                     .filter(|auth| !(spec.is_t0() && auth.signature().is_keychain())),
                 &mut ctx.journaled_state,
             )?
-            .0
         } else {
             apply_auth_list::<_, Self::Error>(
                 ctx.cfg.chain_id,
                 ctx.tx.authorization_list(),
                 &mut ctx.journaled_state,
             )?
-            .0
         };
 
         let refunded_gas = ctx
@@ -954,7 +1023,7 @@ where
             .tx_eip7702_auth_refund_regular()
             .saturating_mul(refunded_accounts);
 
-        Ok(refunded_gas)
+        Ok(Some(refunded_gas))
     }
 
     #[inline]
@@ -2067,7 +2136,21 @@ where
                 acc as u64,
                 storage as u64,
                 tx.authorization_list_len() as u64,
+                // Tempo keeps EIP-2780 disabled.
+                None,
             );
+
+            // Upstream moved the EIP-8037 state-gas intrinsics (per-auth
+            // account creation and CREATE state gas) into the EIP-2780
+            // runtime gas phase. Tempo keeps EIP-2780 disabled, so charge
+            // them at the intrinsic phase exactly like revm 41.0.0 did.
+            // Pre-T4 gas tables have these at zero.
+            init_gas.initial_state_gas += tx.authorization_list_len() as u64
+                * (gas_params.new_account_state_gas()
+                    + gas_params.tx_eip7702_state_gas_bytecode());
+            if tx.kind().is_create() {
+                init_gas.initial_state_gas += gas_params.create_state_gas();
+            }
             // TIP-1000: Storage pricing updates for launch
             // EIP-7702 authorisation list entries with `auth_list.nonce == 0` require an additional 250,000 gas.
             // no need for v1 fork check as gas_params would be zero
@@ -2180,7 +2263,8 @@ where
         evm: &mut TempoEvm<DB, I>,
     ) -> Result<ValidationContext, EVMError<DB::Error, TempoInvalidTransaction>> {
         let mut init_and_floor_gas = self.validate(evm)?;
-        self.pre_execution(evm, &mut init_and_floor_gas)?;
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+        self.pre_execution(evm, &mut init_and_floor_gas, &mut gas)?;
         let result = ValidationContext {
             fee_token: evm
                 .fee_token
@@ -2246,10 +2330,10 @@ pub fn calculate_aa_batch_intrinsic_gas<'a>(
 
     // 4. Authorization list costs (EIP-7702)
     let num_auths = authorization_list.len() as u64;
-    gas.initial_regular_gas +=
-        num_auths * gas_params.get(GasId::tx_eip7702_per_empty_account_cost());
+    gas.initial_regular_gas += num_auths * gas_params.get(GasId::tx_eip7702_regular_gas());
     // TIP-1016: Track state gas portion of per-auth cost (225k on T4, 0 pre-T4).
-    gas.initial_state_gas += num_auths * gas_params.tx_eip7702_state_gas();
+    gas.initial_state_gas += num_auths
+        * (gas_params.new_account_state_gas() + gas_params.tx_eip7702_state_gas_bytecode());
 
     // Add signature verification costs for each authorization
     // No need for v1 fork check as gas_params would be zero
@@ -2443,27 +2527,65 @@ where
 {
     type IT = EthInterpreter;
 
+    /// Overridden inspect run flow that inserts Tempo's T0+ intrinsic-gas-limit
+    /// check between pre-execution and execution.
+    ///
+    /// Mirrors [`Handler::run_without_catch_error`] as overridden above, using
+    /// the inspector-aware execution path.
+    #[inline]
+    fn inspect_run_without_catch_error(
+        &mut self,
+        evm: &mut Self::Evm,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        let mut init_and_floor_gas = self.validate(evm)?;
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+        let pre_execution = self.pre_execution(evm, &mut init_and_floor_gas, &mut gas)?;
+
+        // See `run_without_catch_error`: rebuild the transaction-level gas to
+        // pick up intrinsic charges added during pre-execution.
+        let mut gas = self.tx_gas(evm, &init_and_floor_gas);
+
+        let refund = pre_execution.map(|pe| pe.eip7702_refund).unwrap_or(0) as i64;
+
+        let mut exec_result = None;
+        if let Some(pre_execution) = pre_execution {
+            let spec = evm.ctx_ref().cfg().spec();
+            if let Some(oog) = check_gas_limit(*spec, evm.ctx_ref().tx(), &init_and_floor_gas) {
+                // See `run_without_catch_error`: included as an out-of-gas
+                // halt with the applied authorizations persisted.
+                evm.ctx().journal_mut().checkpoint_commit();
+                exec_result = Some(oog);
+            } else {
+                exec_result = self.inspect_execution(evm, pre_execution.checkpoint, &mut gas)?;
+            }
+        }
+        let mut exec_result = match exec_result {
+            Some(exec_result) => exec_result,
+            None => self.runtime_oog_result(evm, &init_and_floor_gas, &mut gas)?,
+        };
+
+        let result_gas = self.post_execution(evm, &mut exec_result, init_and_floor_gas, refund)?;
+
+        self.execution_result(evm, exec_result, result_gas)
+    }
+
     /// Overridden execution method with inspector support that handles AA vs standard transactions.
     #[inline]
     fn inspect_execution(
         &mut self,
         evm: &mut Self::Evm,
-        init_and_floor_gas: &InitialAndFloorGas,
-    ) -> Result<FrameResult, Self::Error> {
-        let spec = evm.ctx_ref().cfg().spec();
-        let tx = evm.tx();
-
-        if let Some(oog) = check_gas_limit(*spec, tx, init_and_floor_gas) {
-            return Ok(oog);
-        }
-
-        let (gas_limit, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
+        _checkpoint: JournalCheckpoint,
+        gas: &mut Gas,
+    ) -> Result<Option<FrameResult>, Self::Error> {
+        // See `Handler::execution`: EIP-2780 is disabled, commit the phase
+        // checkpoint immediately.
+        evm.ctx().journal_mut().checkpoint_commit();
 
         if let Some(tempo_tx_env) = evm.ctx().tx().tempo_tx_env.as_ref() {
             let calls = tempo_tx_env.aa_calls.clone();
-            self.inspect_execute_multi_call(evm, gas_limit, reservoir, calls)
+            self.inspect_execute_multi_call(evm, gas, calls).map(Some)
         } else {
-            self.inspect_execute_single_call(evm, gas_limit, reservoir)
+            self.inspect_execute_single_call(evm, gas).map(Some)
         }
     }
 }
@@ -2662,9 +2784,14 @@ mod tests {
         }
 
         fn execute(&mut self, init_gas: &InitialAndFloorGas) -> FrameResult {
+            let mut gas = self.handler.tx_gas(&mut self.evm, init_gas);
+            // `execution` commits the runtime gas phase checkpoint that
+            // `pre_execution` normally opens; open one here to match.
+            let checkpoint = self.evm.ctx().journal_mut().checkpoint();
             self.handler
-                .execution(&mut self.evm, init_gas)
+                .execution(&mut self.evm, checkpoint, &mut gas)
                 .expect("execution should return a frame result")
+                .expect("EIP-2780 is disabled: execution never runs out of runtime gas")
         }
     }
 
@@ -3117,6 +3244,7 @@ mod tests {
             0,     // no access list accounts
             0,     // no access list storage
             0,     // no authorization list
+            None,
         );
 
         // AA with secp256k1 + single call should match normal tx exactly
@@ -3173,7 +3301,7 @@ mod tests {
         .unwrap();
 
         // Calculate base gas for a single normal tx
-        let base_tx_gas = calculate_initial_tx_gas(spec.into(), &calldata, false, 0, 0, 0);
+        let base_tx_gas = calculate_initial_tx_gas(spec.into(), &calldata, false, 0, 0, 0, None);
 
         // For 3 calls: base (21k) + 3*calldata + 2*per-call overhead (calls 2 and 3)
         // = 21k + 2*(calldata cost) + 2*COLD_ACCOUNT_ACCESS_COST
@@ -3227,7 +3355,7 @@ mod tests {
         .unwrap();
 
         // Calculate base gas for normal tx
-        let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
+        let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0, None);
 
         // Expected: normal tx + P256_VERIFY_GAS
         let expected = base_gas.initial_total_gas() + P256_VERIFY_GAS;
@@ -3271,7 +3399,7 @@ mod tests {
         // Calculate expected using revm's function for CREATE tx
         let base_gas = calculate_initial_tx_gas(
             spec, &initcode, true, // is_create = true
-            0, 0, 0,
+            0, 0, 0, None,
         );
 
         // AA CREATE should match normal CREATE exactly
@@ -3351,7 +3479,7 @@ mod tests {
         .unwrap();
 
         // Calculate expected using revm's function
-        let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
+        let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0, None);
 
         // Expected: normal tx
         assert_eq!(gas.initial_total_gas(), base_gas.initial_total_gas(),);
@@ -3442,7 +3570,7 @@ mod tests {
         .unwrap();
 
         // Calculate expected floor gas using revm's function
-        let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0);
+        let base_gas = calculate_initial_tx_gas(spec, &calldata, false, 0, 0, 0, None);
 
         // Floor gas should match revm's calculation for same calldata
         assert_eq!(
@@ -3975,7 +4103,7 @@ mod tests {
 
         // Also verify absolute values
         let spec = tempo_chainspec::hardfork::TempoHardfork::default();
-        let base_tx_gas = calculate_initial_tx_gas(spec.into(), &calldata, false, 0, 0, 0);
+        let base_tx_gas = calculate_initial_tx_gas(spec.into(), &calldata, false, 0, 0, 0, None);
         let expected_without = base_tx_gas.initial_total_gas(); // no cold access for single call
         let expected_with = expected_without + expected_key_auth_gas;
 
@@ -4387,9 +4515,12 @@ mod tests {
             .validate_against_state_and_deduct_caller(&mut evm, &mut Default::default())
             .expect("scope validation no longer runs during state validation");
 
+        let mut gas = handler.tx_gas(&mut evm, &init_gas);
+        let checkpoint = evm.ctx().journal_mut().checkpoint();
         let result = handler
-            .execution(&mut evm, &init_gas)
-            .expect("execution should return a frame result");
+            .execution(&mut evm, checkpoint, &mut gas)
+            .expect("execution should return a frame result")
+            .expect("EIP-2780 is disabled: execution never runs out of runtime gas");
 
         let expected_revert: Bytes = AccountKeychainError::call_not_allowed().abi_encode().into();
 
@@ -4566,12 +4697,12 @@ mod tests {
             GAS_LIMIT - INTRINSIC_GAS,
             0,
             calls,
-            |_handler, _evm, gas, _reservoir| {
+            |_handler, _evm, call_gas: &mut Gas| {
                 let (spent, refund) = calls_gas[call_idx];
                 call_idx += 1;
 
                 // Create gas with specific spent and refund values
-                let mut gas = Gas::new(gas);
+                let mut gas = Gas::new(call_gas.remaining());
                 gas.set_spent(spent);
                 gas.record_refund(refund);
 
@@ -6190,31 +6321,40 @@ mod tests {
 
     /// TIP-1016: Standard CREATE tx should populate initial_state_gas with
     /// create_state_gas when state gas is enabled (T4+).
+    ///
+    /// Upstream moved the state-gas intrinsics into the EIP-2780 runtime gas
+    /// phase, so Tempo now charges them in `validate_initial_tx_gas`; this
+    /// test goes through the handler rather than raw `initial_tx_gas`.
+    ///
     /// Note: new_account_state_gas for the caller (nonce==0 with 2D nonce) is added
-    /// later in validate_against_state_and_deduct_caller, not in upstream initial_tx_gas.
+    /// later in validate_against_state_and_deduct_caller.
     #[test]
     fn test_state_gas_standard_create_tx_populates_initial_state_gas() {
         // TIP-1016 is opt-in via amsterdam_eip8037; manually enable for this test.
-        let gas_params =
-            crate::gas_params::tempo_gas_params_with_amsterdam(TempoHardfork::T4, true);
         let initcode = Bytes::from(vec![0x60, 0x80]);
+        let mut tx_env = TempoTxEnv::default();
+        tx_env.inner.kind = TxKind::Create;
+        tx_env.inner.data = initcode;
+        tx_env.inner.gas_limit = 10_000_000;
+        // Avoid the T1+ nonce==0 new-account surcharge.
+        tx_env.inner.nonce = 1;
 
-        let init_gas = gas_params.initial_tx_gas(
-            &initcode, true, // is_create
-            0, 0, 0,
-        );
+        let mut test = TestHandlerEvm::with_cfg(TempoHardfork::T4, tx_env, |cfg| {
+            cfg.gas_params =
+                crate::gas_params::tempo_gas_params_with_amsterdam(TempoHardfork::T4, true);
+            cfg.enable_amsterdam_eip8037 = true;
+        });
 
-        let expected_state_gas = gas_params.create_state_gas();
+        let init_gas = test.validate_initial_tx_gas();
+        let expected_state_gas = test.gas_params().create_state_gas();
 
         assert!(
             expected_state_gas > 0,
             "State gas constants should be non-zero"
         );
         assert_eq!(
-            init_gas.initial_state_gas,
-            expected_state_gas,
-            "CREATE tx should have initial_state_gas = create_state_gas ({})",
-            gas_params.create_state_gas()
+            init_gas.initial_state_gas, expected_state_gas,
+            "CREATE tx should have initial_state_gas = create_state_gas ({expected_state_gas})",
         );
     }
 
@@ -6226,7 +6366,7 @@ mod tests {
 
         let init_gas = gas_params.initial_tx_gas(
             &calldata, false, // not create
-            0, 0, 0,
+            0, 0, 0, None,
         );
 
         assert_eq!(
@@ -6996,12 +7136,12 @@ mod tests {
                 gas_limit,
                 reservoir,
                 calls,
-                |_handler, _evm, gas, _reservoir| {
+                |_handler, _evm, call_gas: &mut Gas| {
                     // Feed the batch executor deterministic per-call outcomes without running real EVM code.
                     let (instruction_result, spent) = call_results[call_idx];
                     call_idx += 1;
 
-                    let mut gas = Gas::new(gas);
+                    let mut gas = Gas::new(call_gas.remaining());
                     gas.set_spent(spent);
 
                     Ok(FrameResult::Call(CallOutcome::new(


### PR DESCRIPTION
Bump reth git deps to 4f36452 (glamsterdam-devnet-7) and mirror its patch section: revm 0c688c68, revm-inspectors 1f82bd2 (0.41.2), alloy-evm 1e54097, reth-core 8cc57a8.

Adapt to the revm EIP-2780 runtime gas phase restructuring while keeping EIP-2780 disabled on Tempo:
- thread the transaction-level Gas through the AA single/multi-call execution paths and commit the runtime phase checkpoint upfront
- move the T0+ intrinsic-gas-limit OOG check into run_without_catch_error overrides and rebuild the tx-level gas after pre-execution so the 2D-nonce CREATE surcharge still applies
- charge the EIP-8037 state-gas intrinsics (per-auth and CREATE) in validate_initial_tx_gas now that upstream defers them to the runtime phase
- follow the tx_eip7702_regular_gas/tx_eip7702_regular_refund GasId renames and the signed PrecompileOutput::state_gas_used

Adapt to reth API changes: BuildArguments::state_root_handle rename with the take-once state hook and Arc'd hashed state, the new EthSubscriptions helper trait, and the GetSnap eth request variant.