### PR TITLE
deps: update reth from main (2026-07-27)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8607,7 +8607,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8700,7 +8700,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8915,7 +8915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8944,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9040,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9273,6 +9273,7 @@ dependencies = [
  "itertools 0.14.0",
  "metrics",
  "moka",
+ "parking_lot",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9314,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9344,7 +9345,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9362,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9378,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9401,7 +9402,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9412,7 +9413,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9440,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9462,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9503,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "clap",
  "eyre",
@@ -9526,7 +9527,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9542,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9558,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9571,7 +9572,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9601,7 +9602,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9615,7 +9616,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9625,7 +9626,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9650,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9670,7 +9671,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9688,7 +9689,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9701,7 +9702,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9720,7 +9721,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9758,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9772,7 +9773,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "serde",
  "serde_json",
@@ -9782,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9808,7 +9809,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "bytes",
  "futures",
@@ -9828,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9845,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "bindgen",
  "cc",
@@ -9854,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "futures",
  "libc",
@@ -9868,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9877,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9891,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9949,7 +9950,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9974,7 +9975,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9998,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10013,7 +10014,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10027,7 +10028,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10044,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10068,7 +10069,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10136,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10191,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10240,7 +10241,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10264,7 +10265,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10289,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "bytes",
  "eyre",
@@ -10317,7 +10318,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10329,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10353,7 +10354,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10365,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10388,7 +10389,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10431,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10479,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10506,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10522,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10537,7 +10538,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10614,7 +10615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10644,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10687,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10707,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10738,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10785,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10836,7 +10837,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10850,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10881,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10932,7 +10933,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10960,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10974,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10994,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11009,7 +11010,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11035,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11052,7 +11053,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11073,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11089,7 +11090,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11099,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "clap",
  "eyre",
@@ -11119,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11138,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11181,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11206,7 +11207,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11233,7 +11234,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11252,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11277,7 +11278,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8607,7 +8607,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8700,7 +8700,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8915,7 +8915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8944,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9040,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9362,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9401,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9412,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9440,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9462,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9503,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "clap",
  "eyre",
@@ -9526,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9542,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9558,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9601,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9615,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9625,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9650,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9670,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9701,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9720,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9772,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "serde",
  "serde_json",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9808,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "bytes",
  "futures",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "bindgen",
  "cc",
@@ -9854,7 +9854,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "futures",
  "libc",
@@ -9868,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9877,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9891,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9974,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10027,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "bytes",
  "eyre",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10329,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10353,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10431,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10479,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10506,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10522,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10537,7 +10537,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10614,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10644,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10687,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10785,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10836,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10850,7 +10850,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10881,7 +10881,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10960,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10974,7 +10974,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10994,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11009,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11052,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11089,7 +11089,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11099,7 +11099,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "clap",
  "eyre",
@@ -11119,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11138,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11181,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11206,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11252,7 +11252,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11277,7 +11277,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
+source = "git+https://github.com/paradigmxyz/reth?rev=48df75d#48df75d88b08ddf4fffb20649858dd624eada74d"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8607,7 +8607,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8700,7 +8700,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8915,7 +8915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8944,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9040,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9270,6 +9270,7 @@ dependencies = [
  "derive_more",
  "futures",
  "indexmap 2.14.0",
+ "itertools 0.14.0",
  "metrics",
  "moka",
  "rayon",
@@ -9313,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9343,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9361,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9377,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9400,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9411,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9439,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9461,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9502,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "clap",
  "eyre",
@@ -9525,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9541,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9557,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9570,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9600,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9614,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9624,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9649,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9669,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9687,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9700,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9719,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9757,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9771,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "serde",
  "serde_json",
@@ -9781,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9807,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "bytes",
  "futures",
@@ -9827,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9844,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "bindgen",
  "cc",
@@ -9853,9 +9854,10 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "futures",
+ "libc",
  "metrics",
  "metrics-derive",
  "reth-primitives-traits",
@@ -9866,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9875,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9889,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9947,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9972,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9996,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10011,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10025,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10042,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10066,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10134,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10189,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10238,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10262,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10286,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "bytes",
  "eyre",
@@ -10315,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10327,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10351,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10363,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10386,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10429,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10477,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10504,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10520,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10535,7 +10537,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10612,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10642,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10685,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10705,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10736,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10783,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10834,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10848,7 +10850,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10879,7 +10881,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10930,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10958,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10972,7 +10974,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10992,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11007,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11033,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11050,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11071,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11087,7 +11089,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11097,7 +11099,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "clap",
  "eyre",
@@ -11117,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11136,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11179,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11204,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11231,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11250,7 +11252,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11275,7 +11277,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=01d3400#01d3400ffa06ff8912ade8c693cdafce54d0c936"
+source = "git+https://github.com/paradigmxyz/reth?rev=6441034#6441034264e33a03d14f90218f4e413c077a8d69"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8607,7 +8607,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8667,7 +8667,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8687,7 +8687,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8700,7 +8700,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8784,7 +8784,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8847,7 +8847,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8863,7 +8863,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8877,7 +8877,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8890,7 +8890,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8915,7 +8915,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8944,7 +8944,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8970,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9000,7 +9000,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9015,7 +9015,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9040,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9088,7 +9088,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9123,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9180,7 +9180,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9207,7 +9207,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9230,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9257,7 +9257,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9270,7 +9270,6 @@ dependencies = [
  "derive_more",
  "futures",
  "indexmap 2.14.0",
- "itertools 0.14.0",
  "metrics",
  "moka",
  "parking_lot",
@@ -9315,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9345,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9363,7 +9362,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9379,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9402,7 +9401,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9413,7 +9412,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9441,7 +9440,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9463,7 +9462,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9504,7 +9503,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -9527,7 +9526,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9543,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9559,7 +9558,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9572,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9602,7 +9601,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9616,7 +9615,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9626,7 +9625,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9651,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9671,7 +9670,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9689,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9702,7 +9701,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9721,7 +9720,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9759,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9773,7 +9772,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "serde",
  "serde_json",
@@ -9783,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9809,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "futures",
@@ -9829,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9846,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bindgen",
  "cc",
@@ -9855,7 +9854,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures",
  "libc",
@@ -9869,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9878,7 +9877,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9892,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9950,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9975,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9999,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10014,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10028,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10045,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10069,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10137,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10192,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10241,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10265,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10289,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "bytes",
  "eyre",
@@ -10318,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10330,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10354,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10366,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10389,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10432,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10480,7 +10479,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10507,7 +10506,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10523,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10538,7 +10537,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10615,7 +10614,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10645,7 +10644,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10688,7 +10687,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10708,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10739,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10786,7 +10785,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10837,7 +10836,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10851,7 +10850,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10882,7 +10881,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10933,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10961,7 +10960,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10975,7 +10974,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10995,7 +10994,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11010,7 +11009,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11036,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11053,7 +11052,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11074,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11090,7 +11089,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11100,7 +11099,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "clap",
  "eyre",
@@ -11120,7 +11119,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11139,7 +11138,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11182,7 +11181,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11207,7 +11206,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11234,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "metrics",
@@ -11253,7 +11252,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11278,7 +11277,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=1c2942a#1c2942abc6d3b78a7656acdaa985bdac03408a26"
+source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "01d3400", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "6441034" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "6441034", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "48df75d", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1c2942a", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/e2e/src/tests/restart.rs
+++ b/crates/e2e/src/tests/restart.rs
@@ -495,11 +495,19 @@ fn backfill_on_start_after_crash() {
         // Wait for the node to recover and produce past the pre-unwind height
         wait_for_height(&context, 1, el_before + 5).await;
 
-        // Verify EL actually persisted the recovered blocks
-        let el_recovered = validators[0]
-            .execution_provider()
-            .last_block_number()
-            .unwrap();
+        // Verify EL actually persisted the recovered blocks. Reth keeps recent
+        // canonical blocks in memory, so consensus progress can precede the DB.
+        let mut el_recovered = 0;
+        for _ in 0..10 {
+            el_recovered = validators[0]
+                .execution_provider()
+                .last_block_number()
+                .unwrap();
+            if el_recovered >= el_before {
+                break;
+            }
+            context.sleep(Duration::from_secs(1)).await;
+        }
         assert!(
             el_recovered >= el_before,
             "EL should have recovered to at least {el_before} after backfill, \


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`01d3400...84f4c98`](https://github.com/paradigmxyz/reth/compare/01d3400...84f4c98)

🔗 Amp thread: https://ampcode.com/threads/T-019fa1cd-371f-713e-9363-662e8cb3156e
- **Trie**
  - Removed sparse-trie memory accounting and LFU caching, parallelized pruning retention-set calculation, and added epoch-based node pruning with duration metrics ([#26458](https://github.com/paradigmxyz/reth/pull/26458), [#26439](https://github.com/paradigmxyz/reth/pull/26439), [#26485](https://github.com/paradigmxyz/reth/pull/26485), [#26470](https://github.com/paradigmxyz/reth/pull/26470)).
  - Added partial-proof root rebasing and fixed proof traversal to start below a known parent ([#26421](https://github.com/paradigmxyz/reth/pull/26421), [#26471](https://github.com/paradigmxyz/reth/pull/26471)).

- **Engine**
  - Added engine-thread resource-usage metrics ([#26459](https://github.com/paradigmxyz/reth/pull/26459)).
  - Reduced the default in-memory block count to five ([#26462](https://github.com/paradigmxyz/reth/pull/26462)).
  - Added transaction-pool prewarming and enabled it on nightly builds ([#26378](https://github.com/paradigmxyz/reth/pull/26378), [#26493](https://github.com/paradigmxyz/reth/pull/26493)).

- **Provider / Database**
  - Added split persistence frontiers for overlays and allowed overlay anchors at prune checkpoints ([#26457](https://github.com/paradigmxyz/reth/pull/26457), [#26475](https://github.com/paradigmxyz/reth/pull/26475)).
  - Fixed storage-history pruning accounting ([#26476](https://github.com/paradigmxyz/reth/pull/26476)).
  - Avoided a range scan when finding the first transaction during `remove_state_above` ([#26484](https://github.com/paradigmxyz/reth/pull/26484)).

- **ExEx**
  - Allowed an `ExEx` to catch up to the current chain head after being paused ([#26474](https://github.com/paradigmxyz/reth/pull/26474)).

- **CLI**
  - Added JSON output for modular download plans and configurable development defaults ([#26480](https://github.com/paradigmxyz/reth/pull/26480), [#26488](https://github.com/paradigmxyz/reth/pull/26488)).

- **RPC**
  - Aligned debug-trace error codes ([#26479](https://github.com/paradigmxyz/reth/pull/26479)).

- **EVM**
  - Decoupled EVM references ([#26463](https://github.com/paradigmxyz/reth/pull/26463)).

- **Bench**
  - Seeded benchmark run summaries from configuration ([#26460](https://github.com/paradigmxyz/reth/pull/26460)).

- **Operations**
  - Updated the Lighthouse Docker image to v8.2.1 ([#26469](https://github.com/paradigmxyz/reth/pull/26469)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019fa1cd-683f-77a3-9732-b02564fadd4d
- Migrated all Reth git dependencies from revision `01d3400` to `84f4c98` to adopt the newer Reth SDK version consistently across the workspace.
- Updated the crash-recovery end-to-end test to poll the execution provider for up to 10 seconds before asserting persisted block height, accounting for recent canonical blocks being available in memory before reaching the database.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/30236559888)
