### PR TITLE
feat(evm): allow custom fee token validation

### DIFF
--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -82,6 +82,15 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
     /// Validates whether a TIP-20 can be used to pay fees.
     ///
     /// The handler checks the TIP-20 prefix first. Implementations define which tokens are valid.
+    /// `journal` is mutable because validation reads can warm accounts and storage, but
+    /// implementations must not stage state changes here.
+    ///
+    /// This hook runs before nonce and replay state are consumed. Do not return
+    /// `CollectFeePreTx`, `FeeTokenPaused`, or `LackOfFundForMaxFee`; subblock handling treats
+    /// those as post-nonce fee collection failures.
+    ///
+    /// Implementations charging non-zero fees in non-USD tokens must normalize them to the fee
+    /// unit used by admission, ordering, charging, and settlement.
     fn validate_fee_token(
         &self,
         journal: &mut Journal<DB>,

--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -79,11 +79,9 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
         TempoFeeManager::new().resolve_fee_token(journal, tx, fee_payer, spec, actions)
     }
 
-    /// Validates protocol-specific eligibility for a TIP-20 fee token.
+    /// Validates whether a TIP-20 can be used to pay fees.
     ///
-    /// The handler validates the TIP-20 address prefix before calling this hook. Tempo keeps the
-    /// canonical USD-only policy by default; downstream EVMs may replace it with their own
-    /// state-backed eligibility rule.
+    /// The handler checks the TIP-20 prefix first. Implementations define which tokens are valid.
     fn validate_fee_token(
         &self,
         journal: &mut Journal<DB>,

--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -1,12 +1,13 @@
 use crate::{
-    TempoBlockEnv, TempoStateAccess, TempoTx, TempoTxEnv, common::is_tip20_fee_inference_call,
+    TempoBlockEnv, TempoInvalidTransaction, TempoStateAccess, TempoTx, TempoTxEnv,
+    common::is_tip20_fee_inference_call,
 };
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolCall;
 use core::fmt::Debug;
 use revm::{
     Database,
-    context::{CfgEnv, Journal},
+    context::{CfgEnv, Journal, result::EVMError},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
@@ -76,6 +77,21 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
         actions: StorageActions,
     ) -> TempoResult<Address> {
         TempoFeeManager::new().resolve_fee_token(journal, tx, fee_payer, spec, actions)
+    }
+
+    /// Validates protocol-specific eligibility for a TIP-20 fee token.
+    ///
+    /// The handler validates the TIP-20 address prefix before calling this hook. Tempo keeps the
+    /// canonical USD-only policy by default; downstream EVMs may replace it with their own
+    /// state-backed eligibility rule.
+    fn validate_fee_token(
+        &self,
+        journal: &mut Journal<DB>,
+        fee_token: Address,
+        spec: TempoHardfork,
+        actions: StorageActions,
+    ) -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
+        journal.ensure_tip20_usd(spec, fee_token, actions)
     }
 
     /// Resolves the validator token used to receive protocol fees.

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -984,9 +984,8 @@ where
             return Err(TempoInvalidTransaction::FeeTokenNotTip20 { address: fee_token }.into());
         }
 
-        // Skip fee-token policy validation for cases when the transaction is free and is not a
-        // part of a subblock. The TIP20 prefix is always validated above; the fee manager owns the
-        // remaining protocol-specific eligibility rule.
+        // Skip fee token validation when the transaction is free and not part of a subblock.
+        // The TIP20 prefix is already validated above.
         if !tx.max_balance_spending()?.is_zero() || tx.is_subblock_transaction() {
             fee_manager.validate_fee_token(journal, fee_token, cfg.spec, actions.clone())?;
         }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -65,7 +65,6 @@ use tempo_primitives::{
 
 use crate::{
     ProtocolFeeContext, TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction, TempoTxEnv,
-    common::TempoStateAccess,
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
     gas_credits,
@@ -985,10 +984,11 @@ where
             return Err(TempoInvalidTransaction::FeeTokenNotTip20 { address: fee_token }.into());
         }
 
-        // Skip USD currency check for cases when the transaction is free and is not a part of a subblock.
-        // Since we already validated the TIP20 prefix above, we only need to check the USD currency.
+        // Skip fee-token policy validation for cases when the transaction is free and is not a
+        // part of a subblock. The TIP20 prefix is always validated above; the fee manager owns the
+        // remaining protocol-specific eligibility rule.
         if !tx.max_balance_spending()?.is_zero() || tx.is_subblock_transaction() {
-            journal.ensure_tip20_usd(cfg.spec, fee_token, actions.clone())?;
+            fee_manager.validate_fee_token(journal, fee_token, cfg.spec, actions.clone())?;
         }
 
         // Load the fee payer balance


### PR DESCRIPTION
Routes fee-token validation through ProtocolFeeManager while preserving Tempo's USD-only default. Zones overrides the hook to accept any initialized TIP-20 without changing Tempo storage-credit behavior.