### PR TITLE
docs(tip-1091): remove zone creation gas floor

### DIFF
--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -62,7 +62,6 @@ interface IZoneFactory {
     error NotOwner();
     error InvalidAdmin();
     error InvalidSequencer();
-    error InsufficientGas();
 
     function owner() external view returns (address);
 

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -15,10 +15,6 @@ abstract contract ZoneFactory is IZoneFactory {
                                 CONSTANTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Minimum gas required for zone creation.
-    /// @dev Prevents low-cost zone spam. The caller must supply at least this much gas.
-    uint256 public constant ZONE_CREATION_GAS = 15_000_000;
-
     /// @notice 12-byte prefix reserved for zone portal vanity addresses.
     bytes12 public constant ZONE_PORTAL_PREFIX = 0x5AD000000000000000000000;
 
@@ -66,7 +62,6 @@ abstract contract ZoneFactory is IZoneFactory {
         }
         if (params.admin == address(0)) revert InvalidAdmin();
         if (params.sequencer == address(0)) revert InvalidSequencer();
-        if (gasleft() < ZONE_CREATION_GAS) revert InsufficientGas();
 
         zoneId = nextZoneId;
         nextZoneId = zoneId + 1;


### PR DESCRIPTION
Removes the fixed 15M gas precondition and `InsufficientGas` error from the TIP-1091 reference artifact.

Zone creation operations are already gas-metered and naturally run out of gas atomically; requiring unused gas headroom neither charges that gas nor prevents spam.
