### PR TITLE
feat(precompiles): expose TokenTransferPolicy

### DIFF
--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -70,7 +70,7 @@ pub struct TIP403Registry {
 
 /// Packed TIP-1092 token-to-policy binding.
 #[derive(Debug, Clone, Default, Storable)]
-struct TokenTransferPolicy {
+pub struct TokenTransferPolicy {
     /// Active transfer policy ID.
     policy_id: u64,
     /// Distinguishes an unset binding from the valid reject-all policy ID `0`.


### PR DESCRIPTION
## Summary

Make `TokenTransferPolicy` public so downstream code can reference the packed TIP-1092 binding type.

## Validation

- `cargo +nightly fmt --check`
- `cargo check -p tempo-precompiles` *(blocked: Cargo received HTTP 401 fetching the pinned `commonwarexyz/monorepo` Git dependency)*

Prompted by: @0xrusowsky