### PR TITLE
fix: start TIP-1091 configuration nonce at zero

### DIFF
--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -90,7 +90,7 @@ crate::sol! {
     #[derive(Debug, PartialEq, Eq)]
     #[sol(abi)]
     interface IZonePortal {
-        event SequencerSetUpdated(uint64 indexed version, uint8 threshold, address[] sequencers);
+        event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers);
         event TokenEnabled(address indexed token, string name, string symbol, string currency);
     }
 }

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -223,7 +223,7 @@ impl ZoneFactory {
         self.storage.emit_event(
             portal,
             ZonePortalEvent::sequencer_set_updated(
-                1,
+                0,
                 call.params.threshold,
                 call.params.sequencers.clone(),
             )
@@ -407,7 +407,7 @@ mod tests {
             assert_eq!(portal.messenger.read()?, ZONE_MESSENGER_ADDRESS);
             assert_eq!(portal.verifier.read()?, ZONE_VERIFIER_ADDRESS);
             assert!(portal.initialized.read()?);
-            assert_eq!(portal.sequencer_set_version.read()?, 1);
+            assert_eq!(portal.sequencer_set_version.read()?, 0);
             assert_eq!(portal.sequencer_threshold.read()?, 2);
             assert_eq!(portal.sequencers.read()?, vec![SEQUENCER_A, SEQUENCER_B]);
             assert!(portal.is_sequencer[SEQUENCER_A].read()?);

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -311,7 +311,10 @@ mod tests {
         storage::{StorageCtx, hashmap::HashMapStorageProvider},
         test_util::TIP20Setup,
     };
-    use alloy::primitives::{B256, Bytes, address};
+    use alloy::{
+        primitives::{B256, Bytes, U256, address, keccak256},
+        sol_types::SolValue,
+    };
     use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -391,7 +394,6 @@ mod tests {
             );
 
             let portal = ZonePortalStorage::new(created.portal);
-            assert_eq!(portal.sequencer.read()?, SEQUENCER_A);
             assert_eq!(portal.admin.read()?, ADMIN);
             assert_eq!(portal.block_hash.read()?, B256::ZERO);
             assert_eq!(
@@ -412,6 +414,22 @@ mod tests {
             assert_eq!(portal.sequencers.read()?, vec![SEQUENCER_A, SEQUENCER_B]);
             assert!(portal.is_sequencer[SEQUENCER_A].read()?);
             assert!(portal.is_sequencer[SEQUENCER_B].read()?);
+
+            // Pin the native storage handlers to the canonical Solidity layout.
+            assert_eq!(
+                StorageCtx.sload(created.portal, U256::ZERO)?,
+                U256::from_be_slice(ADMIN.as_slice())
+            );
+            assert_eq!(
+                StorageCtx.sload(created.portal, U256::from(18))?,
+                U256::from(2)
+            );
+            let membership_slot =
+                U256::from_be_bytes(keccak256((SEQUENCER_A, U256::from(19)).abi_encode()).0);
+            assert_eq!(
+                StorageCtx.sload(created.portal, membership_slot)?,
+                U256::ONE
+            );
             Ok(())
         })
     }

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -93,8 +93,8 @@ impl ZonePortalStorage {
             Bytecode::new_legacy(Bytes::from_static(&ZONE_PORTAL_PROXY_RUNTIME)),
         )?;
 
-        // Preserve the legacy getter expected by the portal storage layout. Authority comes from
-        // `is_sequencer` for versioned sets, so the first member is not a primary sequencer.
+        // Preserve the block-producer representative expected by zone-side components. Authority
+        // on Tempo comes from `is_sequencer`, so the first member has no distinct permissions.
         self.sequencer.write(params.sequencers[0])?;
         self.admin.write(params.admin)?;
         self.token_configs[params.initialToken].write(PortalTokenConfig {
@@ -107,7 +107,6 @@ impl ZonePortalStorage {
         self.messenger.write(ZONE_MESSENGER_ADDRESS)?;
         self.verifier.write(ZONE_VERIFIER_ADDRESS)?;
         self.initialized.write(true)?;
-        self.sequencer_set_version.write(1)?;
         self.sequencer_threshold.write(params.threshold)?;
         self.sequencers.write(params.sequencers.clone())?;
         for sequencer in &params.sequencers {

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -48,9 +48,7 @@ struct PortalWithdrawalQueue {
 /// slot numbers. This contract type is deliberately absent from the EVM precompile map.
 #[contract]
 pub(super) struct ZonePortalStorage {
-    sequencer: Address,
     admin: Address,
-    pending_sequencer: Address,
     zone_gas_rate: u128,
     withdrawal_batch_index: u64,
     block_hash: B256,
@@ -93,9 +91,6 @@ impl ZonePortalStorage {
             Bytecode::new_legacy(Bytes::from_static(&ZONE_PORTAL_PROXY_RUNTIME)),
         )?;
 
-        // Preserve the block-producer representative expected by zone-side components. Authority
-        // on Tempo comes from `is_sequencer`, so the first member has no distinct permissions.
-        self.sequencer.write(params.sequencers[0])?;
         self.admin.write(params.admin)?;
         self.token_configs[params.initialToken].write(PortalTokenConfig {
             enabled: true,

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -66,14 +66,15 @@ nonzero and unique. Their order has no protocol significance and implementations
 MUST NOT reject a sequencer set based on address ordering. All members have
 the same permissions: any sequencer MAY submit a settlement carrying a valid
 threshold certificate or perform another sequencer-authorized portal operation.
-There is no primary or distinguished sequencer. The portal admin MAY atomically
-replace the set and threshold; every replacement increments the configuration
-version and invalidates certificates from prior versions.
+There is no primary or distinguished sequencer. The initial configuration nonce
+is `0`. The portal admin MAY atomically replace the set and threshold; every
+later replacement increments the nonce and invalidates certificates from prior
+configurations.
 
 A settlement certificate MUST contain at least `threshold` distinct signatures
 from the active set. Its domain-separated commitment MUST bind the Tempo chain,
-portal, zone ID, configuration version, zone height, and every input that affects
-the resulting settlement. Duplicate, malformed, unregistered, or stale-version
+portal, zone ID, configuration nonce, zone height, and every input that affects
+the resulting settlement. Duplicate, malformed, unregistered, or stale-configuration
 signatures MUST be rejected. Any active sequencer MAY submit a valid certificate;
 the submitter has no additional authority and need not occupy a distinguished
 position in the set.


### PR DESCRIPTION
## Summary
- initialize TIP-1091 portal configuration nonces at `0`
- emit the initial `SequencerSetUpdated` event with nonce `0`
- document the nonce as replay protection that increments on later configuration changes

This matches the certificate-only `submitBatch` path in tempoxyz/zones#754: nonce `0` is the first valid configuration, not a legacy-mode sentinel.

## Validation
- `cargo test -p tempo-precompiles zone_factory --locked`
- `cargo clippy -p tempo-precompiles --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`