### PR TITLE
docs(tip-1024): limit liquidity summation to view path

### DIFF
--- a/tips/tip-1024.md
+++ b/tips/tip-1024.md
@@ -75,9 +75,8 @@ Dropping the `totalLiquidity` sync requirement also opens flexibility for the fu
    - `getTickLevel` keeps its current return shape, including `totalLiquidity`.
    - `getTickLevel.totalLiquidity` MUST be computed on demand by traversing the tick's linked-list orders and summing `remaining`, rather than reading a maintained aggregate slot.
 
-6. Overflow safety:
-   - Implementations MUST use checked arithmetic when summing `remaining` across orders at a tick. Placing a new order MUST revert if the resulting per-tick `totalLiquidity` would exceed `2^128 - 1`. If a flip-order placement would cause overflow, the flip MUST fail silently (the flip is skipped, not the parent swap).
-   - This replaces the previous overflow guard provided by the maintained `totalLiquidity` accumulator's `checked_add` on each order placement.
+6. On-demand sum overflow:
+   - `getTickLevel` MUST use checked arithmetic when summing `remaining` across orders at a tick and revert if the result exceeds `2^128 - 1`.
 
 7. Migration:
    - The per-tick `totalLiquidity` storage field in `TickLevel` becomes unused by swap execution after this change.


### PR DESCRIPTION
Removes the order-placement and flip-placement overflow requirements from TIP-1024 after benchmarks showed that traversing the full tick on every placement causes an unacceptable performance regression.

The spec now requires checked summation only in `getTickLevel`, matching the implementation in #6939. Order placement no longer computes tick liquidity on T9.

Prompted by: @0xrusowsky