### PR TITLE
fix(evm): constrain fee token validation

### DIFF
--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -58,7 +58,8 @@ pub struct FeeTokenValidationContext<'a, DB: Database> {
 }
 
 impl<DB: Database> FeeTokenValidationContext<'_, DB> {
-    pub(crate) fn new(
+    /// Creates a read-only validation view over the transaction journal.
+    pub fn new(
         journal: &mut Journal<DB>,
         spec: TempoHardfork,
         actions: StorageActions,

--- a/crates/revm/src/fee_manager.rs
+++ b/crates/revm/src/fee_manager.rs
@@ -1,13 +1,12 @@
 use crate::{
-    TempoBlockEnv, TempoInvalidTransaction, TempoStateAccess, TempoTx, TempoTxEnv,
-    common::is_tip20_fee_inference_call,
+    TempoBlockEnv, TempoStateAccess, TempoTx, TempoTxEnv, common::is_tip20_fee_inference_call,
 };
 use alloy_primitives::{Address, U256};
 use alloy_sol_types::SolCall;
 use core::fmt::Debug;
 use revm::{
     Database,
-    context::{CfgEnv, Journal, result::EVMError},
+    context::{CfgEnv, Journal},
 };
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
@@ -16,8 +15,9 @@ use tempo_contracts::precompiles::{
 use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     error::Result as TempoResult,
-    storage::{Handler, StorageActions, StorageCtx},
+    storage::{ContractStorage, Handler, StorageActions, StorageCtx},
     tip_fee_manager::TipFeeManager,
+    tip20::TIP20Token,
 };
 
 /// EVM state needed to install storage for an internal protocol fee hook.
@@ -48,6 +48,66 @@ impl<DB: alloy_evm::Database> ProtocolFeeContext<'_, DB> {
             f,
         )
     }
+}
+
+/// Read-only state exposed to fee-token validation.
+pub struct FeeTokenValidationContext<'a, DB: Database> {
+    journal: &'a mut Journal<DB>,
+    spec: TempoHardfork,
+    actions: StorageActions,
+}
+
+impl<DB: Database> FeeTokenValidationContext<'_, DB> {
+    pub(crate) fn new(
+        journal: &mut Journal<DB>,
+        spec: TempoHardfork,
+        actions: StorageActions,
+    ) -> FeeTokenValidationContext<'_, DB> {
+        FeeTokenValidationContext {
+            journal,
+            spec,
+            actions,
+        }
+    }
+
+    fn enter<R>(&mut self, f: impl FnOnce() -> R) -> R {
+        self.journal
+            .with_read_only_storage_ctx(self.spec, self.actions.clone(), f)
+    }
+
+    /// Returns whether a TIP-20 has been initialized.
+    pub fn is_initialized(&mut self, fee_token: Address) -> TempoResult<bool> {
+        self.enter(|| TIP20Token::from_address_unchecked(fee_token).is_initialized())
+    }
+
+    /// Reads the TIP-20 currency without allocating unbounded malformed data.
+    pub fn currency(&mut self, fee_token: Address) -> TempoResult<String> {
+        self.enter(|| {
+            let token = TIP20Token::from_address_unchecked(fee_token);
+            let len = token.currency.len()?;
+            if len > 31 {
+                Ok(format!("<{len} bytes>"))
+            } else {
+                token.currency.read()
+            }
+        })
+    }
+
+    /// Reads a storage slot for a custom eligibility policy.
+    pub fn storage(&mut self, address: Address, key: U256) -> TempoResult<U256> {
+        self.enter(|| StorageCtx.sload(address, key))
+    }
+}
+
+/// Protocol-level result of fee-token eligibility validation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FeeTokenValidation {
+    /// The token can pay fees.
+    Valid,
+    /// The token is not eligible to pay fees.
+    Invalid,
+    /// The token uses an unsupported currency.
+    UnsupportedCurrency(String),
 }
 
 /// Resolves a transaction's fee token for state consumers outside the EVM handler.
@@ -84,12 +144,15 @@ pub trait ProtocolFeeManager<DB: Database>: Debug {
     /// The handler checks the TIP-20 prefix first. Implementations define which tokens are valid.
     fn validate_fee_token(
         &self,
-        journal: &mut Journal<DB>,
+        ctx: &mut FeeTokenValidationContext<'_, DB>,
         fee_token: Address,
-        spec: TempoHardfork,
-        actions: StorageActions,
-    ) -> Result<(), EVMError<DB::Error, TempoInvalidTransaction>> {
-        journal.ensure_tip20_usd(spec, fee_token, actions)
+    ) -> TempoResult<FeeTokenValidation> {
+        let currency = ctx.currency(fee_token)?;
+        Ok(if currency == "USD" {
+            FeeTokenValidation::Valid
+        } else {
+            FeeTokenValidation::UnsupportedCurrency(currency)
+        })
     }
 
     /// Resolves the validator token used to receive protocol fees.

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -64,7 +64,8 @@ use tempo_primitives::{
 };
 
 use crate::{
-    ProtocolFeeContext, TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction, TempoTxEnv,
+    FeeTokenValidation, FeeTokenValidationContext, ProtocolFeeContext, TempoBatchCallEnv, TempoEvm,
+    TempoInvalidTransaction, TempoTxEnv,
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
     gas_credits,
@@ -987,7 +988,25 @@ where
         // Skip fee token validation when the transaction is free and not part of a subblock.
         // The TIP20 prefix is already validated above.
         if !tx.max_balance_spending()?.is_zero() || tx.is_subblock_transaction() {
-            fee_manager.validate_fee_token(journal, fee_token, cfg.spec, actions.clone())?;
+            let mut validation_ctx =
+                FeeTokenValidationContext::new(journal, cfg.spec, actions.clone());
+            let validation = fee_manager
+                .validate_fee_token(&mut validation_ctx, fee_token)
+                .map_err(|error| EVMError::Custom(error.to_string()))?;
+
+            match validation {
+                FeeTokenValidation::Valid => {}
+                FeeTokenValidation::Invalid => {
+                    return Err(TempoInvalidTransaction::InvalidFeeToken(fee_token).into());
+                }
+                FeeTokenValidation::UnsupportedCurrency(currency) => {
+                    return Err(TempoInvalidTransaction::FeeTokenNotUsdCurrency {
+                        address: fee_token,
+                        currency,
+                    }
+                    .into());
+                }
+            }
         }
 
         // Load the fee payer balance

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -21,7 +21,10 @@ mod tx;
 
 pub use error::{TempoHaltReason, TempoInvalidTransaction};
 pub use evm::TempoEvm;
-pub use fee_manager::{FeeTokenResolver, ProtocolFeeContext, ProtocolFeeManager, TempoFeeManager};
+pub use fee_manager::{
+    FeeTokenResolver, FeeTokenValidation, FeeTokenValidationContext, ProtocolFeeContext,
+    ProtocolFeeManager, TempoFeeManager,
+};
 pub use handler::{ValidationContext, calculate_aa_batch_intrinsic_gas};
 pub use revm::interpreter::instructions::utility::IntoAddress;
 pub use tempo_primitives::TempoBlockEnv;


### PR DESCRIPTION
Makes fee token validation read-only and constrains the hook result so downstream implementations cannot mutate state or surface fee-payment errors before nonce consumption. Zones can still define eligibility from state without expanding the handler error surface.