### PR TITLE
fix(follower): retain execution node for engine lifetime

### DIFF
--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -24,7 +24,7 @@ use eyre::{WrapErr as _, eyre};
 use futures::{StreamExt as _, stream::FuturesUnordered};
 use rand_08::{CryptoRng, Rng};
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_node_builder::NodeTypesWithDBAdapter;
+use reth_node_builder::{NodeTypesWithDBAdapter, rpc::RethRpcServerHandles};
 use reth_provider::providers::BlockchainProvider;
 use tempo_chainspec::NetworkIdentity;
 use tempo_node::{TempoFullNode, TempoPayloadTypes, node::TempoNode};
@@ -188,6 +188,14 @@ impl<TUpstream> Config<TUpstream> {
 
         Ok(Engine {
             context: ContextCell::new(context),
+            // Keep the RPC server handles alive after the builder's execution node is dropped.
+            // Followers only retain the narrower provider and engine handles below, but dropping
+            // the last RPC handles shuts down the HTTP, WS, IPC, and auth servers.
+            _rpc_server_handles: self
+                .execution_node
+                .add_ons_handle
+                .rpc_server_handles
+                .clone(),
             driver,
             driver_mailbox,
             resolver,
@@ -209,6 +217,7 @@ where
     TUpstreamActor:,
 {
     context: ContextCell<TContext>,
+    _rpc_server_handles: RethRpcServerHandles,
     driver: driver::Driver<
         TContext,
         BlockchainProvider<

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -189,7 +189,7 @@ impl<TUpstream> Config<TUpstream> {
         Ok(Engine {
             context: ContextCell::new(context),
             // Keep every execution-node service alive for the lifetime of the follower engine.
-            _execution_node: self.execution_node.clone(),
+            _execution_node: self.execution_node,
             driver,
             driver_mailbox,
             resolver,
@@ -259,6 +259,8 @@ where
 
     async fn run(self) -> eyre::Result<()> {
         let Self {
+            context: _context,
+            _execution_node,
             upstream,
             driver,
             driver_mailbox,
@@ -270,7 +272,6 @@ where
             executor_mailbox,
             feed,
             broadcast,
-            ..
         } = self;
 
         let actors = vec![

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -24,7 +24,7 @@ use eyre::{WrapErr as _, eyre};
 use futures::{StreamExt as _, stream::FuturesUnordered};
 use rand_08::{CryptoRng, Rng};
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_node_builder::{NodeTypesWithDBAdapter, rpc::RethRpcServerHandles};
+use reth_node_builder::NodeTypesWithDBAdapter;
 use reth_provider::providers::BlockchainProvider;
 use tempo_chainspec::NetworkIdentity;
 use tempo_node::{TempoFullNode, TempoPayloadTypes, node::TempoNode};
@@ -188,14 +188,8 @@ impl<TUpstream> Config<TUpstream> {
 
         Ok(Engine {
             context: ContextCell::new(context),
-            // Keep the RPC server handles alive after the builder's execution node is dropped.
-            // Followers only retain the narrower provider and engine handles below, but dropping
-            // the last RPC handles shuts down the HTTP, WS, IPC, and auth servers.
-            _rpc_server_handles: self
-                .execution_node
-                .add_ons_handle
-                .rpc_server_handles
-                .clone(),
+            // Keep every execution-node service alive for the lifetime of the follower engine.
+            _execution_node: self.execution_node.clone(),
             driver,
             driver_mailbox,
             resolver,
@@ -217,7 +211,7 @@ where
     TUpstreamActor:,
 {
     context: ContextCell<TContext>,
-    _rpc_server_handles: RethRpcServerHandles,
+    _execution_node: Arc<TempoFullNode>,
     driver: driver::Driver<
         TContext,
         BlockchainProvider<

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -259,7 +259,6 @@ where
 
     async fn run(self) -> eyre::Result<()> {
         let Self {
-            context: _context,
             _execution_node,
             upstream,
             driver,
@@ -272,6 +271,7 @@ where
             executor_mailbox,
             feed,
             broadcast,
+            ..
         } = self;
 
         let actors = vec![

--- a/crates/e2e/src/tests/follow.rs
+++ b/crates/e2e/src/tests/follow.rs
@@ -3,7 +3,7 @@
 //! These tests verify that a follower node can sync blocks from an upstream
 //! node (validator or another follower) using in-process direct access.
 
-use std::{sync::Arc, time::Duration};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use crate::{
     Setup, TestingNode, connect_execution_peers,
@@ -20,13 +20,75 @@ use commonware_runtime::{
     BufferPooler, Clock, Handle, Metrics as RuntimeMetrics, Pacer, Runner as _, Spawner, Storage,
     deterministic::{self, Context, Runner},
 };
-use futures::future::join_all;
+use futures::{channel::oneshot, future::join_all};
+use jsonrpsee::{core::client::ClientT as _, http_client::HttpClientBuilder, rpc_params};
 use rand_core::CryptoRngCore;
 use reth_ethereum::provider::BlockIdReader as _;
 use tempo_consensus::{feed::FeedStateHandle, follow};
 use tempo_node::rpc::consensus::{ConsensusFeed as _, Query, types::Response};
 
 static EPOCH_LENGTH: u64 = 10;
+
+#[tokio::test]
+#[test_traced]
+async fn follower_rpc_survives_execution_node_handle_drop() {
+    let _ = tempo_eyre::install();
+
+    let setup = Setup::new().how_many_signers(1).epoch_length(EPOCH_LENGTH);
+    let cfg = deterministic::Config::default().with_seed(setup.seed);
+    let (addr_tx, addr_rx) = oneshot::channel::<SocketAddr>();
+    let (done_tx, done_rx) = oneshot::channel::<()>();
+
+    let executor_handle = std::thread::spawn(move || {
+        let executor = Runner::from(cfg);
+        executor.start(|mut context| async move {
+            let (mut validators, execution_runtime) = setup_validators(&mut context, setup).await;
+            validators[0].start(&context).await;
+
+            let follower = Follower::builder()
+                .runtime(execution_runtime.handle())
+                .follow(&mut context, &validators[0])
+                .await;
+
+            let http_addr = follower
+                .execution_node
+                .node
+                .add_ons_handle
+                .rpc_server_handles
+                .rpc
+                .http_local_addr()
+                .unwrap();
+
+            let Follower {
+                execution_node,
+                _handle,
+                ..
+            } = follower;
+            let ExecutionNode {
+                node,
+                runtime: _runtime,
+                exit_fut: _exit_fut,
+            } = execution_node;
+
+            // Production drops this owner after starting the follower engine. The engine must
+            // retain every lifetime-sensitive handle needed to keep RPC available.
+            drop(node);
+            addr_tx.send(http_addr).unwrap();
+
+            let _ = done_rx.await;
+            drop(_handle);
+        });
+    });
+
+    let http_addr = addr_rx.await.unwrap();
+    let client = HttpClientBuilder::default()
+        .build(format!("http://{http_addr}"))
+        .unwrap();
+    let _: String = client.request("eth_chainId", rpc_params![]).await.unwrap();
+
+    done_tx.send(()).unwrap();
+    executor_handle.join().unwrap();
+}
 
 trait FeedStateProvider {
     fn feed_state(&self) -> FeedStateHandle;


### PR DESCRIPTION
## Summary
- retain `Arc<TempoFullNode>` for the full lifetime of `follow::Engine`
- prevent RPC and any other execution-node services from shutting down when the builder-owned handle is dropped
- preserve the narrower provider and consensus-engine handles used by follower actors

## Regression test
- start a follower and capture its HTTP RPC address
- drop the original `TempoFullNode` owner while keeping the execution runtime alive
- verify `eth_chainId` remains callable

## Evidence
Affected followers logged RPC startup, then failed every TCP startup probe and received SIGTERM at the 30-minute startup-probe threshold. Validators were unaffected.

## Validation
- `cargo +nightly fmt --check`
- `git diff --check`
- local focused test was blocked before compilation by HTTP 401 fetching the pinned `commonwarexyz/monorepo` revision; CI runs the full checks

Prompted by: @kamsz

Prompted by: @joshieDo