### PR TITLE
chore(consensus): recover dkg share if revealed & ignore stale state

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -264,13 +264,10 @@ where
     {
         let mut state = storage.current();
 
+        // Recovery is best-effort and shouldn't fail the dkg loop
         if !state.share.is_present()
-            && let Some(share) = self
-                .maybe_recover_revealed_share(storage, &state)
-                .await
-                .wrap_err("failed to attempt share recovery from public dealer logs")?
+            && let Ok(Some(share)) = self.maybe_recover_revealed_share(storage, &state).await
         {
-            // Recovery is a fallback, hence the warn severity
             warn!(%state.epoch, "recovered share from public dealer logs");
 
             state.share = state::ShareState::Plaintext(Some(share));
@@ -542,7 +539,7 @@ where
     /// The on-chain DKG outcome only records which players may have had their shares revealed. The
     /// scalar dealings themselves remain in the dealer logs included in regular block headers, so
     /// a node without the previous epoch's consensus journal must scan those headers.
-    #[instrument(skip_all, fields(epoch = %state.epoch))]
+    #[instrument(skip_all, fields(epoch = %state.epoch), err)]
     async fn maybe_recover_revealed_share<TStorageContext>(
         &mut self,
         storage: &state::Storage<TStorageContext>,
@@ -587,6 +584,13 @@ where
             "boundary outcome is for epoch `{}`, expected ceremony epoch `{ceremony_epoch}`",
             ceremony_outcome.epoch,
         );
+
+        // A failed ceremony carries its input output forward. In that case, the current share was
+        // produced by an older ceremony, not by the dealer logs from the immediately previous
+        // epoch. Do not attempt an unbounded search through earlier epochs here.
+        if ceremony_outcome.output == state.output {
+            return Ok(None);
+        }
 
         let ceremony_state = State {
             epoch: ceremony_outcome.epoch,

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -54,6 +54,7 @@ use tracing::{Level, Span, debug, info, info_span, instrument, warn, warn_span};
 
 use crate::{
     consensus::{Digest, block::Block},
+    dkg::manager::actor::state::ShareState,
     validators::{read_active_and_known_peers_at_block_hash, read_validator_config_at_block_hash},
 };
 
@@ -190,31 +191,14 @@ where
 
         let Ok(opened) = state::builder()
             .partition_prefix(&self.config.partition_prefix)
-            .init(self.context.child("state"))
+            .init_unverified(self.context.child("state"))
             .await
         else {
             return;
         };
 
-        let mut storage = match opened {
-            state::Opened::Existing(storage) => {
-                let mut storage = storage;
-                if self.heal(&mut storage).await.is_err() {
-                    return;
-                }
-
-                storage
-            }
-            state::Opened::Empty(storage) => {
-                let Ok(initial_state) = self.establish_initial_state().await else {
-                    return;
-                };
-                let Ok(storage) = storage.set_initial_state(initial_state).await else {
-                    return;
-                };
-
-                storage
-            }
+        let Ok(mut storage) = self.heal(opened).await else {
+            return;
         };
 
         if self
@@ -519,65 +503,59 @@ where
         }
     }
 
+    /// Turns freshly opened storage into storage that is guaranteed to hold a
+    /// state matching the finalized floor:
+    ///
+    /// 1. The persisted state is up-to-date: it is used as-is.
+    /// 2. The persisted state is stale: the state is re-initialized from the
+    ///    chain, reusing the stale share if it still matches the on-chain
+    ///    outcome, or recovering it from revealed dealings otherwise.
+    /// 3. No state is persisted: like 2., but without a stale share to fall
+    ///    back on.
     #[instrument(skip_all, err)]
     async fn heal<TStorageContext>(
         &mut self,
-        storage: &mut state::Storage<TStorageContext>,
-    ) -> eyre::Result<()>
+        storage: state::Unverified<TStorageContext>,
+    ) -> eyre::Result<state::Storage<TStorageContext>>
     where
         TStorageContext: commonware_runtime::BufferPooler
             + commonware_runtime::Metrics
             + Clock
             + commonware_runtime::Storage,
     {
-        let state = storage.current();
-        let round = state::Round::from_state(&state, &self.config.namespace);
-        let epoch_info = self
-            .config
-            .epoch_strategy
-            .containing(self.config.last_finalized_height.next())
-            .expect("epoch strategy is covering all heights");
-
-        match round.epoch().cmp(&epoch_info.epoch()) {
-            std::cmp::Ordering::Less => {
+        let mut share_candidate = ShareState::unset_plaintext();
+        if let Some(state) = storage.state() {
+            let epoch_info = self
+                .config
+                .epoch_strategy
+                .containing(self.config.last_finalized_height.next())
+                .expect("epoch strategy is covering all heights");
+            let round = state::Round::from_state(state, &self.config.namespace);
+            if round.epoch() < epoch_info.epoch() {
                 warn!(
                     "latest DKG state is for `{}`, but the next block will be \
                     for epoch `{}`. Resetting DKG initial state",
                     round.epoch(),
                     epoch_info.epoch(),
                 );
-
-                let mut initial_state = self
-                    .establish_initial_state()
+                share_candidate = state.share.clone();
+            } else {
+                let state = state.clone();
+                return storage
+                    .init_verified(state)
                     .await
-                    .wrap_err("failed constructing initial staste")?;
-
-                // If the outcomes match (failed DKG), fall back to the persisted share.
-                if initial_state.output == state.output
-                    && matches!(&initial_state.share, state::ShareState::Plaintext(None))
-                {
-                    initial_state.share = state.share;
-                }
-
-                storage
-                    .set_state(initial_state)
-                    .await
-                    .wrap_err("failed setting initial state")?;
+                    .wrap_err("failed writing initial state back to storage");
             }
-            std::cmp::Ordering::Greater => {
-                warn!(
-                    "ignoring block for prior epoch; older blocks are replayed \
-                    against DKG when a node was shut down right after a \
-                    boundary block completed an epoch, but before it was fully \
-                    processed by other actors"
-                );
-            }
-            std::cmp::Ordering::Equal => {
-                // Normal, expected behavior.
-            }
-        }
+        };
+        let initial_state = self
+            .establish_initial_state(share_candidate)
+            .await
+            .wrap_err("failed constructing initial state")?;
 
-        Ok(())
+        storage
+            .init_verified(initial_state)
+            .await
+            .wrap_err("failed setting initial state")
     }
 
     #[instrument(skip_all, err)]
@@ -1296,8 +1274,19 @@ where
             .wrap_err("could not instruct epoch manager to enter epoch")
     }
 
+    /// Constructs a fresh state from the on-chain DKG outcome at the last
+    /// finalized boundary.
+    ///
+    /// The share is sourced, in order of preference, from the configured
+    /// initial share, from `share_candidate` (salvaged from a stale persisted
+    /// state), or by recovering it from publicly revealed dealings. The first
+    /// two are only used if they match the polynomial of the on-chain
+    /// outcome.
     #[instrument(skip_all, err)]
-    async fn establish_initial_state(&mut self) -> eyre::Result<State> {
+    async fn establish_initial_state(
+        &mut self,
+        share_candidate: ShareState,
+    ) -> eyre::Result<State> {
         let latest_boundary = latest_boundary_at_or_before(
             &self.config.epoch_strategy,
             self.config.last_finalized_height,
@@ -1316,32 +1305,40 @@ where
         )
         .await?;
 
-        let share = state::ShareState::Plaintext('verify_initial_share: {
-            let Some(share) = self.config.initial_share.clone() else {
-                break 'verify_initial_share None;
+        // The configured initial share takes precedence over the candidate
+        // salvaged from a stale state. Either is only usable if it matches
+        // the polynomial of the on-chain DKG outcome.
+        let mut share = None;
+        for candidate in [
+            self.config.initial_share.clone(),
+            share_candidate.into_inner(),
+        ] {
+            let Some(candidate) = candidate else {
+                continue;
             };
-            let Ok(partial) = onchain_outcome.sharing().partial_public(share.index) else {
+            let Ok(partial) = onchain_outcome.sharing().partial_public(candidate.index) else {
                 warn!(
                     "the index of the provided share exceeds the polynomial of the \
                     on-chain DKG outcome; ignoring the share"
                 );
-                break 'verify_initial_share None;
+                continue;
             };
-            if share.public::<MinSig>() != partial {
+            if candidate.public::<MinSig>() != partial {
                 warn!(
                     "the provided share does not match the polynomial of the \
                     on-chain DKG outcome; ignoring the share"
                 );
-                break 'verify_initial_share None;
+                continue;
             }
-            Some(share)
-        });
+            share = Some(candidate);
+            break;
+        }
 
         let mut state = State {
             epoch: onchain_outcome.epoch,
             seed: Summary::random(&mut self.context),
             output: onchain_outcome.output.clone(),
-            share,
+            share: state::ShareState::Plaintext(share),
             players: onchain_outcome.next_players,
             is_full_dkg: onchain_outcome.is_next_full_dkg,
         };
@@ -1362,7 +1359,8 @@ where
     async fn maybe_recover_revealed_share(&mut self, state: &State) -> eyre::Result<Option<Share>> {
         let public_key = self.config.me.public_key();
         if state.output.players().position(&public_key).is_none()
-            || state.output.revealed().position(&public_key).is_none()
+        // TODO: currently unreliable; use once fixed
+        // || state.output.revealed().position(&public_key).is_none()
         {
             return Ok(None);
         }

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -186,32 +186,28 @@ where
             impl Receiver<PublicKey = PublicKey>,
         ),
     ) {
-        let Ok(mut storage) = state::builder()
+        let Ok(opened) = state::builder()
             .partition_prefix(&self.config.partition_prefix)
-            .initial_state({
-                let mut context = self.context.child("initial_state");
-                let execution_node = self.config.execution_node.clone();
-                let initial_share = self.config.initial_share.clone();
-                let epoch_strategy = self.config.epoch_strategy.clone();
-                let last_finalized_height = self.config.last_finalized_height;
-                let mut marshal = self.config.marshal.clone();
-                async move {
-                    establish_initial_state(
-                        &mut context,
-                        &execution_node,
-                        initial_share.clone(),
-                        &epoch_strategy,
-                        last_finalized_height,
-                        &mut marshal,
-                    )
-                    .await
-                }
-            })
             .init(self.context.child("state"))
             .await
         else {
             // NOTE: Builder::init emits en error event.
             return;
+        };
+
+        let mut storage = match opened {
+            state::Opened::Existing(storage) => storage,
+            state::Opened::Empty(storage) => {
+                // The following emit error events
+                let Ok(initial_state) = self.establish_initial_state().await else {
+                    return;
+                };
+                let Ok(storage) = storage.set_initial_state(initial_state).await else {
+                    return;
+                };
+
+                storage
+            }
         };
 
         if let Err(reason) = self
@@ -262,20 +258,7 @@ where
         TSender: Sender<PublicKey = PublicKey>,
         TReceiver: Receiver<PublicKey = PublicKey>,
     {
-        let mut state = storage.current();
-
-        // Recovery is best-effort and shouldn't fail the dkg loop
-        if !state.share.is_present()
-            && let Ok(Some(share)) = self.maybe_recover_revealed_share(storage, &state).await
-        {
-            warn!(%state.epoch, "recovered share from public dealer logs");
-
-            state.share = state::ShareState::Plaintext(Some(share));
-            storage
-                .set_state(state.clone())
-                .await
-                .wrap_err("failed persisting recovered threshold share")?;
-        }
+        let state = storage.current();
 
         self.metrics.reset();
         self.metrics
@@ -531,154 +514,6 @@ where
                 }
             )
         }
-    }
-
-    /// Attempts to reconstruct our current threshold share from dealer logs finalized during the
-    /// previous epoch.
-    ///
-    /// The on-chain DKG outcome only records which players may have had their shares revealed. The
-    /// scalar dealings themselves remain in the dealer logs included in regular block headers, so
-    /// a node without the previous epoch's consensus journal must scan those headers.
-    #[instrument(skip_all, fields(epoch = %state.epoch), err)]
-    async fn maybe_recover_revealed_share<TStorageContext>(
-        &mut self,
-        storage: &state::Storage<TStorageContext>,
-        state: &State,
-    ) -> eyre::Result<Option<Share>>
-    where
-        TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
-    {
-        let me = self.config.me.public_key();
-        if state.output.players().position(&me).is_none()
-            || state.output.revealed().position(&me).is_none()
-        {
-            return Ok(None);
-        }
-
-        let Some(ceremony_epoch) = state.epoch.previous() else {
-            return Ok(None);
-        };
-
-        let ceremony_boundary = ceremony_epoch.previous().map_or(Height::zero(), |epoch| {
-            self.config
-                .epoch_strategy
-                .last(epoch)
-                .expect("epoch strategy is valid for all epochs")
-        });
-
-        let ceremony_outcome = read_outcome_from_boundary(
-            &self.config.execution_node,
-            &self.config.marshal,
-            ceremony_boundary,
-        )
-        .await
-        .wrap_err("failed reading outcome for ceremony boundary")?;
-
-        ensure!(
-            ceremony_outcome.epoch == ceremony_epoch,
-            "boundary outcome is for epoch `{}`, expected ceremony epoch `{ceremony_epoch}`",
-            ceremony_outcome.epoch,
-        );
-
-        // A failed ceremony carries its input output forward. In that case, the current share was
-        // produced by an older ceremony, not by the dealer logs from the immediately previous
-        // epoch. Do not attempt an unbounded search through earlier epochs here.
-        if ceremony_outcome.output == state.output {
-            return Ok(None);
-        }
-
-        let ceremony_state = State {
-            epoch: ceremony_outcome.epoch,
-            seed: state.seed,
-            output: ceremony_outcome.output,
-            share: state::ShareState::Plaintext(None),
-            players: ceremony_outcome.next_players,
-            is_full_dkg: ceremony_outcome.is_next_full_dkg,
-        };
-
-        let round = state::Round::from_state(&ceremony_state, &self.config.namespace);
-        ensure!(
-            round.players().position(&me).is_some(),
-            "our identity is in the current output but was not a player in ceremony epoch \
-            `{ceremony_epoch}`"
-        );
-
-        // State journals retain the previous epoch, so a normal restart can avoid the scan. A
-        // fresh validator with no consensus state falls back to canonical finalized headers.
-        let selected_dealers = state.output.dealers();
-        let mut dealer_logs = storage
-            .logs_for_epoch(ceremony_epoch)
-            .filter(|(dealer, _)| selected_dealers.position(dealer).is_some())
-            .map(|(dealer, log)| (dealer.clone(), log.clone()))
-            .collect::<BTreeMap<_, _>>();
-
-        if dealer_logs.len() < selected_dealers.len() {
-            let first = self
-                .config
-                .epoch_strategy
-                .first(ceremony_epoch)
-                .ok_or_eyre("ceremony epoch has no first height")?;
-            let last = self
-                .config
-                .epoch_strategy
-                .last(ceremony_epoch)
-                .ok_or_eyre("ceremony epoch has no last height")?;
-
-            // Honest dealers do not finalize logs before the midpoint, but block validation does
-            // not enforce that timing, so scan the entire ceremony epoch. This path only runs when
-            // the node lacks the share it needs to participate in the current epoch.
-            let mut height = first;
-            while height < last && dealer_logs.len() < selected_dealers.len() {
-                let header = get_header(&self.config.execution_node, &self.config.marshal, height)
-                    .await
-                    .wrap_err("failed reading finalized header")?;
-
-                if !header.extra_data().is_empty()
-                    && let Ok((dealer, log)) = read_dealer_log(header.extra_data().as_ref(), &round)
-                    && selected_dealers.position(&dealer).is_some()
-                {
-                    // DKG storage keeps the first finalized log for each dealer. Scan in
-                    // chronological order and preserve the same first-log-wins behavior.
-                    dealer_logs.entry(dealer).or_insert(log);
-                }
-
-                height = height.next();
-            }
-        }
-
-        ensure!(
-            dealer_logs.len() == selected_dealers.len(),
-            "found only {} of {} selected dealer logs in finalized headers for ceremony epoch {ceremony_epoch}`",
-            dealer_logs.len(),
-            selected_dealers.len(),
-        );
-
-        let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
-        for (dealer, log) in dealer_logs {
-            logs.record(dealer, log);
-        }
-
-        let player = state::Player::new(
-            dkg::Player::new(round.info().clone(), self.config.me.clone())
-                .wrap_err("failed creating player to recover revealed share")?,
-        );
-
-        let (recovered_output, share) = match player.finalize(&mut self.context, logs, &Sequential)
-        {
-            Ok(recovered) => recovered,
-            Err(dkg::Error::MissingPlayerDealing) => return Ok(None),
-            Err(error) => {
-                return Err(eyre::Report::new(error))
-                    .wrap_err("failed finalizing revealed share from dealer logs");
-            }
-        };
-
-        ensure!(
-            recovered_output == state.output,
-            "recovered output does not match the on-chain output"
-        );
-
-        Ok(Some(share))
     }
 
     #[instrument(skip_all, err)]
@@ -1414,59 +1249,194 @@ where
             .exit(state.epoch)
             .wrap_err("could not instruct epoch manager to enter epoch")
     }
-}
 
-#[instrument(skip_all, err)]
-async fn establish_initial_state<TContext>(
-    context: &mut TContext,
-    node: &TempoFullNode,
-    share: Option<Share>,
-    epoch_strategy: &FixedEpocher,
-    last_finalized_height: Height,
-    marshal: &mut crate::alias::marshal::Mailbox,
-) -> eyre::Result<State>
-where
-    TContext: Clock + CryptoRng,
-{
-    let latest_boundary = latest_boundary_at_or_before(epoch_strategy, last_finalized_height);
-    info!(
-        %latest_boundary,
-        last_finalized = %last_finalized_height,
-        "marshal reported finalized floor at startup, reading on-chain DKG \
-        outcome from last boundary height"
-    );
+    #[instrument(skip_all, err)]
+    async fn establish_initial_state(&mut self) -> eyre::Result<State> {
+        let latest_boundary = latest_boundary_at_or_before(
+            &self.config.epoch_strategy,
+            self.config.last_finalized_height,
+        );
+        info!(
+            %latest_boundary,
+            last_finalized = %self.config.last_finalized_height,
+            "marshal reported finalized floor at startup, reading on-chain DKG \
+            outcome from last boundary height"
+        );
 
-    let onchain_outcome = read_outcome_from_boundary(node, marshal, latest_boundary).await?;
+        let onchain_outcome = read_outcome_from_boundary(
+            &self.config.execution_node,
+            &self.config.marshal,
+            latest_boundary,
+        )
+        .await?;
 
-    let share = state::ShareState::Plaintext('verify_initial_share: {
-        let Some(share) = share else {
-            break 'verify_initial_share None;
+        let share = state::ShareState::Plaintext('verify_initial_share: {
+            let Some(share) = self.config.initial_share.clone() else {
+                break 'verify_initial_share None;
+            };
+            let Ok(partial) = onchain_outcome.sharing().partial_public(share.index) else {
+                warn!(
+                    "the index of the provided share exceeds the polynomial of the \
+                    on-chain DKG outcome; ignoring the share"
+                );
+                break 'verify_initial_share None;
+            };
+            if share.public::<MinSig>() != partial {
+                warn!(
+                    "the provided share does not match the polynomial of the \
+                    on-chain DKG outcome; ignoring the share"
+                );
+                break 'verify_initial_share None;
+            }
+            Some(share)
+        });
+
+        let mut state = State {
+            epoch: onchain_outcome.epoch,
+            seed: Summary::random(&mut self.context),
+            output: onchain_outcome.output.clone(),
+            share,
+            players: onchain_outcome.next_players,
+            is_full_dkg: onchain_outcome.is_next_full_dkg,
         };
-        let Ok(partial) = onchain_outcome.sharing().partial_public(share.index) else {
-            warn!(
-                "the index of the provided share exceeds the polynomial of the \
-                on-chain DKG outcome; ignoring the share"
-            );
-            break 'verify_initial_share None;
-        };
-        if share.public::<MinSig>() != partial {
-            warn!(
-                "the provided share does not match the polynomial of the \
-                on-chain DKG outcome; ignoring the share"
-            );
-            break 'verify_initial_share None;
+
+        if let state::ShareState::Plaintext(None) = &state.share
+            && let Ok(Some(share)) = self.maybe_recover_revealed_share(&state).await
+        {
+            info!(epoch = %state.epoch, "recovered share from public dealings");
+            state.share = state::ShareState::Plaintext(Some(share));
         }
-        Some(share)
-    });
 
-    Ok(State {
-        epoch: onchain_outcome.epoch,
-        seed: Summary::random(context),
-        output: onchain_outcome.output.clone(),
-        share,
-        players: onchain_outcome.next_players,
-        is_full_dkg: onchain_outcome.is_next_full_dkg,
-    })
+        Ok(state)
+    }
+
+    /// Attempts to reconstruct our current threshold share from dealer logs finalized during the
+    /// previous epoch.
+    ///
+    /// This is only called while initializing an empty DKG partition, so all dealer logs are read
+    /// from finalized block headers.
+    #[instrument(skip_all, fields(epoch = %state.epoch), err)]
+    async fn maybe_recover_revealed_share(&mut self, state: &State) -> eyre::Result<Option<Share>> {
+        let public_key = self.config.me.public_key();
+        if state.output.players().position(&public_key).is_none()
+            || state.output.revealed().position(&public_key).is_none()
+        {
+            return Ok(None);
+        }
+
+        let Some(ceremony_epoch) = state.epoch.previous() else {
+            return Ok(None);
+        };
+
+        let ceremony_boundary = ceremony_epoch.previous().map_or(Height::zero(), |epoch| {
+            self.config
+                .epoch_strategy
+                .last(epoch)
+                .expect("epoch strategy is valid for all epochs")
+        });
+
+        let ceremony_outcome = read_outcome_from_boundary(
+            &self.config.execution_node,
+            &self.config.marshal,
+            ceremony_boundary,
+        )
+        .await
+        .wrap_err("failed reading outcome for ceremony boundary")?;
+
+        ensure!(
+            ceremony_outcome.epoch == ceremony_epoch,
+            "boundary outcome is for epoch `{}`, expected ceremony epoch `{ceremony_epoch}`",
+            ceremony_outcome.epoch,
+        );
+
+        // A failed ceremony carries its input output forward. In that case, the current share was
+        // produced by an older ceremony, not by the dealer logs from the immediately previous epoch.
+        // Do not attempt an unbounded search through earlier epochs here.
+        if ceremony_outcome.output == state.output {
+            return Ok(None);
+        }
+
+        let ceremony_state = State {
+            epoch: ceremony_outcome.epoch,
+            seed: state.seed,
+            output: ceremony_outcome.output,
+            share: state::ShareState::Plaintext(None),
+            players: ceremony_outcome.next_players,
+            is_full_dkg: ceremony_outcome.is_next_full_dkg,
+        };
+
+        let round = state::Round::from_state(&ceremony_state, &self.config.namespace);
+        ensure!(
+            round.players().position(&public_key).is_some(),
+            "our identity is in the current output but was not a player in ceremony epoch \
+        `{ceremony_epoch}`"
+        );
+
+        let selected_dealers = state.output.dealers();
+        let first = self
+            .config
+            .epoch_strategy
+            .first(ceremony_epoch)
+            .ok_or_eyre("ceremony epoch has no first height")?;
+        let last = self
+            .config
+            .epoch_strategy
+            .last(ceremony_epoch)
+            .ok_or_eyre("ceremony epoch has no last height")?;
+
+        // Honest dealers do not finalize logs before the midpoint, but block validation does not
+        // enforce that timing, so scan the entire ceremony epoch.
+        let mut height = first;
+        let mut dealer_logs = BTreeMap::new();
+        while height < last && dealer_logs.len() < selected_dealers.len() {
+            let header = get_header(&self.config.execution_node, &self.config.marshal, height)
+                .await
+                .wrap_err("failed reading finalized header")?;
+
+            if !header.extra_data().is_empty()
+                && let Ok((dealer, log)) = read_dealer_log(header.extra_data().as_ref(), &round)
+                && selected_dealers.position(&dealer).is_some()
+            {
+                dealer_logs.entry(dealer).or_insert(log);
+            }
+
+            height = height.next();
+        }
+
+        ensure!(
+            dealer_logs.len() == selected_dealers.len(),
+            "found only {} of {} selected dealer logs in finalized headers for ceremony epoch `{ceremony_epoch}`",
+            dealer_logs.len(),
+            selected_dealers.len(),
+        );
+
+        let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
+        for (dealer, log) in dealer_logs {
+            logs.record(dealer, log);
+        }
+
+        let player = state::Player::new(
+            dkg::Player::new(round.info().clone(), self.config.me.clone())
+                .wrap_err("failed creating player to recover revealed share")?,
+        );
+
+        let (recovered_output, share) = match player.finalize(&mut self.context, logs, &Sequential)
+        {
+            Ok(recovered) => recovered,
+            Err(dkg::Error::MissingPlayerDealing) => return Ok(None),
+            Err(error) => {
+                return Err(eyre::Report::new(error))
+                    .wrap_err("failed finalizing revealed share from dealer logs");
+            }
+        };
+
+        ensure!(
+            recovered_output == state.output,
+            "recovered output does not match the on-chain output"
+        );
+
+        Ok(Some(share))
+    }
 }
 
 fn latest_boundary_at_or_before(epoch_strategy: &FixedEpocher, height: Height) -> Height {

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -262,10 +262,25 @@ where
         TSender: Sender<PublicKey = PublicKey>,
         TReceiver: Receiver<PublicKey = PublicKey>,
     {
-        let state = storage.current();
+        let mut state = storage.current();
+
+        if !state.share.is_present()
+            && let Some(share) = self
+                .maybe_recover_revealed_share(storage, &state)
+                .await
+                .wrap_err("failed to attempt share recovery from public dealer logs")?
+        {
+            // Recovery is a fallback, hence the warn severity
+            warn!(%state.epoch, "recovered share from public dealer logs");
+
+            state.share = state::ShareState::Plaintext(Some(share));
+            storage
+                .set_state(state.clone())
+                .await
+                .wrap_err("failed persisting recovered threshold share")?;
+        }
 
         self.metrics.reset();
-
         self.metrics
             .dealers
             .metric()
@@ -519,6 +534,152 @@ where
                 }
             )
         }
+    }
+
+    /// Attempts to reconstruct our current threshold share from dealer logs finalized during the
+    /// previous epoch.
+    ///
+    /// The on-chain DKG outcome only records which players may have had their shares revealed. The
+    /// scalar dealings themselves remain in the dealer logs included in regular block headers, so
+    /// a node without the previous epoch's consensus journal must scan those headers.
+    #[instrument(skip_all, fields(epoch = %state.epoch))]
+    async fn maybe_recover_revealed_share<TStorageContext>(
+        &mut self,
+        storage: &state::Storage<TStorageContext>,
+        state: &State,
+    ) -> eyre::Result<Option<Share>>
+    where
+        TStorageContext: commonware_runtime::Metrics + Clock + commonware_runtime::Storage,
+    {
+        let me = self.config.me.public_key();
+        if state.output.players().position(&me).is_none()
+            || state.output.revealed().position(&me).is_none()
+        {
+            return Ok(None);
+        }
+
+        let Some(ceremony_epoch) = state.epoch.previous() else {
+            return Ok(None);
+        };
+
+        let ceremony_boundary = ceremony_epoch.previous().map_or(Height::zero(), |epoch| {
+            self.config
+                .epoch_strategy
+                .last(epoch)
+                .expect("epoch strategy is valid for all epochs")
+        });
+
+        let ceremony_outcome = read_outcome_from_boundary(
+            &self.config.execution_node,
+            &self.config.marshal,
+            ceremony_boundary,
+        )
+        .await
+        .wrap_err_with(|| {
+            format!(
+                "failed reading boundary outcome that initialized ceremony epoch \
+                `{ceremony_epoch}`"
+            )
+        })?;
+
+        ensure!(
+            ceremony_outcome.epoch == ceremony_epoch,
+            "boundary outcome is for epoch `{}`, expected ceremony epoch `{ceremony_epoch}`",
+            ceremony_outcome.epoch,
+        );
+
+        let ceremony_state = State {
+            epoch: ceremony_outcome.epoch,
+            seed: state.seed,
+            output: ceremony_outcome.output,
+            share: state::ShareState::Plaintext(None),
+            players: ceremony_outcome.next_players,
+            is_full_dkg: ceremony_outcome.is_next_full_dkg,
+        };
+
+        let round = state::Round::from_state(&ceremony_state, &self.config.namespace);
+        ensure!(
+            round.players().position(&me).is_some(),
+            "our identity is in the current output but was not a player in ceremony epoch \
+            `{ceremony_epoch}`"
+        );
+
+        // State journals retain the previous epoch, so a normal restart can avoid the scan. A
+        // fresh validator with no consensus state falls back to canonical finalized headers.
+        let selected_dealers = state.output.dealers();
+        let mut dealer_logs = storage
+            .logs_for_epoch(ceremony_epoch)
+            .filter(|(dealer, _)| selected_dealers.position(dealer).is_some())
+            .map(|(dealer, log)| (dealer.clone(), log.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        if dealer_logs.len() < selected_dealers.len() {
+            let first = self
+                .config
+                .epoch_strategy
+                .first(ceremony_epoch)
+                .ok_or_eyre("ceremony epoch has no first height")?;
+            let last = self
+                .config
+                .epoch_strategy
+                .last(ceremony_epoch)
+                .ok_or_eyre("ceremony epoch has no last height")?;
+
+            // Honest dealers do not finalize logs before the midpoint, but block validation does
+            // not enforce that timing, so scan the entire ceremony epoch. This path only runs when
+            // the node lacks the share it needs to participate in the current epoch.
+            let mut height = first;
+            while height < last && dealer_logs.len() < selected_dealers.len() {
+                let header = get_header(&self.config.execution_node, &self.config.marshal, height)
+                    .await
+                    .wrap_err("failed reading finalized header")?;
+
+                if !header.extra_data().is_empty()
+                    && let Ok((dealer, log)) = read_dealer_log(header.extra_data().as_ref(), &round)
+                    && selected_dealers.position(&dealer).is_some()
+                {
+                    // DKG storage keeps the first finalized log for each dealer. Scan in
+                    // chronological order and preserve the same first-log-wins behavior.
+                    dealer_logs.entry(dealer).or_insert(log);
+                }
+
+                height = height.next();
+            }
+        }
+
+        ensure!(
+            dealer_logs.len() == selected_dealers.len(),
+            "found only {} of {} selected dealer logs in finalized headers for ceremony epoch {ceremony_epoch}`",
+            dealer_logs.len(),
+            selected_dealers.len(),
+        );
+
+        let mut logs = Logs::<MinSig, PublicKey, N3f1>::new(round.info().clone());
+        for (dealer, log) in dealer_logs {
+            logs.record(dealer, log);
+        }
+
+        let player = state::Player::new(
+            dkg::Player::new(round.info().clone(), self.config.me.clone())
+                .wrap_err("failed creating player to recover revealed share")?,
+        );
+
+        let (recovered_output, share) = match player.finalize(&mut self.context, logs, &Sequential)
+        {
+            Ok(recovered) => recovered,
+            Err(dkg::Error::MissingPlayerDealing) => return Ok(None),
+            Err(error) => {
+                return Err(eyre::Report::new(error))
+                    .wrap_err("failed finalizing revealed share from dealer logs");
+            }
+        };
+
+        ensure!(
+            recovered_output == state.output,
+            "recovered output does not match the on-chain output"
+        );
+
+        Ok(Some(share))
     }
 
     #[instrument(skip_all, err)]

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -572,12 +572,7 @@ where
             ceremony_boundary,
         )
         .await
-        .wrap_err_with(|| {
-            format!(
-                "failed reading boundary outcome that initialized ceremony epoch \
-                `{ceremony_epoch}`"
-            )
-        })?;
+        .wrap_err("failed reading outcome for ceremony boundary")?;
 
         ensure!(
             ceremony_outcome.epoch == ceremony_epoch,

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -186,19 +186,26 @@ where
             impl Receiver<PublicKey = PublicKey>,
         ),
     ) {
+        // NOTE: The instrumented fns emits on error events
+
         let Ok(opened) = state::builder()
             .partition_prefix(&self.config.partition_prefix)
             .init(self.context.child("state"))
             .await
         else {
-            // NOTE: Builder::init emits en error event.
             return;
         };
 
         let mut storage = match opened {
-            state::Opened::Existing(storage) => storage,
+            state::Opened::Existing(storage) => {
+                let mut storage = storage;
+                if self.heal(&mut storage).await.is_err() {
+                    return;
+                }
+
+                storage
+            }
             state::Opened::Empty(storage) => {
-                // The following emit error events
                 let Ok(initial_state) = self.establish_initial_state().await else {
                     return;
                 };
@@ -210,16 +217,11 @@ where
             }
         };
 
-        if let Err(reason) = self
+        if self
             .prepopulate_to_last_finalized_height(&mut storage)
             .await
+            .is_err()
         {
-            tracing::warn_span!("dkg_actor").in_scope(|| {
-                warn!(
-                    %reason,
-                    "failed prepopulating DKG state",
-                );
-            });
             return;
         }
 
@@ -229,6 +231,7 @@ where
             receiver,
             self.config.mailbox_size.into(),
         );
+
         mux.start();
 
         let reason = loop {
@@ -517,6 +520,67 @@ where
     }
 
     #[instrument(skip_all, err)]
+    async fn heal<TStorageContext>(
+        &mut self,
+        storage: &mut state::Storage<TStorageContext>,
+    ) -> eyre::Result<()>
+    where
+        TStorageContext: commonware_runtime::BufferPooler
+            + commonware_runtime::Metrics
+            + Clock
+            + commonware_runtime::Storage,
+    {
+        let state = storage.current();
+        let round = state::Round::from_state(&state, &self.config.namespace);
+        let epoch_info = self
+            .config
+            .epoch_strategy
+            .containing(self.config.last_finalized_height.next())
+            .expect("epoch strategy is covering all heights");
+
+        match round.epoch().cmp(&epoch_info.epoch()) {
+            std::cmp::Ordering::Less => {
+                warn!(
+                    "latest DKG state is for `{}`, but the next block will be \
+                    for epoch `{}`. Resetting DKG initial state",
+                    round.epoch(),
+                    epoch_info.epoch(),
+                );
+
+                let mut initial_state = self
+                    .establish_initial_state()
+                    .await
+                    .wrap_err("failed constructing initial staste")?;
+
+                // If the outcomes match (failed DKG), fall back to the persisted share.
+                if initial_state.output == state.output
+                    && matches!(&initial_state.share, state::ShareState::Plaintext(None))
+                {
+                    initial_state.share = state.share;
+                }
+
+                storage
+                    .set_state(initial_state)
+                    .await
+                    .wrap_err("failed setting initial state")?;
+            }
+            std::cmp::Ordering::Greater => {
+                warn!(
+                    "ignoring block for prior epoch; older blocks are replayed \
+                    against DKG when a node was shut down right after a \
+                    boundary block completed an epoch, but before it was fully \
+                    processed by other actors"
+                );
+            }
+            std::cmp::Ordering::Equal => {
+                // Normal, expected behavior.
+            }
+        }
+
+        Ok(())
+    }
+
+    #[instrument(skip_all, err)]
     async fn prepopulate_to_last_finalized_height<TStorageContext>(
         &self,
         storage: &mut state::Storage<TStorageContext>,
@@ -536,28 +600,10 @@ where
             .containing(target_height.next())
             .expect("epoch strategy is covering all heights");
 
-        match round.epoch().cmp(&epoch_info.epoch()) {
-            std::cmp::Ordering::Less => {
-                bail!(
-                    "latest DKG state is for `{}`, but the next block will be \
-                    for epoch `{}`; this is a contract violation and the \
-                    state is invalid",
-                    round.epoch(),
-                    epoch_info.epoch(),
-                );
-            }
-            std::cmp::Ordering::Greater => {
-                warn!(
-                    "ignoring block for prior epoch; older blocks are replayed \
-                    against DKG when a node was shut down right after a \
-                    boundary block completed an epoch, but before it was fully \
-                    processed by other actors"
-                );
-                return Ok(());
-            }
-            std::cmp::Ordering::Equal => {
-                // Normal, expected behavior.
-            }
+        // The DKG actor may have persisted the new epoch before the finalized floor caught up
+        // during shutdown. Do not replay prior-epoch headers against the newer DKG round.
+        if round.epoch() > epoch_info.epoch() {
+            return Ok(());
         }
 
         let mut height = storage

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -1358,9 +1358,6 @@ where
 
     /// Attempts to reconstruct our current threshold share from dealer logs finalized during the
     /// previous epoch.
-    ///
-    /// This is only called while initializing an empty DKG partition, so all dealer logs are read
-    /// from finalized block headers.
     #[instrument(skip_all, fields(epoch = %state.epoch), err)]
     async fn maybe_recover_revealed_share(&mut self, state: &State) -> eyre::Result<Option<Share>> {
         let public_key = self.config.me.public_key();

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -509,7 +509,8 @@ where
     /// 1. The persisted state is up-to-date: it is used as-is.
     /// 2. The persisted state is stale: the state is re-initialized from the
     ///    chain, reusing the stale share if it still matches the on-chain
-    ///    outcome, or recovering it from revealed dealings otherwise.
+    ///    outcome, or recovering it from persisted or revealed dealings
+    ///    otherwise.
     /// 3. No state is persisted: like 2., but without a stale share to fall
     ///    back on.
     #[instrument(skip_all, err)]
@@ -548,7 +549,7 @@ where
             }
         };
         let initial_state = self
-            .establish_initial_state(share_candidate)
+            .establish_initial_state(&storage, share_candidate)
             .await
             .wrap_err("failed constructing initial state")?;
 
@@ -1283,10 +1284,17 @@ where
     /// two are only used if they match the polynomial of the on-chain
     /// outcome.
     #[instrument(skip_all, err)]
-    async fn establish_initial_state(
+    async fn establish_initial_state<TStorageContext>(
         &mut self,
+        storage: &state::Unverified<TStorageContext>,
         share_candidate: ShareState,
-    ) -> eyre::Result<State> {
+    ) -> eyre::Result<State>
+    where
+        TStorageContext: commonware_runtime::BufferPooler
+            + commonware_runtime::Metrics
+            + Clock
+            + commonware_runtime::Storage,
+    {
         let latest_boundary = latest_boundary_at_or_before(
             &self.config.epoch_strategy,
             self.config.last_finalized_height,
@@ -1344,19 +1352,30 @@ where
         };
 
         if let state::ShareState::Plaintext(None) = &state.share
-            && let Ok(Some(share)) = self.maybe_recover_revealed_share(&state).await
+            && let Ok(Some(share)) = self.maybe_recover_share(storage, &state).await
         {
-            info!(epoch = %state.epoch, "recovered share from public dealings");
+            info!(epoch = %state.epoch, "recovered share from persisted or public dealings");
             state.share = state::ShareState::Plaintext(Some(share));
         }
 
         Ok(state)
     }
 
-    /// Attempts to reconstruct our current threshold share from dealer logs finalized during the
-    /// previous epoch.
+    /// Attempts to reconstruct our current threshold share from dealings persisted during the
+    /// previous epoch and dealer logs finalized on-chain. Publicly revealed dealings in those logs
+    /// allow recovery when no persisted player state is available.
     #[instrument(skip_all, fields(epoch = %state.epoch), err)]
-    async fn maybe_recover_revealed_share(&mut self, state: &State) -> eyre::Result<Option<Share>> {
+    async fn maybe_recover_share<TStorageContext>(
+        &mut self,
+        storage: &state::Unverified<TStorageContext>,
+        state: &State,
+    ) -> eyre::Result<Option<Share>>
+    where
+        TStorageContext: commonware_runtime::BufferPooler
+            + commonware_runtime::Metrics
+            + Clock
+            + commonware_runtime::Storage,
+    {
         let public_key = self.config.me.public_key();
         if state.output.players().position(&public_key).is_none()
         // TODO: currently unreliable; use once fixed
@@ -1456,10 +1475,12 @@ where
             logs.record(dealer, log);
         }
 
-        let player = state::Player::new(
-            dkg::Player::new(round.info().clone(), self.config.me.clone())
-                .wrap_err("failed creating player to recover revealed share")?,
-        );
+        let Some(player) = storage
+            .create_player_for_round(self.config.me.clone(), &round)
+            .wrap_err("failed creating player to recover share")?
+        else {
+            return Ok(None);
+        };
 
         let (recovered_output, share) = match player.finalize(&mut self.context, logs, &Sequential)
         {

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -1229,7 +1229,7 @@ mod tests {
         transcript::Summary,
     };
     use commonware_math::algebra::Random as _;
-    use commonware_runtime::{Runner as _, deterministic};
+    use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
     use commonware_utils::TryFromIterator as _;
 
     fn make_test_state(rng: &mut impl rand_core::CryptoRng, epoch: u64) -> State {
@@ -1327,7 +1327,7 @@ mod tests {
         executor.start(|mut context| async move {
             let opened = builder()
                 .partition_prefix("empty_storage_requires_an_initial_state")
-                .init(context.with_label("initial"))
+                .init(context.child("initial"))
                 .await
                 .unwrap();
             let Opened::Empty(empty) = opened else {
@@ -1341,7 +1341,7 @@ mod tests {
 
             let reopened = builder()
                 .partition_prefix("empty_storage_requires_an_initial_state")
-                .init(context.with_label("reopened"))
+                .init(context.child("reopened"))
                 .await
                 .unwrap();
             let Opened::Existing(storage) = reopened else {
@@ -1357,7 +1357,7 @@ mod tests {
         executor.start(|context| async move {
             let opened = builder()
                 .partition_prefix("empty_states_reject_retained_events")
-                .init(context.with_label("initial"))
+                .init(context.child("initial"))
                 .await
                 .unwrap();
             let Opened::Empty(mut empty) = opened else {
@@ -1381,7 +1381,7 @@ mod tests {
 
             let result = builder()
                 .partition_prefix("empty_states_reject_retained_events")
-                .init(context.with_label("reopened"))
+                .init(context.child("reopened"))
                 .await;
             let Err(error) = result else {
                 panic!("retained events without state metadata must be rejected");

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -28,7 +28,7 @@ use commonware_parallel::Strategy;
 use commonware_runtime::{BufferPooler, Clock, Metrics, buffer::paged::CacheRef};
 use commonware_storage::{journal::segmented, metadata};
 use commonware_utils::{N3f1, NZU16, NZU32, NZUsize, ordered};
-use eyre::{OptionExt, WrapErr as _, bail, eyre};
+use eyre::{OptionExt, WrapErr as _, bail};
 use futures::StreamExt as _;
 use tempo_primitives::TempoHeader;
 use tracing::{debug, info, instrument, warn};
@@ -58,47 +58,39 @@ where
     states: metadata::Metadata<TContext, u64, State>,
     events: segmented::variable::Journal<TContext, Event>,
 
-    current: State,
+    current: Option<State>,
     cache: BTreeMap<Epoch, Events>,
 }
 
-#[allow(clippy::large_enum_variant)]
-pub(super) enum Opened<TContext>
+/// Storage as read from disk, holding a state that has not yet been checked
+/// against the finalized floor (or no state at all).
+///
+/// [`Unverified::init_verified`] persists the verified state and turns this
+/// into a usable [`Storage`].
+pub(super) struct Unverified<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    Existing(Storage<TContext>),
-    Empty(EmptyStorage<TContext>),
+    storage: Storage<TContext>,
 }
 
-pub(super) struct EmptyStorage<TContext>
+impl<TContext> Unverified<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    states: metadata::Metadata<TContext, u64, State>,
-    events: segmented::variable::Journal<TContext, Event>,
-}
+    pub(super) fn state(&self) -> Option<&State> {
+        self.storage.current.as_ref()
+    }
 
-impl<TContext> EmptyStorage<TContext>
-where
-    TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
-{
-    #[instrument(skip_all, err)]
-    pub(super) async fn set_initial_state(
-        mut self,
-        state: State,
-    ) -> eyre::Result<Storage<TContext>> {
-        self.states
+    pub(super) async fn init_verified(self, state: State) -> eyre::Result<Storage<TContext>> {
+        let Self { mut storage } = self;
+        storage
+            .states
             .put_sync(state.epoch.get(), state.clone())
             .await
             .wrap_err("unable to write initial state to metadata")?;
-
-        Ok(Storage {
-            states: self.states,
-            events: self.events,
-            current: state,
-            cache: BTreeMap::new(),
-        })
+        storage.current = Some(state);
+        Ok(storage)
     }
 }
 
@@ -141,7 +133,7 @@ where
 
     /// Returns the DKG outcome for the current epoch.
     pub(super) fn current(&self) -> State {
-        self.current.clone()
+        self.current.clone().expect("invariant: state must be set")
     }
 
     /// Persists the outcome of a DKG ceremony to state
@@ -150,7 +142,7 @@ where
             warn!(epoch = %old.epoch, "overwriting existing state");
         }
         self.states.sync().await.wrap_err("failed writing state")?;
-        self.current = state;
+        self.current = Some(state);
         Ok(())
     }
 
@@ -524,7 +516,10 @@ impl Builder {
     }
 
     #[instrument(skip_all, err)]
-    pub(super) async fn init<TContext>(self, context: TContext) -> eyre::Result<Opened<TContext>>
+    pub(super) async fn init_unverified<TContext>(
+        self,
+        context: TContext,
+    ) -> eyre::Result<Unverified<TContext>>
     where
         TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
     {
@@ -583,18 +578,18 @@ impl Builder {
             }
         }
 
-        match current {
-            Some(current) => Ok(Opened::Existing(Storage {
+        eyre::ensure!(
+            current.is_some() || cache.is_empty(),
+            "DKG states metadata is empty, but events journal contains retained events",
+        );
+        Ok(Unverified {
+            storage: Storage {
                 states,
                 events,
                 current,
                 cache,
-            })),
-            None if cache.is_empty() => Ok(Opened::Empty(EmptyStorage { states, events })),
-            None => Err(eyre!(
-                "DKG states metadata is empty, but the events journal contains retained events"
-            )),
-        }
+            },
+        })
     }
 }
 
@@ -611,6 +606,10 @@ pub(super) enum ShareState {
 }
 
 impl ShareState {
+    pub(super) fn unset_plaintext() -> Self {
+        Self::Plaintext(None)
+    }
+
     pub(super) fn into_inner(self) -> Option<Share> {
         match self {
             Self::Plaintext(share) => share,
@@ -1325,29 +1324,31 @@ mod tests {
     fn empty_storage_requires_an_initial_state() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let opened = builder()
+            let unverified = builder()
                 .partition_prefix("empty_storage_requires_an_initial_state")
-                .init(context.child("initial"))
+                .init_unverified(context.child("initial"))
                 .await
                 .unwrap();
-            let Opened::Empty(empty) = opened else {
-                panic!("new storage must be empty");
-            };
+            assert!(
+                unverified.state().is_none(),
+                "new storage must not contain a state"
+            );
 
             let state = make_test_state(&mut context, 0);
-            let storage = empty.set_initial_state(state.clone()).await.unwrap();
+            let storage = unverified.init_verified(state.clone()).await.unwrap();
             assert_eq!(storage.current(), state);
             drop(storage);
 
             let reopened = builder()
                 .partition_prefix("empty_storage_requires_an_initial_state")
-                .init(context.child("reopened"))
+                .init_unverified(context.child("reopened"))
                 .await
                 .unwrap();
-            let Opened::Existing(storage) = reopened else {
-                panic!("storage with an initial state must reopen as existing");
-            };
-            assert_eq!(storage.current(), state);
+            assert_eq!(
+                reopened.state(),
+                Some(&state),
+                "storage with an initial state must reopen with it"
+            );
         });
     }
 
@@ -1355,16 +1356,18 @@ mod tests {
     fn empty_states_reject_retained_events() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let opened = builder()
+            let mut unverified = builder()
                 .partition_prefix("empty_states_reject_retained_events")
-                .init(context.child("initial"))
+                .init_unverified(context.child("initial"))
                 .await
                 .unwrap();
-            let Opened::Empty(mut empty) = opened else {
-                panic!("new storage must be empty");
-            };
+            assert!(
+                unverified.state().is_none(),
+                "new storage must not contain a state"
+            );
 
-            empty
+            unverified
+                .storage
                 .events
                 .append(
                     0,
@@ -1376,12 +1379,12 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            empty.events.sync(0).await.unwrap();
-            drop(empty);
+            unverified.storage.events.sync(0).await.unwrap();
+            drop(unverified);
 
             let result = builder()
                 .partition_prefix("empty_states_reject_retained_events")
-                .init(context.child("reopened"))
+                .init_unverified(context.child("reopened"))
                 .await;
             let Err(error) = result else {
                 panic!("retained events without state metadata must be rejected");
@@ -1389,7 +1392,7 @@ mod tests {
             assert!(
                 error
                     .to_string()
-                    .contains("states metadata is empty, but the events journal contains")
+                    .contains("states metadata is empty, but events journal contains")
             );
         });
     }

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -62,6 +62,7 @@ where
     cache: BTreeMap<Epoch, Events>,
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(super) enum Opened<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
@@ -519,7 +520,6 @@ impl Builder {
     pub(super) fn partition_prefix(self, partition_prefix: &str) -> Self {
         Self {
             partition_prefix: Some(partition_prefix.to_string()),
-            ..self
         }
     }
 

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -29,7 +29,7 @@ use commonware_runtime::{BufferPooler, Clock, Metrics, buffer::paged::CacheRef};
 use commonware_storage::{journal::segmented, metadata};
 use commonware_utils::{N3f1, NZU16, NZU32, NZUsize, ordered};
 use eyre::{OptionExt, WrapErr as _, bail, eyre};
-use futures::{FutureExt as _, StreamExt as _, future::BoxFuture};
+use futures::StreamExt as _;
 use tempo_primitives::TempoHeader;
 use tracing::{debug, info, instrument, warn};
 
@@ -60,6 +60,45 @@ where
 
     current: State,
     cache: BTreeMap<Epoch, Events>,
+}
+
+pub(super) enum Opened<TContext>
+where
+    TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
+{
+    Existing(Storage<TContext>),
+    Empty(EmptyStorage<TContext>),
+}
+
+pub(super) struct EmptyStorage<TContext>
+where
+    TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
+{
+    states: metadata::Metadata<TContext, u64, State>,
+    events: segmented::variable::Journal<TContext, Event>,
+}
+
+impl<TContext> EmptyStorage<TContext>
+where
+    TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
+{
+    #[instrument(skip_all, err)]
+    pub(super) async fn set_initial_state(
+        mut self,
+        state: State,
+    ) -> eyre::Result<Storage<TContext>> {
+        self.states
+            .put_sync(state.epoch.get(), state.clone())
+            .await
+            .wrap_err("unable to write initial state to metadata")?;
+
+        Ok(Storage {
+            states: self.states,
+            events: self.events,
+            current: state,
+            cache: BTreeMap::new(),
+        })
+    }
 }
 
 impl<TContext> Storage<TContext>
@@ -473,21 +512,10 @@ where
 
 #[derive(Default)]
 pub(super) struct Builder {
-    initial_state: Option<BoxFuture<'static, eyre::Result<State>>>,
     partition_prefix: Option<String>,
 }
 
 impl Builder {
-    pub(super) fn initial_state(
-        self,
-        initial_state: impl Future<Output = eyre::Result<State>> + Send + 'static,
-    ) -> Self {
-        Self {
-            initial_state: Some(initial_state.boxed()),
-            ..self
-        }
-    }
-
     pub(super) fn partition_prefix(self, partition_prefix: &str) -> Self {
         Self {
             partition_prefix: Some(partition_prefix.to_string()),
@@ -496,22 +524,18 @@ impl Builder {
     }
 
     #[instrument(skip_all, err)]
-    pub(super) async fn init<TContext>(self, context: TContext) -> eyre::Result<Storage<TContext>>
+    pub(super) async fn init<TContext>(self, context: TContext) -> eyre::Result<Opened<TContext>>
     where
         TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
     {
-        let Self {
-            initial_state,
-            partition_prefix,
-        } = self;
+        let Self { partition_prefix } = self;
         let partition_prefix =
             partition_prefix.ok_or_eyre("DKG actors state must have its partition prefix set")?;
 
         let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, POOL_CAPACITY);
 
         let states_metadata_partition = format!("{partition_prefix}_states_metadata");
-
-        let mut states = metadata::Metadata::init(
+        let states: metadata::Metadata<TContext, u64, State> = metadata::Metadata::init(
             context.child("states"),
             metadata::Config {
                 partition: states_metadata_partition,
@@ -521,33 +545,12 @@ impl Builder {
         .await
         .wrap_err("unable to initialize DKG states metadata")?;
 
-        if states.keys().max().is_none() {
-            let initial_state = match initial_state {
-                None => {
-                    return Err(eyre!(
-                        "states metadata was empty and initializer was not set"
-                    ));
-                }
-                Some(initial_state) => initial_state
-                    .await
-                    .wrap_err("failed constructing initial state to populate storage")?,
-            };
+        let current = states.keys().max().map(|epoch| {
             states
-                .put_sync(initial_state.epoch.get(), initial_state)
-                .await
-                .wrap_err("unable to write initial state to metadata")?;
-        }
-
-        let current = states
-            .keys()
-            .max()
-            .map(|epoch| {
-                states
-                    .get(epoch)
-                    .expect("state at keys iterator must exist")
-                    .clone()
-            })
-            .expect("states storage must contain a state after initialization");
+                .get(epoch)
+                .expect("state at keys iterator must exist")
+                .clone()
+        });
 
         let mut events = segmented::variable::Journal::init(
             context.child("events"),
@@ -580,12 +583,18 @@ impl Builder {
             }
         }
 
-        Ok(Storage {
-            states,
-            events,
-            current,
-            cache,
-        })
+        match current {
+            Some(current) => Ok(Opened::Existing(Storage {
+                states,
+                events,
+                current,
+                cache,
+            })),
+            None if cache.is_empty() => Ok(Opened::Empty(EmptyStorage { states, events })),
+            None => Err(eyre!(
+                "DKG states metadata is empty, but the events journal contains retained events"
+            )),
+        }
     }
 }
 
@@ -605,12 +614,6 @@ impl ShareState {
     pub(super) fn into_inner(self) -> Option<Share> {
         match self {
             Self::Plaintext(share) => share,
-        }
-    }
-
-    pub(super) fn is_present(&self) -> bool {
-        match self {
-            Self::Plaintext(share) => share.is_some(),
         }
     }
 }
@@ -1316,5 +1319,78 @@ mod tests {
 
         let share = shares.into_iter().next().unwrap().1;
         assert_roundtrip(&ShareState::Plaintext(Some(share)));
+    }
+
+    #[test]
+    fn empty_storage_requires_an_initial_state() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let opened = builder()
+                .partition_prefix("empty_storage_requires_an_initial_state")
+                .init(context.with_label("initial"))
+                .await
+                .unwrap();
+            let Opened::Empty(empty) = opened else {
+                panic!("new storage must be empty");
+            };
+
+            let state = make_test_state(&mut context, 0);
+            let storage = empty.set_initial_state(state.clone()).await.unwrap();
+            assert_eq!(storage.current(), state);
+            drop(storage);
+
+            let reopened = builder()
+                .partition_prefix("empty_storage_requires_an_initial_state")
+                .init(context.with_label("reopened"))
+                .await
+                .unwrap();
+            let Opened::Existing(storage) = reopened else {
+                panic!("storage with an initial state must reopen as existing");
+            };
+            assert_eq!(storage.current(), state);
+        });
+    }
+
+    #[test]
+    fn empty_states_reject_retained_events() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let opened = builder()
+                .partition_prefix("empty_states_reject_retained_events")
+                .init(context.with_label("initial"))
+                .await
+                .unwrap();
+            let Opened::Empty(mut empty) = opened else {
+                panic!("new storage must be empty");
+            };
+
+            empty
+                .events
+                .append(
+                    0,
+                    &Event::Finalized {
+                        digest: Digest(alloy_primitives::B256::with_last_byte(1)),
+                        parent: Digest(alloy_primitives::B256::ZERO),
+                        height: Height::zero(),
+                    },
+                )
+                .await
+                .unwrap();
+            empty.events.sync(0).await.unwrap();
+            drop(empty);
+
+            let result = builder()
+                .partition_prefix("empty_states_reject_retained_events")
+                .init(context.with_label("reopened"))
+                .await;
+            let Err(error) = result else {
+                panic!("retained events without state metadata must be rejected");
+            };
+            assert!(
+                error
+                    .to_string()
+                    .contains("states metadata is empty, but the events journal contains")
+            );
+        });
     }
 }

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -607,6 +607,12 @@ impl ShareState {
             Self::Plaintext(share) => share,
         }
     }
+
+    pub(super) fn is_present(&self) -> bool {
+        match self {
+            Self::Plaintext(share) => share.is_some(),
+        }
+    }
 }
 
 impl EncodeSize for ShareState {

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -82,6 +82,16 @@ where
         self.storage.current.as_ref()
     }
 
+    /// Creates a player for a persisted round, replaying any dealings loaded
+    /// from the journal while opening storage.
+    pub(super) fn create_player_for_round(
+        &self,
+        me: PrivateKey,
+        round: &Round,
+    ) -> eyre::Result<Option<Player>> {
+        self.storage.create_player_for_round(me, round)
+    }
+
     pub(super) async fn init_verified(self, state: State) -> eyre::Result<Storage<TContext>> {
         let Self { mut storage } = self;
         storage

--- a/crates/e2e/src/tests/dkg/mod.rs
+++ b/crates/e2e/src/tests/dkg/mod.rs
@@ -5,5 +5,6 @@ mod current_committee;
 mod dynamic;
 mod fast_sync_after_full_dkg;
 mod full_ceremony;
+mod revealed_share_recovery;
 mod share_loss;
 mod static_transitions;

--- a/crates/e2e/src/tests/dkg/mod.rs
+++ b/crates/e2e/src/tests/dkg/mod.rs
@@ -7,4 +7,5 @@ mod fast_sync_after_full_dkg;
 mod full_ceremony;
 mod revealed_share_recovery;
 mod share_loss;
+mod stale_state_recovery;
 mod static_transitions;

--- a/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
+++ b/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
@@ -1,0 +1,121 @@
+//! Tests recovery of a publicly revealed DKG share.
+
+use commonware_macros::test_traced;
+use commonware_runtime::{
+    Runner as _,
+    deterministic::{Config, Runner},
+};
+use futures::future::join_all;
+
+use crate::{
+    Setup, connect_execution_peers, connect_execution_to_peers,
+    consensus_snapshot::write_consensus_snapshot, metrics::wait_for_metrics, setup_validators,
+};
+
+/// A validator with no private dealings can reconstruct its next share while replaying the
+/// ceremony's revealed dealer logs.
+#[test_traced]
+fn validator_recovers_revealed_share_while_replaying_ceremony() {
+    let _ = tempo_eyre::install();
+
+    let epoch_length = 30;
+    let setup = Setup::new().how_many_signers(4).epoch_length(epoch_length);
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+        let mut recovering = validators.pop().expect("at least one validator");
+
+        // Keep this validator offline for epoch 0 so every selected dealer reveals its dealing.
+        // Remove its genesis share so the only way it can sign in epoch 1 is recovery from chain.
+        recovering
+            .consensus_config_mut()
+            .share
+            .take()
+            .expect("validator starts with a genesis share");
+
+        join_all(validators.iter_mut().map(|node| node.start(&context))).await;
+        connect_execution_peers(&validators).await;
+
+        wait_for_metrics(&context, |m| m.consensus_at_epoch(1) == validators.len()).await;
+
+        recovering.start(&context).await;
+        connect_execution_to_peers(&recovering, &validators).await;
+
+        wait_for_metrics(&context, |metrics| {
+            assert!(
+                metrics.consensus_before_epoch(2),
+                "validator did not reconstruct its share while replaying epoch 0"
+            );
+
+            let recovering_metrics = metrics.for_scope(&recovering);
+            recovering_metrics.latest_consensus_epoch() == Some(1)
+                && recovering_metrics
+                    .value::<u64>("_epoch_manager_how_often_signer_total")
+                    .is_some_and(|started_as_signer| started_as_signer > 0)
+        })
+        .await;
+    });
+}
+
+/// A validator with synced execution state and no consensus state can reconstruct its current
+/// share by scanning the previous epoch's revealed dealer logs.
+#[test_traced]
+fn validator_recovers_revealed_share_without_consensus_state() {
+    let _ = tempo_eyre::install();
+
+    let epoch_length = 30;
+    let setup = Setup::new().how_many_signers(4).epoch_length(epoch_length);
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+        let mut recovering = validators.pop().expect("at least one validator");
+
+        recovering
+            .consensus_config_mut()
+            .share
+            .take()
+            .expect("validator starts with a genesis share");
+
+        join_all(validators.iter_mut().map(|node| node.start(&context))).await;
+        connect_execution_peers(&validators).await;
+
+        wait_for_metrics(&context, |m| m.consensus_at_epoch(1) == validators.len()).await;
+
+        // Give the offline validator an already-synced execution database and consensus snapshot,
+        // but no DKG state. Its first DKG-manager loop therefore starts at the current boundary and
+        // must scan the previous epoch rather than replaying it.
+        let mut donor = validators.pop().expect("at least one running validator");
+        let execution_provider = donor.execution_provider();
+        donor.stop().await;
+        write_consensus_snapshot(
+            &context,
+            &donor,
+            execution_provider,
+            &recovering.consensus_config.partition_prefix,
+        )
+        .await;
+
+        recovering.consensus_config.strict_startup = true;
+        donor.adopt_identity_from(recovering);
+        donor.start(&context).await;
+        connect_execution_to_peers(&donor, &validators).await;
+
+        let recovering = donor;
+        wait_for_metrics(&context, |metrics| {
+            assert!(
+                metrics.consensus_before_epoch(3),
+                "network advanced without the validator recovering its current share"
+            );
+
+            metrics
+                .for_scope(&recovering)
+                .value::<u64>("_epoch_manager_how_often_signer_total")
+                .is_some_and(|started_as_signer| started_as_signer > 0)
+        })
+        .await;
+    });
+}

--- a/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
+++ b/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
@@ -1,5 +1,6 @@
 //! Tests recovery of a publicly revealed DKG share.
 
+use alloy::transports::http::reqwest::Url;
 use commonware_macros::test_traced;
 use commonware_runtime::{
     Runner as _,
@@ -7,6 +8,7 @@ use commonware_runtime::{
 };
 use futures::future::join_all;
 
+use super::common::{target_epoch, wait_for_outcome};
 use crate::{
     Setup, connect_execution_peers, connect_execution_to_peers,
     consensus_snapshot::write_consensus_snapshot, metrics::wait_for_metrics, setup_validators,
@@ -18,7 +20,7 @@ use crate::{
 fn validator_recovers_revealed_share_while_replaying_ceremony() {
     let _ = tempo_eyre::install();
 
-    let epoch_length = 30;
+    let epoch_length = 20;
     let setup = Setup::new().how_many_signers(4).epoch_length(epoch_length);
     let cfg = Config::default().with_seed(setup.seed);
     let executor = Runner::from(cfg);
@@ -65,7 +67,7 @@ fn validator_recovers_revealed_share_while_replaying_ceremony() {
 fn validator_recovers_revealed_share_without_consensus_state() {
     let _ = tempo_eyre::install();
 
-    let epoch_length = 30;
+    let epoch_length = 20;
     let setup = Setup::new().how_many_signers(4).epoch_length(epoch_length);
     let cfg = Config::default().with_seed(setup.seed);
     let executor = Runner::from(cfg);
@@ -115,6 +117,135 @@ fn validator_recovers_revealed_share_without_consensus_state() {
                 .for_scope(&recovering)
                 .value::<u64>("_epoch_manager_how_often_signer_total")
                 .is_some_and(|started_as_signer| started_as_signer > 0)
+        })
+        .await;
+    });
+}
+
+/// A carried-forward output belongs to an older successful ceremony and is not recovered from the
+/// immediately preceding failed ceremony.
+#[test_traced]
+fn validator_skips_recovery_after_failed_ceremony() {
+    let _ = tempo_eyre::install();
+
+    let epoch_length = 20;
+    let setup = Setup::new()
+        .how_many_signers(4)
+        .how_many_verifiers(1)
+        .epoch_length(epoch_length);
+
+    let cfg = Config::default().with_seed(setup.seed);
+    let executor = Runner::from(cfg);
+
+    executor.start(|mut context| async move {
+        let (mut nodes, execution_runtime) = setup_validators(&mut context, setup).await;
+        let verifier_index = nodes
+            .iter()
+            .position(|node| node.is_verifier())
+            .expect("setup includes a verifier");
+
+        let mut offline_player = nodes.remove(verifier_index);
+        let signer_index = nodes
+            .iter()
+            .position(|node| node.is_signer())
+            .expect("setup includes signers");
+
+        let mut recovering = nodes.remove(signer_index);
+        recovering
+            .consensus_config_mut()
+            .share
+            .take()
+            .expect("validator starts with a genesis share");
+
+        join_all(nodes.iter_mut().map(|node| node.start(&context))).await;
+        connect_execution_peers(&nodes).await;
+
+        // Add another offline player during epoch 0. Together with the recovering validator this
+        // exceeds the reveal limit in epoch 1, causing that ceremony to fail while the three
+        // online members of the current four-validator committee keep consensus live.
+        let http_url = nodes[0]
+            .execution()
+            .rpc_server_handle()
+            .http_url()
+            .expect("execution RPC is enabled")
+            .parse::<Url>()
+            .expect("execution RPC URL is valid");
+
+        let receipt = execution_runtime
+            .add_validator_v2(http_url, &offline_player)
+            .await
+            .expect("validator is added");
+        assert_eq!(
+            target_epoch(
+                epoch_length,
+                receipt.block_number.expect("receipt has a block number")
+            )
+            .get(),
+            1,
+            "offline player must join the epoch 1 ceremony"
+        );
+
+        let epoch_one = wait_for_outcome(&context, &nodes, 0, epoch_length).await;
+        assert!(
+            epoch_one
+                .output
+                .revealed()
+                .position(&recovering.public_key())
+                .is_some(),
+            "offline validator's share must be revealed by the successful epoch 0 ceremony"
+        );
+
+        let epoch_two = wait_for_outcome(&context, &nodes, 1, epoch_length).await;
+        assert_eq!(
+            epoch_two.output, epoch_one.output,
+            "failed epoch 1 ceremony must carry its input output forward"
+        );
+
+        // Sync the added verifier after it has served its purpose as an offline player. Using it as
+        // the snapshot donor keeps all three original signers online to maintain quorum in epoch 2.
+        offline_player.start(&context).await;
+        connect_execution_to_peers(&offline_player, &nodes).await;
+        wait_for_metrics(&context, |metrics| {
+            metrics
+                .for_scope(&offline_player)
+                .latest_consensus_epoch()
+                .is_some_and(|epoch| epoch >= 2)
+        })
+        .await;
+
+        let execution_provider = offline_player.execution_provider();
+        offline_player.stop().await;
+        write_consensus_snapshot(
+            &context,
+            &offline_player,
+            execution_provider,
+            &recovering.consensus_config.partition_prefix,
+        )
+        .await;
+
+        // Start the revealed validator at epoch 2 with synced execution and consensus state but no
+        // DKG state. Recovery must recognize that epoch 1 did not produce the current output,
+        // continue as an observer, and obtain a new share from the epoch 2 ceremony.
+        recovering.consensus_config.strict_startup = true;
+        offline_player.adopt_identity_from(recovering);
+        offline_player.start(&context).await;
+        connect_execution_to_peers(&offline_player, &nodes).await;
+
+        wait_for_metrics(&context, |metrics| {
+            let recovering_metrics = metrics.for_scope(&offline_player);
+            let Some(epoch) = recovering_metrics.latest_consensus_epoch() else {
+                return false;
+            };
+            assert!(
+                epoch <= 3,
+                "recovering validator advanced past epoch 3 before becoming a signer"
+            );
+
+            epoch == 3
+                && recovering_metrics.value::<u64>("_epoch_manager_how_often_verifier_total")
+                    == Some(1)
+                && recovering_metrics.value::<u64>("_epoch_manager_how_often_signer_total")
+                    == Some(1)
         })
         .await;
     });

--- a/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
+++ b/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
@@ -14,53 +14,6 @@ use crate::{
     consensus_snapshot::write_consensus_snapshot, metrics::wait_for_metrics, setup_validators,
 };
 
-/// A validator with no private dealings can reconstruct its next share while replaying the
-/// ceremony's revealed dealer logs.
-#[test_traced]
-fn validator_recovers_revealed_share_while_replaying_ceremony() {
-    let _ = tempo_eyre::install();
-
-    let epoch_length = 20;
-    let setup = Setup::new().how_many_signers(4).epoch_length(epoch_length);
-    let cfg = Config::default().with_seed(setup.seed);
-    let executor = Runner::from(cfg);
-
-    executor.start(|mut context| async move {
-        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
-        let mut recovering = validators.pop().expect("at least one validator");
-
-        // Keep this validator offline for epoch 0 so every selected dealer reveals its dealing.
-        // Remove its genesis share so the only way it can sign in epoch 1 is recovery from chain.
-        recovering
-            .consensus_config_mut()
-            .share
-            .take()
-            .expect("validator starts with a genesis share");
-
-        join_all(validators.iter_mut().map(|node| node.start(&context))).await;
-        connect_execution_peers(&validators).await;
-
-        wait_for_metrics(&context, |m| m.consensus_at_epoch(1) == validators.len()).await;
-
-        recovering.start(&context).await;
-        connect_execution_to_peers(&recovering, &validators).await;
-
-        wait_for_metrics(&context, |metrics| {
-            assert!(
-                metrics.consensus_before_epoch(2),
-                "validator did not reconstruct its share while replaying epoch 0"
-            );
-
-            let recovering_metrics = metrics.for_scope(&recovering);
-            recovering_metrics.latest_consensus_epoch() == Some(1)
-                && recovering_metrics
-                    .value::<u64>("_epoch_manager_how_often_signer_total")
-                    .is_some_and(|started_as_signer| started_as_signer > 0)
-        })
-        .await;
-    });
-}
-
 /// A validator with synced execution state and no consensus state can reconstruct its current
 /// share by scanning the previous epoch's revealed dealer logs.
 #[test_traced]

--- a/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
+++ b/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
@@ -1,6 +1,5 @@
 //! Tests recovery of a publicly revealed DKG share.
 
-use alloy::transports::http::reqwest::Url;
 use commonware_macros::test_traced;
 use commonware_runtime::{
     Runner as _,
@@ -8,7 +7,6 @@ use commonware_runtime::{
 };
 use futures::future::join_all;
 
-use super::common::{target_epoch, wait_for_outcome};
 use crate::{
     Setup, connect_execution_peers, connect_execution_to_peers,
     consensus_snapshot::write_consensus_snapshot, metrics::wait_for_metrics, setup_validators,
@@ -69,134 +67,6 @@ fn validator_recovers_revealed_share_without_consensus_state() {
                 .for_scope(&recovering)
                 .value::<u64>("_epoch_manager_how_often_signer_total")
                 .is_some_and(|started_as_signer| started_as_signer > 0)
-        })
-        .await;
-    });
-}
-
-/// A carried-forward output belongs to an older successful ceremony and is not recovered from the
-/// immediately preceding failed ceremony.
-#[test_traced]
-fn validator_skips_recovery_after_failed_ceremony() {
-    let _ = tempo_eyre::install();
-
-    let epoch_length = 20;
-    let setup = Setup::new()
-        .how_many_signers(4)
-        .how_many_verifiers(1)
-        .epoch_length(epoch_length);
-
-    let cfg = Config::default().with_seed(setup.seed);
-    let executor = Runner::from(cfg);
-
-    executor.start(|mut context| async move {
-        let (mut nodes, execution_runtime) = setup_validators(&mut context, setup).await;
-        let verifier_index = nodes
-            .iter()
-            .position(|node| node.is_verifier())
-            .expect("setup includes a verifier");
-
-        let mut offline_player = nodes.remove(verifier_index);
-        let signer_index = nodes
-            .iter()
-            .position(|node| node.is_signer())
-            .expect("setup includes signers");
-
-        let mut recovering = nodes.remove(signer_index);
-        recovering
-            .consensus_config_mut()
-            .share
-            .take()
-            .expect("validator starts with a genesis share");
-
-        join_all(nodes.iter_mut().map(|node| node.start(&context))).await;
-        connect_execution_peers(&nodes).await;
-
-        // Add another offline player during epoch 0. Together with the recovering validator this
-        // exceeds the reveal limit in epoch 1, causing that ceremony to fail while the three
-        // online members of the current four-validator committee keep consensus live.
-        let http_url = nodes[0]
-            .execution()
-            .rpc_server_handle()
-            .http_url()
-            .expect("execution RPC is enabled")
-            .parse::<Url>()
-            .expect("execution RPC URL is valid");
-
-        let receipt = execution_runtime
-            .add_validator_v2(http_url, &offline_player)
-            .await
-            .expect("validator is added");
-        assert_eq!(
-            target_epoch(
-                epoch_length,
-                receipt.block_number.expect("receipt has a block number")
-            )
-            .get(),
-            1,
-            "offline player must join the epoch 1 ceremony"
-        );
-
-        let epoch_one = wait_for_outcome(&context, &nodes, 0, epoch_length).await;
-        assert!(
-            epoch_one
-                .output
-                .revealed()
-                .position(&recovering.public_key())
-                .is_some(),
-            "offline validator's share must be revealed by the successful epoch 0 ceremony"
-        );
-
-        let epoch_two = wait_for_outcome(&context, &nodes, 1, epoch_length).await;
-        assert_eq!(
-            epoch_two.output, epoch_one.output,
-            "failed epoch 1 ceremony must carry its input output forward"
-        );
-
-        // Sync the added verifier after it has served its purpose as an offline player. Using it as
-        // the snapshot donor keeps all three original signers online to maintain quorum in epoch 2.
-        offline_player.start(&context).await;
-        connect_execution_to_peers(&offline_player, &nodes).await;
-        wait_for_metrics(&context, |metrics| {
-            metrics
-                .for_scope(&offline_player)
-                .latest_consensus_epoch()
-                .is_some_and(|epoch| epoch >= 2)
-        })
-        .await;
-
-        let execution_provider = offline_player.execution_provider();
-        offline_player.stop().await;
-        write_consensus_snapshot(
-            &context,
-            &offline_player,
-            execution_provider,
-            &recovering.consensus_config.partition_prefix,
-        )
-        .await;
-
-        // Start the revealed validator at epoch 2 with synced execution and consensus state but no
-        // DKG state. Recovery must recognize that epoch 1 did not produce the current output,
-        // continue as an observer, and obtain a new share from the epoch 2 ceremony.
-        offline_player.adopt_identity_from(recovering);
-        offline_player.start(&context).await;
-        connect_execution_to_peers(&offline_player, &nodes).await;
-
-        wait_for_metrics(&context, |metrics| {
-            let recovering_metrics = metrics.for_scope(&offline_player);
-            let Some(epoch) = recovering_metrics.latest_consensus_epoch() else {
-                return false;
-            };
-            assert!(
-                epoch <= 3,
-                "recovering validator advanced past epoch 3 before becoming a signer"
-            );
-
-            epoch == 3
-                && recovering_metrics.value::<u64>("_epoch_manager_how_often_verifier_total")
-                    == Some(1)
-                && recovering_metrics.value::<u64>("_epoch_manager_how_often_signer_total")
-                    == Some(1)
         })
         .await;
     });

--- a/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
+++ b/crates/e2e/src/tests/dkg/revealed_share_recovery.rs
@@ -54,7 +54,6 @@ fn validator_recovers_revealed_share_without_consensus_state() {
         )
         .await;
 
-        recovering.consensus_config.strict_startup = true;
         donor.adopt_identity_from(recovering);
         donor.start(&context).await;
         connect_execution_to_peers(&donor, &validators).await;
@@ -179,7 +178,6 @@ fn validator_skips_recovery_after_failed_ceremony() {
         // Start the revealed validator at epoch 2 with synced execution and consensus state but no
         // DKG state. Recovery must recognize that epoch 1 did not produce the current output,
         // continue as an observer, and obtain a new share from the epoch 2 ceremony.
-        recovering.consensus_config.strict_startup = true;
         offline_player.adopt_identity_from(recovering);
         offline_player.start(&context).await;
         connect_execution_to_peers(&offline_player, &nodes).await;

--- a/crates/e2e/src/tests/dkg/stale_state_recovery.rs
+++ b/crates/e2e/src/tests/dkg/stale_state_recovery.rs
@@ -1,0 +1,71 @@
+//! Tests recovery from DKG state that predates the installed consensus snapshot.
+
+use commonware_macros::test_traced;
+use commonware_runtime::{Runner as _, Storage as _, deterministic};
+use futures::future::join_all;
+
+use super::common::wait_for_validators_to_reach_epoch;
+use crate::{
+    Setup, connect_execution_peers, connect_execution_to_peers,
+    consensus_snapshot::write_consensus_snapshot, setup_validators,
+};
+
+/// Snapshot storage partitions materialized by `write_consensus_snapshot`.
+const SNAPSHOT_PARTITION_SUFFIXES: &[&str] = &[
+    "finalizations-by-height-metadata",
+    "finalizations-by-height-freezer-table",
+    "finalizations-by-height-freezer-key",
+    "finalizations-by-height-freezer-value",
+    "finalizations-by-height-ordinal",
+    "finalized-blocks-prunable-key",
+    "finalized-blocks-prunable-value",
+];
+
+/// A validator retains its DKG journal while replacing the finalized consensus snapshot with one
+/// from a later epoch. On restart, the DKG actor must rebuild its state from the snapshot boundary
+/// and rejoin consensus.
+#[test_traced]
+fn validator_heals_dkg_state_behind_consensus_snapshot() {
+    let _ = tempo_eyre::install();
+
+    let setup = Setup::new().how_many_signers(4).epoch_length(10);
+    let executor = deterministic::Runner::seeded(setup.seed);
+
+    executor.start(|mut context| async move {
+        let (mut validators, _execution_runtime) = setup_validators(&mut context, setup).await;
+
+        join_all(validators.iter_mut().map(|node| node.start(&context))).await;
+        connect_execution_peers(&validators).await;
+
+        // Ensure the validator has persisted epoch 1 DKG state before taking it offline.
+        wait_for_validators_to_reach_epoch(&context, 1, validators.len() as u32).await;
+        let mut stale = validators.pop().expect("setup includes validators");
+        stale.stop().await;
+
+        // Advance the remaining quorum and capture a snapshot rooted in epoch 2.
+        wait_for_validators_to_reach_epoch(&context, 2, validators.len() as u32).await;
+        let mut donor = validators.pop().expect("setup includes a snapshot donor");
+        let execution_provider = donor.execution_provider();
+        donor.stop().await;
+
+        let target_prefix = stale.consensus_config().partition_prefix.clone();
+        for suffix in SNAPSHOT_PARTITION_SUFFIXES {
+            context
+                .remove(&format!("{target_prefix}-{suffix}"), None)
+                .await
+                .expect("stopped validator's snapshot partition must be removable");
+        }
+        write_consensus_snapshot(&context, &donor, execution_provider, &target_prefix).await;
+
+        // Reuse the donor's synced execution database with the stale validator's identity and
+        // consensus partition. The DKG partitions still contain epoch 1 state, while the installed
+        // snapshot starts in epoch 2.
+        donor.adopt_identity_from(stale);
+        donor.start(&context).await;
+        connect_execution_to_peers(&donor, &validators).await;
+        validators.push(donor);
+
+        // Healing must restore a usable share and let the three online validators advance.
+        wait_for_validators_to_reach_epoch(&context, 3, validators.len() as u32).await;
+    });
+}


### PR DESCRIPTION
 ## Share Recovery

If a node doesn't have any share present

- A player ~~and marked as revealed~~ in current state output
- Previous epoch's dkg was successful
- Check storage for cached dealer logs (partial consensus state)
- Otherwise replay headers and populate the dealer logs
- Recover the Share


Best-effort, any failure just logs and doesn't exit startup. Worst case performance cost is iterating through the previous epoch's headers to populate dealer logs. These nodes are already a no-op in the existing epoch with no share.


## Stale DKG State

On startup if the local dkg state is stale relative to the finalized floor, we overwrite with a fresh initial state instead of failing hard