### PR TITLE
feat(tx-pool): generic evm config

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -4,7 +4,7 @@ use alloy_evm::{
     revm::{
         Context, ExecuteEvm, InspectEvm, Inspector, SystemCallEvm,
         context::{
-            DBErrorMarker,
+            ContextTr, DBErrorMarker, JournalTr,
             result::{EVMError, ResultAndState, ResultGas},
         },
         inspector::NoOpInspector,
@@ -71,6 +71,30 @@ impl EvmFactory for TempoEvmFactory {
 pub struct TempoEvm<DB: Database, I = NoOpInspector> {
     inner: tempo_revm::TempoEvm<DB, I>,
     inspect: bool,
+}
+
+/// An EVM that can run Tempo's transaction-pool validation lifecycle.
+///
+/// Implementations must run the full Tempo validation pipeline without executing the transaction
+/// and apply the pool-specific semantics:
+/// - skip `valid_after`, because the pool queues transactions until they become executable;
+/// - disable protocol nonce checking, because the pool queues future-nonce transactions;
+/// - skip the EVM liquidity check, because the pool checks liquidity against its cached AMM view;
+/// - restore `tx` and clear transaction-local state after both success and error;
+/// - discard journaled writes (nonce updates, fee deduction, and key authorization) while retaining
+///   warmed database reads for the rest of the batch.
+///
+/// Owning the complete lifecycle lets custom EVMs additionally clear adapter-specific state without
+/// exposing their internal contexts or databases to the transaction pool.
+pub trait TempoPoolValidationEvm: Evm<Tx = TempoTxEnv> {
+    /// Validates `tx` using transaction-pool semantics.
+    fn validate_pool_transaction(
+        &mut self,
+        tx: &mut TempoTxEnv,
+    ) -> Result<
+        ValidationContext,
+        EVMError<<<Self as Evm>::DB as alloy_evm::revm::Database>::Error, TempoInvalidTransaction>,
+    >;
 }
 
 impl<DB: Database> TempoEvm<DB> {
@@ -189,6 +213,32 @@ impl<DB: Database, I> TempoEvm<DB, I> {
     /// Replaces the recorded storage actions with the given ones, returning the previous actions.
     pub fn replace_actions(&mut self, actions: Vec<StorageAction>) -> Option<Vec<StorageAction>> {
         self.inner.actions().replace(actions)
+    }
+}
+
+impl<DB, I> TempoPoolValidationEvm for TempoEvm<DB, I>
+where
+    DB: Database,
+    I: Inspector<TempoContext<DB>>,
+{
+    fn validate_pool_transaction(
+        &mut self,
+        tx: &mut TempoTxEnv,
+    ) -> Result<ValidationContext, EVMError<DB::Error, TempoInvalidTransaction>> {
+        // The pool admits future-time and future-nonce transactions and performs its own cached
+        // AMM liquidity check after EVM validation.
+        self.inner.skip_valid_after_check = true;
+        self.inner.skip_liquidity_check = true;
+        self.ctx_mut().cfg.disable_nonce_check = true;
+
+        core::mem::swap(&mut self.ctx_mut().tx, tx);
+        let result = {
+            let mut handler = TempoEvmHandler::<DB, I>::new();
+            handler.validate_transaction(&mut self.inner)
+        };
+        core::mem::swap(&mut self.ctx_mut().tx, tx);
+        self.ctx_mut().journal_mut().discard_tx();
+        result
     }
 }
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -27,7 +27,7 @@ use tempo_revm::{
     evm::TempoContext, handler::TempoEvmHandler,
 };
 
-use crate::TempoBlockEnv;
+use crate::{TempoBlockEnv, TempoPoolValidationEvm};
 
 /// Factory for creating Tempo EVM instances.
 #[derive(Debug, Default, Clone, Copy)]
@@ -71,30 +71,6 @@ impl EvmFactory for TempoEvmFactory {
 pub struct TempoEvm<DB: Database, I = NoOpInspector> {
     inner: tempo_revm::TempoEvm<DB, I>,
     inspect: bool,
-}
-
-/// An EVM that can run Tempo's transaction-pool validation lifecycle.
-///
-/// Implementations must run the full Tempo validation pipeline without executing the transaction
-/// and apply the pool-specific semantics:
-/// - skip `valid_after`, because the pool queues transactions until they become executable;
-/// - disable protocol nonce checking, because the pool queues future-nonce transactions;
-/// - skip the EVM liquidity check, because the pool checks liquidity against its cached AMM view;
-/// - restore `tx` and clear transaction-local state after both success and error;
-/// - discard journaled writes (nonce updates, fee deduction, and key authorization) while retaining
-///   warmed database reads for the rest of the batch.
-///
-/// Owning the complete lifecycle lets custom EVMs additionally clear adapter-specific state without
-/// exposing their internal contexts or databases to the transaction pool.
-pub trait TempoPoolValidationEvm: Evm<Tx = TempoTxEnv> {
-    /// Validates `tx` using transaction-pool semantics.
-    fn validate_pool_transaction(
-        &mut self,
-        tx: &mut TempoTxEnv,
-    ) -> Result<
-        ValidationContext,
-        EVMError<<<Self as Evm>::DB as alloy_evm::revm::Database>::Error, TempoInvalidTransaction>,
-    >;
 }
 
 impl<DB: Database> TempoEvm<DB> {

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -27,7 +27,7 @@ use tempo_revm::{
     evm::TempoContext, handler::TempoEvmHandler,
 };
 
-use crate::{TempoBlockEnv, TempoPoolValidationEvm};
+use crate::{TempoBlockEnv, TempoPoolValidationEvm, TempoPoolValidationResult};
 
 /// Factory for creating Tempo EVM instances.
 #[derive(Debug, Default, Clone, Copy)]
@@ -197,19 +197,25 @@ where
     DB: Database,
     I: Inspector<TempoContext<DB>>,
 {
-    fn validate_pool_transaction(
-        &mut self,
-        tx: TempoTxEnv,
-    ) -> Result<ValidationContext, EVMError<DB::Error, TempoInvalidTransaction>> {
+    fn configure_for_pool(&mut self) {
         // The pool admits future-time and future-nonce transactions and performs its own cached
         // AMM liquidity check after EVM validation.
         self.inner.skip_valid_after_check = true;
         self.inner.skip_liquidity_check = true;
         self.ctx_mut().cfg.disable_nonce_check = true;
+    }
 
+    fn validate_pool_transaction(
+        &mut self,
+        tx: TempoTxEnv,
+    ) -> (TempoPoolValidationResult<DB::Error>, TempoTxEnv) {
         let result = self.validate_transaction(tx);
+        let tx = core::mem::take(&mut self.ctx_mut().tx);
+        // Discard this transaction's journaled writes (nonce bumps, fee deduction,
+        // key authorisation) while keeping loaded accounts and storage warm for the
+        // rest of the batch.
         self.ctx_mut().journal_mut().discard_tx();
-        result
+        (result, tx)
     }
 }
 

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -199,7 +199,7 @@ where
 {
     fn validate_pool_transaction(
         &mut self,
-        tx: &mut TempoTxEnv,
+        mut tx: TempoTxEnv,
     ) -> Result<ValidationContext, EVMError<DB::Error, TempoInvalidTransaction>> {
         // The pool admits future-time and future-nonce transactions and performs its own cached
         // AMM liquidity check after EVM validation.
@@ -207,12 +207,12 @@ where
         self.inner.skip_liquidity_check = true;
         self.ctx_mut().cfg.disable_nonce_check = true;
 
-        core::mem::swap(&mut self.ctx_mut().tx, tx);
+        core::mem::swap(&mut self.ctx_mut().tx, &mut tx);
         let result = {
             let mut handler = TempoEvmHandler::<DB, I>::new();
             handler.validate_transaction(&mut self.inner)
         };
-        core::mem::swap(&mut self.ctx_mut().tx, tx);
+        core::mem::swap(&mut self.ctx_mut().tx, &mut tx);
         self.ctx_mut().journal_mut().discard_tx();
         result
     }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -199,7 +199,7 @@ where
 {
     fn validate_pool_transaction(
         &mut self,
-        mut tx: TempoTxEnv,
+        tx: TempoTxEnv,
     ) -> Result<ValidationContext, EVMError<DB::Error, TempoInvalidTransaction>> {
         // The pool admits future-time and future-nonce transactions and performs its own cached
         // AMM liquidity check after EVM validation.
@@ -207,12 +207,7 @@ where
         self.inner.skip_liquidity_check = true;
         self.ctx_mut().cfg.disable_nonce_check = true;
 
-        core::mem::swap(&mut self.ctx_mut().tx, &mut tx);
-        let result = {
-            let mut handler = TempoEvmHandler::<DB, I>::new();
-            handler.validate_transaction(&mut self.inner)
-        };
-        core::mem::swap(&mut self.ctx_mut().tx, &mut tx);
+        let result = self.validate_transaction(tx);
         self.ctx_mut().journal_mut().discard_tx();
         result
     }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -31,7 +31,7 @@ use core::num::NonZeroU64;
 use std::{borrow::Cow, sync::Arc};
 
 use alloy_evm::{
-    self, Database, EvmEnv as EthEvmEnv,
+    self, EvmEnv as EthEvmEnv,
     block::BlockExecutorFactory,
     eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
     revm::Inspector,
@@ -97,16 +97,6 @@ impl TempoEvmConfig {
     /// Returns the mainnet EVM config.
     pub fn mainnet() -> Self {
         Self::new(Arc::new(TempoChainSpec::mainnet()))
-    }
-}
-
-impl ConfigureTempoPoolEvm for TempoEvmConfig {
-    fn pool_evm_env(&self, header: &TempoHeader) -> Result<EvmEnv, Self::Error> {
-        ConfigureEvm::evm_env(self, header)
-    }
-
-    fn pool_evm<DB: Database>(&self, db: DB, env: EvmEnv) -> impl TempoPoolValidationEvm<DB = DB> {
-        self.evm_with_env(db, env)
     }
 }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -13,7 +13,7 @@ pub use action_replay::{
 use alloy_consensus::{BlockHeader as _, Transaction};
 use alloy_rlp::Decodable;
 pub use assemble::TempoBlockAssembler;
-pub use pool::TempoPoolValidationEvm;
+pub use pool::{TempoPoolValidationEvm, TempoPoolValidationResult};
 mod block;
 pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 mod context;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -13,8 +13,7 @@ pub use action_replay::{
 use alloy_consensus::{BlockHeader as _, Transaction};
 use alloy_rlp::Decodable;
 pub use assemble::TempoBlockAssembler;
-use pool::EvmEnv;
-pub use pool::{TempoPoolValidationEvm};
+pub use pool::TempoPoolValidationEvm;
 mod block;
 pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 mod context;
@@ -31,7 +30,7 @@ use core::num::NonZeroU64;
 use std::{borrow::Cow, sync::Arc};
 
 use alloy_evm::{
-    self, EvmEnv as EthEvmEnv,
+    self, EvmEnv,
     block::BlockExecutorFactory,
     eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
     revm::Inspector,
@@ -141,7 +140,7 @@ impl ConfigureEvm for TempoEvmConfig {
     }
 
     fn evm_env(&self, header: &TempoHeader) -> Result<EvmEnvFor<Self>, Self::Error> {
-        let EthEvmEnv { cfg_env, block_env } = EthEvmEnv::for_eth_block(
+        let EvmEnv { cfg_env, block_env } = EvmEnv::for_eth_block(
             header,
             self.chain_spec(),
             self.chain_spec().chain().id(),
@@ -189,7 +188,7 @@ impl ConfigureEvm for TempoEvmConfig {
         parent: &TempoHeader,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnvFor<Self>, Self::Error> {
-        let EthEvmEnv { cfg_env, block_env } = EthEvmEnv::for_eth_next_block(
+        let EvmEnv { cfg_env, block_env } = EvmEnv::for_eth_next_block(
             parent,
             NextEvmEnvAttributes {
                 timestamp: attributes.timestamp,

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -5,6 +5,7 @@
 
 mod action_replay;
 mod assemble;
+mod pool;
 pub use action_replay::{
     ExpiringNonceReplay, StorageActionReplay, StorageActionReplayError, StorageActionReplayOutcome,
     StorageActionReplayState,
@@ -12,6 +13,8 @@ pub use action_replay::{
 use alloy_consensus::{BlockHeader as _, Transaction};
 use alloy_rlp::Decodable;
 pub use assemble::TempoBlockAssembler;
+use pool::EvmEnv;
+pub use pool::{ConfigureTempoPoolEvm, TempoPoolValidationEvm};
 mod block;
 pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 mod context;
@@ -33,7 +36,7 @@ use alloy_evm::{
     eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
     revm::Inspector,
 };
-pub use evm::{TempoEvmFactory, TempoPoolValidationEvm};
+pub use evm::TempoEvmFactory;
 use reth_chainspec::EthChainSpec;
 use reth_evm::{self, ConfigureEvm, EvmEnvFor, block::StateDB};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
@@ -46,8 +49,6 @@ use crate::evm::TempoEvm;
 use reth_evm_ethereum::EthEvmConfig;
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params_with_amsterdam};
-
-type EvmEnv = alloy_evm::EvmEnv<tempo_chainspec::hardfork::TempoHardfork, TempoBlockEnv>;
 
 pub use tempo_revm::{
     ProtocolFeeContext, ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoHaltReason,
@@ -65,18 +66,6 @@ pub struct TempoEvmConfig {
 
     /// Block assembler
     pub block_assembler: TempoBlockAssembler,
-}
-
-/// Configuration capable of constructing an EVM with Tempo transaction-pool semantics.
-///
-/// This pins pool validation to Tempo's EVM environment while allowing the configured EVM
-/// implementation to adapt its database and precompiles.
-pub trait ConfigureTempoPoolEvm: ConfigureEvm<Primitives = TempoPrimitives> + 'static {
-    /// Builds the Tempo environment used by pool validation for `header`.
-    fn pool_evm_env(&self, header: &TempoHeader) -> Result<EvmEnv, Self::Error>;
-
-    /// Creates the configured EVM with the pool-validation capability.
-    fn pool_evm<DB: Database>(&self, db: DB, env: EvmEnv) -> impl TempoPoolValidationEvm<DB = DB>;
 }
 
 impl TempoEvmConfig {

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -14,7 +14,7 @@ use alloy_consensus::{BlockHeader as _, Transaction};
 use alloy_rlp::Decodable;
 pub use assemble::TempoBlockAssembler;
 use pool::EvmEnv;
-pub use pool::{ConfigureTempoPoolEvm, TempoPoolValidationEvm};
+pub use pool::{TempoPoolValidationEvm};
 mod block;
 pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 mod context;

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -28,12 +28,12 @@ use core::num::NonZeroU64;
 use std::{borrow::Cow, sync::Arc};
 
 use alloy_evm::{
-    self, EvmEnv,
+    self, Database, EvmEnv as EthEvmEnv,
     block::BlockExecutorFactory,
     eth::{EthBlockExecutionCtx, NextEvmEnvAttributes},
     revm::Inspector,
 };
-pub use evm::TempoEvmFactory;
+pub use evm::{TempoEvmFactory, TempoPoolValidationEvm};
 use reth_chainspec::EthChainSpec;
 use reth_evm::{self, ConfigureEvm, EvmEnvFor, block::StateDB};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
@@ -46,6 +46,8 @@ use crate::evm::TempoEvm;
 use reth_evm_ethereum::EthEvmConfig;
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_revm::{evm::TempoContext, gas_params::tempo_gas_params_with_amsterdam};
+
+type EvmEnv = alloy_evm::EvmEnv<tempo_chainspec::hardfork::TempoHardfork, TempoBlockEnv>;
 
 pub use tempo_revm::{
     ProtocolFeeContext, ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoHaltReason,
@@ -63,6 +65,18 @@ pub struct TempoEvmConfig {
 
     /// Block assembler
     pub block_assembler: TempoBlockAssembler,
+}
+
+/// Configuration capable of constructing an EVM with Tempo transaction-pool semantics.
+///
+/// This pins pool validation to Tempo's EVM environment while allowing the configured EVM
+/// implementation to adapt its database and precompiles.
+pub trait ConfigureTempoPoolEvm: ConfigureEvm<Primitives = TempoPrimitives> + 'static {
+    /// Builds the Tempo environment used by pool validation for `header`.
+    fn pool_evm_env(&self, header: &TempoHeader) -> Result<EvmEnv, Self::Error>;
+
+    /// Creates the configured EVM with the pool-validation capability.
+    fn pool_evm<DB: Database>(&self, db: DB, env: EvmEnv) -> impl TempoPoolValidationEvm<DB = DB>;
 }
 
 impl TempoEvmConfig {
@@ -94,6 +108,16 @@ impl TempoEvmConfig {
     /// Returns the mainnet EVM config.
     pub fn mainnet() -> Self {
         Self::new(Arc::new(TempoChainSpec::mainnet()))
+    }
+}
+
+impl ConfigureTempoPoolEvm for TempoEvmConfig {
+    fn pool_evm_env(&self, header: &TempoHeader) -> Result<EvmEnv, Self::Error> {
+        ConfigureEvm::evm_env(self, header)
+    }
+
+    fn pool_evm<DB: Database>(&self, db: DB, env: EvmEnv) -> impl TempoPoolValidationEvm<DB = DB> {
+        self.evm_with_env(db, env)
     }
 }
 
@@ -138,7 +162,7 @@ impl ConfigureEvm for TempoEvmConfig {
     }
 
     fn evm_env(&self, header: &TempoHeader) -> Result<EvmEnvFor<Self>, Self::Error> {
-        let EvmEnv { cfg_env, block_env } = EvmEnv::for_eth_block(
+        let EthEvmEnv { cfg_env, block_env } = EthEvmEnv::for_eth_block(
             header,
             self.chain_spec(),
             self.chain_spec().chain().id(),
@@ -186,7 +210,7 @@ impl ConfigureEvm for TempoEvmConfig {
         parent: &TempoHeader,
         attributes: &Self::NextBlockEnvCtx,
     ) -> Result<EvmEnvFor<Self>, Self::Error> {
-        let EvmEnv { cfg_env, block_env } = EvmEnv::for_eth_next_block(
+        let EthEvmEnv { cfg_env, block_env } = EthEvmEnv::for_eth_next_block(
             parent,
             NextEvmEnvAttributes {
                 timestamp: attributes.timestamp,

--- a/crates/evm/src/pool.rs
+++ b/crates/evm/src/pool.rs
@@ -1,8 +1,6 @@
 use crate::{TempoBlockEnv, TempoInvalidTransaction};
-use alloy_evm::{Database, Evm, revm::context::result::EVMError};
-use reth_evm::ConfigureEvm;
+use alloy_evm::{Evm, revm::context::result::EVMError};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::{TempoHeader, TempoPrimitives};
 use tempo_revm::{TempoTxEnv, ValidationContext};
 
 pub(crate) type EvmEnv = alloy_evm::EvmEnv<TempoHardfork, TempoBlockEnv>;
@@ -29,16 +27,4 @@ pub trait TempoPoolValidationEvm: Evm<Tx = TempoTxEnv> {
         ValidationContext,
         EVMError<<<Self as Evm>::DB as alloy_evm::revm::Database>::Error, TempoInvalidTransaction>,
     >;
-}
-
-/// Configuration capable of constructing an EVM with Tempo transaction-pool semantics.
-///
-/// This pins pool validation to Tempo's EVM environment while allowing the configured EVM
-/// implementation to adapt its database and precompiles.
-pub trait ConfigureTempoPoolEvm: ConfigureEvm<Primitives = TempoPrimitives> + 'static {
-    /// Builds the Tempo environment used by pool validation for `header`.
-    fn pool_evm_env(&self, header: &TempoHeader) -> Result<EvmEnv, Self::Error>;
-
-    /// Creates the configured EVM with the pool-validation capability.
-    fn pool_evm<DB: Database>(&self, db: DB, env: EvmEnv) -> impl TempoPoolValidationEvm<DB = DB>;
 }

--- a/crates/evm/src/pool.rs
+++ b/crates/evm/src/pool.rs
@@ -1,6 +1,13 @@
 use crate::TempoInvalidTransaction;
-use alloy_evm::{Evm, revm::context::result::EVMError};
+use alloy_evm::{
+    Evm,
+    revm::{Database, context::result::EVMError},
+};
 use tempo_revm::{TempoTxEnv, ValidationContext};
+
+/// Result of validating a transaction with Tempo transaction-pool semantics.
+pub type TempoPoolValidationResult<DBError> =
+    Result<ValidationContext, EVMError<DBError, TempoInvalidTransaction>>;
 
 /// An EVM that can run Tempo's transaction-pool validation lifecycle.
 ///
@@ -9,19 +16,22 @@ use tempo_revm::{TempoTxEnv, ValidationContext};
 /// - skip `valid_after`, because the pool queues transactions until they become executable;
 /// - disable protocol nonce checking, because the pool queues future-nonce transactions;
 /// - skip the EVM liquidity check, because the pool checks liquidity against its cached AMM view;
-/// - restore `tx` and clear transaction-local state after both success and error;
+/// - return `tx` and clear transaction-local state after both success and error;
 /// - discard journaled writes (nonce updates, fee deduction, and key authorization) while retaining
 ///   warmed database reads for the rest of the batch.
 ///
 /// Owning the complete lifecycle lets custom EVMs additionally clear adapter-specific state without
 /// exposing their internal contexts or databases to the transaction pool.
 pub trait TempoPoolValidationEvm: Evm<Tx = TempoTxEnv> {
-    /// Validates `tx` using transaction-pool semantics.
+    /// Configures this EVM for transaction-pool validation.
+    fn configure_for_pool(&mut self);
+
+    /// Validates `tx` using transaction-pool semantics and returns the transaction environment.
     fn validate_pool_transaction(
         &mut self,
         tx: TempoTxEnv,
-    ) -> Result<
-        ValidationContext,
-        EVMError<<<Self as Evm>::DB as alloy_evm::revm::Database>::Error, TempoInvalidTransaction>,
-    >;
+    ) -> (
+        TempoPoolValidationResult<<<Self as Evm>::DB as Database>::Error>,
+        TempoTxEnv,
+    );
 }

--- a/crates/evm/src/pool.rs
+++ b/crates/evm/src/pool.rs
@@ -1,0 +1,44 @@
+use crate::{TempoBlockEnv, TempoInvalidTransaction};
+use alloy_evm::{Database, Evm, revm::context::result::EVMError};
+use reth_evm::ConfigureEvm;
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::{TempoHeader, TempoPrimitives};
+use tempo_revm::{TempoTxEnv, ValidationContext};
+
+pub(crate) type EvmEnv = alloy_evm::EvmEnv<TempoHardfork, TempoBlockEnv>;
+
+/// An EVM that can run Tempo's transaction-pool validation lifecycle.
+///
+/// Implementations must run the full Tempo validation pipeline without executing the transaction
+/// and apply the pool-specific semantics:
+/// - skip `valid_after`, because the pool queues transactions until they become executable;
+/// - disable protocol nonce checking, because the pool queues future-nonce transactions;
+/// - skip the EVM liquidity check, because the pool checks liquidity against its cached AMM view;
+/// - restore `tx` and clear transaction-local state after both success and error;
+/// - discard journaled writes (nonce updates, fee deduction, and key authorization) while retaining
+///   warmed database reads for the rest of the batch.
+///
+/// Owning the complete lifecycle lets custom EVMs additionally clear adapter-specific state without
+/// exposing their internal contexts or databases to the transaction pool.
+pub trait TempoPoolValidationEvm: Evm<Tx = TempoTxEnv> {
+    /// Validates `tx` using transaction-pool semantics.
+    fn validate_pool_transaction(
+        &mut self,
+        tx: &mut TempoTxEnv,
+    ) -> Result<
+        ValidationContext,
+        EVMError<<<Self as Evm>::DB as alloy_evm::revm::Database>::Error, TempoInvalidTransaction>,
+    >;
+}
+
+/// Configuration capable of constructing an EVM with Tempo transaction-pool semantics.
+///
+/// This pins pool validation to Tempo's EVM environment while allowing the configured EVM
+/// implementation to adapt its database and precompiles.
+pub trait ConfigureTempoPoolEvm: ConfigureEvm<Primitives = TempoPrimitives> + 'static {
+    /// Builds the Tempo environment used by pool validation for `header`.
+    fn pool_evm_env(&self, header: &TempoHeader) -> Result<EvmEnv, Self::Error>;
+
+    /// Creates the configured EVM with the pool-validation capability.
+    fn pool_evm<DB: Database>(&self, db: DB, env: EvmEnv) -> impl TempoPoolValidationEvm<DB = DB>;
+}

--- a/crates/evm/src/pool.rs
+++ b/crates/evm/src/pool.rs
@@ -24,7 +24,7 @@ pub trait TempoPoolValidationEvm: Evm<Tx = TempoTxEnv> {
     /// Validates `tx` using transaction-pool semantics.
     fn validate_pool_transaction(
         &mut self,
-        tx: &mut TempoTxEnv,
+        tx: TempoTxEnv,
     ) -> Result<
         ValidationContext,
         EVMError<<<Self as Evm>::DB as alloy_evm::revm::Database>::Error, TempoInvalidTransaction>,

--- a/crates/evm/src/pool.rs
+++ b/crates/evm/src/pool.rs
@@ -1,9 +1,6 @@
-use crate::{TempoBlockEnv, TempoInvalidTransaction};
+use crate::TempoInvalidTransaction;
 use alloy_evm::{Evm, revm::context::result::EVMError};
-use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_revm::{TempoTxEnv, ValidationContext};
-
-pub(crate) type EvmEnv = alloy_evm::EvmEnv<TempoHardfork, TempoBlockEnv>;
 
 /// An EVM that can run Tempo's transaction-pool validation lifecycle.
 ///

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -5,6 +5,7 @@ use crate::{
     metrics::TempoPoolMaintenanceMetrics,
     paused::{PausedEntry, PausedFeeTokenPool},
     transaction::TempoPooledTransaction,
+    validator::ConfigureTempoPoolEvm,
 };
 use alloy_primitives::{
     Address, B256, Log, TxHash,
@@ -24,7 +25,6 @@ use std::{
 };
 use tempo_chainspec::hardfork::TempoHardforks;
 use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
-use tempo_evm::ConfigureTempoPoolEvm;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
 };

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -24,6 +24,7 @@ use std::{
 };
 use tempo_chainspec::hardfork::TempoHardforks;
 use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
+use tempo_evm::ConfigureTempoPoolEvm;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
 };
@@ -580,8 +581,9 @@ impl Default for PendingStalenessTracker {
 ///
 /// Consolidates these operations into a single event loop to avoid multiple tasks
 /// competing for canonical state updates and to minimize contention on pool locks.
-pub async fn maintain_tempo_pool<Client>(pool: TempoTransactionPool<Client>)
+pub async fn maintain_tempo_pool<Client, EvmConfig>(pool: TempoTransactionPool<Client, EvmConfig>)
 where
+    EvmConfig: ConfigureTempoPoolEvm,
     Client: StateProviderFactory
         + HeaderProvider<Header = TempoHeader>
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>

--- a/crates/transaction-pool/src/state_cache.rs
+++ b/crates/transaction-pool/src/state_cache.rs
@@ -44,7 +44,8 @@ impl StateCache {
 /// A [`DatabaseRef`] adapter that serves reads from a shared [`StateCache`], falling back
 /// to the wrapped database and populating the cache on miss.
 #[derive(Debug)]
-pub(crate) struct StateCacheDb<'a, DB> {
+#[expect(unnameable_types)]
+pub struct StateCacheDb<'a, DB> {
     /// The shared read cache.
     cache: &'a StateCache,
     /// The underlying database.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -30,6 +30,7 @@ use reth_transaction_pool::{
 use revm::database::BundleAccount;
 use std::{sync::Arc, time::Instant};
 use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
+use tempo_evm::{ConfigureTempoPoolEvm, TempoEvmConfig};
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     account_keychain::AccountKeychain,
@@ -42,10 +43,10 @@ use tempo_primitives::{Block, TempoHeader};
 use tempo_revm::TempoStateAccess;
 
 /// Tempo transaction pool that routes based on nonce_key
-pub struct TempoTransactionPool<Client> {
+pub struct TempoTransactionPool<Client, EvmConfig = TempoEvmConfig> {
     /// Vanilla pool for all standard transactions and AA transactions with regular nonce.
     protocol_pool: Pool<
-        TransactionValidationTaskExecutor<TempoTransactionValidator<Client>>,
+        TransactionValidationTaskExecutor<TempoTransactionValidator<Client, EvmConfig>>,
         TempoTipOrdering<TempoPooledTransaction>,
         InMemoryBlobStore,
     >,
@@ -53,15 +54,16 @@ pub struct TempoTransactionPool<Client> {
     aa_2d_pool: Arc<RwLock<AA2dPool>>,
 }
 
-impl<Client> TempoTransactionPool<Client>
+impl<Client, EvmConfig> TempoTransactionPool<Client, EvmConfig>
 where
     Client: StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + 'static,
+    EvmConfig: ConfigureTempoPoolEvm,
 {
     pub fn new(
         protocol_pool: Pool<
-            TransactionValidationTaskExecutor<TempoTransactionValidator<Client>>,
+            TransactionValidationTaskExecutor<TempoTransactionValidator<Client, EvmConfig>>,
             TempoTipOrdering<TempoPooledTransaction>,
             InMemoryBlobStore,
         >,
@@ -74,11 +76,12 @@ where
         }
     }
 }
-impl<Client> TempoTransactionPool<Client>
+impl<Client, EvmConfig> TempoTransactionPool<Client, EvmConfig>
 where
     Client: StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + 'static,
+    EvmConfig: ConfigureTempoPoolEvm,
 {
     /// Obtains a clone of the shared [`AmmLiquidityCache`].
     pub fn amm_liquidity_cache(&self) -> AmmLiquidityCache {
@@ -598,7 +601,7 @@ where
 }
 
 // Manual Clone implementation
-impl<Client> Clone for TempoTransactionPool<Client> {
+impl<Client, EvmConfig> Clone for TempoTransactionPool<Client, EvmConfig> {
     fn clone(&self) -> Self {
         Self {
             protocol_pool: self.protocol_pool.clone(),
@@ -608,7 +611,7 @@ impl<Client> Clone for TempoTransactionPool<Client> {
 }
 
 // Manual Debug implementation
-impl<Client> std::fmt::Debug for TempoTransactionPool<Client> {
+impl<Client, EvmConfig> std::fmt::Debug for TempoTransactionPool<Client, EvmConfig> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TempoTransactionPool")
             .field("protocol_pool", &"Pool<...>")
@@ -619,8 +622,9 @@ impl<Client> std::fmt::Debug for TempoTransactionPool<Client> {
 }
 
 // Implement the TransactionPool trait
-impl<Client> TransactionPool for TempoTransactionPool<Client>
+impl<Client, EvmConfig> TransactionPool for TempoTransactionPool<Client, EvmConfig>
 where
+    EvmConfig: ConfigureTempoPoolEvm,
     Client: StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + Send
@@ -1227,8 +1231,9 @@ where
     }
 }
 
-impl<Client> TransactionPoolExt for TempoTransactionPool<Client>
+impl<Client, EvmConfig> TransactionPoolExt for TempoTransactionPool<Client, EvmConfig>
 where
+    EvmConfig: ConfigureTempoPoolEvm,
     Client: StateProviderFactory
         + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + 'static,

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -3,9 +3,12 @@
 // Routes user nonces (nonce_key>0) to minimal 2D nonce pool
 
 use crate::{
-    amm::AmmLiquidityCache, best::MergeBestTransactions, ordering::TempoTipOrdering,
-    transaction::TempoPooledTransaction, tt_2d_pool::AA2dPool,
-    validator::TempoTransactionValidator,
+    amm::AmmLiquidityCache,
+    best::MergeBestTransactions,
+    ordering::TempoTipOrdering,
+    transaction::TempoPooledTransaction,
+    tt_2d_pool::AA2dPool,
+    validator::{ConfigureTempoPoolEvm, TempoTransactionValidator},
 };
 use alloy_consensus::Transaction;
 use alloy_primitives::{
@@ -30,7 +33,7 @@ use reth_transaction_pool::{
 use revm::database::BundleAccount;
 use std::{sync::Arc, time::Instant};
 use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
-use tempo_evm::{ConfigureTempoPoolEvm, TempoEvmConfig};
+use tempo_evm::TempoEvmConfig;
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     account_keychain::AccountKeychain,

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -9,7 +9,6 @@ use alloy_evm::{Database, EvmEnv};
 use alloy_primitives::{Address, B256};
 use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
-use reth_evm::ConfigureEvm;
 use reth_primitives_traits::{
     Account, Bytecode, SealedBlock, transaction::error::InvalidTransactionError,
 };
@@ -25,17 +24,14 @@ use reth_transaction_pool::{
 };
 use revm::{
     DatabaseRef,
-    context::{
-        ContextTr, JournalTr,
-        result::{EVMError, InvalidTransaction},
-    },
+    context::result::{EVMError, InvalidTransaction},
 };
 use std::sync::{
     Arc,
     atomic::{AtomicU8, Ordering},
 };
 use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
-use tempo_evm::{TempoEvmConfig, evm::TempoEvm};
+use tempo_evm::{ConfigureTempoPoolEvm, TempoEvmConfig, TempoPoolValidationEvm};
 use tempo_precompiles::{
     nonce::{INonce, NonceManager},
     storage::StorageActions,
@@ -89,9 +85,9 @@ const MAX_KEYCHAIN_RECIPIENTS_PER_SELECTOR: u8 = 64;
 
 /// Validator for Tempo transactions.
 #[derive(Debug)]
-pub struct TempoTransactionValidator<Client> {
+pub struct TempoTransactionValidator<Client, EvmConfig = TempoEvmConfig> {
     /// Inner validator that performs default Ethereum tx validation.
-    pub(crate) inner: EthTransactionValidator<Client, TempoPooledTransaction, TempoEvmConfig>,
+    pub(crate) inner: EthTransactionValidator<Client, TempoPooledTransaction, EvmConfig>,
     /// Maximum allowed `valid_after` offset for AA txs.
     pub(crate) aa_valid_after_max_secs: u64,
     /// Maximum number of authorizations allowed in an AA transaction.
@@ -111,13 +107,14 @@ pub struct TempoTransactionValidator<Client> {
     active_hardfork: AtomicU8,
 }
 
-impl<Client> TempoTransactionValidator<Client>
+impl<Client, EvmConfig> TempoTransactionValidator<Client, EvmConfig>
 where
     Client: ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + StateProviderFactory,
+    EvmConfig: ConfigureTempoPoolEvm,
 {
     pub fn new(
-        inner: EthTransactionValidator<Client, TempoPooledTransaction, TempoEvmConfig>,
+        inner: EthTransactionValidator<Client, TempoPooledTransaction, EvmConfig>,
         aa_valid_after_max_secs: u64,
         max_tempo_authorizations: usize,
         amm_liquidity_cache: AmmLiquidityCache,
@@ -132,7 +129,7 @@ where
             .expect("latest header is None");
         let evm_env = inner
             .evm_config()
-            .evm_env(latest_header.header())
+            .pool_evm_env(latest_header.header())
             .expect("failed constructing EvmEnv from latest header");
         let active_hardfork = AtomicU8::new(evm_env.cfg_env.spec.variant_index());
         Self {
@@ -334,7 +331,7 @@ where
 
     /// Validates a batch of transactions against the same state snapshot.
     ///
-    /// All transactions share one throwaway [`TempoEvm`] (journaled writes are discarded
+    /// All transactions share one throwaway pool-validation EVM (journaled writes are discarded
     /// after each transaction while loaded state stays warm) and the validator's tip-scoped
     /// [`StateCache`], so repeated state reads are served from memory across transactions
     /// and across concurrent validation calls.
@@ -347,28 +344,14 @@ where
         let mut db = StateCacheDb::new(&cached_state, StateProviderDatabase::new(&state_provider));
         let evm_env = self.cached_evm_env.read().clone();
 
-        // Create a throwaway EVM for the whole batch and run validation, reusing the same
-        // validation logic that the block executor uses ([`TempoEvm::validate_transaction`]).
-        // - Skip `valid_after` check: the pool intentionally accepts transactions with a
-        //   future `valid_after` (queued until executable).
-        // - Disable nonce check: the pool accepts future-nonce transactions (queued)
-        //   and handles nonce ordering separately.
-        // - Skip liquidity check: the pool performs its own liquidity validation against a cached view of the AMM state.
-        let mut evm = TempoEvm::new(&mut db, evm_env);
-        evm.inner_mut().skip_valid_after_check = true;
-        evm.inner_mut().skip_liquidity_check = true;
-        evm.ctx_mut().cfg.disable_nonce_check = true;
+        // Create one throwaway EVM through the configured factory for the whole batch. The
+        // capability hook owns all pool-only configuration and per-transaction cleanup while the
+        // EVM and tip-scoped state cache keep repeated reads warm.
+        let mut evm = self.inner.evm_config().pool_evm(&mut db, evm_env);
 
         transactions
             .into_iter()
-            .map(|(origin, transaction)| {
-                let outcome = self.validate_one_with_evm(origin, transaction, &mut evm);
-                // Discard this transaction's journaled writes (nonce bumps, fee deduction,
-                // key authorisation) while keeping loaded accounts and storage warm for the
-                // rest of the batch.
-                evm.ctx_mut().journal_mut().discard_tx();
-                outcome
-            })
+            .map(|(origin, transaction)| self.validate_one_with_evm(origin, transaction, &mut evm))
             .collect()
     }
 
@@ -396,15 +379,16 @@ where
 
     /// Validates one transaction with the given throwaway EVM.
     ///
-    /// The caller is responsible for discarding the journaled writes afterwards.
-    fn validate_one_with_evm<DB>(
+    /// The EVM's pool-validation hook is responsible for discarding transaction-local writes.
+    fn validate_one_with_evm<EV>(
         &self,
         origin: TransactionOrigin,
         transaction: TempoPooledTransaction,
-        evm: &mut TempoEvm<DB>,
+        evm: &mut EV,
     ) -> TransactionValidationOutcome<TempoPooledTransaction>
     where
-        DB: Database<Error = ProviderError> + DatabaseRef<Error = ProviderError>,
+        EV: TempoPoolValidationEvm,
+        EV::DB: Database<Error = ProviderError> + DatabaseRef<Error = ProviderError>,
     {
         // Get the hardfork active at the current tip
         let spec = self.active_hardfork();
@@ -463,10 +447,12 @@ where
         //
         // Returns resolved fee token and key expiry for pool caching.
         let result = if let Some(tx_env) = transaction.cached_tx_env() {
-            evm.validate_transaction(tx_env.clone())
+            let mut tx_env = tx_env.clone();
+            evm.validate_pool_transaction(&mut tx_env)
         } else {
-            let result = evm.validate_transaction(transaction.tx_env_slow());
-            transaction.cache_tx_env(core::mem::take(&mut evm.ctx_mut().tx));
+            let mut tx_env = transaction.tx_env_slow();
+            let result = evm.validate_pool_transaction(&mut tx_env);
+            transaction.cache_tx_env(tx_env);
             result
         };
         let validation_ctx = match result {
@@ -552,7 +538,7 @@ where
         // (chain_id, EIP-3607 code check, protocol nonce, etc.) and to produce
         // the Valid outcome with state_nonce and balance for pool ordering.
         let inner_validation = {
-            let cached_state_provider = CachedAccountInfoReader::new(evm.db_ref());
+            let cached_state_provider = CachedAccountInfoReader::new(evm.db());
             self.inner
                 .validate_one_with_state_provider(origin, transaction, &cached_state_provider)
         };
@@ -666,10 +652,11 @@ where
     }
 }
 
-impl<Client> TransactionValidator for TempoTransactionValidator<Client>
+impl<Client, EvmConfig> TransactionValidator for TempoTransactionValidator<Client, EvmConfig>
 where
     Client: ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
         + StateProviderFactory,
+    EvmConfig: ConfigureTempoPoolEvm,
 {
     type Transaction = TempoPooledTransaction;
     type Block = Block;
@@ -746,7 +733,7 @@ where
         let evm_env = self
             .inner
             .evm_config()
-            .evm_env(new_tip_block.header())
+            .pool_evm_env(new_tip_block.header())
             .expect("invalid block in on_new_head_block");
         self.active_hardfork
             .store(evm_env.cfg_env.spec.variant_index(), Ordering::Relaxed);

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -451,11 +451,10 @@ where
         //
         // Returns resolved fee token and key expiry for pool caching.
         let result = if let Some(tx_env) = transaction.cached_tx_env() {
-            let tx_env = tx_env.clone();
-            evm.validate_pool_transaction(tx_env)
+            let (result, _) = evm.validate_pool_transaction(tx_env.clone());
+            result
         } else {
-            let tx_env = transaction.tx_env_slow();
-            let result = evm.validate_pool_transaction(tx_env.clone());
+            let (result, tx_env) = evm.validate_pool_transaction(transaction.tx_env_slow());
             transaction.cache_tx_env(tx_env);
             result
         };
@@ -821,7 +820,9 @@ where
     ) -> impl TempoPoolValidationEvm<
         DB = StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
     > + 'a {
-        self.evm_with_env(db, evm_env)
+        let mut evm = self.evm_with_env(db, evm_env);
+        evm.configure_for_pool();
+        evm
     }
 }
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -451,11 +451,11 @@ where
         //
         // Returns resolved fee token and key expiry for pool caching.
         let result = if let Some(tx_env) = transaction.cached_tx_env() {
-            let mut tx_env = tx_env.clone();
-            evm.validate_pool_transaction(&mut tx_env)
+            let tx_env = tx_env.clone();
+            evm.validate_pool_transaction(tx_env)
         } else {
-            let mut tx_env = transaction.tx_env_slow();
-            let result = evm.validate_pool_transaction(&mut tx_env);
+            let tx_env = transaction.tx_env_slow();
+            let result = evm.validate_pool_transaction(tx_env.clone());
             transaction.cache_tx_env(tx_env);
             result
         };

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -9,6 +9,7 @@ use alloy_evm::{Database, EvmEnv};
 use alloy_primitives::{Address, B256};
 use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
+use reth_evm::{ConfigureEvm, EvmEnvFor, EvmFactory, EvmFor, block::BlockExecutorFactory};
 use reth_primitives_traits::{
     Account, Bytecode, SealedBlock, transaction::error::InvalidTransactionError,
 };
@@ -31,13 +32,13 @@ use std::sync::{
     atomic::{AtomicU8, Ordering},
 };
 use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
-use tempo_evm::{ConfigureTempoPoolEvm, TempoEvmConfig, TempoPoolValidationEvm};
+use tempo_evm::{TempoEvmConfig, TempoPoolValidationEvm};
 use tempo_precompiles::{
     nonce::{INonce, NonceManager},
     storage::StorageActions,
 };
 use tempo_primitives::{
-    Block, TempoHeader,
+    Block, TempoHeader, TempoPrimitives,
     subblock::has_sub_block_nonce_key_prefix,
     transaction::{TEMPO_EXPIRING_NONCE_KEY, TempoTransaction},
 };
@@ -129,7 +130,7 @@ where
             .expect("latest header is None");
         let evm_env = inner
             .evm_config()
-            .pool_evm_env(latest_header.header())
+            .evm_env(latest_header.header())
             .expect("failed constructing EvmEnv from latest header");
         let active_hardfork = AtomicU8::new(evm_env.cfg_env.spec.variant_index());
         Self {
@@ -341,13 +342,16 @@ where
         cached_state: Arc<StateCache>,
         transactions: impl IntoIterator<Item = (TransactionOrigin, TempoPooledTransaction)>,
     ) -> Vec<TransactionValidationOutcome<TempoPooledTransaction>> {
-        let mut db = StateCacheDb::new(&cached_state, StateProviderDatabase::new(&state_provider));
+        let db = StateCacheDb::new(
+            &cached_state,
+            StateProviderDatabase::new(&state_provider as &dyn StateProvider),
+        );
         let evm_env = self.cached_evm_env.read().clone();
 
         // Create one throwaway EVM through the configured factory for the whole batch. The
         // capability hook owns all pool-only configuration and per-transaction cleanup while the
         // EVM and tip-scoped state cache keep repeated reads warm.
-        let mut evm = self.inner.evm_config().pool_evm(&mut db, evm_env);
+        let mut evm = self.inner.evm_config().pool_evm(db, evm_env);
 
         transactions
             .into_iter()
@@ -733,7 +737,7 @@ where
         let evm_env = self
             .inner
             .evm_config()
-            .pool_evm_env(new_tip_block.header())
+            .evm_env(new_tip_block.header())
             .expect("invalid block in on_new_head_block");
         self.active_hardfork
             .store(evm_env.cfg_env.spec.variant_index(), Ordering::Relaxed);
@@ -775,6 +779,49 @@ where
 {
     fn bytecode_by_hash(&self, code_hash: &B256) -> ProviderResult<Option<Bytecode>> {
         Ok(Some(Bytecode(self.db.code_by_hash_ref(*code_hash)?)))
+    }
+}
+
+/// Configuration capable of constructing an EVM with Tempo transaction-pool semantics.
+///
+/// This pins pool validation to Tempo's EVM environment while allowing the configured EVM
+/// implementation to adapt its database and precompiles.
+pub trait ConfigureTempoPoolEvm:
+    ConfigureEvm<
+        Primitives = TempoPrimitives,
+        BlockExecutorFactory: BlockExecutorFactory<
+            EvmFactory: EvmFactory<Spec = TempoHardfork, BlockEnv = TempoBlockEnv>,
+        >,
+    > + 'static
+{
+    fn pool_evm<'a>(
+        &self,
+        db: StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
+        evm_env: EvmEnvFor<Self>,
+    ) -> impl TempoPoolValidationEvm<
+        DB = StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
+    > + 'a;
+}
+
+impl<T> ConfigureTempoPoolEvm for T
+where
+    T: ConfigureEvm<
+            Primitives = TempoPrimitives,
+            BlockExecutorFactory: BlockExecutorFactory<
+                EvmFactory: EvmFactory<Spec = TempoHardfork, BlockEnv = TempoBlockEnv>,
+            >,
+        > + 'static,
+    for<'a> EvmFor<T, StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>>:
+        TempoPoolValidationEvm,
+{
+    fn pool_evm<'a>(
+        &self,
+        db: StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
+        evm_env: EvmEnvFor<Self>,
+    ) -> impl TempoPoolValidationEvm<
+        DB = StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
+    > + 'a {
+        self.evm_with_env(db, evm_env)
     }
 }
 


### PR DESCRIPTION
this PR allows tx-pool validation to use the configured EVM rather than creating `TempoEvm` directly. This allows custom EVM wrappers to preserve their database adapters and precompiles while retaining pool-specific validation semantics, cleanup, and state-read caching.