### PR TITLE
docs(tip-1091): require minimum zone creation gas

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -67,6 +67,8 @@ This gate is temporary: the hardfork that enables open zone creation MUST remove
 the caller restriction, after which any account may call `createZone` subject to
 its normal validation rules.
 
+A successful createZone call MUST consume at least 15,000,000 gas.
+
 Each zone portal is installed at:
 
 ```text


### PR DESCRIPTION
Requires every successful `createZone` call to consume at least 15,000,000 gas.

This gives permissionless zone creation an explicit minimum gas cost while preserving normal metering above that floor.
