### PR TITLE
feat(tip-1092): emit transfer policy migration events

### DIFF
--- a/crates/contracts/src/precompiles/tip403_registry.rs
+++ b/crates/contracts/src/precompiles/tip403_registry.rs
@@ -49,6 +49,7 @@ crate::sol! {
         event BlacklistUpdated(uint64 indexed policyId, address indexed updater, address indexed account, bool restricted);
         event CompoundPolicyCreated(uint64 indexed policyId, address indexed creator, uint64 senderPolicyId, uint64 recipientPolicyId, uint64 mintRecipientPolicyId);
         event ReceivePolicyUpdated(address indexed account, uint64 senderPolicyId, uint64 tokenFilterId, address recoveryAuthority);
+        event TransferPolicyIdMigrated(address indexed token, uint64 policyId);
 
         // Errors
         error Unauthorized();

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1596,7 +1596,7 @@ pub(crate) mod tests {
     use rand_08::{Rng, distributions::Alphanumeric, thread_rng};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
-        IReceivePolicyGuard, ReceivePolicyGuardEvent, createTokenCall,
+        IReceivePolicyGuard, ReceivePolicyGuardEvent, TIP403RegistryEvent, createTokenCall,
     };
 
     #[test]
@@ -3656,6 +3656,12 @@ pub(crate) mod tests {
                 )?,
                 U256::ZERO
             );
+            registry.assert_emitted_events(vec![TIP403RegistryEvent::TransferPolicyIdMigrated(
+                ITIP403Registry::TransferPolicyIdMigrated {
+                    token: token.address,
+                    policyId: ALLOW_ALL_POLICY_ID,
+                },
+            )]);
             assert!(
                 registry
                     .registered_token_transfer_policy_id(token.address)?
@@ -3689,6 +3695,12 @@ pub(crate) mod tests {
                 )?,
                 U256::ZERO
             );
+            registry.assert_emitted_events(vec![TIP403RegistryEvent::TransferPolicyIdMigrated(
+                ITIP403Registry::TransferPolicyIdMigrated {
+                    token: token.address,
+                    policyId: ALLOW_ALL_POLICY_ID,
+                },
+            )]);
             assert_eq!(token.transfer_policy_id()?, REJECT_ALL_POLICY_ID);
 
             Ok(())

--- a/crates/precompiles/src/tip403_registry/mod.rs
+++ b/crates/precompiles/src/tip403_registry/mod.rs
@@ -304,6 +304,12 @@ impl TIP403Registry {
             let policy_id = token_contract.legacy_transfer_policy_id()?;
             self.set_token_transfer_policy(token, policy_id)?;
             token_contract.delete_legacy_transfer_policy_id()?;
+            self.emit_event(TIP403RegistryEvent::TransferPolicyIdMigrated(
+                ITIP403Registry::TransferPolicyIdMigrated {
+                    token,
+                    policyId: policy_id,
+                },
+            ))?;
             migrated += U256::ONE;
         }
 

--- a/tips/tip-1092.md
+++ b/tips/tip-1092.md
@@ -54,6 +54,7 @@ TIP-403 exposes token-keyed policy lookup:
 ```solidity
 function tokenTransferPolicyId(address token) external view returns (bool isSet, uint64 policyId);
 function migrateTransferPolicyIds(address[] calldata tokens) external returns (uint256 migrated);
+event TransferPolicyIdMigrated(address indexed token, uint64 policyId);
 ```
 
 `tokenTransferPolicyId(token)` returns `isSet == true` and the TIP-403 binding if one exists.
@@ -85,7 +86,7 @@ TIP-403 exposes a batch migration path:
 function migrateTransferPolicyIds(address[] calldata tokens) external returns (uint256 migrated);
 ```
 
-`migrateTransferPolicyIds(tokens)` MUST, for each valid TIP-20 token without a TIP-403 binding, copy the local policy ID into TIP-403, then delete the local TIP-20 policy slot. It MUST skip an existing TIP-403 binding without reading local state. Invalid token addresses are skipped. The function is callable by any account.
+`migrateTransferPolicyIds(tokens)` MUST, for each valid TIP-20 token without a TIP-403 binding, copy the local policy ID into TIP-403, then delete the local TIP-20 policy slot and emit `TransferPolicyIdMigrated(token, policyId)`. It MUST skip an existing TIP-403 binding without reading local state or emitting an event. Invalid token addresses are skipped without emitting an event. The function is callable by any account.
 
 Operators manually migrate existing tokens that are already enabled on a running zone. Zone token enablement migrates an unset binding before accepting the token. An admin policy update also creates the binding for an otherwise unmigrated token, but does not copy or delete the prior local policy ID because `newPolicyId` replaces it.
 
@@ -111,7 +112,7 @@ SDKs and indexers that read `transferPolicyId()` from TIP-20 can keep using that
 
 # Observability
 
-This TIP does not change policy-update events. The existing TIP-20 `TransferPolicyUpdate` event remains the event for active policy changes. It is emitted from the TIP-20 token address, so the token identity is already part of the log.
+The TIP-403 registry emits `TransferPolicyIdMigrated(token, policyId)` once for every token whose binding is migrated. The existing TIP-20 `TransferPolicyUpdate` event remains the event for active policy changes. It is emitted from the TIP-20 token address, so the token identity is already part of the log.
 
 # Invariants
 


### PR DESCRIPTION
Superseded by enforcing the existing portal invariant: `ZonePortal` migrates and rechecks a token binding before emitting `TokenEnabled`, and the native `ZoneFactory` requires the initial binding before portal creation. Zones can therefore use `TokenEnabled` as the cache invalidation barrier without adding a protocol event.