### PR TITLE
feat(precompiles): export ZonePortal storage slots

### DIFF
--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -18,8 +18,6 @@ use tempo_contracts::precompiles::{
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::TempoAddressExt;
 
-#[cfg(test)]
-use portal::PortalTokenConfig;
 /// Generated storage slots for ZonePortal accounts.
 pub use portal::slots as zone_portal_slots;
 pub use portal::{ZONE_PORTAL_PROXY_RUNTIME, ZonePortalStorage};
@@ -316,6 +314,7 @@ mod tests {
         primitives::{B256, Bytes, U256, address, keccak256},
         sol_types::SolValue,
     };
+    use portal::PortalTokenConfig;
     use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
 

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -20,10 +20,9 @@ use tempo_primitives::TempoAddressExt;
 
 #[cfg(test)]
 use portal::PortalTokenConfig;
-pub use portal::ZONE_PORTAL_PROXY_RUNTIME;
-use portal::ZonePortalStorage;
 /// Generated storage slots for ZonePortal accounts.
 pub use portal::slots as zone_portal_slots;
+pub use portal::{ZONE_PORTAL_PROXY_RUNTIME, ZonePortalStorage};
 /// Minimum gas consumed by a successful zone creation.
 pub const ZONE_CREATION_GAS: u64 = 15_000_000;
 

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -22,6 +22,8 @@ use tempo_primitives::TempoAddressExt;
 use portal::PortalTokenConfig;
 pub use portal::ZONE_PORTAL_PROXY_RUNTIME;
 use portal::ZonePortalStorage;
+/// Generated storage slots for ZonePortal accounts.
+pub use portal::slots as zone_portal_slots;
 /// Minimum gas consumed by a successful zone creation.
 pub const ZONE_CREATION_GAS: u64 = 15_000_000;
 

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -47,7 +47,7 @@ struct PortalWithdrawalQueue {
 /// The generated handlers let the native factory initialize a portal without duplicating raw
 /// slot numbers. This contract type is deliberately absent from the EVM precompile map.
 #[contract]
-pub(super) struct ZonePortalStorage {
+pub struct ZonePortalStorage {
     admin: Address,
     zone_gas_rate: u128,
     withdrawal_batch_index: u64,
@@ -77,7 +77,7 @@ pub(super) struct ZonePortalStorage {
 }
 
 impl ZonePortalStorage {
-    pub(super) fn new(address: Address) -> Self {
+    pub fn new(address: Address) -> Self {
         Self::__new(address)
     }
 

--- a/crates/precompiles/tests/zone_factory.rs
+++ b/crates/precompiles/tests/zone_factory.rs
@@ -1,0 +1,5 @@
+#[test]
+fn exports_zone_portal_storage_slots() {
+    let _ = tempo_precompiles::zone_factory::zone_portal_slots::ADMIN;
+    let _ = tempo_precompiles::zone_factory::zone_portal_slots::TOKEN_CONFIGS;
+}

--- a/crates/precompiles/tests/zone_factory.rs
+++ b/crates/precompiles/tests/zone_factory.rs
@@ -1,5 +1,0 @@
-#[test]
-fn exports_zone_portal_storage_slots() {
-    let _ = tempo_precompiles::zone_factory::zone_portal_slots::ADMIN;
-    let _ = tempo_precompiles::zone_factory::zone_portal_slots::TOKEN_CONFIGS;
-}


### PR DESCRIPTION
## Summary

- re-export the `#[contract]`-generated ZonePortal storage slot module as `zone_portal_slots`
- add an integration test proving downstream crates can access the public slot constants

## Motivation

Zone consumers currently have to duplicate ZonePortal storage slot numbers. Exposing the generated layout lets downstream code derive those constants from the canonical native ZonePortal definition instead. This unblocks tempoxyz/zones#753 from removing its hardcoded portal slots.

## Impact

This is an additive public API change. The internal ZonePortal storage handle remains private.

## Validation

- `cargo test -p tempo-precompiles --test zone_factory --locked`
- `cargo clippy -p tempo-precompiles --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`