### PR TITLE
fix(sidecar): exit non-zero when tx latency monitor fails

### DIFF
--- a/bin/tempo-sidecar/src/cmd/tx_latency.rs
+++ b/bin/tempo-sidecar/src/cmd/tx_latency.rs
@@ -4,16 +4,19 @@ use alloy::{
     providers::{Provider, ProviderBuilder, WsConnect},
 };
 use clap::Parser;
-use eyre::{Context, Result};
+use eyre::{Context, Result, eyre};
 use futures::StreamExt;
 use metrics::{describe_gauge, describe_histogram, gauge, histogram};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use poem::{EndpointExt, Route, Server, get, listener::TcpListener};
 use reqwest::Url;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    future::Future,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tempo_alloy::{TempoNetwork, primitives::TempoHeader};
-use tokio::signal;
-use tracing::{debug, error, warn};
+use tokio::{signal, task::JoinHandle};
+use tracing::{debug, warn};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -174,11 +177,7 @@ impl TxLatencyArgs {
             Duration::from_secs(self.max_pending_age_secs),
         );
 
-        let monitor_handle = tokio::spawn(async move {
-            if let Err(err) = monitor.watch_transactions().await {
-                error!(err = %err, "tx latency monitor exited with error");
-            }
-        });
+        let monitor_handle = tokio::spawn(async move { monitor.watch_transactions().await });
 
         let server = Server::new(TcpListener::bind(addr));
         let server_handle = tokio::spawn(async move { server.run(app).await });
@@ -188,15 +187,130 @@ impl TxLatencyArgs {
         let mut sigint = signal::unix::signal(signal::unix::SignalKind::interrupt())
             .context("failed to install SIGINT handler")?;
 
-        tokio::select! {
-            _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down gracefully"),
-            _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down gracefully"),
-        }
+        let shutdown = async move {
+            tokio::select! {
+                _ = sigterm.recv() => tracing::info!("Received SIGTERM, shutting down gracefully"),
+                _ = sigint.recv() => tracing::info!("Received SIGINT, shutting down gracefully"),
+            }
+        };
 
-        monitor_handle.abort();
+        let result = wait_for_shutdown_or_monitor_failure(monitor_handle, shutdown).await;
+
         server_handle.abort();
 
         tracing::info!("Shutdown complete");
-        Ok(())
+        result
+    }
+}
+
+/// Waits for either a graceful shutdown signal or the transaction latency monitor task ending.
+///
+/// The monitor task is expected to run indefinitely; it only completes when it hits an
+/// unrecoverable error (or panics), so any completion of `monitor_handle` before `shutdown`
+/// resolves is treated as fatal and its error is propagated so the process exits non-zero.
+async fn wait_for_shutdown_or_monitor_failure(
+    monitor_handle: JoinHandle<Result<()>>,
+    shutdown: impl Future<Output = ()>,
+) -> Result<()> {
+    tokio::pin!(monitor_handle);
+
+    tokio::select! {
+        _ = shutdown => {
+            monitor_handle.abort();
+            Ok(())
+        }
+        result = &mut monitor_handle => match result {
+            Ok(Ok(())) => Err(eyre!("tx latency monitor task exited unexpectedly")),
+            Ok(Err(err)) => Err(err).context("tx latency monitor failed"),
+            Err(join_err) => Err(eyre::Report::new(join_err)).context("tx latency monitor task panicked"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{sync::Once, time::Duration};
+
+    /// Installs the process-level rustls crypto provider exactly once.
+    ///
+    /// `main()` normally does this before any TLS-capable transport is built; tests bypass
+    /// `main()`, so `watch_transactions` needs it installed explicitly before it can construct a
+    /// websocket provider.
+    fn ensure_crypto_provider() {
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
+
+    /// Regression test for https://github.com/tempoxyz/tempo/issues/6898: an unrecoverable
+    /// monitor failure must surface as an `Err`, matching the issue's own repro
+    /// (`--rpc-url ws://127.0.0.1:9`), rather than being silently swallowed.
+    #[tokio::test]
+    async fn watch_transactions_errors_on_unreachable_endpoint() {
+        ensure_crypto_provider();
+
+        let rpc_url: Url = "ws://127.0.0.1:9".parse().expect("valid url");
+        let mut monitor = TransactionLatencyMonitor::new(rpc_url, Duration::from_secs(600));
+
+        let result = tokio::time::timeout(Duration::from_secs(10), monitor.watch_transactions())
+            .await
+            .expect("watch_transactions should fail fast on a refused connection, not hang");
+
+        let err = result.expect_err("an unreachable websocket endpoint must produce an Err");
+        assert!(
+            err.to_string()
+                .contains("failed to connect websocket provider"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A monitor task that ends (here, with an error) before shutdown is requested must cause
+    /// `wait_for_shutdown_or_monitor_failure` to return that error, so the caller's process exits
+    /// non-zero instead of idling until a signal arrives.
+    #[tokio::test]
+    async fn monitor_failure_is_propagated_before_shutdown() {
+        let monitor_handle =
+            tokio::spawn(async { Err(eyre!("failed to connect websocket provider")) });
+        let shutdown = std::future::pending::<()>();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            wait_for_shutdown_or_monitor_failure(monitor_handle, shutdown),
+        )
+        .await
+        .expect("a failed monitor task must not make wait_for_shutdown_or_monitor_failure hang");
+
+        let err = result.expect_err("a failed monitor task must produce an Err");
+        assert!(
+            err.chain().any(|cause| cause
+                .to_string()
+                .contains("failed to connect websocket provider")),
+            "unexpected error chain: {err:#}"
+        );
+    }
+
+    /// Graceful shutdown must still return `Ok`, and must abort the monitor task rather than
+    /// leaking it.
+    #[tokio::test]
+    async fn shutdown_signal_returns_ok_and_stops_monitor() {
+        let monitor_handle = tokio::spawn(async {
+            std::future::pending::<()>().await;
+            Ok(())
+        });
+        let shutdown = async {};
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            wait_for_shutdown_or_monitor_failure(monitor_handle, shutdown),
+        )
+        .await
+        .expect("shutdown must not make wait_for_shutdown_or_monitor_failure hang");
+
+        assert!(
+            result.is_ok(),
+            "graceful shutdown must return Ok: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Bug

`tx-latency-monitor` spawned `watch_transactions()` and only logged its `Err` inside the spawned task; the `JoinHandle` was kept but never awaited. The outer command then waited *exclusively* on `SIGTERM`/`SIGINT`. A permanently failed monitor (e.g. an unreachable RPC endpoint) therefore:

- kept the process alive
- kept `GET /metrics` returning `200`
- exited `0`, but only once someone sent `SIGTERM`

...making a dead deployment look healthy.

## Fix

`TxLatencyArgs::run` now selects over **both** the shutdown signal and the monitor task via a new `wait_for_shutdown_or_monitor_failure` helper:

- Shutdown signal arrives first → abort the monitor task, return `Ok(())` (unchanged graceful-shutdown behavior, still exits 0).
- Monitor task completes first (`Err`, unexpected `Ok(())`, or a panic/`JoinError`) → propagate that failure as an `Err` from `run()`, so `main()`'s default `Result` `Termination` impl exits the process non-zero with the original error context (e.g. `failed to connect websocket provider`) preserved in the chain.

The select/wait logic was extracted into `wait_for_shutdown_or_monitor_failure(monitor_handle, shutdown)` specifically to make the fatal path unit-testable without booting the full command (which installs a global tracing subscriber and Prometheus recorder, and binds a real port — none of which are safe to invoke repeatedly in a test binary).

## Scope

Per the issue's option 3, this is intentionally narrow: it only makes an unrecoverable monitor failure fatal. It does **not** touch:
- subscription retry/recovery policy (the pending-tx stream reconnect logic, or the block-subscription-ignoring-errors behavior the issue also flags)
- reconnect/backoff behavior
- any other metrics/HTTP behavior

Those are left as a deliberate follow-up — happy to switch to in-process recovery (recreating both subscriptions from a fresh provider) instead of fail-fast if that's the preferred operational policy; wanted to get the "looks healthy but is dead" problem fixed first without presupposing the answer to that question.

## Tests

Added 3 tests in `bin/tempo-sidecar/src/cmd/tx_latency.rs` (previously 0 tests in this crate):
- `watch_transactions_errors_on_unreachable_endpoint` — drives the actual code path against the issue's own repro endpoint (`ws://127.0.0.1:9`, refused immediately, no network/mainnet dependency) and asserts `Err`.
- `monitor_failure_is_propagated_before_shutdown` — asserts a failed monitor task causes `wait_for_shutdown_or_monitor_failure` to return `Err` without waiting on shutdown.
- `shutdown_signal_returns_ok_and_stops_monitor` — asserts graceful shutdown still returns `Ok` and aborts the monitor task.

All three run under a 5–10s `tokio::time::timeout` so a regression fails fast instead of hanging CI.

## Before / after (issue's repro)

```
RUST_LOG=debug target/debug/tempo-sidecar tx-latency-monitor \
  --rpc-url ws://127.0.0.1:9 --chain-id local-audit --port 19463
```

**Before:** logs `tx latency monitor exited with error err=failed to connect websocket provider`, process stays up, `/metrics` returns `200`, exits `0` only after `SIGTERM`.

**After:**
```
Error: tx latency monitor failed

Caused by:
   0: failed to connect websocket provider
   1: IO error: Connection refused (os error 111)
   2: IO error: Connection refused (os error 111)
   3: Connection refused (os error 111)

Location:
    bin/tempo-sidecar/src/cmd/tx_latency.rs:62:14
Shutdown complete
exit=1
```

Also ran `cargo build -p tempo-sidecar --bin tempo-sidecar`, `cargo test -p tempo-sidecar` (3 passed), `cargo fmt --all -- --check`, and `cargo clippy -p tempo-sidecar --all-targets -- -D warnings` — all clean.

Closes #6898
