### PR TITLE
fix(hardfork): sync T8 activation constants

### DIFF
--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -754,6 +754,27 @@ mod tests {
         use super::*;
 
         #[test]
+        fn builtin_schedules_match_hardfork_constants() {
+            let mainnet = super::super::TempoChainSpecParser::parse("mainnet")
+                .expect("the mainnet chainspec must always be well formed");
+            let moderato = super::super::TempoChainSpecParser::parse("moderato")
+                .expect("the moderato chainspec must always be well formed");
+
+            for &fork in TempoHardfork::VARIANTS {
+                assert_eq!(
+                    mainnet.info.fork_time(fork),
+                    fork.mainnet_activation_timestamp(),
+                    "mainnet {fork} activation mismatch"
+                );
+                assert_eq!(
+                    moderato.info.fork_time(fork),
+                    fork.moderato_activation_timestamp(),
+                    "moderato {fork} activation mismatch"
+                );
+            }
+        }
+
+        #[test]
         fn mainnet() {
             let cs = super::super::TempoChainSpecParser::parse("mainnet")
                 .expect("the mainnet chainspec must always be well formed");

--- a/crates/hardfork/src/constants.rs
+++ b/crates/hardfork/src/constants.rs
@@ -219,8 +219,8 @@ pub mod mainnet {
     /// T7 activation timestamp (Jul 9th 2026 14:00 UTC).
     pub const MAINNET_T7_TIMESTAMP: u64 = 1_783_605_600;
 
-    /// T8 activation timestamp (Jul 28th 2026 14:00 UTC).
-    pub const MAINNET_T8_TIMESTAMP: u64 = 1_785_247_200;
+    /// T8 activation timestamp (Jul 30th 2026 14:00 UTC).
+    pub const MAINNET_T8_TIMESTAMP: u64 = 1_785_420_000;
 }
 
 pub mod moderato {
@@ -277,6 +277,6 @@ pub mod moderato {
     /// T7 activation timestamp (Jul 2nd 2026 14:00 UTC).
     pub const MODERATO_T7_TIMESTAMP: u64 = 1_783_000_800;
 
-    /// T8 activation timestamp (Jul 23rd 2026 14:00 UTC).
-    pub const MODERATO_T8_TIMESTAMP: u64 = 1_784_815_200;
+    /// T8 activation timestamp (Jul 27th 2026 14:00 UTC).
+    pub const MODERATO_T8_TIMESTAMP: u64 = 1_785_160_800;
 }


### PR DESCRIPTION
Syncs the exported mainnet and Moderato T8 activation timestamps with the dates rescheduled in #6888. Adds a regression test that compares every built-in chainspec schedule with the public `tempo-hardfork` constants so SDK helpers cannot silently drift from node configuration again.

The node already selected forks from the correct genesis chainspec values; the stale constants affected `tempo-hardfork` API consumers such as `from_chain_and_timestamp`.

Validation: `cargo +nightly fmt --all -- --check`, `cargo +nightly test -p tempo-hardfork`, and `cargo +nightly test -p tempo-chainspec spec::tests::tempo_hardfork_at`.
