### PR TITLE
docs(tip-1091): allow unordered sequencer sets

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -62,7 +62,8 @@ canonical Zones implementation: monotonically increasing zone IDs, `zones`,
 
 Each zone is created with a nonempty set of at most 8 sequencers and a nonzero
 settlement `threshold` no greater than the set size. Sequencer addresses MUST be
-nonzero and unique. All members have
+nonzero and unique. Their order has no protocol significance and implementations
+MUST NOT reject a sequencer set based on address ordering. All members have
 the same permissions: any sequencer MAY submit a settlement carrying a valid
 threshold certificate or perform another sequencer-authorized portal operation.
 There is no primary or distinguished sequencer. The portal admin MAY atomically

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -186,11 +186,12 @@ abstract contract ZoneFactory is IZoneFactory {
             revert InvalidSequencerSet();
         }
 
-        address previous;
         for (uint256 i = 0; i < length; ++i) {
             address current = sequencers[i];
-            if (current == address(0) || current <= previous) revert InvalidSequencerSet();
-            previous = current;
+            if (current == address(0)) revert InvalidSequencerSet();
+            for (uint256 j = 0; j < i; ++j) {
+                if (current == sequencers[j]) revert InvalidSequencerSet();
+            }
         }
     }
 


### PR DESCRIPTION
Clarifies that sequencer-set ordering has no protocol significance and must not be validated.

Updates the Solidity reference to reject zero and duplicate addresses without requiring ascending order, aligning it with the native implementation and [the TIP-1091 audit finding](https://github.com/tempoxyz/tempo/pull/6874#discussion_r3622707259).

Validated with `FOUNDRY_HARDFORK=cancun forge build` from `tips/verify`.
