### PR TITLE
fix(precompiles): require zone token policy binding

### DIFF
--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -63,6 +63,7 @@ crate::sol! {
         );
 
         error InvalidToken();
+        error TokenTransferPolicyNotSet();
         error NotOwner();
         error InvalidAdmin();
         error InvalidSequencerSet();

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     storage::{Handler, Mapping},
     tip20::TIP20Token,
     tip20_factory::TIP20Factory,
+    tip403_registry::TIP403Registry,
 };
 use alloy::primitives::{Address, IntoLogData};
 use tempo_contracts::precompiles::{
@@ -184,6 +185,12 @@ impl ZoneFactory {
         }
         if !TIP20Factory::new().is_tip20(call.params.initialToken)? {
             return Err(ZoneFactoryError::invalid_token().into());
+        }
+        if TIP403Registry::new()
+            .registered_token_transfer_policy_id(call.params.initialToken)?
+            .is_none()
+        {
+            return Err(ZoneFactoryError::token_transfer_policy_not_set().into());
         }
         if call.params.admin.is_zero() {
             return Err(ZoneFactoryError::invalid_admin().into());
@@ -466,6 +473,42 @@ mod tests {
             params.sequencers = vec![SEQUENCER_B, SEQUENCER_A];
             factory.create_zone(OWNER, IZoneFactory::createZoneCall { params })?;
             assert_eq!(factory.zone(1)?.sequencers, vec![SEQUENCER_B, SEQUENCER_A]);
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn create_zone_requires_initial_token_policy_binding() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            TIP20Setup::path_usd(ADMIN).apply()?;
+            let mut factory = factory_with_owner(OWNER)?;
+            StorageCtx.set_spec(TempoHardfork::T9);
+
+            let err = factory
+                .create_zone(
+                    OWNER,
+                    IZoneFactory::createZoneCall {
+                        params: create_params(PATH_USD_ADDRESS),
+                    },
+                )
+                .unwrap_err();
+            assert_eq!(
+                err,
+                TempoPrecompileError::from(ZoneFactoryError::token_transfer_policy_not_set())
+            );
+            assert_eq!(factory.next_zone_id()?, 1);
+            assert!(!factory.is_zone_portal(portal_address(1))?);
+
+            TIP403Registry::new().set_token_transfer_policy(PATH_USD_ADDRESS, 1)?;
+            factory.create_zone(
+                OWNER,
+                IZoneFactory::createZoneCall {
+                    params: create_params(PATH_USD_ADDRESS),
+                },
+            )?;
+            assert_eq!(factory.next_zone_id()?, 2);
+
             Ok(())
         })
     }

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -88,6 +88,8 @@ the caller restriction, after which any account may call `createZone` subject to
 its normal validation rules.
 
 A successful createZone call MUST consume at least 15,000,000 gas.
+`createZone` MUST reject an initial token that does not have an explicit TIP-403
+transfer-policy binding.
 
 Each zone portal is installed at:
 

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -60,6 +60,7 @@ interface IZoneFactory {
     );
 
     error InvalidToken();
+    error TokenTransferPolicyNotSet();
     error NotOwner();
     error InvalidAdmin();
     error InvalidSequencerSet();

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -69,6 +69,9 @@ abstract contract ZoneFactory is IZoneFactory {
         if (!ITIP20Factory(StdPrecompiles.TIP20_FACTORY_ADDRESS).isTIP20(params.initialToken)) {
             revert InvalidToken();
         }
+        if (!_nativeTokenTransferPolicyIsSet(params.initialToken)) {
+            revert TokenTransferPolicyNotSet();
+        }
         if (params.admin == address(0)) revert InvalidAdmin();
         _validateSequencerSet(params.sequencers, params.threshold);
 
@@ -198,6 +201,9 @@ abstract contract ZoneFactory is IZoneFactory {
     /// @dev Native host hook: etch proxy/caller runtime bytecode at `portal`.
     function _nativeEtchPortalProxy(address portal, bytes memory runtime) internal virtual;
 
+    /// @dev Native host hook: return whether TIP-403 stores an explicit policy binding for `token`.
+    function _nativeTokenTransferPolicyIsSet(address token) internal virtual returns (bool);
+
     /// @dev Native host hook: copy `source` runtime bytecode to `destination`.
     /// Returns `EXTCODEHASH(source)` for the emitted update event.
     function _nativeCopyRuntime(
@@ -221,4 +227,4 @@ abstract contract ZoneFactory is IZoneFactory {
         return bytes12(bytes20(portal)) == ZONE_PORTAL_PREFIX && zoneId != 0 && zoneId < nextZoneId;
     }
 
-}
+    }

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -227,4 +227,4 @@ abstract contract ZoneFactory is IZoneFactory {
         return bytes12(bytes20(portal)) == ZONE_PORTAL_PREFIX && zoneId != 0 && zoneId < nextZoneId;
     }
 
-    }
+}


### PR DESCRIPTION
## Summary

- require an explicit TIP-403 transfer-policy binding before native `ZoneFactory::createZone` accepts the initial token
- add a dedicated `TokenTransferPolicyNotSet` error and keep the Rust ABI, TIP-1091 reference interface, and reference factory aligned
- add regression coverage proving a missing binding leaves `nextZoneId` and portal creation untouched, while creation succeeds once the binding exists

## Why

The native T9 `createZone` path bypasses Solidity `ZonePortal.initialize` and writes the initial enabled-token state directly. As a result, the Solidity enablement guard does not protect direct native factory calls. Provisioning can migrate the binding first, but the invariant belongs at the native factory boundary so every caller is protected.

## Validation

- `rustup run nightly cargo test -p tempo-precompiles 'zone_factory::tests' --features test-utils` — 7 passed
- `FOUNDRY_HARDFORK=cancun forge build` in `tips/verify`
- `FOUNDRY_HARDFORK=cancun forge fmt --check` in `tips/verify`
- `rustup run stable cargo run -p tempo-xtask -- check-abi` — 13/13 interfaces compatible
- `git diff --check`