### PR TITLE
refactor(zone-factory): restrict runtime updates to hardforks

### DIFF
--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -54,10 +54,6 @@ crate::sol! {
 
         event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-        event PortalUpdated(address indexed source, bytes32 indexed codeHash);
-        event MessengerUpdated(address indexed source, bytes32 indexed codeHash);
-        event VerifierUpdated(address indexed source, bytes32 indexed codeHash);
-
         event ZoneCreated(
             uint32 indexed zoneId,
             address indexed portal,
@@ -76,18 +72,8 @@ crate::sol! {
         error NotOwner();
         error InvalidAdmin();
         error InvalidSequencerSet();
-        error InvalidPortalImplementation();
-        error InvalidZoneMessengerImplementation();
-        error InvalidVerifierImplementation();
-        error ImplementationUpdatesLocked();
-
         function owner() external view returns (address);
-        function implementationUpdatesLocked() external view returns (bool);
         function transferOwnership(address newOwner) external;
-        function lockImplementationUpdates() external;
-        function setPortalImplementation(address source) external;
-        function setZoneMessengerImplementation(address source) external;
-        function setVerifierImplementation(address source) external;
         function createZone(CreateZoneParams calldata params)
             external
             returns (uint32 zoneId, address portal);

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -358,7 +358,9 @@ mod tests {
     };
     use std::{assert_matches, collections::BTreeMap};
     use tempo_chainspec::hardfork::TempoHardfork;
-    use tempo_contracts::precompiles::{IZoneFactory, ZONE_FACTORY_ADDRESS};
+    use tempo_contracts::precompiles::{
+        IZoneFactory, ZONE_FACTORY_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS,
+    };
     use tempo_precompiles::{
         NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, STORAGE_CREDITS_ADDRESS,
         TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
@@ -556,14 +558,13 @@ mod tests {
         let owner = Address::repeat_byte(0x11);
         let admin = Address::repeat_byte(0x22);
         let sequencer = Address::repeat_byte(0x33);
-        let implementation_source = Address::repeat_byte(0x44);
         // Returns 42 for every call. The portal proxy should delegate to this deployed runtime.
         let logic_runtime = Bytecode::new_legacy(Bytes::from_static(&[
             0x60, 0x2a, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3,
         ]));
         let mut db = CacheDB::new(EmptyDB::default());
         db.insert_account_info(
-            implementation_source,
+            ZONE_PORTAL_IMPL_ADDRESS,
             AccountInfo {
                 code_hash: logic_runtime.hash_slow(),
                 code: Some(logic_runtime),
@@ -579,24 +580,6 @@ mod tests {
         .unwrap();
         let setup_state = evm.ctx_mut().journaled_state.finalize();
         evm.db_mut().commit(setup_state);
-
-        let result = evm
-            .transact_system_call(
-                owner,
-                ZONE_FACTORY_ADDRESS,
-                IZoneFactory::setPortalImplementationCall {
-                    source: implementation_source,
-                }
-                .abi_encode()
-                .into(),
-            )
-            .unwrap();
-        assert!(
-            result.result.is_success(),
-            "setPortalImplementation failed: {:?}",
-            result.result
-        );
-        evm.db_mut().commit(result.state);
 
         let result = evm
             .transact_system_call(

--- a/crates/precompiles/src/zone_factory/dispatch.rs
+++ b/crates/precompiles/src/zone_factory/dispatch.rs
@@ -18,32 +18,9 @@ impl Precompile for ZoneFactory {
             |call| match call {
                 IZoneFactory::IZoneFactoryCalls {
                     owner(call) => view(call, |_| self.owner()),
-                    implementationUpdatesLocked(call) => {
-                        view(call, |_| self.implementation_updates_locked())
-                    },
                     transferOwnership(call) => {
                         mutate_void(call, msg_sender, |sender, call| {
                             self.transfer_ownership(sender, call)
-                        })
-                    },
-                    lockImplementationUpdates(call) => {
-                        mutate_void(call, msg_sender, |sender, _| {
-                            self.lock_implementation_updates(sender)
-                        })
-                    },
-                    setPortalImplementation(call) => {
-                        mutate_void(call, msg_sender, |sender, call| {
-                            self.set_portal_implementation(sender, call)
-                        })
-                    },
-                    setZoneMessengerImplementation(call) => {
-                        mutate_void(call, msg_sender, |sender, call| {
-                            self.set_zone_messenger_implementation(sender, call)
-                        })
-                    },
-                    setVerifierImplementation(call) => {
-                        mutate_void(call, msg_sender, |sender, call| {
-                            self.set_verifier_implementation(sender, call)
                         })
                     },
                     createZone(call) => {

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -14,8 +14,8 @@ use crate::{
 use alloy::primitives::{Address, IntoLogData};
 use std::collections::HashMap;
 use tempo_contracts::precompiles::{
-    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
-    ZoneFactoryError, ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
+    IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactoryError,
+    ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
 };
 use tempo_precompiles_macros::{Storable, contract};
 use tempo_primitives::TempoAddressExt;
@@ -31,13 +31,12 @@ pub const MAX_SEQUENCERS: usize = 8;
 
 /// Native ZoneFactory storage.
 ///
-/// The field order mirrors the TIP-1091 Solidity reference artifact: `nextZoneId`, `owner`, and
-/// `implementationUpdatesLocked` share slot 0, and `zones` occupies slot 1.
+/// The field order mirrors the TIP-1091 Solidity reference artifact: `nextZoneId` and `owner`
+/// share slot 0, and `zones` occupies slot 1.
 #[contract(addr = ZONE_FACTORY_ADDRESS)]
 pub struct ZoneFactory {
     next_zone_id: u32,
     owner: Address,
-    implementation_updates_locked: bool,
     zones: Mapping<u32, ZoneInfoStorage>,
 }
 
@@ -77,11 +76,6 @@ impl ZoneFactory {
         self.owner.read()
     }
 
-    /// Returns whether shared runtime updates have been permanently disabled.
-    pub fn implementation_updates_locked(&self) -> Result<bool> {
-        self.implementation_updates_locked.read()
-    }
-
     /// Atomically transfers zone-creation authority.
     pub fn transfer_ownership(
         &mut self,
@@ -97,83 +91,6 @@ impl ZoneFactory {
             previous_owner,
             call.newOwner,
         ))
-    }
-
-    /// Permanently disables updates to the shared portal, messenger, and verifier runtimes.
-    pub fn lock_implementation_updates(&mut self, msg_sender: Address) -> Result<()> {
-        if msg_sender != self.owner()? {
-            return Err(ZoneFactoryError::not_owner().into());
-        }
-        self.implementation_updates_locked.write(true)
-    }
-
-    fn ensure_implementation_updates_unlocked(&self) -> Result<()> {
-        if self.implementation_updates_locked()? {
-            return Err(ZoneFactoryError::implementation_updates_locked().into());
-        }
-        Ok(())
-    }
-
-    /// Copies a deployed runtime into the shared ZonePortal implementation account.
-    pub fn set_portal_implementation(
-        &mut self,
-        msg_sender: Address,
-        call: IZoneFactory::setPortalImplementationCall,
-    ) -> Result<()> {
-        if msg_sender != self.owner()? {
-            return Err(ZoneFactoryError::not_owner().into());
-        }
-        self.ensure_implementation_updates_unlocked()?;
-
-        let code_hash = self
-            .storage
-            .copy_runtime(call.source, ZONE_PORTAL_IMPL_ADDRESS)?
-            .ok_or_else(|| {
-                TempoPrecompileError::from(ZoneFactoryError::invalid_portal_implementation())
-            })?;
-        self.emit_event(ZoneFactoryEvent::portal_updated(call.source, code_hash))
-    }
-
-    /// Copies a deployed runtime into the shared ZoneMessenger account.
-    pub fn set_zone_messenger_implementation(
-        &mut self,
-        msg_sender: Address,
-        call: IZoneFactory::setZoneMessengerImplementationCall,
-    ) -> Result<()> {
-        if msg_sender != self.owner()? {
-            return Err(ZoneFactoryError::not_owner().into());
-        }
-        self.ensure_implementation_updates_unlocked()?;
-
-        let code_hash =
-            self.storage
-                .copy_runtime(call.source, ZONE_MESSENGER_ADDRESS)?
-                .ok_or_else(|| {
-                    TempoPrecompileError::from(
-                        ZoneFactoryError::invalid_zone_messenger_implementation(),
-                    )
-                })?;
-        self.emit_event(ZoneFactoryEvent::messenger_updated(call.source, code_hash))
-    }
-
-    /// Copies a deployed runtime into the shared Verifier account.
-    pub fn set_verifier_implementation(
-        &mut self,
-        msg_sender: Address,
-        call: IZoneFactory::setVerifierImplementationCall,
-    ) -> Result<()> {
-        if msg_sender != self.owner()? {
-            return Err(ZoneFactoryError::not_owner().into());
-        }
-        self.ensure_implementation_updates_unlocked()?;
-
-        let code_hash = self
-            .storage
-            .copy_runtime(call.source, ZONE_VERIFIER_ADDRESS)?
-            .ok_or_else(|| {
-                TempoPrecompileError::from(ZoneFactoryError::invalid_verifier_implementation())
-            })?;
-        self.emit_event(ZoneFactoryEvent::verifier_updated(call.source, code_hash))
     }
 
     /// Creates and initializes a deterministic ZonePortal account.
@@ -374,11 +291,10 @@ mod tests {
         test_util::TIP20Setup,
     };
     use alloy::{
-        primitives::{B256, Bytes, U256, address, keccak256},
+        primitives::{B256, U256, address, keccak256},
         sol_types::SolValue,
     };
     use portal::PortalTokenConfig;
-    use revm::state::Bytecode;
     use tempo_chainspec::hardfork::TempoHardfork;
 
     const OWNER: Address = address!("0x0000000000000000000000000000000000000011");
@@ -728,176 +644,6 @@ mod tests {
                 TempoPrecompileError::from(ZoneFactoryError::not_owner())
             );
             assert_eq!(factory.next_zone_id()?, 1);
-
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn owner_can_install_and_upgrade_shared_runtimes() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
-        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
-            let mut factory = factory_with_owner(OWNER)?;
-            let source = address!("0x0000000000000000000000000000000000000044");
-            let runtime = Bytecode::new_legacy(Bytes::from_static(&[0x60, 0x2a]));
-            factory.storage.set_code(source, runtime.clone())?;
-
-            let err = factory
-                .set_portal_implementation(
-                    ADMIN,
-                    IZoneFactory::setPortalImplementationCall { source },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::not_owner())
-            );
-
-            factory.set_portal_implementation(
-                OWNER,
-                IZoneFactory::setPortalImplementationCall { source },
-            )?;
-            factory.set_zone_messenger_implementation(
-                OWNER,
-                IZoneFactory::setZoneMessengerImplementationCall { source },
-            )?;
-            factory.set_verifier_implementation(
-                OWNER,
-                IZoneFactory::setVerifierImplementationCall { source },
-            )?;
-            for destination in [
-                ZONE_PORTAL_IMPL_ADDRESS,
-                ZONE_MESSENGER_ADDRESS,
-                ZONE_VERIFIER_ADDRESS,
-            ] {
-                let installed = factory.storage.with_account_info(destination, |info| {
-                    Ok(info.code.clone().expect("shared runtime installed"))
-                })?;
-                assert_eq!(installed, runtime);
-            }
-
-            // Source validation is based on runtime length, so even an existing account with the
-            // empty-code hash is rejected.
-            let empty_source = address!("0x0000000000000000000000000000000000000055");
-            factory
-                .storage
-                .set_code(empty_source, Bytecode::default())?;
-            let err = factory
-                .set_verifier_implementation(
-                    OWNER,
-                    IZoneFactory::setVerifierImplementationCall {
-                        source: empty_source,
-                    },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::invalid_verifier_implementation())
-            );
-            let installed = factory
-                .storage
-                .with_account_info(ZONE_VERIFIER_ADDRESS, |info| {
-                    Ok(info.code.clone().expect("shared runtime preserved"))
-                })?;
-            assert_eq!(installed, runtime);
-
-            let err = factory
-                .set_portal_implementation(
-                    OWNER,
-                    IZoneFactory::setPortalImplementationCall {
-                        source: Address::ZERO,
-                    },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::invalid_portal_implementation())
-            );
-
-            factory.transfer_ownership(
-                OWNER,
-                IZoneFactory::transferOwnershipCall {
-                    newOwner: Address::ZERO,
-                },
-            )?;
-            assert_eq!(factory.owner()?, Address::ZERO);
-            factory.set_portal_implementation(
-                Address::ZERO,
-                IZoneFactory::setPortalImplementationCall { source },
-            )?;
-            Ok(())
-        })
-    }
-
-    #[test]
-    fn owner_can_permanently_lock_shared_runtime_updates() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
-        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
-            let mut factory = factory_with_owner(OWNER)?;
-            let source = address!("0x0000000000000000000000000000000000000044");
-            factory.storage.set_code(
-                source,
-                Bytecode::new_legacy(Bytes::from_static(&[0x60, 0x2a])),
-            )?;
-
-            assert!(!factory.implementation_updates_locked()?);
-            let err = factory.lock_implementation_updates(ADMIN).unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::not_owner())
-            );
-            assert!(!factory.implementation_updates_locked()?);
-
-            factory.lock_implementation_updates(OWNER)?;
-            assert!(factory.implementation_updates_locked()?);
-
-            let err = factory
-                .set_portal_implementation(
-                    OWNER,
-                    IZoneFactory::setPortalImplementationCall { source },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::implementation_updates_locked())
-            );
-
-            let err = factory
-                .set_zone_messenger_implementation(
-                    OWNER,
-                    IZoneFactory::setZoneMessengerImplementationCall { source },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::implementation_updates_locked())
-            );
-
-            let err = factory
-                .set_verifier_implementation(
-                    OWNER,
-                    IZoneFactory::setVerifierImplementationCall { source },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::implementation_updates_locked())
-            );
-
-            factory.transfer_ownership(
-                OWNER,
-                IZoneFactory::transferOwnershipCall { newOwner: ADMIN },
-            )?;
-            let err = factory
-                .set_portal_implementation(
-                    ADMIN,
-                    IZoneFactory::setPortalImplementationCall { source },
-                )
-                .unwrap_err();
-            assert_eq!(
-                err,
-                TempoPrecompileError::from(ZoneFactoryError::implementation_updates_locked())
-            );
 
             Ok(())
         })

--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -139,46 +139,26 @@ portal_proxy_runtime =
 ### Initial Factory Configuration
 
 The native factory MUST start with zone ID `1`. Its initial owner is configured
-by T9. `implementationUpdatesLocked` MUST initially be `false`. The owner MAY
-transfer ownership to any address, including the zero address. The shared
-messenger at `ZONE_MESSENGER_ADDRESS` MUST authorize `ZONE_FACTORY_ADDRESS`.
+by T9. The owner MAY transfer ownership to any address, including the zero
+address. The shared messenger at `ZONE_MESSENGER_ADDRESS` MUST authorize
+`ZONE_FACTORY_ADDRESS`.
 
 ### Shared Runtime Management
 
-`setPortalImplementation(address source)` MUST be callable only by the factory
-owner. After authorization, its only source validation MUST require
-`EXTCODESIZE(source) > 0`; the factory MUST NOT otherwise validate `source` or
-its runtime bytecode. A successful call MUST copy the complete runtime bytecode
-at `source` to `ZONE_PORTAL_IMPL_ADDRESS`, equivalent to `EXTCODECOPY`, and emit
-`PortalUpdated(source, codeHash)` with the observed
-`EXTCODEHASH(source)`.
+At the T9 boundary, the protocol MUST copy the complete runtime bytecode from
+the hardfork-specified portal implementation, verifier, and shared messenger
+source deployments to their protocol-managed addresses, equivalent to
+`EXTCODECOPY`. Each source MUST have non-empty runtime bytecode. The ZoneFactory
+MUST NOT expose any function that allows its owner or another account to invoke
+these copies or replace the installed runtimes.
 
-`setZoneMessengerImplementation(address source)` and
-`setVerifierImplementation(address source)` MUST use the same authorization,
-source validation, and bytecode-copy semantics, targeting
-`ZONE_MESSENGER_ADDRESS` and `ZONE_VERIFIER_ADDRESS` and emitting
-`MessengerUpdated(source, codeHash)` and `VerifierUpdated(source, codeHash)`,
-respectively. Validators
-MUST NOT embed these full runtime bytecodes in their binaries.
-
-The owner MAY call `lockImplementationUpdates()` to set
-`implementationUpdatesLocked` to `true`. This transition is irreversible. Once
-locked, `setPortalImplementation`, `setZoneMessengerImplementation`, and
-`setVerifierImplementation` MUST revert with `ImplementationUpdatesLocked`,
-regardless of the current owner.
-
-These functions install the initial shared runtimes and support later upgrades.
-Replacing the portal implementation upgrades every existing portal, because
-every portal proxy delegates to the fixed `ZONE_PORTAL_IMPL_ADDRESS`.
-Replacement portal implementations MUST preserve the existing storage layout.
-The portal implementation and shared messenger MUST embed
-`ZONE_FACTORY_ADDRESS` as their factory authority.
-
-Transferring ownership to the zero address disables ordinary account-controlled
-upgrades. A future hardfork MAY submit any of the runtime-management calls as a
-system transaction from the zero address at a hardfork boundary, allowing
-upgrades to be hardfork-gated without changing the factory ABI, unless
-`implementationUpdatesLocked` is `true`.
+Any later runtime replacement MUST be specified by a hardfork and applied
+with the same copy operation at that hardfork boundary. Replacing the portal
+implementation upgrades every existing portal, because every portal proxy
+delegates to the fixed `ZONE_PORTAL_IMPL_ADDRESS`; replacement implementations
+MUST therefore preserve the existing storage layout. The portal implementation
+and shared messenger MUST embed `ZONE_FACTORY_ADDRESS` as their factory
+authority.
 
 `createZone` MUST NOT deploy the portal with EVM `CREATE` or `CREATE2`, and
 MUST NOT rely on nonce-based address prediction. Instead, the native factory:

--- a/tips/verify/src/zones/interfaces/IZone.sol
+++ b/tips/verify/src/zones/interfaces/IZone.sol
@@ -53,12 +53,6 @@ interface IZoneFactory {
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
-    event PortalUpdated(address indexed source, bytes32 indexed codeHash);
-
-    event MessengerUpdated(address indexed source, bytes32 indexed codeHash);
-
-    event VerifierUpdated(address indexed source, bytes32 indexed codeHash);
-
     event ZoneCreated(
         uint32 indexed zoneId,
         address indexed portal,
@@ -77,24 +71,9 @@ interface IZoneFactory {
     error NotOwner();
     error InvalidAdmin();
     error InvalidSequencerSet();
-    error InvalidPortalImplementation();
-    error InvalidZoneMessengerImplementation();
-    error InvalidVerifierImplementation();
-    error ImplementationUpdatesLocked();
-
     function owner() external view returns (address);
 
-    function implementationUpdatesLocked() external view returns (bool);
-
     function transferOwnership(address newOwner) external;
-
-    function lockImplementationUpdates() external;
-
-    function setPortalImplementation(address source) external;
-
-    function setZoneMessengerImplementation(address source) external;
-
-    function setVerifierImplementation(address source) external;
 
     function createZone(CreateZoneParams calldata params)
         external

--- a/tips/verify/src/zones/tempo/ZoneFactory.sol
+++ b/tips/verify/src/zones/tempo/ZoneFactory.sol
@@ -51,9 +51,6 @@ abstract contract ZoneFactory is IZoneFactory {
     /// @notice Initial value is configured by the T9 activation.
     address public owner;
 
-    /// @notice Whether shared runtime updates have been permanently disabled.
-    bool public override implementationUpdatesLocked;
-
     mapping(uint32 => ZoneInfo) internal _zones;
 
     /*//////////////////////////////////////////////////////////////
@@ -156,42 +153,6 @@ abstract contract ZoneFactory is IZoneFactory {
         emit OwnershipTransferred(previousOwner, newOwner);
     }
 
-    /// @inheritdoc IZoneFactory
-    function lockImplementationUpdates() external {
-        if (msg.sender != owner) revert NotOwner();
-        implementationUpdatesLocked = true;
-    }
-
-    /// @inheritdoc IZoneFactory
-    function setPortalImplementation(address source) external {
-        if (msg.sender != owner) revert NotOwner();
-        if (implementationUpdatesLocked) revert ImplementationUpdatesLocked();
-        if (source.code.length == 0) revert InvalidPortalImplementation();
-
-        bytes32 codeHash = _nativeCopyRuntime(source, ZONE_PORTAL_IMPL_ADDRESS);
-        emit PortalUpdated(source, codeHash);
-    }
-
-    /// @inheritdoc IZoneFactory
-    function setZoneMessengerImplementation(address source) external {
-        if (msg.sender != owner) revert NotOwner();
-        if (implementationUpdatesLocked) revert ImplementationUpdatesLocked();
-        if (source.code.length == 0) revert InvalidZoneMessengerImplementation();
-
-        bytes32 codeHash = _nativeCopyRuntime(source, ZONE_MESSENGER_ADDRESS);
-        emit MessengerUpdated(source, codeHash);
-    }
-
-    /// @inheritdoc IZoneFactory
-    function setVerifierImplementation(address source) external {
-        if (msg.sender != owner) revert NotOwner();
-        if (implementationUpdatesLocked) revert ImplementationUpdatesLocked();
-        if (source.code.length == 0) revert InvalidVerifierImplementation();
-
-        bytes32 codeHash = _nativeCopyRuntime(source, ZONE_VERIFIER_ADDRESS);
-        emit VerifierUpdated(source, codeHash);
-    }
-
     /// @notice Returns the deterministic portal vanity address for a zone ID.
     function portalAddress(uint32 zoneId) public pure returns (address) {
         uint160 prefix = uint160(bytes20(ZONE_PORTAL_PREFIX));
@@ -224,15 +185,8 @@ abstract contract ZoneFactory is IZoneFactory {
     /// @dev Native host hook: return whether TIP-403 stores an explicit policy binding for `token`.
     function _nativeTokenTransferPolicyIsSet(address token) internal virtual returns (bool);
 
-    /// @dev Native host hook: copy `source` runtime bytecode to `destination`.
-    /// Returns `EXTCODEHASH(source)` for the emitted update event.
-    function _nativeCopyRuntime(
-        address source,
-        address destination
-    )
-        internal
-        virtual
-        returns (bytes32 codeHash);
+    /// @dev Hardfork-only host hook: copy `source` runtime bytecode to `destination`.
+    function _nativeCopyRuntime(address source, address destination) internal virtual;
 
     /*//////////////////////////////////////////////////////////////
                                  VIEWS


### PR DESCRIPTION
Removes owner-callable Zone runtime setters and their lock from TIP-1091, the ABI, and native dispatch. Runtime installation remains an internal EXTCODECOPY-equivalent operation reserved for the hardfork boundary; concrete T9 source addresses will be wired once deployments are finalized.

Companion: https://github.com/tempoxyz/zones/pull/828