### PR TITLE
chore(ci): rebalance e2e test shards

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -3,6 +3,9 @@ fail-fast = false
 retries = 2
 test-threads = "num-cpus"
 
+[profile.ci.junit]
+path = "junit.xml"
+
 # Treat timeout as success while debugging snapshot-restart flakiness.
 [[profile.ci.overrides]]
 filter = "test(can_restart_after_joining_from_snapshot)"

--- a/.github/workflows/rpc-tests.yml
+++ b/.github/workflows/rpc-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
-          tool: nextest@0.9.124
+          tool: nextest@0.9.127
       - name: Build RPC tests
         id: build
         continue-on-error: ${{ matrix.allow_failure }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,6 +178,14 @@ jobs:
         run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --partition slice:${{ matrix.partition }}/4 --no-run
       - name: Run e2e tests
         run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --partition slice:${{ matrix.partition }}/4
+      - name: Upload e2e test timings
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-junit-${{ matrix.partition }}
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: warn
+          retention-days: 30
 
   e2e-flaky:
     name: e2e-flaky

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,7 +108,7 @@ jobs:
           version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
-          tool: nextest@0.9.124
+          tool: nextest@0.9.127
       # Build and run tests WITH coverage (only when precompiles changed)
       - name: Build and compile tests with coverage
         if: needs.check-precompiles.outputs.coverage == 'true'
@@ -150,7 +150,7 @@ jobs:
           retention-days: 1
 
   e2e:
-    name: e2e (${{ matrix.partition }}/3)
+    name: e2e (${{ matrix.partition }}/4)
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     permissions:
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3]
+        partition: [1, 2, 3, 4]
     env:
       # Set to 8 MiB because some tests run into stack overflows with jemalloc
       RUST_MIN_STACK: 8388608
@@ -173,11 +173,11 @@ jobs:
           version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
-          tool: nextest@0.9.124
+          tool: nextest@0.9.127
       - name: Build e2e tests
-        run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --partition count:${{ matrix.partition }}/3 --no-run
+        run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --partition slice:${{ matrix.partition }}/4 --no-run
       - name: Run e2e tests
-        run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --partition count:${{ matrix.partition }}/3
+        run: cargo nextest run --profile ci -E 'package(tempo-e2e)' --partition slice:${{ matrix.partition }}/4
 
   e2e-flaky:
     name: e2e-flaky
@@ -199,7 +199,7 @@ jobs:
           version: v0.15.0
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
-          tool: nextest@0.9.124
+          tool: nextest@0.9.127
       - name: Build flaky e2e tests
         run: cargo nextest run --profile ci-flaky --no-run
       - name: Run flaky e2e tests

--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -101,7 +101,7 @@ jobs:
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: taiki-e/install-action@d0f23220b09a75c6db730f13bb37c4f8144b4382 # v2.75.9
         with:
-          tool: nextest@0.9.124
+          tool: nextest@0.9.127
 
       # ── amp CLI ────────────────────────────────────────────────
       - name: Install Amp CLI


### PR DESCRIPTION
Upgrade cargo-nextest to 0.9.127 and move the e2e matrix from deprecated per-binary count partitioning to four cross-binary slices. This should distribute tests more evenly and reduce the required Test workflow critical path.

Prompted by: @Zygimantass