### PR TITLE
docs(tip-1088): derive tick liquidity on demand

### DIFF
--- a/tips/tip-1088.md
+++ b/tips/tip-1088.md
@@ -1,20 +1,22 @@
 ---
 id: TIP-1088
-title: Unify quote/swap fill logic and derive tick liquidity on demand
-description: Route StablecoinDEX quotes through per-order swap fill logic and stop maintaining the per-tick liquidity aggregate.
+title: Unify quote/swap fill logic
+description: Route the StablecoinDEX quote paths through the same per-order fill engine as the swap paths to eliminate deterministic quote/swap drift.
 authors: Dan Robinson
 status: Draft
 related: TIP-1002, TIP-1005
 protocolVersion: T9
 ---
 
-# TIP-1088: Unify quote/swap fill logic and derive tick liquidity on demand
+# TIP-1088: Unify quote/swap fill logic
 
 ## Abstract
 
-`quote()` and `swap()` currently use different internal logic to traverse liquidity and apply rounding. `quote()` operates per-tick using a stored tick-level aggregate, while `swap()` operates per-order. Over multi-order paths, this causes deterministic divergence between quoted and executed prices due to accumulated rounding differences at order boundaries within a tick.
+`quote()` and `swap()` currently use different internal logic to traverse liquidity and apply rounding. `quote()` operates per-tick using the tick-level aggregate, while `swap()` operates per-order. Over multi-order paths, this causes deterministic divergence between quoted and executed prices due to accumulated rounding differences at order boundaries within a tick.
 
-This TIP routes `quote()` through the same per-order fill logic as `swap()`, executed in a read-only simulation. Quote becomes "swap without state writes," so a quote returns exactly what the matching swap executes. Since quote no longer depends on the stored per-tick `totalLiquidity` aggregate, this TIP also stops maintaining that aggregate and derives `getTickLevel.totalLiquidity` on demand from active orders. The change is gated at T9; below T9 the existing behavior is unchanged.
+This TIP routes `quote()` through the same per-order fill logic as `swap()`, executed in a read-only simulation. Quote becomes "swap without state writes," so a quote returns exactly what the matching swap executes. The change is gated at T9; below T9 the existing per-tick quote is unchanged.
+
+Since T9 quotes no longer use the stored per-tick `totalLiquidity` aggregate, T9 also stops maintaining that aggregate and instead derives `getTickLevel.totalLiquidity` on demand from active orders.
 
 ## Motivation
 
@@ -29,26 +31,28 @@ The four affected entrypoints are:
 - `swapExactAmountIn(tokenIn, tokenOut, amountIn, minAmountOut)` → executes swap
 - `swapExactAmountOut(tokenIn, tokenOut, amountOut, maxAmountIn)` → executes swap
 
-When multiple orders exist at the same tick, `quote()` rounds once against the aggregate while `swap()` rounds per order, causing deterministic price divergence with no intervening state change. Because `swap()` rounds each order's output down, the executed output can be strictly less than the quote — as little as one unit — so a caller that sets `minAmountOut` to the quote can see the swap revert with `InsufficientOutput`.
+When multiple orders exist at the same tick, `quote()` rounds once against the aggregate while `swap()` rounds per order, causing deterministic price divergence with no intervening state change. Because `swap()` rounds each order's output down, the executed output can be strictly less than the quote — as little as one unit — so a caller that sets `minAmountOut` to the quote can see the swap revert with `InsufficientOutput`. This is surprising for integrators and makes swap routing harder, since quoted prices cannot be trusted as exact execution prices.
 
-Making `quote()` accurate requires iterating over individual orders, exactly as `swap()` does. Once quote no longer uses `totalLiquidity`, maintaining that aggregate imposes storage writes during order placement, fills, and cancellation without serving matching. Removing those writes reduces swap and order-management cost and allows future fill behavior to evolve without keeping a redundant aggregate synchronized.
+Making `quote()` accurate requires an implementation that iterates over individual orders, exactly as `swap()` does.
+
+Once quotes no longer use `totalLiquidity`, maintaining that aggregate imposes redundant storage writes during order placement, fills, and cancellation.
 
 ---
 
 # Specification
 
-1. Introduce shared per-order traversal and fill arithmetic used by quote and swap:
-   - Quote traverses orders without mutation.
-   - Swap retains its existing orderbook mutations and side effects.
+1. Introduce a shared fill engine with two modes:
+   - `Simulate`: identical per-order matching and rounding logic, no state mutation.
+   - `Execute`: existing swap behavior with state mutation.
 
-2. Route both quote and swap entrypoints through the shared logic:
-   - `quoteSwapExactAmountIn` and `quoteSwapExactAmountOut` use read-only per-order traversal.
-   - `swapExactAmountIn` and `swapExactAmountOut` use the same traversal and arithmetic while executing fills.
+2. Route both quote and swap entrypoints through this shared engine:
+   - `quoteSwapExactAmountIn` and `quoteSwapExactAmountOut` call shared fill logic in `Simulate` mode.
+   - `swapExactAmountIn` and `swapExactAmountOut` call shared fill logic in `Execute` mode.
 
-3. The read-only quote path MUST:
-   - Traverse the same reachable ticks and the same individual orders within those ticks, in the same priority order as the swap path. Traversal occurs at **order granularity**, not tick-aggregate granularity.
+3. In `Simulate` mode, the engine MUST:
+   - Traverse the same reachable ticks and the same individual orders within those ticks, in the same priority order as `Execute` mode. Traversal occurs at **order granularity**, not tick-aggregate granularity.
    - Apply the same rounding direction at every conversion step.
-   - Produce the same fill amounts and price progression as swap for an identical state snapshot.
+   - Produce the same fill amounts and price progression as `Execute` mode for an identical state snapshot.
    - Avoid all writes and side effects:
      - no order remaining updates
      - no order/tick removals
@@ -59,44 +63,33 @@ Making `quote()` accurate requires iterating over individual orders, exactly as 
      - no transient storage writes
      - no gas refunds, discounts, or flip-specific gas accounting (e.g. TIP-1044)
 
-4. Swap fill behavior remains functionally equivalent to pre-T9 semantics, except that write paths MUST NOT update the stored per-tick `totalLiquidity` field. This applies to order placement, partial and full fills, cancellation, and flip-order placement.
+4. In `Execute` mode, the engine behavior remains functionally equivalent to current swap semantics, except that at T9 write paths MUST NOT update the stored per-tick `totalLiquidity` field. This applies to order placement, partial and full fills, cancellation, and flip-order placement.
 
-5. `getTickLevel` compatibility:
-   - The function signature and return shape remain unchanged.
-   - At T9, `getTickLevel.totalLiquidity` MUST equal the sum of `remaining` across all active orders in the tick's linked list.
-   - The getter MUST compute this value on demand with checked addition and MUST revert on arithmetic overflow.
-   - Write paths MUST NOT traverse the tick's orders to compute or validate aggregate liquidity.
+5. Tick liquidity compatibility at T9:
+   - The `getTickLevel` function signature and return shape remain unchanged.
+   - `getTickLevel.totalLiquidity` MUST equal the checked sum of `remaining` across all active orders in the tick's linked list.
+   - Write paths MUST NOT traverse a tick's orders to compute or validate aggregate liquidity.
+   - Existing `TickLevel.totalLiquidity` storage slots remain in place but become stale, deprecated state. No migration or clearing is required.
 
-6. Storage compatibility:
-   - Existing `TickLevel.totalLiquidity` storage slots MUST remain in place because storage layout is consensus state.
-   - At T9, those slots become deprecated stale state and MUST NOT affect matching, placement, fills, cancellation, or the value returned by `getTickLevel`.
-   - No migration or clearing of existing slots is required.
-   - Raw-slot readers MUST switch to `getTickLevel` or derive liquidity from active orders.
-
-7. API and error compatibility:
+6. API compatibility:
    - External quote and swap method signatures remain unchanged.
-   - Quote precision now matches swap precision exactly for the same state snapshot. Parity is scoped to fill math; caller-level and token-specific constraints and execute-only side effects are outside this guarantee.
-   - When available liquidity cannot satisfy the trade, quote fails with `InsufficientLiquidity`, matching swap.
-
-8. Performance:
-   - Quote changes from per-tick to per-order traversal.
-   - `getTickLevel` changes from O(1) to O(N) in the number of active orders at the requested tick.
-   - Placement, fills, cancellation, and flip-order placement MUST NOT incur an O(N) liquidity scan.
-   - Swap and order-management paths save the storage operations previously used to maintain `totalLiquidity`.
+   - Quote precision now matches swap precision exactly for the same state snapshot. Parity is scoped to the fill math (tick/order traversal, rounding, and fill amounts); caller-level and token-specific constraints (e.g., TIP-20 transfer fees) and execute-only side effects are outside this guarantee. In particular, `swap()` places flip orders and `quote()` does not: a flip-order placement that raises a system error reverts `swap()` (post-T1A) but not `quote()`. Business-logic flip failures are swallowed and do not change the taker fill, so fill-math parity still holds; only execute-only revert outcomes differ.
+   - Gas costs change: `quote()` and `getTickLevel()` become more expensive because they traverse individual orders, while swap and order-management paths avoid the storage operations previously used to maintain `totalLiquidity`. Callers SHOULD NOT depend on specific gas costs for these functions.
+   - When available liquidity cannot satisfy the trade, `quote()` fails with `InsufficientLiquidity`, matching `swap()`.
 
 # Invariants
 
 1. Execution price preservation:
-   - This change MUST NOT alter the execution price of swap or any orders filled for identical inputs and state.
+   - This change MUST NOT alter the execution price of the `swap()` function, or any of the orders filled by it, for identical inputs and state.
 
 2. Quote/swap deterministic parity (fill math only):
-   - For any fixed state snapshot and identical inputs, quote MUST produce the same fill amounts and price progression as the orderbook fill engine of swap before state writes are applied. This means identical tick/order traversal, rounding direction, and terminal fill amounts.
+   - For any fixed state snapshot and identical inputs, `quote()` MUST produce the same fill amounts and price progression as the orderbook fill engine of `swap()` before state writes are applied. This means identical tick/order traversal sequence, identical rounding direction at every conversion step, and identical terminal fill amounts. Caller-level and token-specific constraints (e.g., TIP-20 transfer fees) and execute-only side effects (e.g. flip-order placement, which can revert `swap()` via a system error) are outside this guarantee.
 
-3. No-write quote:
-   - Running quote MUST leave orderbook state, balances, and tick metadata unchanged.
+3. No-write simulation:
+   - Running `quote()` MUST leave orderbook state, balances, and tick metadata unchanged.
 
-4. Tick-level liquidity correctness:
-   - `getTickLevel.totalLiquidity` MUST equal the checked sum of `remaining` across all active orders in the requested tick.
+4. Liquidity-exhaustion parity:
+   - `quote()` MUST fail with `InsufficientLiquidity` for exactly the inputs where the matching `swap()` runs out of liquidity.
 
-5. Liquidity-exhaustion parity:
-   - Quote MUST fail with `InsufficientLiquidity` for exactly the inputs where the matching swap runs out of liquidity.
+5. Tick-level liquidity correctness:
+   - At T9, `getTickLevel.totalLiquidity` MUST equal the checked sum of `remaining` across all active orders in the requested tick.

--- a/tips/tip-1088.md
+++ b/tips/tip-1088.md
@@ -1,20 +1,20 @@
 ---
 id: TIP-1088
-title: Unify quote/swap fill logic
-description: Route the StablecoinDEX quote paths through the same per-order fill engine as the swap paths to eliminate deterministic quote/swap drift.
+title: Unify quote/swap fill logic and derive tick liquidity on demand
+description: Route StablecoinDEX quotes through per-order swap fill logic and stop maintaining the per-tick liquidity aggregate.
 authors: Dan Robinson
 status: Draft
 related: TIP-1002, TIP-1005
 protocolVersion: T9
 ---
 
-# TIP-1088: Unify quote/swap fill logic
+# TIP-1088: Unify quote/swap fill logic and derive tick liquidity on demand
 
 ## Abstract
 
-`quote()` and `swap()` currently use different internal logic to traverse liquidity and apply rounding. `quote()` operates per-tick using the tick-level aggregate, while `swap()` operates per-order. Over multi-order paths, this causes deterministic divergence between quoted and executed prices due to accumulated rounding differences at order boundaries within a tick.
+`quote()` and `swap()` currently use different internal logic to traverse liquidity and apply rounding. `quote()` operates per-tick using a stored tick-level aggregate, while `swap()` operates per-order. Over multi-order paths, this causes deterministic divergence between quoted and executed prices due to accumulated rounding differences at order boundaries within a tick.
 
-This TIP routes `quote()` through the same per-order fill logic as `swap()`, executed in a read-only simulation. Quote becomes "swap without state writes," so a quote returns exactly what the matching swap executes. The change is gated at T9; below T9 the existing per-tick quote is unchanged.
+This TIP routes `quote()` through the same per-order fill logic as `swap()`, executed in a read-only simulation. Quote becomes "swap without state writes," so a quote returns exactly what the matching swap executes. Since quote no longer depends on the stored per-tick `totalLiquidity` aggregate, this TIP also stops maintaining that aggregate and derives `getTickLevel.totalLiquidity` on demand from active orders. The change is gated at T9; below T9 the existing behavior is unchanged.
 
 ## Motivation
 
@@ -29,26 +29,26 @@ The four affected entrypoints are:
 - `swapExactAmountIn(tokenIn, tokenOut, amountIn, minAmountOut)` → executes swap
 - `swapExactAmountOut(tokenIn, tokenOut, amountOut, maxAmountIn)` → executes swap
 
-When multiple orders exist at the same tick, `quote()` rounds once against the aggregate while `swap()` rounds per order, causing deterministic price divergence with no intervening state change. Because `swap()` rounds each order's output down, the executed output can be strictly less than the quote — as little as one unit — so a caller that sets `minAmountOut` to the quote can see the swap revert with `InsufficientOutput`. This is surprising for integrators and makes swap routing harder, since quoted prices cannot be trusted as exact execution prices.
+When multiple orders exist at the same tick, `quote()` rounds once against the aggregate while `swap()` rounds per order, causing deterministic price divergence with no intervening state change. Because `swap()` rounds each order's output down, the executed output can be strictly less than the quote — as little as one unit — so a caller that sets `minAmountOut` to the quote can see the swap revert with `InsufficientOutput`.
 
-Making `quote()` accurate requires an implementation that iterates over individual orders, exactly as `swap()` does.
+Making `quote()` accurate requires iterating over individual orders, exactly as `swap()` does. Once quote no longer uses `totalLiquidity`, maintaining that aggregate imposes storage writes during order placement, fills, and cancellation without serving matching. Removing those writes reduces swap and order-management cost and allows future fill behavior to evolve without keeping a redundant aggregate synchronized.
 
 ---
 
 # Specification
 
-1. Introduce a shared fill engine with two modes:
-   - `Simulate`: identical per-order matching and rounding logic, no state mutation.
-   - `Execute`: existing swap behavior with state mutation.
+1. Introduce shared per-order traversal and fill arithmetic used by quote and swap:
+   - Quote traverses orders without mutation.
+   - Swap retains its existing orderbook mutations and side effects.
 
-2. Route both quote and swap entrypoints through this shared engine:
-   - `quoteSwapExactAmountIn` and `quoteSwapExactAmountOut` call shared fill logic in `Simulate` mode.
-   - `swapExactAmountIn` and `swapExactAmountOut` call shared fill logic in `Execute` mode.
+2. Route both quote and swap entrypoints through the shared logic:
+   - `quoteSwapExactAmountIn` and `quoteSwapExactAmountOut` use read-only per-order traversal.
+   - `swapExactAmountIn` and `swapExactAmountOut` use the same traversal and arithmetic while executing fills.
 
-3. In `Simulate` mode, the engine MUST:
-   - Traverse the same reachable ticks and the same individual orders within those ticks, in the same priority order as `Execute` mode. Traversal occurs at **order granularity**, not tick-aggregate granularity.
+3. The read-only quote path MUST:
+   - Traverse the same reachable ticks and the same individual orders within those ticks, in the same priority order as the swap path. Traversal occurs at **order granularity**, not tick-aggregate granularity.
    - Apply the same rounding direction at every conversion step.
-   - Produce the same fill amounts and price progression as `Execute` mode for an identical state snapshot.
+   - Produce the same fill amounts and price progression as swap for an identical state snapshot.
    - Avoid all writes and side effects:
      - no order remaining updates
      - no order/tick removals
@@ -59,24 +59,44 @@ Making `quote()` accurate requires an implementation that iterates over individu
      - no transient storage writes
      - no gas refunds, discounts, or flip-specific gas accounting (e.g. TIP-1044)
 
-4. In `Execute` mode, the engine behavior remains functionally equivalent to current swap semantics.
+4. Swap fill behavior remains functionally equivalent to pre-T9 semantics, except that write paths MUST NOT update the stored per-tick `totalLiquidity` field. This applies to order placement, partial and full fills, cancellation, and flip-order placement.
 
-5. API compatibility:
+5. `getTickLevel` compatibility:
+   - The function signature and return shape remain unchanged.
+   - At T9, `getTickLevel.totalLiquidity` MUST equal the sum of `remaining` across all active orders in the tick's linked list.
+   - The getter MUST compute this value on demand with checked addition and MUST revert on arithmetic overflow.
+   - Write paths MUST NOT traverse the tick's orders to compute or validate aggregate liquidity.
+
+6. Storage compatibility:
+   - Existing `TickLevel.totalLiquidity` storage slots MUST remain in place because storage layout is consensus state.
+   - At T9, those slots become deprecated stale state and MUST NOT affect matching, placement, fills, cancellation, or the value returned by `getTickLevel`.
+   - No migration or clearing of existing slots is required.
+   - Raw-slot readers MUST switch to `getTickLevel` or derive liquidity from active orders.
+
+7. API and error compatibility:
    - External quote and swap method signatures remain unchanged.
-   - Quote precision now matches swap precision exactly for the same state snapshot. Parity is scoped to the fill math (tick/order traversal, rounding, and fill amounts); caller-level and token-specific constraints (e.g., TIP-20 transfer fees) and execute-only side effects are outside this guarantee. In particular, `swap()` places flip orders and `quote()` does not: a flip-order placement that raises a system error reverts `swap()` (post-T1A) but not `quote()`. Business-logic flip failures are swallowed and do not change the taker fill, so fill-math parity still holds; only execute-only revert outcomes differ.
-   - Gas costs change: `quote()` becomes more expensive (per-order traversal instead of per-tick approximation), while `swap()` execution is unchanged. Callers SHOULD NOT depend on specific gas costs for these functions.
-   - When available liquidity cannot satisfy the trade, `quote()` fails with `InsufficientLiquidity`, matching `swap()`.
+   - Quote precision now matches swap precision exactly for the same state snapshot. Parity is scoped to fill math; caller-level and token-specific constraints and execute-only side effects are outside this guarantee.
+   - When available liquidity cannot satisfy the trade, quote fails with `InsufficientLiquidity`, matching swap.
+
+8. Performance:
+   - Quote changes from per-tick to per-order traversal.
+   - `getTickLevel` changes from O(1) to O(N) in the number of active orders at the requested tick.
+   - Placement, fills, cancellation, and flip-order placement MUST NOT incur an O(N) liquidity scan.
+   - Swap and order-management paths save the storage operations previously used to maintain `totalLiquidity`.
 
 # Invariants
 
 1. Execution price preservation:
-   - This change MUST NOT alter the execution price of the `swap()` function, or any of the orders filled by it, for identical inputs and state.
+   - This change MUST NOT alter the execution price of swap or any orders filled for identical inputs and state.
 
 2. Quote/swap deterministic parity (fill math only):
-   - For any fixed state snapshot and identical inputs, `quote()` MUST produce the same fill amounts and price progression as the orderbook fill engine of `swap()` before state writes are applied. This means identical tick/order traversal sequence, identical rounding direction at every conversion step, and identical terminal fill amounts. Caller-level and token-specific constraints (e.g., TIP-20 transfer fees) and execute-only side effects (e.g. flip-order placement, which can revert `swap()` via a system error) are outside this guarantee.
+   - For any fixed state snapshot and identical inputs, quote MUST produce the same fill amounts and price progression as the orderbook fill engine of swap before state writes are applied. This means identical tick/order traversal, rounding direction, and terminal fill amounts.
 
-3. No-write simulation:
-   - Running `quote()` MUST leave orderbook state, balances, and tick metadata unchanged.
+3. No-write quote:
+   - Running quote MUST leave orderbook state, balances, and tick metadata unchanged.
 
-4. Liquidity-exhaustion parity:
-   - `quote()` MUST fail with `InsufficientLiquidity` for exactly the inputs where the matching `swap()` runs out of liquidity.
+4. Tick-level liquidity correctness:
+   - `getTickLevel.totalLiquidity` MUST equal the checked sum of `remaining` across all active orders in the requested tick.
+
+5. Liquidity-exhaustion parity:
+   - Quote MUST fail with `InsufficientLiquidity` for exactly the inputs where the matching swap runs out of liquidity.


### PR DESCRIPTION
Updates TIP-1088 to include the remaining tick-liquidity changes implemented by #6939.

- Stops maintaining stored per-tick `totalLiquidity` at T9.
- Derives `getTickLevel.totalLiquidity` on demand with checked summation.
- Deprecates existing aggregate slots in place without migration.
- Explicitly forbids O(N) liquidity scans in placement, fill, cancellation, and flip paths.
- Documents the read/write gas and complexity changes.

Validation: `git diff --check`

Prompted by: @jenpaff