### PR TITLE
docs(tip-1091): load runtimes from verified deployments

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -42,9 +42,9 @@ The canonical portal logic is
 [`ZonePortal.sol`](https://github.com/tempoxyz/zones/blob/main/specs/ref-impls/src/tempo/ZonePortal.sol)
 in the Zones repository. It and its supporting interfaces and libraries are not
 duplicated here to avoid the two repositories drifting out of sync. T9 MUST use
-the `deployedBytecode.object` from the `ZonePortal` Foundry artifact generated
-from the canonical Zones revision selected for activation, and the activation
-configuration MUST record that revision and the runtime bytecode hash.
+the runtime bytecode from a verified deployment of the canonical Zones revision
+selected for activation. The activation configuration MUST record that revision,
+the source deployment address, and the runtime bytecode hash.
 
 T9 MUST define the canonical zone genesis used by the native factory.
 
@@ -89,6 +89,14 @@ protocol-managed addresses:
 address constant ZONE_PORTAL_IMPL_ADDRESS = 0x5AD1000000000000000000000000000000000000;
 address constant ZONE_VERIFIER_ADDRESS = 0x5a56000000000000000000000000000000000000;
 address constant ZONE_MESSENGER_ADDRESS = 0x5A4d000000000000000000000000000000000000;
+```
+
+The verified source deployment addresses remain to be assigned:
+
+```text
+ZONE_PORTAL_IMPL_SOURCE_ADDRESS = TBD
+ZONE_VERIFIER_SOURCE_ADDRESS = TBD
+ZONE_MESSENGER_SOURCE_ADDRESS = TBD
 ```
 
 Each portal account is etched with the standard
@@ -157,10 +165,13 @@ private zone fallback recipient; a withdrawal bounce-back carries the nonce back
 to the zone, where the inbox resolves and consumes the mapping. This keeps the
 recipient out of L1-visible data while preserving deterministic execution.
 
-T9 MUST etch the `ZonePortal` implementation, `Verifier`, and shared
-`ZoneMessenger` runtime bytecode at `ZONE_PORTAL_IMPL_ADDRESS`,
-`ZONE_VERIFIER_ADDRESS`, and `ZONE_MESSENGER_ADDRESS`, respectively, when this
-TIP activates. The `ZonePortal` implementation and shared messenger MUST use
+At activation, T9 MUST copy the `ZonePortal` implementation, `Verifier`, and
+shared `ZoneMessenger` runtime bytecode from their verified source deployments
+to `ZONE_PORTAL_IMPL_ADDRESS`, `ZONE_VERIFIER_ADDRESS`, and
+`ZONE_MESSENGER_ADDRESS`, respectively. This copy MUST be equivalent to
+`EXTCODECOPY`; validators MUST NOT embed the full runtime bytecode in their
+binaries. Each copied runtime MUST match the hash recorded in the activation
+configuration. The `ZonePortal` implementation and shared messenger MUST use
 `ZONE_FACTORY_ADDRESS` as their factory authority.
 
 A later hardfork MAY replace the runtime at `ZONE_PORTAL_IMPL_ADDRESS`, but the


### PR DESCRIPTION
Follow-up to https://github.com/tempoxyz/tempo/pull/6874#discussion_r3605272765.

Requires T9 to copy pinned runtimes from verified source deployments instead of embedding bytecode in validator binaries. Records the source deployment addresses as `TBD` until they are assigned.
