### PR TITLE
feat(bench): add stable public benchmark preset

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -64,7 +64,9 @@ jobs:
           INPUT_REF: ${{ inputs.ref || '' }}
         run: |
           scenarios=(
-            '{"preset":"default","state_key":"default","token_count":"1"}'
+            # Preserve the existing state key so the first public run compares
+            # against the last successfully benchmarked commit for this series.
+            '{"preset":"public","state_key":"default","token_count":"1"}'
             '{"preset":"tip20:recipient=existing,fee-token=any_tip20","state_key":"tip20-existing-any","token_count":"4"}'
           )
           bench_entries=()

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -4,7 +4,7 @@ const TXGEN_HELPER_SCRAPE_INTERVAL_MS = 200
 const TXGEN_HELPER_FUND_DRAIN_TIMEOUT_SECS = 120
 const TXGEN_HELPER_PRESETS_DIR = "contrib/bench/txgen/presets"
 const TXGEN_HELPER_TIP20_PIECES_DIR = "contrib/bench/txgen/presets/tip20"
-const TXGEN_HELPER_TIP20_SCENARIO_PRESETS = ["default" "tip20"]
+const TXGEN_HELPER_TIP20_SCENARIO_PRESETS = ["default" "public" "tip20"]
 const TXGEN_HELPER_ALWAYS_FUND_PRESETS = [
     "dex"
     "neobank-deposit"
@@ -33,7 +33,21 @@ def txgen-tip20-default-scenario [] {
     }
 }
 
+def txgen-tip20-public-scenario [] {
+    {
+        workload: "tip20"
+        recipient: "users"
+        auth: "direct"
+        nonce: "expiring"
+        fee_token: "pathusd"
+    }
+}
+
 def txgen-tip20-scenario-alias [name: string] {
+    if $name == "public" {
+        return (txgen-tip20-public-scenario)
+    }
+
     if $name in ["default" "tip20"] {
         return (txgen-tip20-default-scenario)
     }


### PR DESCRIPTION
[RETH-1025](https://linear.app/tempoxyz/issue/RETH-1025/fix-bench-tps-reporting-across-developer-portal-public-perf-site-and)

Adds an immutable `public` TIP-20 benchmark scenario and switches the scheduled public series to it while retaining the existing state key. This decouples public reporting from changes to the developer-facing `default` preset, including [#6854](https://github.com/tempoxyz/tempo/pull/6854).

Validation:
- `nu bench-e2e.nu render-txgen-spec --preset public`
- `nu --commands 'source contrib/bench/txgen/helpers.nu'`
- parsed `.github/workflows/bench-e2e-scheduled.yml` with Ruby YAML
- `git diff --check`