### PR TITLE
feat(tip-1092): add chain migration scripts [do not merge]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13515,6 +13515,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-tip1092-migration"
+version = "1.10.2"
+dependencies = [
+ "alloy",
+ "clap",
+ "eyre",
+ "futures",
+ "serde",
+ "serde_json",
+ "tempo-alloy",
+ "tokio",
+]
+
+[[package]]
 name = "tempo-transaction-pool"
 version = "1.10.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 members = [
   "bin/tempo",
   "bin/tempo-sidecar",
+  "scripts/tip1092-migration",
   "crates/alloy",
   "crates/chainspec",
   "crates/consensus",

--- a/scripts/tip1092-migrate.sh
+++ b/scripts/tip1092-migrate.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-exec cargo run --manifest-path "$repo_root/Cargo.toml" -p tempo-tip1092-migration --bin tip1092-migrate -- "$@"
+exec cargo run --quiet --manifest-path "$repo_root/Cargo.toml" -p tempo-tip1092-migration --bin tip1092-migrate -- "$@"

--- a/scripts/tip1092-migrate.sh
+++ b/scripts/tip1092-migrate.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec cargo run --manifest-path "$repo_root/Cargo.toml" -p tempo-tip1092-migration --bin tip1092-migrate -- "$@"

--- a/scripts/tip1092-migration/Cargo.toml
+++ b/scripts/tip1092-migration/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "tempo-tip1092-migration"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+tempo-alloy.workspace = true
+
+alloy = { workspace = true, features = [
+  "providers",
+  "reqwest",
+  "rpc-client",
+  "rpc-types-eth",
+  "signers",
+  "signer-local",
+  "sol-types",
+  "transport-http",
+] }
+clap.workspace = true
+eyre.workspace = true
+futures.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+
+[[bin]]
+name = "tip1092-migrate"
+path = "src/bin/migrate.rs"
+
+[[bin]]
+name = "tip1092-verify"
+path = "src/bin/verify.rs"

--- a/scripts/tip1092-migration/README.md
+++ b/scripts/tip1092-migration/README.md
@@ -1,6 +1,6 @@
 # TIP-1092 migration
 
-These scripts migrate every historical TIP-20 token on Presto mainnet or Moderato testnet into
+These scripts migrate every historical TIP-20 token on Tempo mainnet or Moderato testnet into
 the TIP-403 transfer-policy registry, then independently verify the result.
 
 The migrator scans `TIP20Factory.TokenCreated` logs in bounded ranges, includes the genesis tokens
@@ -24,10 +24,11 @@ For mainnet, make the target explicit:
 ./scripts/tip1092-verify.sh --network mainnet --report tip1092-mainnet-report.ndjson
 ```
 
-Both commands select the repository's canonical RPC URL and reject a chain-ID mismatch. Use
-`--rpc-url` to point at an archival or higher-capacity endpoint. The verifier scans independently
-through the latest block captured at startup, checks `tokenTransferPolicyId` for every token, and
-exits nonzero if any binding is unset or any lookup fails.
+Both commands select the repository's canonical public RPC URL and reject a chain-ID mismatch. Use
+`--rpc-url` to point at an archival or higher-capacity endpoint. The authenticated nextfork devnet
+is also supported with `--network nextfork --rpc-url "$TEMPO_NEXTFORK_RPC_URL"`. The verifier scans
+independently through the latest block captured at startup, checks `tokenTransferPolicyId` for every
+token, and exits nonzero if any binding is unset or any lookup fails.
 
 Useful tuning options:
 

--- a/scripts/tip1092-migration/README.md
+++ b/scripts/tip1092-migration/README.md
@@ -1,0 +1,39 @@
+# TIP-1092 migration
+
+These scripts migrate every historical TIP-20 token on Presto mainnet or Moderato testnet into
+the TIP-403 transfer-policy registry, then independently verify the result.
+
+The migrator scans `TIP20Factory.TokenCreated` logs in bounded ranges, includes the genesis tokens
+that have no creation logs, batches registry calls, and submits several transactions concurrently
+with expiring nonces. Each transaction and log query is retried with exponential backoff. Progress
+is checkpointed only after every transaction for a block range is confirmed, so an interrupted run
+can safely resume from the same state file. The migration precompile is idempotent.
+
+Set the signer through the environment so it does not appear in shell history:
+
+```bash
+export TEMPO_PRIVATE_KEY=0x...
+./scripts/tip1092-migrate.sh --network testnet
+./scripts/tip1092-verify.sh --network testnet --report tip1092-testnet-report.ndjson
+```
+
+For mainnet, make the target explicit:
+
+```bash
+./scripts/tip1092-migrate.sh --network mainnet
+./scripts/tip1092-verify.sh --network mainnet --report tip1092-mainnet-report.ndjson
+```
+
+Both commands select the repository's canonical RPC URL and reject a chain-ID mismatch. Use
+`--rpc-url` to point at an archival or higher-capacity endpoint. The verifier scans independently
+through the latest block captured at startup, checks `tokenTransferPolicyId` for every token, and
+exits nonzero if any binding is unset or any lookup fails.
+
+Useful tuning options:
+
+- `--batch-size`: token addresses per migration transaction (default `128`)
+- `--max-in-flight`: concurrent expiring-nonce transactions (default `4`)
+- `--scan-blocks`: initial log-query range; failures automatically halve it (default `50000`)
+- `--max-retries`: RPC/transaction retries (default `5`)
+- `--state-file`: durable migration checkpoint path
+- `--concurrency`: concurrent verification calls (default `64`)

--- a/scripts/tip1092-migration/src/bin/migrate.rs
+++ b/scripts/tip1092-migration/src/bin/migrate.rs
@@ -1,0 +1,241 @@
+use alloy::{
+    network::{EthereumWallet, ReceiptResponse},
+    providers::ProviderBuilder,
+    signers::local::PrivateKeySigner,
+};
+use clap::Parser;
+use eyre::{Context, Result, bail};
+use futures::{StreamExt, stream};
+use std::{path::PathBuf, str::FromStr};
+use tempo_alloy::{
+    TempoNetwork,
+    chainspec::hardfork::TempoHardfork,
+    contracts::precompiles::{ITIP403Registry, TIP403_REGISTRY_ADDRESS},
+    provider::ext::{TempoProviderBuilderExt, TempoProviderExt},
+};
+use tempo_tip1092_migration::{
+    DEFAULT_RPC_RETRIES, DEFAULT_SCAN_BLOCKS, Network, Progress, ScanConfig, ensure_chain,
+    load_state, next_token_chunk, retry_delay, save_state,
+};
+
+#[derive(Debug, Parser)]
+#[command(about = "Migrate every existing TIP-20 transfer-policy binding into TIP-403")]
+struct Args {
+    /// Target chain. Required to guard against sending to the wrong network.
+    #[arg(long, value_enum)]
+    network: Network,
+
+    /// Transaction signer. Prefer TEMPO_PRIVATE_KEY so the key is not recorded in shell history.
+    #[arg(long, env = "TEMPO_PRIVATE_KEY", hide_env_values = true)]
+    private_key: String,
+
+    /// Override the selected network's public RPC endpoint.
+    #[arg(long)]
+    rpc_url: Option<String>,
+
+    /// Number of token addresses included in each TIP-403 transaction.
+    #[arg(long, default_value_t = 128)]
+    batch_size: usize,
+
+    /// Maximum concurrent transactions. Expiring nonces make these independent.
+    #[arg(long, default_value_t = 4)]
+    max_in_flight: usize,
+
+    /// Initial block span for TokenCreated log queries. Failed queries are bisected.
+    #[arg(long, default_value_t = DEFAULT_SCAN_BLOCKS)]
+    scan_blocks: u64,
+
+    /// Number of retries for RPC reads and transactions.
+    #[arg(long, default_value_t = DEFAULT_RPC_RETRIES)]
+    max_retries: u32,
+
+    /// Durable progress file. A confirmed block range is never resent after restart.
+    #[arg(long)]
+    state_file: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    if args.batch_size == 0 || args.max_in_flight == 0 || args.scan_blocks == 0 {
+        bail!("--batch-size, --max-in-flight, and --scan-blocks must be greater than zero");
+    }
+
+    let rpc_url = args
+        .rpc_url
+        .clone()
+        .unwrap_or_else(|| args.network.rpc_url().to_owned());
+    let state_file = args.state_file.clone().unwrap_or_else(|| {
+        PathBuf::from(format!(
+            ".tip1092-migration-{}.json",
+            args.network.chain_id()
+        ))
+    });
+
+    let signer = PrivateKeySigner::from_str(&args.private_key)
+        .context("failed to parse --private-key/TEMPO_PRIVATE_KEY")?;
+    let signer_address = signer.address();
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .with_expiring_nonces()
+        .wallet(EthereumWallet::from(signer))
+        .connect(&rpc_url)
+        .await
+        .with_context(|| format!("failed to connect to {rpc_url}"))?;
+
+    ensure_chain(&provider, args.network).await?;
+    if !provider.is_hardfork_active(TempoHardfork::T9).await? {
+        bail!("T9 is not active on the selected chain; refusing to submit migration calls");
+    }
+
+    let mut progress =
+        load_state::<Progress>(&state_file)?.unwrap_or_else(|| Progress::new(args.network));
+    progress.validate(args.network)?;
+
+    println!("network chain ID: {}", args.network.chain_id());
+    println!("signer: {signer_address}");
+    println!("state file: {}", state_file.display());
+    println!(
+        "using expiring nonces with up to {} transactions in flight",
+        args.max_in_flight
+    );
+
+    if !progress.genesis_done {
+        let tokens = args.network.genesis_tokens().to_vec();
+        let confirmed = migrate_tokens(
+            &provider,
+            &tokens,
+            args.batch_size,
+            args.max_in_flight,
+            args.max_retries,
+        )
+        .await?;
+        progress.genesis_done = true;
+        progress.tokens_seen += tokens.len() as u64;
+        progress.transactions_confirmed += confirmed;
+        save_state(&state_file, &progress)?;
+        println!("confirmed migration of genesis TIP-20 batch");
+    }
+
+    let scan = ScanConfig {
+        block_span: args.scan_blocks,
+        max_retries: args.max_retries,
+    };
+
+    loop {
+        let head = alloy::providers::Provider::get_block_number(&provider)
+            .await
+            .context("failed to read latest block")?;
+        if progress.next_block > head {
+            break;
+        }
+
+        let chunk = next_token_chunk(&provider, progress.next_block, head, &scan).await?;
+        let confirmed = migrate_tokens(
+            &provider,
+            &chunk.tokens,
+            args.batch_size,
+            args.max_in_flight,
+            args.max_retries,
+        )
+        .await?;
+
+        progress.next_block = chunk.to_block.saturating_add(1);
+        progress.tokens_seen += chunk.tokens.len() as u64;
+        progress.transactions_confirmed += confirmed;
+        save_state(&state_file, &progress)?;
+        println!(
+            "blocks {}..={}: {} tokens, {} confirmed transactions",
+            chunk.from_block,
+            chunk.to_block,
+            chunk.tokens.len(),
+            confirmed
+        );
+    }
+
+    println!(
+        "migration complete through block {}: {} tokens scanned, {} transactions confirmed",
+        progress.next_block.saturating_sub(1),
+        progress.tokens_seen,
+        progress.transactions_confirmed
+    );
+    println!(
+        "run scripts/tip1092-verify.sh --network {}",
+        args.network.as_str()
+    );
+    Ok(())
+}
+
+async fn migrate_tokens<P>(
+    provider: &P,
+    tokens: &[alloy::primitives::Address],
+    batch_size: usize,
+    max_in_flight: usize,
+    max_retries: u32,
+) -> Result<u64>
+where
+    P: alloy::providers::Provider<TempoNetwork>,
+{
+    let batches = tokens
+        .chunks(batch_size)
+        .map(<[_]>::to_vec)
+        .collect::<Vec<_>>();
+
+    let results = stream::iter(batches)
+        .map(|batch| migrate_batch(provider, batch, max_retries))
+        .buffer_unordered(max_in_flight)
+        .collect::<Vec<_>>()
+        .await;
+
+    for result in &results {
+        result
+            .as_ref()
+            .map_err(|error| eyre::eyre!(error.to_string()))?;
+    }
+    Ok(results.len() as u64)
+}
+
+async fn migrate_batch<P>(
+    provider: &P,
+    tokens: Vec<alloy::primitives::Address>,
+    max_retries: u32,
+) -> Result<()>
+where
+    P: alloy::providers::Provider<TempoNetwork>,
+{
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider);
+    let mut last_error = None;
+
+    for attempt in 0..=max_retries {
+        let result = async {
+            let pending = registry
+                .migrateTransferPolicyIds(tokens.clone())
+                .send()
+                .await?;
+            let tx_hash = *pending.tx_hash();
+            let receipt = pending.get_receipt().await?;
+            if !receipt.status() {
+                bail!("migration transaction {tx_hash} reverted");
+            }
+            println!("confirmed {tx_hash} ({} tokens)", tokens.len());
+            Ok::<_, eyre::Report>(())
+        }
+        .await;
+
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                last_error = Some(error);
+                if attempt < max_retries {
+                    eprintln!(
+                        "batch of {} tokens failed (attempt {}); retrying with a fresh expiring nonce",
+                        tokens.len(),
+                        attempt + 1
+                    );
+                    tokio::time::sleep(retry_delay(attempt)).await;
+                }
+            }
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| eyre::eyre!("migration batch failed")))
+}

--- a/scripts/tip1092-migration/src/bin/migrate.rs
+++ b/scripts/tip1092-migration/src/bin/migrate.rs
@@ -4,7 +4,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
 };
 use clap::Parser;
-use eyre::{Context, Result, bail};
+use eyre::{Context, ContextCompat, Result, bail};
 use futures::{StreamExt, stream};
 use std::{path::PathBuf, str::FromStr};
 use tempo_alloy::{
@@ -64,7 +64,8 @@ async fn main() -> Result<()> {
     let rpc_url = args
         .rpc_url
         .clone()
-        .unwrap_or_else(|| args.network.rpc_url().to_owned());
+        .or_else(|| args.network.default_rpc_url().map(str::to_owned))
+        .context("--rpc-url is required for nextfork")?;
     let state_file = args.state_file.clone().unwrap_or_else(|| {
         PathBuf::from(format!(
             ".tip1092-migration-{}.json",

--- a/scripts/tip1092-migration/src/bin/verify.rs
+++ b/scripts/tip1092-migration/src/bin/verify.rs
@@ -1,6 +1,6 @@
 use alloy::providers::ProviderBuilder;
 use clap::Parser;
-use eyre::{Context, Result, bail};
+use eyre::{Context, ContextCompat, Result, bail};
 use futures::{StreamExt, stream};
 use std::{fs::File, io::Write, path::PathBuf};
 use tempo_alloy::{
@@ -51,7 +51,8 @@ async fn main() -> Result<()> {
     let rpc_url = args
         .rpc_url
         .clone()
-        .unwrap_or_else(|| args.network.rpc_url().to_owned());
+        .or_else(|| args.network.default_rpc_url().map(str::to_owned))
+        .context("--rpc-url is required for nextfork")?;
     let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
         .connect(&rpc_url)
         .await

--- a/scripts/tip1092-migration/src/bin/verify.rs
+++ b/scripts/tip1092-migration/src/bin/verify.rs
@@ -1,0 +1,180 @@
+use alloy::providers::ProviderBuilder;
+use clap::Parser;
+use eyre::{Context, Result, bail};
+use futures::{StreamExt, stream};
+use std::{fs::File, io::Write, path::PathBuf};
+use tempo_alloy::{
+    TempoNetwork,
+    chainspec::hardfork::TempoHardfork,
+    contracts::precompiles::{ITIP403Registry, TIP403_REGISTRY_ADDRESS},
+    provider::ext::TempoProviderExt,
+};
+use tempo_tip1092_migration::{
+    DEFAULT_RPC_RETRIES, DEFAULT_SCAN_BLOCKS, Network, ScanConfig, ensure_chain, next_token_chunk,
+};
+
+#[derive(Debug, Parser)]
+#[command(about = "Verify that every TIP-20 has a TIP-403 transfer-policy binding")]
+struct Args {
+    /// Target chain. Required to guard against checking the wrong network.
+    #[arg(long, value_enum)]
+    network: Network,
+
+    /// Override the selected network's public RPC endpoint.
+    #[arg(long)]
+    rpc_url: Option<String>,
+
+    /// Initial block span for TokenCreated log queries. Failed queries are bisected.
+    #[arg(long, default_value_t = DEFAULT_SCAN_BLOCKS)]
+    scan_blocks: u64,
+
+    /// Maximum concurrent TIP-403 lookup calls.
+    #[arg(long, default_value_t = 64)]
+    concurrency: usize,
+
+    /// Number of retries for RPC log reads.
+    #[arg(long, default_value_t = DEFAULT_RPC_RETRIES)]
+    max_retries: u32,
+
+    /// Write every missing or failed token lookup as newline-delimited JSON.
+    #[arg(long)]
+    report: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    if args.scan_blocks == 0 || args.concurrency == 0 {
+        bail!("--scan-blocks and --concurrency must be greater than zero");
+    }
+
+    let rpc_url = args
+        .rpc_url
+        .clone()
+        .unwrap_or_else(|| args.network.rpc_url().to_owned());
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .connect(&rpc_url)
+        .await
+        .with_context(|| format!("failed to connect to {rpc_url}"))?;
+    ensure_chain(&provider, args.network).await?;
+    if !provider.is_hardfork_active(TempoHardfork::T9).await? {
+        bail!("T9 is not active on the selected chain; TIP-1092 bindings are unavailable");
+    }
+
+    let head = alloy::providers::Provider::get_block_number(&provider)
+        .await
+        .context("failed to read latest block")?;
+    let scan = ScanConfig {
+        block_span: args.scan_blocks,
+        max_retries: args.max_retries,
+    };
+    let mut report = args.report.as_ref().map(File::create).transpose()?;
+    let mut checked = 0_u64;
+    let mut missing = 0_u64;
+    let mut failed = 0_u64;
+
+    let genesis = verify_tokens(&provider, args.network.genesis_tokens(), args.concurrency).await;
+    record_results(
+        &genesis,
+        &mut report,
+        &mut checked,
+        &mut missing,
+        &mut failed,
+    )?;
+
+    let mut next_block = 0_u64;
+    while next_block <= head {
+        let chunk = next_token_chunk(&provider, next_block, head, &scan).await?;
+        let results = verify_tokens(&provider, &chunk.tokens, args.concurrency).await;
+        record_results(
+            &results,
+            &mut report,
+            &mut checked,
+            &mut missing,
+            &mut failed,
+        )?;
+        println!(
+            "verified blocks {}..={}: {} tokens (missing: {missing}, RPC failures: {failed})",
+            chunk.from_block,
+            chunk.to_block,
+            chunk.tokens.len()
+        );
+        next_block = chunk.to_block.saturating_add(1);
+    }
+
+    println!(
+        "verification complete at block {head}: {checked} tokens checked, {missing} missing bindings, {failed} RPC failures"
+    );
+    if missing != 0 || failed != 0 {
+        bail!("TIP-1092 verification failed");
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+enum Verification {
+    Bound,
+    Missing(alloy::primitives::Address, u64),
+    Failed(alloy::primitives::Address, String),
+}
+
+async fn verify_tokens<P>(
+    provider: &P,
+    tokens: &[alloy::primitives::Address],
+    concurrency: usize,
+) -> Vec<Verification>
+where
+    P: alloy::providers::Provider<TempoNetwork>,
+{
+    let registry = ITIP403Registry::new(TIP403_REGISTRY_ADDRESS, provider);
+    stream::iter(tokens.iter().copied())
+        .map(|token| {
+            let registry = &registry;
+            async move {
+                match registry.tokenTransferPolicyId(token).call().await {
+                    Ok(result) if result.isSet => Verification::Bound,
+                    Ok(result) => Verification::Missing(token, result.policyId),
+                    Err(error) => Verification::Failed(token, error.to_string()),
+                }
+            }
+        })
+        .buffer_unordered(concurrency)
+        .collect()
+        .await
+}
+
+fn record_results(
+    results: &[Verification],
+    report: &mut Option<File>,
+    checked: &mut u64,
+    missing: &mut u64,
+    failed: &mut u64,
+) -> Result<()> {
+    for result in results {
+        *checked += 1;
+        let line = match result {
+            Verification::Bound => None,
+            Verification::Missing(token, policy_id) => {
+                *missing += 1;
+                Some(serde_json::json!({
+                    "token": token,
+                    "status": "missing",
+                    "fallbackPolicyId": policy_id,
+                }))
+            }
+            Verification::Failed(token, error) => {
+                *failed += 1;
+                Some(serde_json::json!({
+                    "token": token,
+                    "status": "rpc_error",
+                    "error": error,
+                }))
+            }
+        };
+
+        if let (Some(file), Some(line)) = (report.as_mut(), line) {
+            writeln!(file, "{line}")?;
+        }
+    }
+    Ok(())
+}

--- a/scripts/tip1092-migration/src/lib.rs
+++ b/scripts/tip1092-migration/src/lib.rs
@@ -1,0 +1,251 @@
+use alloy::{
+    primitives::{Address, address},
+    providers::Provider,
+    rpc::types::Filter,
+    sol_types::SolEvent,
+};
+use clap::ValueEnum;
+use eyre::{Context, Result, bail, eyre};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tempo_alloy::{
+    TempoNetwork,
+    contracts::precompiles::{ITIP20Factory, TIP20_FACTORY_ADDRESS},
+};
+
+pub const DEFAULT_SCAN_BLOCKS: u64 = 50_000;
+pub const DEFAULT_RPC_RETRIES: u32 = 5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub enum Network {
+    Mainnet,
+    Testnet,
+}
+
+impl Network {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Mainnet => "mainnet",
+            Self::Testnet => "testnet",
+        }
+    }
+
+    pub const fn chain_id(self) -> u64 {
+        match self {
+            Self::Mainnet => 4_217,
+            Self::Testnet => 42_431,
+        }
+    }
+
+    pub const fn rpc_url(self) -> &'static str {
+        match self {
+            Self::Mainnet => "https://rpc.presto.tempo.xyz",
+            Self::Testnet => "https://rpc.moderato.tempo.xyz",
+        }
+    }
+
+    /// Genesis TIP-20s do not have `TokenCreated` logs and must be seeded explicitly.
+    pub fn genesis_tokens(self) -> &'static [Address] {
+        const MAINNET: &[Address] = &[
+            address!("0x20C0000000000000000000000000000000000000"),
+            address!("0x20C00000000000000000000016C6514B53947FDC"),
+        ];
+        const TESTNET: &[Address] = &[
+            address!("0x20C0000000000000000000000000000000000000"),
+            address!("0x20C0000000000000000000000000000000000001"),
+            address!("0x20C0000000000000000000000000000000000002"),
+            address!("0x20C0000000000000000000000000000000000003"),
+        ];
+
+        match self {
+            Self::Mainnet => MAINNET,
+            Self::Testnet => TESTNET,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ScanConfig {
+    pub block_span: u64,
+    pub max_retries: u32,
+}
+
+impl Default for ScanConfig {
+    fn default() -> Self {
+        Self {
+            block_span: DEFAULT_SCAN_BLOCKS,
+            max_retries: DEFAULT_RPC_RETRIES,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TokenChunk {
+    pub from_block: u64,
+    pub to_block: u64,
+    pub tokens: Vec<Address>,
+}
+
+pub async fn ensure_chain<P>(provider: &P, network: Network) -> Result<()>
+where
+    P: Provider<TempoNetwork>,
+{
+    let actual = provider
+        .get_chain_id()
+        .await
+        .context("failed to read chain ID")?;
+    let expected = network.chain_id();
+    if actual != expected {
+        bail!("RPC chain ID mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+/// Fetch the next factory-log range. RPCs commonly cap log ranges or result counts, so a failed
+/// range is retried and then bisected until it succeeds.
+pub async fn next_token_chunk<P>(
+    provider: &P,
+    from_block: u64,
+    upper_bound: u64,
+    config: &ScanConfig,
+) -> Result<TokenChunk>
+where
+    P: Provider<TempoNetwork>,
+{
+    let mut span = config.block_span.max(1);
+
+    loop {
+        let to_block = upper_bound.min(from_block.saturating_add(span - 1));
+        let filter = Filter::new()
+            .address(TIP20_FACTORY_ADDRESS)
+            .event_signature(ITIP20Factory::TokenCreated::SIGNATURE_HASH)
+            .from_block(from_block)
+            .to_block(to_block);
+
+        let mut last_error = None;
+        for attempt in 0..=config.max_retries {
+            match provider.get_logs(&filter).await {
+                Ok(logs) => {
+                    let tokens = logs
+                        .iter()
+                        .map(|log| {
+                            log.log_decode::<ITIP20Factory::TokenCreated>()
+                                .map(|event| event.inner.token)
+                                .map_err(|error| eyre!(error))
+                        })
+                        .collect::<Result<Vec<_>>>()?;
+                    return Ok(TokenChunk {
+                        from_block,
+                        to_block,
+                        tokens,
+                    });
+                }
+                Err(error) => {
+                    last_error = Some(error.to_string());
+                    if attempt < config.max_retries {
+                        tokio::time::sleep(retry_delay(attempt)).await;
+                    }
+                }
+            }
+        }
+
+        if span == 1 {
+            return Err(eyre!(
+                "failed to fetch TokenCreated logs for block {from_block}: {}",
+                last_error.unwrap_or_else(|| "unknown RPC error".to_owned())
+            ));
+        }
+
+        span = (span / 2).max(1);
+        eprintln!(
+            "log query failed after retries; reducing range at block {from_block} to {span} blocks"
+        );
+    }
+}
+
+pub const fn retry_delay(attempt: u32) -> Duration {
+    let exponent = if attempt > 5 { 5 } else { attempt };
+    Duration::from_secs(1_u64 << exponent)
+}
+
+pub fn load_state<T: DeserializeOwned>(path: &Path) -> Result<Option<T>> {
+    match fs::read(path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .with_context(|| format!("failed to parse state file {}", path.display()))
+            .map(Some),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to read state file {}", path.display()))
+        }
+    }
+}
+
+pub fn save_state<T: Serialize>(path: &Path, state: &T) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)
+        .with_context(|| format!("failed to create state directory {}", parent.display()))?;
+
+    let mut temporary = PathBuf::from(path);
+    temporary.set_extension("tmp");
+    let bytes = serde_json::to_vec_pretty(state)?;
+    fs::write(&temporary, bytes)
+        .with_context(|| format!("failed to write state file {}", temporary.display()))?;
+    fs::rename(&temporary, path)
+        .with_context(|| format!("failed to install state file {}", path.display()))
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Progress {
+    pub chain_id: u64,
+    pub genesis_done: bool,
+    pub next_block: u64,
+    pub tokens_seen: u64,
+    pub transactions_confirmed: u64,
+}
+
+impl Progress {
+    pub fn new(network: Network) -> Self {
+        Self {
+            chain_id: network.chain_id(),
+            genesis_done: false,
+            next_block: 0,
+            tokens_seen: 0,
+            transactions_confirmed: 0,
+        }
+    }
+
+    pub fn validate(&self, network: Network) -> Result<()> {
+        if self.chain_id != network.chain_id() {
+            bail!(
+                "state file is for chain {}, but --network selects {}",
+                self.chain_id,
+                network.chain_id()
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn network_constants_match_chainspec() {
+        assert_eq!(Network::Mainnet.chain_id(), 4_217);
+        assert_eq!(Network::Testnet.chain_id(), 42_431);
+        assert_eq!(Network::Mainnet.genesis_tokens().len(), 2);
+        assert_eq!(Network::Testnet.genesis_tokens().len(), 4);
+    }
+
+    #[test]
+    fn retry_delay_is_bounded() {
+        assert_eq!(retry_delay(0), Duration::from_secs(1));
+        assert_eq!(retry_delay(3), Duration::from_secs(8));
+        assert_eq!(retry_delay(99), Duration::from_secs(32));
+    }
+}

--- a/scripts/tip1092-migration/src/lib.rs
+++ b/scripts/tip1092-migration/src/lib.rs
@@ -24,6 +24,7 @@ pub const DEFAULT_RPC_RETRIES: u32 = 5;
 pub enum Network {
     Mainnet,
     Testnet,
+    Nextfork,
 }
 
 impl Network {
@@ -31,6 +32,7 @@ impl Network {
         match self {
             Self::Mainnet => "mainnet",
             Self::Testnet => "testnet",
+            Self::Nextfork => "nextfork",
         }
     }
 
@@ -38,13 +40,15 @@ impl Network {
         match self {
             Self::Mainnet => 4_217,
             Self::Testnet => 42_431,
+            Self::Nextfork => 31_318,
         }
     }
 
-    pub const fn rpc_url(self) -> &'static str {
+    pub const fn default_rpc_url(self) -> Option<&'static str> {
         match self {
-            Self::Mainnet => "https://rpc.presto.tempo.xyz",
-            Self::Testnet => "https://rpc.moderato.tempo.xyz",
+            Self::Mainnet => Some("https://rpc.tempo.xyz"),
+            Self::Testnet => Some("https://rpc.moderato.tempo.xyz"),
+            Self::Nextfork => None,
         }
     }
 
@@ -63,7 +67,7 @@ impl Network {
 
         match self {
             Self::Mainnet => MAINNET,
-            Self::Testnet => TESTNET,
+            Self::Testnet | Self::Nextfork => TESTNET,
         }
     }
 }
@@ -238,8 +242,19 @@ mod tests {
     fn network_constants_match_chainspec() {
         assert_eq!(Network::Mainnet.chain_id(), 4_217);
         assert_eq!(Network::Testnet.chain_id(), 42_431);
+        assert_eq!(Network::Nextfork.chain_id(), 31_318);
+        assert_eq!(
+            Network::Mainnet.default_rpc_url(),
+            Some("https://rpc.tempo.xyz")
+        );
+        assert_eq!(
+            Network::Testnet.default_rpc_url(),
+            Some("https://rpc.moderato.tempo.xyz")
+        );
+        assert_eq!(Network::Nextfork.default_rpc_url(), None);
         assert_eq!(Network::Mainnet.genesis_tokens().len(), 2);
         assert_eq!(Network::Testnet.genesis_tokens().len(), 4);
+        assert_eq!(Network::Nextfork.genesis_tokens().len(), 4);
     }
 
     #[test]

--- a/scripts/tip1092-verify.sh
+++ b/scripts/tip1092-verify.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-exec cargo run --manifest-path "$repo_root/Cargo.toml" -p tempo-tip1092-migration --bin tip1092-verify -- "$@"
+exec cargo run --quiet --manifest-path "$repo_root/Cargo.toml" -p tempo-tip1092-migration --bin tip1092-verify -- "$@"

--- a/scripts/tip1092-verify.sh
+++ b/scripts/tip1092-verify.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec cargo run --manifest-path "$repo_root/Cargo.toml" -p tempo-tip1092-migration --bin tip1092-verify -- "$@"

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -107,6 +107,10 @@ The testnet count makes full automatic migration impractical because each migrat
 
 Operators need a small migration script that accepts a list of TIP-20 tokens, migrates them in batches, and verifies that TIP-403 has a binding for each one.
 
+The repository provides `scripts/tip1092-migrate.sh` for the chain-wide migration and
+`scripts/tip1092-verify.sh` for an independent full-chain verification pass. Both tools support
+Presto mainnet and Moderato testnet.
+
 SDKs and indexers that read `transferPolicyId()` from TIP-20 can keep using that API. Low-level tools that need provable token-to-policy bindings must use TIP-403 and must check that `tokenTransferPolicyId(token)` returns `isSet == true`.
 
 # Observability

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -109,7 +109,7 @@ Operators need a small migration script that accepts a list of TIP-20 tokens, mi
 
 The repository provides `scripts/tip1092-migrate.sh` for the chain-wide migration and
 `scripts/tip1092-verify.sh` for an independent full-chain verification pass. Both tools support
-Presto mainnet and Moderato testnet.
+Tempo mainnet, Moderato testnet, and the nextfork devnet.
 
 SDKs and indexers that read `transferPolicyId()` from TIP-20 can keep using that API. Low-level tools that need provable token-to-policy bindings must use TIP-403 and must check that `tokenTransferPolicyId(token)` returns `isSet == true`.
 


### PR DESCRIPTION
This is a draft PR that we will use to run devnet, testnet, and mainnet migrations. It does not need to merge.

Adds resumable tooling to scan every historical TIP-20, migrate policy bindings in concurrent expiring-nonce batches, and retry transient RPC or transaction failures.

Adds a separate full-chain verifier that independently rescans factory events and exits nonzero if any TIP-403 binding is missing or unreadable. Both commands include genesis tokens, enforce the selected chain ID, and refuse to run before T9. Mainnet defaults to the documented `https://rpc.tempo.xyz`; authenticated nextfork runs require an explicit `--rpc-url`.

## Nextfork live validation

Tested against `tempo/v1.10.2-79ab844` on chain ID 31318 after Docker workflow run 29849522137 deployed the TIP-1092 nightly image.

- Before migration at block 5,617,705: 14 tokens checked, 14 missing bindings, 0 RPC failures; verifier exited 1.
- Migration through block 5,617,920: 14 tokens scanned, 3 transactions confirmed; migrator exited 0.
  - `0x7925a1f794550eac60de64998d052fa7f1e54fa5ee4bd035ccef9b65a233097b`
  - `0xa47071444499b17b28d9ef7237f69dbf7bb0ab29bc2c393be63e971f0b56e19a`
  - `0x1660f5afb8504f0d734a0cfcd5f7482ad0f4e31bf303846051c6348ae2b5e54c`
- After migration at block 5,617,982: 14 tokens checked, 0 missing bindings, 0 RPC failures; verifier exited 0 and emitted an empty failure report.

## Local validation

- `cargo test -p tempo-tip1092-migration`
- `cargo clippy -p tempo-tip1092-migration --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n scripts/tip1092-migrate.sh scripts/tip1092-verify.sh`
- `git diff --check`