### PR TITLE
docs(tip-1094): zone virtual deposit addresses

### DIFF
--- a/tips/tip-1106.md
+++ b/tips/tip-1106.md
@@ -1,0 +1,225 @@
+---
+id: TIP-1106
+title: Zone Virtual Deposit Addresses
+description: Zone-specific virtual deposit addresses that conceal the L1 virtual-address master while preserving deposit attribution.
+authors: Dan Robinson
+status: Draft
+related: TIP-1022, TIP-403
+protocolVersion: TBD
+---
+
+# TIP-1106: Zone Virtual Deposit Addresses
+
+## Abstract
+
+This TIP defines **zone virtual deposit addresses**, a reserved 20-byte address format for depositing TIP-20 tokens into a Tempo zone. A deposit address identifies the zone publicly but encrypts a TIP-1022 `masterId` and a 16-bit `userTag` under a zone-specific key. The zone deposit processor decrypts the address, resolves the `masterId` through the immutable TIP-1022 registry on L1, and credits the corresponding 20-byte `masterAddress` inside the zone.
+
+Only the zone sequencer can recover the recipient metadata. L1 observers can identify the destination zone and correlate repeated use of the same deposit address, but cannot determine the recipient without the zone key or auxiliary information.
+
+## Motivation
+
+TIP-1022 virtual addresses expose the recipient's 32-bit `masterId`. Reusing that format for zone deposits would link a user's zone activity to its L1 master and would require a separate identity scheme if the master identifier were replaced with a zone-local identifier.
+
+Zone virtual deposit addresses preserve the existing TIP-1022 registration as the source of truth while hiding the `masterId` from parties outside the zone. Each registered master can request up to 65,536 distinct tags per zone without an additional L1 registration.
+
+This format uses a magic value distinct from TIP-1022's `VIRTUAL_MAGIC`. A zone virtual deposit address is valid only at the zone-deposit boundary; it is not an ordinary TIP-1022 virtual address and MUST NOT receive special treatment in normal TIP-20 transfers.
+
+## Assumptions
+
+1. Each zone has a unique, stable 32-bit `zoneId` used by the deposit-routing layer.
+2. Each participating zone has exactly one active 256-bit address-encryption key. The key is available to every component that must derive or process deposits and is not available to L1 observers.
+3. Once the zone accepts its first zone virtual deposit address, the zone preserves the corresponding key for the lifetime of all outstanding addresses. Key rotation without an address-version or key-epoch field would make old addresses undecipherable and is therefore outside this TIP.
+4. The deposit processor can read or prove the canonical TIP-1022 registry state needed to resolve a decrypted `masterId`. The exact L1-to-zone state-proof mechanism is specified by the zone protocol, not by this TIP.
+5. A zone's confidentiality model already trusts its sequencer with transaction contents and recipient identities. This TIP does not attempt to hide activity from the sequencer.
+
+If assumptions 1, 2, or 4 fail, deposits MUST fail rather than be credited using guessed, stale, or alternate resolution data.
+
+## Threat Model
+
+- **L1 observer or depositor.** May inspect deposits and request addresses available to it. It must not be able to recover other plaintext `(masterId, userTag)` pairs from observed addresses, subject to the limits of the 48-bit domain described in Security Considerations.
+- **Malicious address submitter.** May submit arbitrary 20-byte values. Invalid formats, wrong-zone addresses, and ciphertexts that decrypt to unregistered masters must fail without crediting funds.
+- **Zone sequencer.** Is trusted for recipient confidentiality, correct key custody, correct decryption, and correct execution. A malicious sequencer can recover all recipients and can already violate the zone's execution or availability guarantees; that behavior is out of scope.
+- **Key thief.** Can decrypt every address for the affected zone, past and future. The construction provides no forward secrecy.
+- **TIP-1022 registrant.** Controls its own user-tag allocation. Duplicate tags deliberately produce duplicate addresses and are the registrant's responsibility.
+
+---
+
+# Specification
+
+## Address Format
+
+A zone virtual deposit address is a 20-byte value with this exact layout:
+
+```
+[ zoneId: 4 bytes ][ ZONE_VIRTUAL_MAGIC: 10 bytes ][ stealthId: 6 bytes ]
+```
+
+| Field | Byte range | Description |
+|---|---:|---|
+| `zoneId` | `[0:4]` | Unsigned 32-bit zone identifier, encoded big-endian. |
+| `ZONE_VIRTUAL_MAGIC` | `[4:14]` | `0xFCFCFCFCFCFCFCFCFCFC`. |
+| `stealthId` | `[14:20]` | Encryption of `masterId || userTag` under the destination zone's key. |
+
+The distinct magic value is consensus-critical. TIP-1022 uses `0xFDFDFDFDFDFDFDFDFDFD`; implementations MUST NOT treat the two formats as interchangeable.
+
+An address is syntactically a zone virtual deposit address if and only if bytes `[4:14]` equal `ZONE_VIRTUAL_MAGIC`. Syntactic validity does not imply that the zone exists, that the ciphertext was issued by a sequencer, or that its decrypted `masterId` is registered.
+
+## Plaintext Format
+
+The 6-byte plaintext is:
+
+```
+[ masterId: 4 bytes ][ userTag: 2 bytes ]
+```
+
+`masterId` is the exact 4-byte identifier defined by TIP-1022. `userTag` is an opaque 16-bit value chosen by the master or its address-allocation service. Both fields are byte strings; no integer conversion is performed when concatenating them.
+
+All `userTag` values from `0x0000` through `0xFFFF` are valid. A `(zoneId, masterId, userTag)` tuple deterministically produces one address. Address issuers MUST NOT reuse a `userTag` for two users of the same `masterId` and zone unless they intentionally want the deposits to be indistinguishable.
+
+## Pseudorandom Permutation
+
+The permutation MUST be FF1 with AES-256 as specified by [NIST SP 800-38G](https://csrc.nist.gov/pubs/sp/800/38/g/upd1/final), with these fixed parameters:
+
+| Parameter | Value |
+|---|---|
+| Block cipher | AES-256 |
+| Key `K` | The destination zone's 32-byte address-encryption key |
+| Radix | 2 |
+| Numeral-string length | 48 binary digits |
+| Tweak | `0x54454D504F2D5A5644412D7631 || zoneId` |
+
+The fixed tweak prefix is the 13-byte ASCII string `TEMPO-ZVDA-v1`; `zoneId` is appended as 4 big-endian bytes, producing a 17-byte tweak. It separates this use of the zone key from other protocols and binds the permutation to the encoded zone.
+
+For a six-byte string `x`, define `bits(x)` as the 48 binary digits obtained by expanding each byte from its most-significant bit to its least-significant bit, in byte order. Define `unbits` as the inverse operation. Encryption and decryption are:
+
+```
+plaintext = masterId || userTag
+stealthId = unbits(FF1-AES256-ENCRYPT(K, tweak, bits(plaintext)))
+
+plaintext = unbits(FF1-AES256-DECRYPT(K, tweak, bits(stealthId)))
+masterId  = plaintext[0:4]
+userTag   = plaintext[4:6]
+```
+
+Implementations MUST NOT substitute AES in a conventional mode, truncate a hash or MAC, or use randomized encryption. Those constructions would either not be invertible on the 48-bit domain or would not produce a stable 6-byte `stealthId`.
+
+### Conformance Vectors
+
+All values are hexadecimal. `plaintext` is `masterId || userTag`, and `address` is `zoneId || ZONE_VIRTUAL_MAGIC || stealthId`.
+
+| AES-256 key | `zoneId` | `plaintext` | `stealthId` | `address` |
+|---|---|---|---|---|
+| `0000000000000000000000000000000000000000000000000000000000000000` | `00000000` | `000000000000` | `e56104310de7` | `00000000fcfcfcfcfcfcfcfcfcfce56104310de7` |
+| `ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff` | `ffffffff` | `ffffffffffff` | `da8800b07afe` | `fffffffffcfcfcfcfcfcfcfcfcfcda8800b07afe` |
+| `000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f` | `01020304` | `deadbeef1234` | `90ab85ef21cb` | `01020304fcfcfcfcfcfcfcfcfcfc90ab85ef21cb` |
+
+Conforming decryption MUST recover each listed plaintext from its `stealthId` with the listed key and zone.
+
+## Address Derivation
+
+To derive an address, the zone address service MUST:
+
+1. Confirm that `masterId` is registered in the canonical TIP-1022 registry.
+2. Form `plaintext = masterId || userTag`.
+3. Compute `stealthId` using the permutation above and the key for `zoneId`.
+4. Return `zoneId || ZONE_VIRTUAL_MAGIC || stealthId`.
+
+Derivation is deterministic and does not modify L1 or zone state. An implementation MAY restrict address issuance or maintain an allocation database, but such policy is outside consensus.
+
+## Deposit Processing
+
+The zone deposit entrypoint MUST accept an explicit 20-byte destination and process a zone virtual deposit address atomically as follows:
+
+1. Require `destination[4:14] == ZONE_VIRTUAL_MAGIC`; otherwise continue under the deposit protocol's non-zone-virtual destination rules.
+2. Parse `encodedZoneId = uint32_be(destination[0:4])`.
+3. Require `encodedZoneId` to equal the zone selected by the deposit route. A mismatch MUST revert with `ZoneIdMismatch` before funds are committed.
+4. Decrypt `destination[14:20]` using the key and tweak for `encodedZoneId`.
+5. Parse the plaintext as `masterId = plaintext[0:4]` and `userTag = plaintext[4:6]`.
+6. Resolve `masterId` against the canonical, immutable TIP-1022 registry state recognized by the zone. If it is unregistered, revert with `VirtualAddressUnregistered`.
+7. Apply every recipient validation that an ordinary zone deposit applies to the resolved `masterAddress`, including applicable TIP-403 policy checks. Validation MUST NOT be applied only to the encoded deposit address.
+8. Credit the deposited assets inside the zone to the account whose address is exactly `masterAddress`. The address refers to the zone account with those 20 bytes; it does not request a transfer to `masterAddress` on L1.
+9. Record the original `destination`, `masterId`, and `userTag` in the private zone execution data needed for attribution. Public disclosure of the plaintext fields is not required by this TIP.
+
+Steps 3 through 9 MUST be atomic with the deposit. A failure MUST leave neither a zone credit nor a consumed deposit that cannot be retried or refunded according to the enclosing deposit protocol.
+
+## Scope and Namespace Separation
+
+Zone virtual deposit addresses are interpreted only by the zone deposit entrypoint before ordinary zone execution. They MUST NOT be resolved by normal TIP-20 `transfer`, `transferFrom`, mint, fee-payment, reward-recipient, or generic EVM value-transfer paths on L1 or inside a zone.
+
+In particular:
+
+- An ordinary TIP-20 transfer to an address containing `ZONE_VIRTUAL_MAGIC` credits or rejects the literal address according to the ordinary transfer rules; it MUST NOT decrypt or forward it.
+- An address containing TIP-1022 `VIRTUAL_MAGIC` follows TIP-1022 where that TIP applies and MUST NOT enter the zone virtual deposit path.
+- Wallets and SDKs MUST present zone virtual deposit addresses as deposit-route-specific identifiers, not general-purpose account addresses.
+
+## Key Management
+
+The zone operator MUST generate `K` uniformly at random, keep it confidential, and maintain enough durable, access-controlled backups to process every outstanding address. The same key MUST NOT be shared across zones. Implementations SHOULD isolate permutation operations in a key-management service or hardware security module and SHOULD prevent raw key export.
+
+Because this version has no key epoch, changing or destroying `K` invalidates every address for the zone. Emergency key rotation requires pausing zone virtual deposits and an explicit migration or a future versioned address format.
+
+## Errors
+
+The enclosing deposit interface MUST expose failures equivalent to:
+
+```solidity
+/// The zone encoded in the destination does not match the deposit route.
+error ZoneIdMismatch(uint32 encodedZoneId, uint32 routedZoneId);
+
+/// The decrypted TIP-1022 masterId is not registered in the registry state used by the zone.
+error VirtualAddressUnregistered(bytes4 masterId);
+```
+
+The enclosing protocol MAY encode these errors differently, but callers and operators MUST be able to distinguish them from generic execution failures.
+
+# Tooling
+
+Zone SDKs MUST provide:
+
+- `isZoneVirtualDepositAddress(address) -> bool`
+- `decodeZoneVirtualDepositAddress(address) -> (zoneId, stealthId)`; this is structural decoding only
+- an authenticated address-issuance operation that accepts `masterId` and `userTag` and returns the derived address
+- a deposit builder that rejects a route whose zone does not match the encoded `zoneId`
+- operator-only FF1 encrypt/decrypt test utilities and conformance vectors
+
+Explorers and wallets SHOULD label this format as a zone deposit address, display the encoded zone, warn against ordinary transfers to it, and avoid describing `stealthId` as an account identifier.
+
+# Observability
+
+The public L1 deposit event MUST retain the original 20-byte destination and the selected zone identifier so that routing failures and deposits can be correlated without revealing the plaintext. The enclosing zone protocol defines the event name and remaining fields.
+
+The zone operator MUST maintain private metrics for successful decryptions, `ZoneIdMismatch`, unregistered decrypted masters, registry-proof failures, recipient-policy failures, and key-service failures. Logs MUST NOT publish the zone key and SHOULD avoid publishing decrypted `(masterId, userTag)` values.
+
+# Invariants
+
+1. For every key, zone, and 6-byte plaintext `p`, decryption inverts encryption: `D(K, zoneId, E(K, zoneId, p)) = p`.
+2. For a fixed key and zone, distinct plaintexts produce distinct `stealthId` values.
+3. The encoded `zoneId` always equals the deposit route used for successful processing.
+4. A successful deposit credits exactly the TIP-1022 `masterAddress` resolved from the decrypted `masterId`, inside the selected zone.
+5. No ordinary TIP-20 or EVM transfer path performs zone-address decryption.
+6. TIP-1022 and zone virtual address magic values are distinct and are never dispatched to each other's resolver.
+7. A decryption, registry, policy, or execution failure produces no partial credit.
+
+The conformance suite MUST cover the first and last values of each plaintext field, random round trips, uniqueness over a large sample, incorrect keys, incorrect zone tweaks, malformed magic, cross-zone replay, unregistered masters, policy-denied masters, ordinary-transfer namespace separation, and the published deterministic vectors.
+
+# Security Considerations
+
+FF1 is a permutation, not authenticated encryption. Every 6-byte `stealthId` decrypts to some `(masterId, userTag)`; the format cannot prove that the sequencer issued an address. Randomly constructed addresses will normally resolve to an unregistered 32-bit `masterId`, but may resolve to a registered master. Depositors MUST use an address obtained through an authenticated channel from the intended recipient.
+
+The plaintext domain contains only 2^48 values. FF1 prevents direct recovery without the key, but the small domain limits the security obtainable from any format-preserving construction and permits equality testing because derivation is deterministic. Reusing an address reveals that two deposits use the same hidden tuple. Users SHOULD allocate a fresh `userTag` when unlinkability between deposits is required; the 16-bit tag space bounds this to 65,536 distinct addresses per master and zone.
+
+An address-issuance oracle reveals chosen plaintext/ciphertext pairs. Operators SHOULD authenticate and rate-limit issuance, both to protect allocation integrity and to reduce unnecessary exposure. The zone key is nevertheless the primary secret and must be protected independently of API controls.
+
+Registry freshness is security-critical. Resolving against an unproven or non-canonical registry view can misroute deposits. Because TIP-1022 registrations are immutable, a proven registry entry can be cached indefinitely; absence proofs must correspond to the registry state required by the enclosing deposit protocol.
+
+# Alternatives Considered
+
+- **Expose `masterId` as in TIP-1022.** Simpler, but publicly links zone deposits to the L1 master.
+- **Register a new master per zone.** Avoids encryption, but adds registration cost and fragments identity across zones.
+- **Use a truncated hash or MAC.** Hides the plaintext but is not reversible, requiring a sequencer-side lookup table for every address and introducing state, availability, and collision concerns.
+- **Use a conventional block-cipher mode and truncate it.** Truncation destroys invertibility. FF1 directly defines a permutation over the required 48-bit format.
+- **Reuse TIP-1022 `VIRTUAL_MAGIC`.** Creates ambiguous dispatch: ordinary TIP-1022 handling would interpret `zoneId` as `masterId`. A distinct magic value makes the namespaces unambiguous.
+
+# Success Criteria
+
+This TIP is successful when two independent implementations reproduce the published vectors, a zone can derive and process addresses without per-address state, L1 observers cannot recover recipient metadata without the zone key, existing TIP-1022 behavior is unchanged, and operators can identify every specified failure class without logging decrypted recipient data.


### PR DESCRIPTION
## Summary

- specify a distinct 20-byte namespace for zone virtual deposit addresses
- define FF1 with AES-256 over `masterId || userTag`, including byte order, domain separation, and conformance vectors
- define deposit resolution, registry lookup, trust assumptions, key management, tooling, observability, invariants, and security considerations

## Validation

- reproduced all conformance vectors with an independent Rust FF1 implementation
- verified the published remote blob exactly matches the reviewed local file
- `git diff --check`

Prompted by: @danrobinson