### PR TITLE
feat(zone-factory): initialize zone access modes and roles

### DIFF
--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -22,27 +22,13 @@ pub const ZONE_VERIFIER_ADDRESS: Address = address!("0x5A56000000000000000000000
 pub const ZONE_MESSENGER_ADDRESS: Address = address!("0x5A4D000000000000000000000000000000000000");
 
 crate::sol! {
-    /// Account allowlist enforcement mode selected for a zone.
-    #[derive(Debug, PartialEq, Eq)]
-    enum ZoneAccessMode {
-        Closed,
-        Open
-    }
-
-    /// Callback gateway enforcement mode selected for a zone.
-    #[derive(Debug, PartialEq, Eq)]
-    enum ZoneGatewayMode {
-        Enforced,
-        Open
-    }
-
     /// Zone metadata recorded by the native factory.
     #[derive(Debug, PartialEq, Eq)]
     struct ZoneInfo {
         uint32 zoneId;
         address portal;
-        ZoneAccessMode accessMode;
-        ZoneGatewayMode gatewayMode;
+        bool accessMode;
+        bool gatewayMode;
         address admin;
         address[] sequencers;
         uint8 threshold;
@@ -56,8 +42,8 @@ crate::sol! {
     interface IZoneFactory {
         struct CreateZoneParams {
             address initialToken;
-            ZoneAccessMode accessMode;
-            ZoneGatewayMode gatewayMode;
+            bool accessMode;
+            bool gatewayMode;
             address[] allowedAccounts;
             address[] zoneGateways;
             address admin;
@@ -76,8 +62,8 @@ crate::sol! {
             uint32 indexed zoneId,
             address indexed portal,
             address initialToken,
-            ZoneAccessMode accessMode,
-            ZoneGatewayMode gatewayMode,
+            bool accessMode,
+            bool gatewayMode,
             address admin,
             address[] sequencers,
             uint8 threshold,
@@ -123,6 +109,6 @@ crate::sol! {
         event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers);
         event TokenEnabled(address indexed token, string name, string symbol, string currency);
         event RoleUpdated(address indexed account, Role prev, Role next);
-        event EnforcementModesUpdated(ZoneAccessMode accessMode, ZoneGatewayMode gatewayMode);
+        event EnforcementModesUpdated(bool accessMode, bool gatewayMode);
     }
 }

--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -22,11 +22,27 @@ pub const ZONE_VERIFIER_ADDRESS: Address = address!("0x5A56000000000000000000000
 pub const ZONE_MESSENGER_ADDRESS: Address = address!("0x5A4D000000000000000000000000000000000000");
 
 crate::sol! {
+    /// Account allowlist enforcement mode selected for a zone.
+    #[derive(Debug, PartialEq, Eq)]
+    enum ZoneAccessMode {
+        Closed,
+        Open
+    }
+
+    /// Callback gateway enforcement mode selected for a zone.
+    #[derive(Debug, PartialEq, Eq)]
+    enum ZoneGatewayMode {
+        Enforced,
+        Open
+    }
+
     /// Zone metadata recorded by the native factory.
     #[derive(Debug, PartialEq, Eq)]
     struct ZoneInfo {
         uint32 zoneId;
         address portal;
+        ZoneAccessMode accessMode;
+        ZoneGatewayMode gatewayMode;
         address admin;
         address[] sequencers;
         uint8 threshold;
@@ -40,6 +56,8 @@ crate::sol! {
     interface IZoneFactory {
         struct CreateZoneParams {
             address initialToken;
+            ZoneAccessMode accessMode;
+            ZoneGatewayMode gatewayMode;
             address[] allowedAccounts;
             address[] zoneGateways;
             address admin;
@@ -58,6 +76,8 @@ crate::sol! {
             uint32 indexed zoneId,
             address indexed portal,
             address initialToken,
+            ZoneAccessMode accessMode,
+            ZoneGatewayMode gatewayMode,
             address admin,
             address[] sequencers,
             uint8 threshold,
@@ -103,5 +123,6 @@ crate::sol! {
         event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers);
         event TokenEnabled(address indexed token, string name, string symbol, string currency);
         event RoleUpdated(address indexed account, Role prev, Role next);
+        event EnforcementModesUpdated(ZoneAccessMode accessMode, ZoneGatewayMode gatewayMode);
     }
 }

--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -3,7 +3,7 @@ use alloy_primitives::{Address, address};
 pub use IZoneFactory::{
     IZoneFactoryErrors as ZoneFactoryError, IZoneFactoryEvents as ZoneFactoryEvent,
 };
-pub use IZonePortal::IZonePortalEvents as ZonePortalEvent;
+pub use IZonePortal::{IZonePortalEvents as ZonePortalEvent, Role as ZonePortalRole};
 
 /// Native TIP-1091 ZoneFactory precompile address.
 pub const ZONE_FACTORY_ADDRESS: Address = address!("0x5AF2000000000000000000000000000000000000");
@@ -40,6 +40,8 @@ crate::sol! {
     interface IZoneFactory {
         struct CreateZoneParams {
             address initialToken;
+            address[] allowedAccounts;
+            address[] zoneGateways;
             address admin;
             address[] sequencers;
             uint8 threshold;
@@ -64,6 +66,7 @@ crate::sol! {
 
         error InvalidToken();
         error TokenTransferPolicyNotSet();
+        error InvalidClosedLoopConfig();
         error NotOwner();
         error InvalidAdmin();
         error InvalidSequencerSet();
@@ -91,7 +94,14 @@ crate::sol! {
     #[derive(Debug, PartialEq, Eq)]
     #[sol(abi)]
     interface IZonePortal {
+        enum Role {
+            None,
+            Account,
+            CallbackGateway
+        }
+
         event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers);
         event TokenEnabled(address indexed token, string name, string symbol, string currency);
+        event RoleUpdated(address indexed account, Role prev, Role next);
     }
 }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -358,9 +358,7 @@ mod tests {
     };
     use std::{assert_matches, collections::BTreeMap};
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::{
-        IZoneFactory, ZONE_FACTORY_ADDRESS, ZoneAccessMode, ZoneGatewayMode,
-    };
+    use tempo_contracts::precompiles::{IZoneFactory, ZONE_FACTORY_ADDRESS};
     use tempo_precompiles::{
         NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS,
         TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
@@ -607,8 +605,8 @@ mod tests {
                 IZoneFactory::createZoneCall {
                     params: IZoneFactory::CreateZoneParams {
                         initialToken: PATH_USD_ADDRESS,
-                        accessMode: ZoneAccessMode::Closed,
-                        gatewayMode: ZoneGatewayMode::Enforced,
+                        accessMode: true,
+                        gatewayMode: true,
                         allowedAccounts: vec![admin],
                         zoneGateways: vec![Address::repeat_byte(0x44)],
                         admin,
@@ -672,8 +670,8 @@ mod tests {
         let input = IZoneFactory::createZoneCall {
             params: IZoneFactory::CreateZoneParams {
                 initialToken: PATH_USD_ADDRESS,
-                accessMode: ZoneAccessMode::Closed,
-                gatewayMode: ZoneGatewayMode::Enforced,
+                accessMode: true,
+                gatewayMode: true,
                 allowedAccounts: vec![admin],
                 zoneGateways: vec![Address::repeat_byte(0x44)],
                 admin,

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -358,7 +358,9 @@ mod tests {
     };
     use std::{assert_matches, collections::BTreeMap};
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::{IZoneFactory, ZONE_FACTORY_ADDRESS};
+    use tempo_contracts::precompiles::{
+        IZoneFactory, ZONE_FACTORY_ADDRESS, ZoneAccessMode, ZoneGatewayMode,
+    };
     use tempo_precompiles::{
         NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS,
         TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
@@ -605,6 +607,8 @@ mod tests {
                 IZoneFactory::createZoneCall {
                     params: IZoneFactory::CreateZoneParams {
                         initialToken: PATH_USD_ADDRESS,
+                        accessMode: ZoneAccessMode::Closed,
+                        gatewayMode: ZoneGatewayMode::Enforced,
                         allowedAccounts: vec![admin],
                         zoneGateways: vec![Address::repeat_byte(0x44)],
                         admin,
@@ -668,6 +672,8 @@ mod tests {
         let input = IZoneFactory::createZoneCall {
             params: IZoneFactory::CreateZoneParams {
                 initialToken: PATH_USD_ADDRESS,
+                accessMode: ZoneAccessMode::Closed,
+                gatewayMode: ZoneGatewayMode::Enforced,
                 allowedAccounts: vec![admin],
                 zoneGateways: vec![Address::repeat_byte(0x44)],
                 admin,

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -605,6 +605,8 @@ mod tests {
                 IZoneFactory::createZoneCall {
                     params: IZoneFactory::CreateZoneParams {
                         initialToken: PATH_USD_ADDRESS,
+                        allowedAccounts: vec![admin],
+                        zoneGateways: vec![Address::repeat_byte(0x44)],
                         admin,
                         sequencers: vec![sequencer],
                         threshold: 1,
@@ -666,6 +668,8 @@ mod tests {
         let input = IZoneFactory::createZoneCall {
             params: IZoneFactory::CreateZoneParams {
                 initialToken: PATH_USD_ADDRESS,
+                allowedAccounts: vec![admin],
+                zoneGateways: vec![Address::repeat_byte(0x44)],
                 admin,
                 sequencers: vec![sequencer],
                 threshold: 1,

--- a/crates/precompiles/src/zone_factory/dispatch.rs
+++ b/crates/precompiles/src/zone_factory/dispatch.rs
@@ -72,7 +72,7 @@ mod tests {
     fn create_zone_selector_matches_tip_1091() {
         assert_eq!(
             IZoneFactory::createZoneCall::SELECTOR,
-            [0xff, 0xad, 0x87, 0x49]
+            [0x89, 0x67, 0x7d, 0x9e]
         );
     }
 

--- a/crates/precompiles/src/zone_factory/dispatch.rs
+++ b/crates/precompiles/src/zone_factory/dispatch.rs
@@ -72,7 +72,7 @@ mod tests {
     fn create_zone_selector_matches_tip_1091() {
         assert_eq!(
             IZoneFactory::createZoneCall::SELECTOR,
-            [0xf2, 0xc5, 0x8f, 0x2b]
+            [0x97, 0x32, 0xa8, 0x0a]
         );
     }
 

--- a/crates/precompiles/src/zone_factory/dispatch.rs
+++ b/crates/precompiles/src/zone_factory/dispatch.rs
@@ -72,7 +72,7 @@ mod tests {
     fn create_zone_selector_matches_tip_1091() {
         assert_eq!(
             IZoneFactory::createZoneCall::SELECTOR,
-            [0x97, 0x32, 0xa8, 0x0a]
+            [0xff, 0xad, 0x87, 0x49]
         );
     }
 

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     tip403_registry::TIP403Registry,
 };
 use alloy::primitives::{Address, IntoLogData};
+use std::collections::HashMap;
 use tempo_contracts::precompiles::{
     IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
     ZoneFactoryError, ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
@@ -235,6 +236,15 @@ impl ZoneFactory {
 
         self.storage.emit_event(
             portal,
+            ZonePortalEvent::enforcement_modes_updated(
+                call.params.accessMode,
+                call.params.gatewayMode,
+            )
+            .into_log_data(),
+        )?;
+
+        self.storage.emit_event(
+            portal,
             ZonePortalEvent::sequencer_set_updated(
                 0,
                 call.params.threshold,
@@ -243,36 +253,26 @@ impl ZoneFactory {
             .into_log_data(),
         )?;
 
-        self.storage.emit_event(
-            portal,
-            ZonePortalEvent::enforcement_modes_updated(
-                call.params.accessMode,
-                call.params.gatewayMode,
-            )
-            .into_log_data(),
-        )?;
-
+        let mut emitted_roles = HashMap::new();
         for gateway in &call.params.zoneGateways {
+            let previous = emitted_roles
+                .insert(*gateway, ZonePortalRole::CallbackGateway)
+                .unwrap_or(ZonePortalRole::None);
             self.storage.emit_event(
                 portal,
-                ZonePortalEvent::role_updated(
-                    *gateway,
-                    ZonePortalRole::None,
-                    ZonePortalRole::CallbackGateway,
-                )
-                .into_log_data(),
+                ZonePortalEvent::role_updated(*gateway, previous, ZonePortalRole::CallbackGateway)
+                    .into_log_data(),
             )?;
         }
 
         for account in &call.params.allowedAccounts {
+            let previous = emitted_roles
+                .insert(*account, ZonePortalRole::Account)
+                .unwrap_or(ZonePortalRole::None);
             self.storage.emit_event(
                 portal,
-                ZonePortalEvent::role_updated(
-                    *account,
-                    ZonePortalRole::None,
-                    ZonePortalRole::Account,
-                )
-                .into_log_data(),
+                ZonePortalEvent::role_updated(*account, previous, ZonePortalRole::Account)
+                    .into_log_data(),
             )?;
         }
 
@@ -523,6 +523,58 @@ mod tests {
             );
             Ok(())
         })
+    }
+
+    #[test]
+    fn create_zone_emits_constructor_events_in_order_with_duplicate_roles() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        let portal = StorageCtx::enter(&mut storage, || -> eyre::Result<Address> {
+            TIP20Setup::path_usd(ADMIN).apply()?;
+            let mut factory = factory_with_owner(OWNER)?;
+            let mut params = create_params(PATH_USD_ADDRESS);
+            params.zoneGateways = vec![ZONE_GATEWAY, ZONE_GATEWAY];
+            params.allowedAccounts = vec![ALLOWED_ACCOUNT, ALLOWED_ACCOUNT];
+
+            Ok(factory
+                .create_zone(OWNER, IZoneFactory::createZoneCall { params })?
+                .portal)
+        })?;
+
+        let events = storage.get_events(portal);
+        assert!(events.len() >= 6);
+        assert_eq!(
+            &events[..6],
+            &[
+                ZonePortalEvent::enforcement_modes_updated(true, true).into_log_data(),
+                ZonePortalEvent::sequencer_set_updated(0, 2, vec![SEQUENCER_A, SEQUENCER_B],)
+                    .into_log_data(),
+                ZonePortalEvent::role_updated(
+                    ZONE_GATEWAY,
+                    ZonePortalRole::None,
+                    ZonePortalRole::CallbackGateway,
+                )
+                .into_log_data(),
+                ZonePortalEvent::role_updated(
+                    ZONE_GATEWAY,
+                    ZonePortalRole::CallbackGateway,
+                    ZonePortalRole::CallbackGateway,
+                )
+                .into_log_data(),
+                ZonePortalEvent::role_updated(
+                    ALLOWED_ACCOUNT,
+                    ZonePortalRole::None,
+                    ZonePortalRole::Account,
+                )
+                .into_log_data(),
+                ZonePortalEvent::role_updated(
+                    ALLOWED_ACCOUNT,
+                    ZonePortalRole::Account,
+                    ZonePortalRole::Account,
+                )
+                .into_log_data(),
+            ]
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 use alloy::primitives::{Address, IntoLogData};
 use tempo_contracts::precompiles::{
     IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
-    ZoneFactoryError, ZoneFactoryEvent, ZoneInfo, ZonePortalEvent,
+    ZoneFactoryError, ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::TempoAddressExt;
@@ -191,6 +191,7 @@ impl ZoneFactory {
         {
             return Err(ZoneFactoryError::token_transfer_policy_not_set().into());
         }
+        validate_closed_loop_config(&call.params.allowedAccounts, &call.params.zoneGateways)?;
         if call.params.admin.is_zero() {
             return Err(ZoneFactoryError::invalid_admin().into());
         }
@@ -235,6 +236,30 @@ impl ZoneFactory {
             )
             .into_log_data(),
         )?;
+
+        for gateway in &call.params.zoneGateways {
+            self.storage.emit_event(
+                portal,
+                ZonePortalEvent::role_updated(
+                    *gateway,
+                    ZonePortalRole::None,
+                    ZonePortalRole::CallbackGateway,
+                )
+                .into_log_data(),
+            )?;
+        }
+
+        for account in &call.params.allowedAccounts {
+            self.storage.emit_event(
+                portal,
+                ZonePortalEvent::role_updated(
+                    *account,
+                    ZonePortalRole::None,
+                    ZonePortalRole::Account,
+                )
+                .into_log_data(),
+            )?;
+        }
 
         self.storage.emit_event(
             portal,
@@ -283,6 +308,22 @@ impl ZoneFactory {
     }
 }
 
+fn validate_closed_loop_config(
+    allowed_accounts: &[Address],
+    zone_gateways: &[Address],
+) -> Result<()> {
+    if allowed_accounts.is_empty()
+        || zone_gateways.is_empty()
+        || allowed_accounts.contains(&ZONE_MESSENGER_ADDRESS)
+        || zone_gateways
+            .iter()
+            .any(|gateway| allowed_accounts.contains(gateway))
+    {
+        return Err(ZoneFactoryError::invalid_closed_loop_config().into());
+    }
+    Ok(())
+}
+
 fn validate_sequencer_set(sequencers: &[Address], threshold: u8) -> Result<()> {
     if sequencers.is_empty()
         || sequencers.len() > MAX_SEQUENCERS
@@ -329,10 +370,14 @@ mod tests {
     const ADMIN: Address = address!("0x0000000000000000000000000000000000000022");
     const SEQUENCER_A: Address = address!("0x0000000000000000000000000000000000000033");
     const SEQUENCER_B: Address = address!("0x0000000000000000000000000000000000000044");
+    const ALLOWED_ACCOUNT: Address = address!("0x0000000000000000000000000000000000000055");
+    const ZONE_GATEWAY: Address = address!("0x0000000000000000000000000000000000000066");
 
     fn create_params(initial_token: Address) -> IZoneFactory::CreateZoneParams {
         IZoneFactory::CreateZoneParams {
             initialToken: initial_token,
+            allowedAccounts: vec![ALLOWED_ACCOUNT],
+            zoneGateways: vec![ZONE_GATEWAY],
             admin: ADMIN,
             sequencers: vec![SEQUENCER_A, SEQUENCER_B],
             threshold: 2,
@@ -421,6 +466,14 @@ mod tests {
             assert_eq!(portal.sequencers.read()?, vec![SEQUENCER_A, SEQUENCER_B]);
             assert!(portal.is_sequencer[SEQUENCER_A].read()?);
             assert!(portal.is_sequencer[SEQUENCER_B].read()?);
+            assert_eq!(
+                portal.role[ALLOWED_ACCOUNT].read()?,
+                ZonePortalRole::Account as u8
+            );
+            assert_eq!(
+                portal.role[ZONE_GATEWAY].read()?,
+                ZonePortalRole::CallbackGateway as u8
+            );
 
             // Pin the native storage handlers to the canonical Solidity layout.
             assert_eq!(
@@ -437,6 +490,41 @@ mod tests {
                 StorageCtx.sload(created.portal, membership_slot)?,
                 U256::ONE
             );
+            let role_slot =
+                U256::from_be_bytes(keccak256((ALLOWED_ACCOUNT, U256::from(20)).abi_encode()).0);
+            assert_eq!(
+                StorageCtx.sload(created.portal, role_slot)?,
+                U256::from(ZonePortalRole::Account as u8)
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn create_zone_rejects_invalid_closed_loop_config() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            TIP20Setup::path_usd(ADMIN).apply()?;
+            let mut factory = factory_with_owner(OWNER)?;
+
+            for (allowed_accounts, zone_gateways) in [
+                (vec![], vec![ZONE_GATEWAY]),
+                (vec![ALLOWED_ACCOUNT], vec![]),
+                (vec![ZONE_MESSENGER_ADDRESS], vec![ZONE_GATEWAY]),
+                (vec![ALLOWED_ACCOUNT], vec![ALLOWED_ACCOUNT]),
+            ] {
+                let mut params = create_params(PATH_USD_ADDRESS);
+                params.allowedAccounts = allowed_accounts;
+                params.zoneGateways = zone_gateways;
+                let err = factory
+                    .create_zone(OWNER, IZoneFactory::createZoneCall { params })
+                    .unwrap_err();
+                assert_eq!(
+                    err,
+                    TempoPrecompileError::from(ZoneFactoryError::invalid_closed_loop_config())
+                );
+                assert_eq!(factory.next_zone_id()?, 1);
+            }
             Ok(())
         })
     }

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -14,8 +14,7 @@ use crate::{
 use alloy::primitives::{Address, IntoLogData};
 use tempo_contracts::precompiles::{
     IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
-    ZoneAccessMode, ZoneFactoryError, ZoneFactoryEvent, ZoneGatewayMode, ZoneInfo, ZonePortalEvent,
-    ZonePortalRole,
+    ZoneFactoryError, ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::TempoAddressExt;
@@ -46,8 +45,8 @@ pub struct ZoneFactory {
 struct ZoneInfoStorage {
     zone_id: u32,
     portal: Address,
-    access_mode: u8,
-    gateway_mode: u8,
+    access_mode: bool,
+    gateway_mode: bool,
     admin: Address,
     sequencers: Vec<Address>,
     threshold: u8,
@@ -60,16 +59,8 @@ impl From<ZoneInfoStorage> for ZoneInfo {
         Self {
             zoneId: value.zone_id,
             portal: value.portal,
-            accessMode: if value.access_mode == ZoneAccessMode::Closed as u8 {
-                ZoneAccessMode::Closed
-            } else {
-                ZoneAccessMode::Open
-            },
-            gatewayMode: if value.gateway_mode == ZoneGatewayMode::Enforced as u8 {
-                ZoneGatewayMode::Enforced
-            } else {
-                ZoneGatewayMode::Open
-            },
+            accessMode: value.access_mode,
+            gatewayMode: value.gateway_mode,
             admin: value.admin,
             sequencers: value.sequencers,
             threshold: value.threshold,
@@ -233,8 +224,8 @@ impl ZoneFactory {
         self.zones[zone_id].write(ZoneInfoStorage {
             zone_id,
             portal,
-            access_mode: call.params.accessMode as u8,
-            gateway_mode: call.params.gatewayMode as u8,
+            access_mode: call.params.accessMode,
+            gateway_mode: call.params.gatewayMode,
             admin: call.params.admin,
             sequencers: call.params.sequencers.clone(),
             threshold: call.params.threshold,
@@ -386,9 +377,7 @@ mod tests {
         primitives::{B256, Bytes, U256, address, keccak256},
         sol_types::SolValue,
     };
-    use portal::{
-        ACCOUNT_ALLOWLIST_ENFORCED_FLAG, GATEWAY_ALLOWLIST_ENFORCED_FLAG, PortalTokenConfig,
-    };
+    use portal::PortalTokenConfig;
     use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -402,8 +391,8 @@ mod tests {
     fn create_params(initial_token: Address) -> IZoneFactory::CreateZoneParams {
         IZoneFactory::CreateZoneParams {
             initialToken: initial_token,
-            accessMode: ZoneAccessMode::Closed,
-            gatewayMode: ZoneGatewayMode::Enforced,
+            accessMode: true,
+            gatewayMode: true,
             allowedAccounts: vec![ALLOWED_ACCOUNT],
             zoneGateways: vec![ZONE_GATEWAY],
             admin: ADMIN,
@@ -457,8 +446,8 @@ mod tests {
                 ZoneInfo {
                     zoneId: 1,
                     portal: created.portal,
-                    accessMode: ZoneAccessMode::Closed,
-                    gatewayMode: ZoneGatewayMode::Enforced,
+                    accessMode: true,
+                    gatewayMode: true,
                     admin: ADMIN,
                     sequencers: vec![SEQUENCER_A, SEQUENCER_B],
                     threshold: 2,
@@ -504,10 +493,8 @@ mod tests {
                 portal.role[ZONE_GATEWAY].read()?,
                 ZonePortalRole::CallbackGateway as u8
             );
-            assert_eq!(
-                portal.enforcement_flags.read()?,
-                ACCOUNT_ALLOWLIST_ENFORCED_FLAG | GATEWAY_ALLOWLIST_ENFORCED_FLAG
-            );
+            assert!(portal.is_access_enforced.read()?);
+            assert!(portal.is_gateway_enforced.read()?);
 
             // Pin the native storage handlers to the canonical Solidity layout.
             assert_eq!(
@@ -532,7 +519,7 @@ mod tests {
             );
             assert_eq!(
                 StorageCtx.sload(created.portal, U256::from(21))?,
-                U256::from(ACCOUNT_ALLOWLIST_ENFORCED_FLAG | GATEWAY_ALLOWLIST_ENFORCED_FLAG)
+                U256::from(0x0101)
             );
             Ok(())
         })
@@ -554,27 +541,18 @@ mod tests {
                     params: params.clone(),
                 },
             )?;
-            assert_eq!(
-                ZonePortalStorage::new(closed.portal)
-                    .enforcement_flags
-                    .read()?,
-                ACCOUNT_ALLOWLIST_ENFORCED_FLAG | GATEWAY_ALLOWLIST_ENFORCED_FLAG
-            );
+            let closed_portal = ZonePortalStorage::new(closed.portal);
+            assert!(closed_portal.is_access_enforced.read()?);
+            assert!(closed_portal.is_gateway_enforced.read()?);
 
-            params.accessMode = ZoneAccessMode::Open;
-            params.gatewayMode = ZoneGatewayMode::Open;
+            params.accessMode = false;
+            params.gatewayMode = false;
             let open = factory.create_zone(OWNER, IZoneFactory::createZoneCall { params })?;
-            assert_eq!(
-                ZonePortalStorage::new(open.portal)
-                    .enforcement_flags
-                    .read()?,
-                0
-            );
-            assert_eq!(factory.zone(open.zoneId)?.accessMode, ZoneAccessMode::Open);
-            assert_eq!(
-                factory.zone(open.zoneId)?.gatewayMode,
-                ZoneGatewayMode::Open
-            );
+            let open_portal = ZonePortalStorage::new(open.portal);
+            assert!(!open_portal.is_access_enforced.read()?);
+            assert!(!open_portal.is_gateway_enforced.read()?);
+            assert!(!factory.zone(open.zoneId)?.accessMode);
+            assert!(!factory.zone(open.zoneId)?.gatewayMode);
             Ok(())
         })
     }

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -14,7 +14,8 @@ use crate::{
 use alloy::primitives::{Address, IntoLogData};
 use tempo_contracts::precompiles::{
     IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
-    ZoneFactoryError, ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
+    ZoneAccessMode, ZoneFactoryError, ZoneFactoryEvent, ZoneGatewayMode, ZoneInfo, ZonePortalEvent,
+    ZonePortalRole,
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::TempoAddressExt;
@@ -45,6 +46,8 @@ pub struct ZoneFactory {
 struct ZoneInfoStorage {
     zone_id: u32,
     portal: Address,
+    access_mode: u8,
+    gateway_mode: u8,
     admin: Address,
     sequencers: Vec<Address>,
     threshold: u8,
@@ -57,6 +60,16 @@ impl From<ZoneInfoStorage> for ZoneInfo {
         Self {
             zoneId: value.zone_id,
             portal: value.portal,
+            accessMode: if value.access_mode == ZoneAccessMode::Closed as u8 {
+                ZoneAccessMode::Closed
+            } else {
+                ZoneAccessMode::Open
+            },
+            gatewayMode: if value.gateway_mode == ZoneGatewayMode::Enforced as u8 {
+                ZoneGatewayMode::Enforced
+            } else {
+                ZoneGatewayMode::Open
+            },
             admin: value.admin,
             sequencers: value.sequencers,
             threshold: value.threshold,
@@ -220,6 +233,8 @@ impl ZoneFactory {
         self.zones[zone_id].write(ZoneInfoStorage {
             zone_id,
             portal,
+            access_mode: call.params.accessMode as u8,
+            gateway_mode: call.params.gatewayMode as u8,
             admin: call.params.admin,
             sequencers: call.params.sequencers.clone(),
             threshold: call.params.threshold,
@@ -233,6 +248,15 @@ impl ZoneFactory {
                 0,
                 call.params.threshold,
                 call.params.sequencers.clone(),
+            )
+            .into_log_data(),
+        )?;
+
+        self.storage.emit_event(
+            portal,
+            ZonePortalEvent::enforcement_modes_updated(
+                call.params.accessMode,
+                call.params.gatewayMode,
             )
             .into_log_data(),
         )?;
@@ -276,6 +300,8 @@ impl ZoneFactory {
             zone_id,
             portal,
             call.params.initialToken,
+            call.params.accessMode,
+            call.params.gatewayMode,
             call.params.admin,
             call.params.sequencers.clone(),
             call.params.threshold,
@@ -312,9 +338,7 @@ fn validate_closed_loop_config(
     allowed_accounts: &[Address],
     zone_gateways: &[Address],
 ) -> Result<()> {
-    if allowed_accounts.is_empty()
-        || zone_gateways.is_empty()
-        || allowed_accounts.contains(&ZONE_MESSENGER_ADDRESS)
+    if allowed_accounts.contains(&ZONE_MESSENGER_ADDRESS)
         || zone_gateways
             .iter()
             .any(|gateway| allowed_accounts.contains(gateway))
@@ -362,7 +386,9 @@ mod tests {
         primitives::{B256, Bytes, U256, address, keccak256},
         sol_types::SolValue,
     };
-    use portal::PortalTokenConfig;
+    use portal::{
+        ACCOUNT_ALLOWLIST_ENFORCED_FLAG, GATEWAY_ALLOWLIST_ENFORCED_FLAG, PortalTokenConfig,
+    };
     use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
 
@@ -376,6 +402,8 @@ mod tests {
     fn create_params(initial_token: Address) -> IZoneFactory::CreateZoneParams {
         IZoneFactory::CreateZoneParams {
             initialToken: initial_token,
+            accessMode: ZoneAccessMode::Closed,
+            gatewayMode: ZoneGatewayMode::Enforced,
             allowedAccounts: vec![ALLOWED_ACCOUNT],
             zoneGateways: vec![ZONE_GATEWAY],
             admin: ADMIN,
@@ -429,6 +457,8 @@ mod tests {
                 ZoneInfo {
                     zoneId: 1,
                     portal: created.portal,
+                    accessMode: ZoneAccessMode::Closed,
+                    gatewayMode: ZoneGatewayMode::Enforced,
                     admin: ADMIN,
                     sequencers: vec![SEQUENCER_A, SEQUENCER_B],
                     threshold: 2,
@@ -474,6 +504,10 @@ mod tests {
                 portal.role[ZONE_GATEWAY].read()?,
                 ZonePortalRole::CallbackGateway as u8
             );
+            assert_eq!(
+                portal.enforcement_flags.read()?,
+                ACCOUNT_ALLOWLIST_ENFORCED_FLAG | GATEWAY_ALLOWLIST_ENFORCED_FLAG
+            );
 
             // Pin the native storage handlers to the canonical Solidity layout.
             assert_eq!(
@@ -496,6 +530,51 @@ mod tests {
                 StorageCtx.sload(created.portal, role_slot)?,
                 U256::from(ZonePortalRole::Account as u8)
             );
+            assert_eq!(
+                StorageCtx.sload(created.portal, U256::from(21))?,
+                U256::from(ACCOUNT_ALLOWLIST_ENFORCED_FLAG | GATEWAY_ALLOWLIST_ENFORCED_FLAG)
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn create_zone_allows_empty_role_sets_and_open_modes() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            TIP20Setup::path_usd(ADMIN).apply()?;
+            let mut factory = factory_with_owner(OWNER)?;
+
+            let mut params = create_params(PATH_USD_ADDRESS);
+            params.allowedAccounts.clear();
+            params.zoneGateways.clear();
+            let closed = factory.create_zone(
+                OWNER,
+                IZoneFactory::createZoneCall {
+                    params: params.clone(),
+                },
+            )?;
+            assert_eq!(
+                ZonePortalStorage::new(closed.portal)
+                    .enforcement_flags
+                    .read()?,
+                ACCOUNT_ALLOWLIST_ENFORCED_FLAG | GATEWAY_ALLOWLIST_ENFORCED_FLAG
+            );
+
+            params.accessMode = ZoneAccessMode::Open;
+            params.gatewayMode = ZoneGatewayMode::Open;
+            let open = factory.create_zone(OWNER, IZoneFactory::createZoneCall { params })?;
+            assert_eq!(
+                ZonePortalStorage::new(open.portal)
+                    .enforcement_flags
+                    .read()?,
+                0
+            );
+            assert_eq!(factory.zone(open.zoneId)?.accessMode, ZoneAccessMode::Open);
+            assert_eq!(
+                factory.zone(open.zoneId)?.gatewayMode,
+                ZoneGatewayMode::Open
+            );
             Ok(())
         })
     }
@@ -508,8 +587,6 @@ mod tests {
             let mut factory = factory_with_owner(OWNER)?;
 
             for (allowed_accounts, zone_gateways) in [
-                (vec![], vec![ZONE_GATEWAY]),
-                (vec![ALLOWED_ACCOUNT], vec![]),
                 (vec![ZONE_MESSENGER_ADDRESS], vec![ZONE_GATEWAY]),
                 (vec![ALLOWED_ACCOUNT], vec![ALLOWED_ACCOUNT]),
             ] {

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -11,8 +11,7 @@ use crate::{
 use alloy::primitives::{Address, B256, Bytes, U256, hex};
 use revm::state::Bytecode;
 use tempo_contracts::precompiles::{
-    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneAccessMode, ZoneGatewayMode,
-    ZonePortalRole,
+    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZonePortalRole,
 };
 use tempo_precompiles_macros::{Storable, contract};
 
@@ -20,9 +19,6 @@ use tempo_precompiles_macros::{Storable, contract};
 pub const ZONE_PORTAL_PROXY_RUNTIME: [u8; 45] = hex!(
     "363d3d373d3d3d363d735ad10000000000000000000000000000000000005af43d82803e903d91602b57fd5bf3"
 );
-
-pub(super) const ACCOUNT_ALLOWLIST_ENFORCED_FLAG: u8 = 1 << 0;
-pub(super) const GATEWAY_ALLOWLIST_ENFORCED_FLAG: u8 = 1 << 1;
 
 /// Packed `TokenConfig` stored in the portal token registry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Storable)]
@@ -81,7 +77,8 @@ pub struct ZonePortalStorage {
     sequencers: Vec<Address>,
     is_sequencer: Mapping<Address, bool>,
     role: Mapping<Address, u8>,
-    enforcement_flags: u8,
+    is_access_enforced: bool,
+    is_gateway_enforced: bool,
 }
 
 impl ZonePortalStorage {
@@ -115,10 +112,8 @@ impl ZonePortalStorage {
         for sequencer in &params.sequencers {
             self.is_sequencer[*sequencer].write(true)?;
         }
-        self.enforcement_flags.write(encode_enforcement_flags(
-            params.accessMode,
-            params.gatewayMode,
-        ))?;
+        self.is_access_enforced.write(params.accessMode)?;
+        self.is_gateway_enforced.write(params.gatewayMode)?;
         for gateway in &params.zoneGateways {
             self.role[*gateway].write(ZonePortalRole::CallbackGateway as u8)?;
         }
@@ -127,15 +122,4 @@ impl ZonePortalStorage {
         }
         Ok(())
     }
-}
-
-fn encode_enforcement_flags(access_mode: ZoneAccessMode, gateway_mode: ZoneGatewayMode) -> u8 {
-    let mut flags = 0;
-    if access_mode == ZoneAccessMode::Closed {
-        flags |= ACCOUNT_ALLOWLIST_ENFORCED_FLAG;
-    }
-    if gateway_mode == ZoneGatewayMode::Enforced {
-        flags |= GATEWAY_ALLOWLIST_ENFORCED_FLAG;
-    }
-    flags
 }

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -10,7 +10,9 @@ use crate::{
 };
 use alloy::primitives::{Address, B256, Bytes, U256, hex};
 use revm::state::Bytecode;
-use tempo_contracts::precompiles::{IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS};
+use tempo_contracts::precompiles::{
+    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZonePortalRole,
+};
 use tempo_precompiles_macros::{Storable, contract};
 
 /// Exact ERC-1167 deployed proxy runtime installed at every ZonePortal address.
@@ -74,6 +76,7 @@ pub struct ZonePortalStorage {
     zone_height: U256,
     sequencers: Vec<Address>,
     is_sequencer: Mapping<Address, bool>,
+    role: Mapping<Address, u8>,
 }
 
 impl ZonePortalStorage {
@@ -106,6 +109,12 @@ impl ZonePortalStorage {
         self.sequencers.write(params.sequencers.clone())?;
         for sequencer in &params.sequencers {
             self.is_sequencer[*sequencer].write(true)?;
+        }
+        for gateway in &params.zoneGateways {
+            self.role[*gateway].write(ZonePortalRole::CallbackGateway as u8)?;
+        }
+        for account in &params.allowedAccounts {
+            self.role[*account].write(ZonePortalRole::Account as u8)?;
         }
         Ok(())
     }

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -11,7 +11,8 @@ use crate::{
 use alloy::primitives::{Address, B256, Bytes, U256, hex};
 use revm::state::Bytecode;
 use tempo_contracts::precompiles::{
-    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZonePortalRole,
+    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneAccessMode, ZoneGatewayMode,
+    ZonePortalRole,
 };
 use tempo_precompiles_macros::{Storable, contract};
 
@@ -19,6 +20,9 @@ use tempo_precompiles_macros::{Storable, contract};
 pub const ZONE_PORTAL_PROXY_RUNTIME: [u8; 45] = hex!(
     "363d3d373d3d3d363d735ad10000000000000000000000000000000000005af43d82803e903d91602b57fd5bf3"
 );
+
+pub(super) const ACCOUNT_ALLOWLIST_ENFORCED_FLAG: u8 = 1 << 0;
+pub(super) const GATEWAY_ALLOWLIST_ENFORCED_FLAG: u8 = 1 << 1;
 
 /// Packed `TokenConfig` stored in the portal token registry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Storable)]
@@ -77,6 +81,7 @@ pub struct ZonePortalStorage {
     sequencers: Vec<Address>,
     is_sequencer: Mapping<Address, bool>,
     role: Mapping<Address, u8>,
+    enforcement_flags: u8,
 }
 
 impl ZonePortalStorage {
@@ -110,6 +115,10 @@ impl ZonePortalStorage {
         for sequencer in &params.sequencers {
             self.is_sequencer[*sequencer].write(true)?;
         }
+        self.enforcement_flags.write(encode_enforcement_flags(
+            params.accessMode,
+            params.gatewayMode,
+        ))?;
         for gateway in &params.zoneGateways {
             self.role[*gateway].write(ZonePortalRole::CallbackGateway as u8)?;
         }
@@ -118,4 +127,15 @@ impl ZonePortalStorage {
         }
         Ok(())
     }
+}
+
+fn encode_enforcement_flags(access_mode: ZoneAccessMode, gateway_mode: ZoneGatewayMode) -> u8 {
+    let mut flags = 0;
+    if access_mode == ZoneAccessMode::Closed {
+        flags |= ACCOUNT_ALLOWLIST_ENFORCED_FLAG;
+    }
+    if gateway_mode == ZoneGatewayMode::Enforced {
+        flags |= GATEWAY_ALLOWLIST_ENFORCED_FLAG;
+    }
+    flags
 }

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -91,6 +91,12 @@ A successful createZone call MUST consume at least 15,000,000 gas.
 `createZone` MUST reject an initial token that does not have an explicit TIP-403
 transfer-policy binding.
 
+Zone creation MUST also provide nonempty `allowedAccounts` and `zoneGateways`
+lists. The shared messenger MUST NOT be an allowed account, and an address MUST
+NOT appear in both lists. Duplicate and zero-address entries are permitted. The
+factory initializes allowed accounts with the `Account` role and zone gateways
+with the `CallbackGateway` role in the new portal.
+
 Each zone portal is installed at:
 
 ```text

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -187,10 +187,10 @@ MUST NOT rely on nonce-based address prediction. Instead, the native factory:
 2. assigns the next zone ID;
 3. computes the portal vanity address;
 4. etches `portal_proxy_runtime` at that address;
-5. calls the portal's factory-only initializer with the enforcement modes, role
+5. calls the portal's factory-only initializer with the enforcement flags, role
    lists, sequencer set, threshold, and protocol-managed verifier and messenger
    addresses;
-6. records the zone ID, portal, initial enforcement modes, admin, sequencer set,
+6. records the zone ID, portal, initial enforcement flags, admin, sequencer set,
    threshold, verifier, and RPC URL, and emits `ZoneCreated`.
 
 The portal account MUST NOT contain a full copy of `ZonePortal` runtime
@@ -208,9 +208,9 @@ derived from the address that deploys the logic.
 The initialized portal MUST use `ZONE_MESSENGER_ADDRESS` as its shared
 messenger. Its initial zone `blockHash` MUST be `bytes32(0)`. Withdrawal callback
 behavior MUST match the canonical `ZonePortal.sol` reference. It MUST store
-account and gateway enforcement in a dedicated flags slot where zero represents
-open/open, and MUST emit `EnforcementModesUpdated` during initialization before
-the initial `RoleUpdated` events.
+account and gateway enforcement as two packed booleans in a dedicated slot where
+zero represents open/open, and MUST emit `EnforcementModesUpdated` during
+initialization before the initial `RoleUpdated` events.
 
 User withdrawals MUST expose only a nonzero `uint64 fallbackNonce` on Tempo.
 The zone outbox assigns this nonce monotonically and stores its mapping to the

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -91,11 +91,15 @@ A successful createZone call MUST consume at least 15,000,000 gas.
 `createZone` MUST reject an initial token that does not have an explicit TIP-403
 transfer-policy binding.
 
-Zone creation MUST also provide nonempty `allowedAccounts` and `zoneGateways`
-lists. The shared messenger MUST NOT be an allowed account, and an address MUST
-NOT appear in both lists. Duplicate and zero-address entries are permitted. The
-factory initializes allowed accounts with the `Account` role and zone gateways
-with the `CallbackGateway` role in the new portal.
+Zone creation selects independent initial enforcement modes for account access
+(`Closed` or `Open`) and callback gateways (`Enforced` or `Open`). The optional
+`allowedAccounts` and `zoneGateways` lists prepopulate roles even while their
+corresponding mode is open. An empty closed or enforced role set denies all such
+access until the admin assigns a role or changes the mode. The shared messenger
+MUST NOT be an allowed account, and an address MUST NOT appear in both lists.
+Duplicate and zero-address entries are permitted. The factory initializes
+allowed accounts with the `Account` role and zone gateways with the
+`CallbackGateway` role in the new portal.
 
 Each zone portal is installed at:
 
@@ -183,10 +187,11 @@ MUST NOT rely on nonce-based address prediction. Instead, the native factory:
 2. assigns the next zone ID;
 3. computes the portal vanity address;
 4. etches `portal_proxy_runtime` at that address;
-5. calls the portal's factory-only initializer with the sequencer set,
-   threshold, and the protocol-managed verifier and messenger addresses;
-6. records the zone ID, portal, admin, sequencer set, threshold, verifier, and
-   RPC URL, and emits `ZoneCreated`.
+5. calls the portal's factory-only initializer with the enforcement modes, role
+   lists, sequencer set, threshold, and protocol-managed verifier and messenger
+   addresses;
+6. records the zone ID, portal, initial enforcement modes, admin, sequencer set,
+   threshold, verifier, and RPC URL, and emits `ZoneCreated`.
 
 The portal account MUST NOT contain a full copy of `ZonePortal` runtime
 bytecode. It MUST route to one protocol-managed portal logic implementation,
@@ -202,7 +207,10 @@ derived from the address that deploys the logic.
 
 The initialized portal MUST use `ZONE_MESSENGER_ADDRESS` as its shared
 messenger. Its initial zone `blockHash` MUST be `bytes32(0)`. Withdrawal callback
-behavior MUST match the canonical `ZonePortal.sol` reference.
+behavior MUST match the canonical `ZonePortal.sol` reference. It MUST store
+account and gateway enforcement in a dedicated flags slot where zero represents
+open/open, and MUST emit `EnforcementModesUpdated` during initialization before
+the initial `RoleUpdated` events.
 
 User withdrawals MUST expose only a nonzero `uint64 fallbackNonce` on Tempo.
 The zone outbox assigns this nonce monotonically and stores its mapping to the

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -1,10 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+enum ZoneAccessMode {
+    Closed,
+    Open
+}
+
+enum ZoneGatewayMode {
+    Enforced,
+    Open
+}
+
 /// @notice Zone metadata recorded by the native factory.
 struct ZoneInfo {
     uint32 zoneId;
     address portal;
+    ZoneAccessMode accessMode;
+    ZoneGatewayMode gatewayMode;
     address admin;
     address[] sequencers;
     uint8 threshold;
@@ -18,6 +30,8 @@ interface IZonePortalInitializer {
     function initialize(
         uint32 zoneId,
         address initialToken,
+        ZoneAccessMode accessMode,
+        ZoneGatewayMode gatewayMode,
         address[] calldata allowedAccounts,
         address[] calldata zoneGateways,
         address messenger,
@@ -37,6 +51,8 @@ interface IZoneFactory {
 
     struct CreateZoneParams {
         address initialToken;
+        ZoneAccessMode accessMode;
+        ZoneGatewayMode gatewayMode;
         address[] allowedAccounts;
         address[] zoneGateways;
         address admin;
@@ -57,6 +73,8 @@ interface IZoneFactory {
         uint32 indexed zoneId,
         address indexed portal,
         address initialToken,
+        ZoneAccessMode accessMode,
+        ZoneGatewayMode gatewayMode,
         address admin,
         address[] sequencers,
         uint8 threshold,

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -18,6 +18,8 @@ interface IZonePortalInitializer {
     function initialize(
         uint32 zoneId,
         address initialToken,
+        address[] calldata allowedAccounts,
+        address[] calldata zoneGateways,
         address messenger,
         address admin,
         address[] calldata sequencers,
@@ -35,6 +37,8 @@ interface IZoneFactory {
 
     struct CreateZoneParams {
         address initialToken;
+        address[] allowedAccounts;
+        address[] zoneGateways;
         address admin;
         address[] sequencers;
         uint8 threshold;
@@ -61,6 +65,7 @@ interface IZoneFactory {
 
     error InvalidToken();
     error TokenTransferPolicyNotSet();
+    error InvalidClosedLoopConfig();
     error NotOwner();
     error InvalidAdmin();
     error InvalidSequencerSet();

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -1,22 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-enum ZoneAccessMode {
-    Closed,
-    Open
-}
-
-enum ZoneGatewayMode {
-    Enforced,
-    Open
-}
-
 /// @notice Zone metadata recorded by the native factory.
 struct ZoneInfo {
     uint32 zoneId;
     address portal;
-    ZoneAccessMode accessMode;
-    ZoneGatewayMode gatewayMode;
+    bool accessMode;
+    bool gatewayMode;
     address admin;
     address[] sequencers;
     uint8 threshold;
@@ -30,8 +20,8 @@ interface IZonePortalInitializer {
     function initialize(
         uint32 zoneId,
         address initialToken,
-        ZoneAccessMode accessMode,
-        ZoneGatewayMode gatewayMode,
+        bool accessMode,
+        bool gatewayMode,
         address[] calldata allowedAccounts,
         address[] calldata zoneGateways,
         address messenger,
@@ -51,8 +41,8 @@ interface IZoneFactory {
 
     struct CreateZoneParams {
         address initialToken;
-        ZoneAccessMode accessMode;
-        ZoneGatewayMode gatewayMode;
+        bool accessMode;
+        bool gatewayMode;
         address[] allowedAccounts;
         address[] zoneGateways;
         address admin;
@@ -73,8 +63,8 @@ interface IZoneFactory {
         uint32 indexed zoneId,
         address indexed portal,
         address initialToken,
-        ZoneAccessMode accessMode,
-        ZoneGatewayMode gatewayMode,
+        bool accessMode,
+        bool gatewayMode,
         address admin,
         address[] sequencers,
         uint8 threshold,

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -72,9 +72,6 @@ abstract contract ZoneFactory is IZoneFactory {
         if (!_nativeTokenTransferPolicyIsSet(params.initialToken)) {
             revert TokenTransferPolicyNotSet();
         }
-        if (params.allowedAccounts.length == 0 || params.zoneGateways.length == 0) {
-            revert InvalidClosedLoopConfig();
-        }
         for (uint256 i; i < params.allowedAccounts.length; ++i) {
             if (params.allowedAccounts[i] == ZONE_MESSENGER_ADDRESS) {
                 revert InvalidClosedLoopConfig();
@@ -113,6 +110,8 @@ abstract contract ZoneFactory is IZoneFactory {
             .initialize(
                 zoneId,
                 params.initialToken,
+                params.accessMode,
+                params.gatewayMode,
                 params.allowedAccounts,
                 params.zoneGateways,
                 ZONE_MESSENGER_ADDRESS,
@@ -126,6 +125,8 @@ abstract contract ZoneFactory is IZoneFactory {
         _zones[zoneId] = ZoneInfo({
             zoneId: zoneId,
             portal: portal,
+            accessMode: params.accessMode,
+            gatewayMode: params.gatewayMode,
             admin: params.admin,
             sequencers: params.sequencers,
             threshold: params.threshold,
@@ -137,6 +138,8 @@ abstract contract ZoneFactory is IZoneFactory {
             zoneId,
             portal,
             params.initialToken,
+            params.accessMode,
+            params.gatewayMode,
             params.admin,
             params.sequencers,
             params.threshold,

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -72,6 +72,21 @@ abstract contract ZoneFactory is IZoneFactory {
         if (!_nativeTokenTransferPolicyIsSet(params.initialToken)) {
             revert TokenTransferPolicyNotSet();
         }
+        if (params.allowedAccounts.length == 0 || params.zoneGateways.length == 0) {
+            revert InvalidClosedLoopConfig();
+        }
+        for (uint256 i; i < params.allowedAccounts.length; ++i) {
+            if (params.allowedAccounts[i] == ZONE_MESSENGER_ADDRESS) {
+                revert InvalidClosedLoopConfig();
+            }
+        }
+        for (uint256 i; i < params.zoneGateways.length; ++i) {
+            for (uint256 j; j < params.allowedAccounts.length; ++j) {
+                if (params.zoneGateways[i] == params.allowedAccounts[j]) {
+                    revert InvalidClosedLoopConfig();
+                }
+            }
+        }
         if (params.admin == address(0)) revert InvalidAdmin();
         _validateSequencerSet(params.sequencers, params.threshold);
 
@@ -98,6 +113,8 @@ abstract contract ZoneFactory is IZoneFactory {
             .initialize(
                 zoneId,
                 params.initialToken,
+                params.allowedAccounts,
+                params.zoneGateways,
                 ZONE_MESSENGER_ADDRESS,
                 params.admin,
                 params.sequencers,


### PR DESCRIPTION
## Summary

- extend TIP-1091 `CreateZoneParams`, `ZoneInfo`, and `ZoneCreated` with independent boolean account-access and callback-gateway enforcement modes
- initialize the portal's two Solidity-packed enforcement booleans and optional account/gateway roles directly from the native factory
- preserve the canonical portal initialization log order: enforcement modes, sequencer set, then roles
- preserve the true previous role in `RoleUpdated` for duplicate gateway or account entries, matching Solidity `_setRole`
- allow empty account and gateway sets while retaining messenger and overlapping-role validation
- update TIP-1091, the Solidity verification artifact, ABI selector, and storage-layout coverage

## Cross-repository alignment

This PR is the Tempo counterpart to [tempoxyz/zones#810](https://github.com/tempoxyz/zones/pull/810), which defines the canonical mutable access and gateway behavior.

[tempoxyz/zones#811](https://github.com/tempoxyz/zones/pull/811) consumes this native factory ABI, passes the complete initial configuration through `createZone`, and re-enables the nine factory-dependent integration tests without post-creation configuration shims.

## Why

Zones may enforce account access and callback gateways independently. Open/open is the zero-value portal configuration; memberships can be staged while enforcement is disabled; and an enforced mode with an empty role set denies access until the administrator changes the mode or grants a role.

Tempo's native `ZoneFactory` bypasses the Solidity initializer and writes portal storage directly. Its ABI, boolean encoding, storage initialization, event order, event payloads, registry snapshot, and verification artifact therefore need to remain exactly aligned with the canonical Zones implementation.

Duplicate entries remain valid because the canonical initializer processes every array entry. The native factory mirrors that behavior and emits the resulting `None -> Role` followed by `Role -> Role` transitions.

## Validation

- `cargo test -p tempo-precompiles zone_factory::tests -- --nocapture` (10 passed)
- `cargo clippy -p tempo-precompiles -p tempo-revm --all-targets -- -D warnings`
- `rustup run nightly cargo fmt --all -- --check`
