### PR TITLE
docs(tip-1092): preserve local policy on update

### DIFF
--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -70,7 +70,7 @@ is active.
 After activation:
 
 - `transferPolicyId()` returns the effective policy ID: the TIP-403 registry binding if one exists, otherwise the token-local policy ID.
-- `changeTransferPolicyId(uint64 newPolicyId)` MUST update TIP-403. If no binding exists, it MUST delete the local TIP-20 policy slot and set the TIP-403 binding to `newPolicyId` atomically; it need not copy the old value first.
+- `changeTransferPolicyId(uint64 newPolicyId)` MUST set the TIP-403 binding to `newPolicyId`. It MUST NOT migrate or delete the local TIP-20 policy slot.
 - TIP-20 authorization paths use the effective policy ID.
 
 ## Token Creation
@@ -87,7 +87,7 @@ function migrateTransferPolicyIds(address[] calldata tokens) external returns (u
 
 `migrateTransferPolicyIds(tokens)` MUST, for each valid TIP-20 token without a TIP-403 binding, copy the local policy ID into TIP-403, then delete the local TIP-20 policy slot. It MUST skip an existing TIP-403 binding without reading local state. Invalid token addresses are skipped. The function is callable by any account.
 
-Operators manually migrate existing tokens that are already enabled on a running zone. Zone token enablement migrates an unset binding before accepting the token. An admin policy update also creates the binding for an otherwise unmigrated token, but does not copy the prior local policy ID because `newPolicyId` replaces it.
+Operators manually migrate existing tokens that are already enabled on a running zone. Zone token enablement migrates an unset binding before accepting the token. An admin policy update also creates the binding for an otherwise unmigrated token, but does not copy or delete the prior local policy ID because `newPolicyId` replaces it.
 
 As of July 10, 2026, chain scans found:
 
@@ -116,5 +116,5 @@ This TIP does not change policy-update events. The existing TIP-20 `TransferPoli
 # Invariants
 
 - Unset registry state remains distinguishable from policy ID `0`.
-- Migration copies the token's current local policy ID into TIP-403 and deletes the local policy ID; a first post-activation policy update instead deletes the local policy ID and writes `newPolicyId` directly to TIP-403.
+- Migration copies the token's current local policy ID into TIP-403 and deletes the local policy ID; a post-activation policy update writes `newPolicyId` directly to TIP-403 without migrating or deleting the local policy ID.
 - Once a TIP-403 binding exists, the token-local policy slot is not read or written.


### PR DESCRIPTION
## Summary
- specify that `changeTransferPolicyId` updates the TIP-403 binding without migrating or deleting the token-local policy slot
- align the migration discussion and invariants with that behavior

## Verification
- reviewed `cfdbc8e74`: the T9 path writes `newPolicyId` directly through `TIP403Registry::set_token_transfer_policy` and does not delete legacy storage
- confirmed `test_change_transfer_policy_id_sets_registry_binding` asserts the registry binding changes while the legacy slot remains `ALLOW_ALL_POLICY_ID`
- `cargo test -p tempo-precompiles test_change_transfer_policy_id_sets_registry_binding -- --exact --nocapture` could not start because dependency fetch for `commonwarexyz/monorepo` returned HTTP 401 / invalid credentials
- `git diff --check` passes

Ref: SIGP-318

Prompted by: @legion2002