### PR TITLE
fix(tip-1092): clear legacy policy on first registry binding

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -276,7 +276,14 @@ impl TIP20Token {
         }
 
         if StorageCtx.spec().is_t9() {
-            TIP403Registry::new().set_token_transfer_policy(self.address, call.newPolicyId)?;
+            let mut registry = TIP403Registry::new();
+            if registry
+                .registered_token_transfer_policy_id(self.address)?
+                .is_none()
+            {
+                self.delete_legacy_transfer_policy_id()?;
+            }
+            registry.set_token_transfer_policy(self.address, call.newPolicyId)?;
         } else {
             self.transfer_policy_id.write(call.newPolicyId)?;
         }
@@ -3696,7 +3703,8 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn test_change_transfer_policy_id_sets_registry_binding() -> eyre::Result<()> {
+    fn test_change_transfer_policy_id_sets_registry_binding_and_clears_legacy_policy()
+    -> eyre::Result<()> {
         let admin = Address::random();
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
 
@@ -3720,7 +3728,7 @@ pub(crate) mod tests {
                     .is_some()
             );
             assert_eq!(token.transfer_policy_id()?, REJECT_ALL_POLICY_ID);
-            assert_eq!(token.legacy_transfer_policy_id()?, ALLOW_ALL_POLICY_ID);
+            assert_eq!(token.legacy_transfer_policy_id()?, 0);
 
             Ok(())
         })


### PR DESCRIPTION
## Summary

- clear the legacy TIP-20 policy slot when the first post-T9 `changeTransferPolicyId` call creates a TIP-403 binding
- keep existing TIP-403 binding updates and pre-T9 token-local updates unchanged
- update the regression test to require canonical TIP-403-only state after the transition

## Root cause

The merged TIP-1092 implementation writes the requested policy into TIP-403 after T9 but does not clear the old token-local value when no binding exists. The effective getter uses TIP-403, so normal behavior is correct, but storage retains a stale second representation and violates TIP-1092's atomic cleanup requirement.

## Impact

After the first post-T9 policy update, TIP-403 is the sole stored source of truth for the token's transfer policy. The binding write and legacy-slot deletion occur in the same precompile call.

## Validation

- `rustup run nightly cargo fmt --all -- --check`
- `rustup run nightly cargo test -p tempo-precompiles --features test-utils 'tip20::tests'` (79 passed)
- `git diff --check`