### PR TITLE
fix(ci): bypass Docker cache for version tags only

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,7 +152,7 @@ jobs:
           targets: default
           project: 0c6tg19qsp
           push: true
-          no-cache: ${{ github.event_name != 'merge_group' }}
+          no-cache: ${{ github.ref_type != 'tag' }}
           pull: ${{ github.event_name != 'merge_group' }}
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -152,7 +152,7 @@ jobs:
           targets: default
           project: 0c6tg19qsp
           push: true
-          no-cache: ${{ github.ref_type != 'tag' }}
+          no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
           pull: ${{ github.event_name != 'merge_group' }}
         env:
           VERGEN_GIT_SHA: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- set `no-cache: true` only for tags whose ref starts with `refs/tags/v`
- keep Docker caching enabled for manual, branch, scheduled, called, and merge-queue builds

## Validation
- `git diff --check`

Prompted by: @Zygimantass