### PR TITLE
feat(tip-1095): add policy-aware channel transfers

### DIFF
--- a/crates/chainspec/src/genesis/dev.json
+++ b/crates/chainspec/src/genesis/dev.json
@@ -36,6 +36,7 @@
     "t7Time": 0,
     "t8Time": 0,
     "t9Time": 0,
+    "t10Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -36,6 +36,7 @@
     "t7Time": 0,
     "t8Time": 0,
     "t9Time": 0,
+    "t10Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/node/tests/assets/test-genesis.json
+++ b/crates/node/tests/assets/test-genesis.json
@@ -36,7 +36,6 @@
     "t7Time": 0,
     "t8Time": 0,
     "t9Time": 0,
-    "t10Time": 0,
     "depositContractAddress": "0x0000000000000000000000000000000000000000"
   },
   "nonce": "0x42",

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -48,6 +48,18 @@ use tracing::trace;
 /// u128::MAX as U256
 pub const U128_MAX: U256 = uint!(0xffffffffffffffffffffffffffffffff_U256);
 
+/// TIP-403 subjects used for a physical TIP-20 balance movement.
+///
+/// Most transfers enforce policy against the physical balance owner and recipient. Protocol
+/// custody may instead enforce a logical payment path, or bypass TIP-403 for a descriptor-bound
+/// refund while retaining all other transfer validation.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum TransferPolicyCheck {
+    Physical,
+    Logical { from: Address, to: Address },
+    Bypass,
+}
+
 /// Validates that the given token's currency is `"USD"`.
 ///
 /// # Errors
@@ -914,6 +926,41 @@ impl TIP20Token {
         Ok(true)
     }
 
+    /// Moves channel-reserve custody while applying policy to the logical payment path.
+    ///
+    /// This is an internal TIP-1034 integration, not an ABI entrypoint. At least one physical
+    /// endpoint must be the canonical channel reserve. `Bypass` is valid only for reserve-originated
+    /// refunds; the reserve derives their recipient and amount from authenticated channel state.
+    pub(crate) fn channel_reserve_transfer(
+        &mut self,
+        from: Address,
+        to: Address,
+        amount: U256,
+        policy_check: TransferPolicyCheck,
+    ) -> Result<bool> {
+        if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
+            return Err(TIP20Error::unauthorized().into());
+        }
+        if matches!(policy_check, TransferPolicyCheck::Bypass)
+            && from != TIP20_CHANNEL_RESERVE_ADDRESS
+        {
+            return Err(TIP20Error::unauthorized().into());
+        }
+
+        let Some(to) =
+            self.validate_transfer_with_policy(None, from, to, amount, B256::ZERO, policy_check)?
+        else {
+            return Ok(true);
+        };
+
+        self._transfer(from, &to, amount)?;
+        if let Some(hop) = to.build_virtual_transfer_event(amount) {
+            self.emit_event(hop)?;
+        }
+
+        Ok(true)
+    }
+
     /// Debits `spender`'s allowance on `owner`. No-op when unlimited.
     fn consume_allowance(&mut self, owner: Address, spender: Address, amount: U256) -> Result<()> {
         let allowed = self.get_allowance(owner, spender)?;
@@ -1080,10 +1127,36 @@ impl TIP20Token {
         amount: U256,
         memo: B256,
     ) -> Result<Option<Recipient>> {
+        self.validate_transfer_with_policy(
+            spender,
+            from,
+            to,
+            amount,
+            memo,
+            TransferPolicyCheck::Physical,
+        )
+    }
+
+    /// Validates a physical balance movement with an explicit TIP-403 policy path.
+    fn validate_transfer_with_policy(
+        &mut self,
+        spender: Option<Address>,
+        from: Address,
+        to: Address,
+        amount: U256,
+        memo: B256,
+        policy_check: TransferPolicyCheck,
+    ) -> Result<Option<Recipient>> {
         let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
-        self.ensure_transfer_authorized(from, to.target)?;
+        match policy_check {
+            TransferPolicyCheck::Physical => self.ensure_transfer_authorized(from, to.target)?,
+            TransferPolicyCheck::Logical { from, to } => {
+                self.ensure_transfer_authorized(from, to)?
+            }
+            TransferPolicyCheck::Bypass => {}
+        }
 
         if let Some(spender) = spender {
             self.consume_allowance(from, spender, amount)?;

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1150,6 +1150,10 @@ impl TIP20Token {
         let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
+        let inbound_originator = match policy_check {
+            TransferPolicyCheck::Logical { from, .. } => from,
+            TransferPolicyCheck::Physical | TransferPolicyCheck::Bypass => from,
+        };
         match policy_check {
             TransferPolicyCheck::Physical => self.ensure_transfer_authorized(from, to.target)?,
             TransferPolicyCheck::Logical { from, to } => {
@@ -1164,7 +1168,7 @@ impl TIP20Token {
             self.check_and_update_spending_limit(from, amount)?;
         }
 
-        if self.validate_inbound_or_block(from, &to, amount, None, memo)? {
+        if self.validate_inbound_or_block(inbound_originator, from, &to, amount, None, memo)? {
             return Ok(None);
         }
 
@@ -1202,7 +1206,14 @@ impl TIP20Token {
             return Err(TIP20Error::policy_forbids().into());
         }
 
-        if self.validate_inbound_or_block(msg_sender, &to, amount, Some(total_supply), memo)? {
+        if self.validate_inbound_or_block(
+            msg_sender,
+            msg_sender,
+            &to,
+            amount,
+            Some(total_supply),
+            memo,
+        )? {
             return Ok(None);
         }
 
@@ -1304,12 +1315,14 @@ impl TIP20Token {
         self.emit_event(to.build_transfer_event(from, amount))
     }
 
-    /// Validates the receive policy of `to.target`. If blocked, moves the funds into the guard
-    /// account and stores a claim receipt; returns `true`. Returns `false` when the inbound is
-    /// authorized and the caller should proceed with the normal transfer or mint.
+    /// Validates the receive policy of `to.target` against `originator`. If blocked, moves funds
+    /// from `transfer_from` into the guard account and stores a claim receipt attributed to
+    /// `originator`; returns `true`. Returns `false` when the inbound is authorized and the caller
+    /// should proceed with the normal transfer or mint.
     pub(crate) fn validate_inbound_or_block(
         &mut self,
         originator: Address,
+        transfer_from: Address,
         to: &Recipient,
         amount: U256,
         mint_total_supply: Option<U256>,
@@ -1335,7 +1348,7 @@ impl TIP20Token {
             self.emit_event(TIP20Event::mint(guard.target, amount))?;
             InboundKind::MINT
         } else {
-            self._transfer(originator, &guard, amount)?;
+            self._transfer(transfer_from, &guard, amount)?;
             InboundKind::TRANSFER
         };
         ReceivePolicyGuard::new()

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -48,18 +48,6 @@ use tracing::trace;
 /// u128::MAX as U256
 pub const U128_MAX: U256 = uint!(0xffffffffffffffffffffffffffffffff_U256);
 
-/// TIP-403 subjects used for a physical TIP-20 balance movement.
-///
-/// Most transfers enforce policy against the physical balance owner and recipient. Protocol
-/// custody may instead enforce a logical payment path, or bypass TIP-403 for a descriptor-bound
-/// refund while retaining all other transfer validation.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum TransferPolicyCheck {
-    Physical,
-    Logical { from: Address, to: Address },
-    Bypass,
-}
-
 /// Validates that the given token's currency is `"USD"`.
 ///
 /// # Errors
@@ -926,32 +914,33 @@ impl TIP20Token {
         Ok(true)
     }
 
-    /// Moves channel-reserve custody while applying policy to the logical payment path.
+    /// Moves channel-reserve custody after the reserve applies operation-specific TIP-403 rules.
     ///
     /// This is an internal TIP-1034 integration, not an ABI entrypoint. At least one physical
-    /// endpoint must be the canonical channel reserve. `Bypass` is valid only for reserve-originated
-    /// refunds; the reserve derives their recipient and amount from authenticated channel state.
+    /// endpoint must be the canonical channel reserve. The reserve checks the logical payer-payee
+    /// path before funding and capture, and derives refunds from authenticated channel state.
+    ///
+    /// `originator` is the sender presented to TIP-1028. It may differ from the physical balance
+    /// owner when reserve custody pays a channel's payee.
     pub(crate) fn channel_reserve_transfer(
         &mut self,
         from: Address,
         to: Address,
         amount: U256,
-        policy_check: TransferPolicyCheck,
+        originator: Address,
     ) -> Result<bool> {
         if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
             return Err(TIP20Error::unauthorized().into());
         }
-        if matches!(policy_check, TransferPolicyCheck::Bypass)
-            && from != TIP20_CHANNEL_RESERVE_ADDRESS
-        {
-            return Err(TIP20Error::unauthorized().into());
-        }
 
-        let Some(to) =
-            self.validate_transfer_with_policy(None, from, to, amount, B256::ZERO, policy_check)?
-        else {
+        let to = Recipient::resolve(to)?;
+        self.check_not_paused()?;
+        to.validate()?;
+        self.check_and_update_spending_limit(from, amount)?;
+
+        if self.validate_inbound_or_block(originator, from, &to, amount, None, B256::ZERO)? {
             return Ok(true);
-        };
+        }
 
         self._transfer(from, &to, amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(amount) {
@@ -1127,40 +1116,10 @@ impl TIP20Token {
         amount: U256,
         memo: B256,
     ) -> Result<Option<Recipient>> {
-        self.validate_transfer_with_policy(
-            spender,
-            from,
-            to,
-            amount,
-            memo,
-            TransferPolicyCheck::Physical,
-        )
-    }
-
-    /// Validates a physical balance movement with an explicit TIP-403 policy path.
-    fn validate_transfer_with_policy(
-        &mut self,
-        spender: Option<Address>,
-        from: Address,
-        to: Address,
-        amount: U256,
-        memo: B256,
-        policy_check: TransferPolicyCheck,
-    ) -> Result<Option<Recipient>> {
         let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
-        let inbound_originator = match policy_check {
-            TransferPolicyCheck::Logical { from, .. } => from,
-            TransferPolicyCheck::Physical | TransferPolicyCheck::Bypass => from,
-        };
-        match policy_check {
-            TransferPolicyCheck::Physical => self.ensure_transfer_authorized(from, to.target)?,
-            TransferPolicyCheck::Logical { from, to } => {
-                self.ensure_transfer_authorized(from, to)?
-            }
-            TransferPolicyCheck::Bypass => {}
-        }
+        self.ensure_transfer_authorized(from, to.target)?;
 
         if let Some(spender) = spender {
             self.consume_allowance(from, spender, amount)?;
@@ -1168,7 +1127,7 @@ impl TIP20Token {
             self.check_and_update_spending_limit(from, amount)?;
         }
 
-        if self.validate_inbound_or_block(inbound_originator, from, &to, amount, None, memo)? {
+        if self.validate_inbound_or_block(from, from, &to, amount, None, memo)? {
             return Ok(None);
         }
 

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -927,37 +927,31 @@ impl TIP20Token {
     pub(crate) fn channel_reserve_transfer(
         &mut self,
         from: Address,
-        to: Address,
+        to: Recipient,
         amount: U256,
         receive_policy_sender: Address,
-    ) -> Result<bool> {
-        if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
+    ) -> Result<()> {
+        if from != TIP20_CHANNEL_RESERVE_ADDRESS
+            && to.original_address() != TIP20_CHANNEL_RESERVE_ADDRESS
+        {
             return Err(TIP20Error::unauthorized().into());
         }
 
-        let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.storage.spec().is_t6() {
-            if to.target == RECEIVE_POLICY_GUARD_ADDRESS {
-                return Err(ReceivePolicyGuardError::address_reserved().into());
-            }
-            if TIP403Registry::new()
-                .validate_receive_policy(self.address, receive_policy_sender, to.target)?
-                .is_some()
-            {
-                return Err(TIP20Error::policy_forbids().into());
-            }
+        if self.storage.spec().is_t6() && to.target == RECEIVE_POLICY_GUARD_ADDRESS {
+            return Err(ReceivePolicyGuardError::address_reserved().into());
         }
+        self.ensure_receive_policy_authorized(receive_policy_sender, to.target)?;
 
         self._transfer(from, &to, amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(amount) {
             self.emit_event(hop)?;
         }
 
-        Ok(true)
+        Ok(())
     }
 
     /// Debits `spender`'s allowance on `owner`. No-op when unlimited.
@@ -1501,6 +1495,11 @@ impl Recipient {
         })
     }
 
+    /// Returns the original recipient address used by the transfer.
+    fn original_address(&self) -> Address {
+        self.virtual_addr.unwrap_or(self.target)
+    }
+
     /// Validates that the recipient is not:
     /// - the zero address (preventing accidental burns)
     /// - an address with the TIP-20 prefix (preventing transfers to token contracts)
@@ -1516,7 +1515,7 @@ impl Recipient {
     /// For virtual recipients `to` is the virtual address (first hop); for regular
     /// recipients this is the only `Transfer` event needed.
     pub(crate) fn build_transfer_event(&self, from: Address, amount: U256) -> TIP20Event {
-        TIP20Event::transfer(from, self.virtual_addr.unwrap_or(self.target), amount)
+        TIP20Event::transfer(from, self.original_address(), amount)
     }
 
     /// Builds the forwarding `Transfer(virtual, master, amount)` event for virtual recipients.

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1211,6 +1211,25 @@ impl TIP20Token {
         Ok(())
     }
 
+    /// Ensures `receiver` currently accepts this token from `sender` under TIP-1028.
+    ///
+    /// Receive policies remain mutable, so a later policy change can still block delivery.
+    pub(crate) fn ensure_receive_policy_authorized(
+        &self,
+        sender: Address,
+        receiver: Address,
+    ) -> Result<()> {
+        if self.storage.spec().is_t6()
+            && TIP403Registry::new()
+                .validate_receive_policy(self.address, sender, receiver)?
+                .is_some()
+        {
+            return Err(TIP20Error::policy_forbids().into());
+        }
+
+        Ok(())
+    }
+
     /// Check whether users are authorized by the token's [`TIP403Registry`] policy for the given
     /// roles.
     ///

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -941,7 +941,7 @@ impl TIP20Token {
         to.validate()?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.storage.spec().is_t6() && to.target == RECEIVE_POLICY_GUARD_ADDRESS {
+        if to.target == RECEIVE_POLICY_GUARD_ADDRESS {
             return Err(ReceivePolicyGuardError::address_reserved().into());
         }
         self.ensure_receive_policy_authorized(receive_policy_sender, to.target)?;
@@ -1213,10 +1213,9 @@ impl TIP20Token {
         sender: Address,
         receiver: Address,
     ) -> Result<()> {
-        if self.storage.spec().is_t6()
-            && TIP403Registry::new()
-                .validate_receive_policy(self.address, sender, receiver)?
-                .is_some()
+        if TIP403Registry::new()
+            .validate_receive_policy(self.address, sender, receiver)?
+            .is_some()
         {
             return Err(TIP20Error::policy_forbids().into());
         }

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -920,14 +920,16 @@ impl TIP20Token {
     /// endpoint must be the canonical channel reserve. The reserve checks the logical payer-payee
     /// path before funding and capture, and derives refunds from authenticated channel state.
     ///
-    /// `originator` is the sender presented to TIP-1028. It may differ from the physical balance
-    /// owner when reserve custody pays a channel's payee.
+    /// `receive_policy_sender` is the sender presented to TIP-1028. It may differ from the physical
+    /// balance owner when reserve custody pays a channel's payee. Unlike ordinary TIP-20 transfers,
+    /// channel custody movements revert when TIP-1028 rejects delivery because channel accounting
+    /// cannot represent a pending guarded payment.
     pub(crate) fn channel_reserve_transfer(
         &mut self,
         from: Address,
         to: Address,
         amount: U256,
-        originator: Address,
+        receive_policy_sender: Address,
     ) -> Result<bool> {
         if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
             return Err(TIP20Error::unauthorized().into());
@@ -938,8 +940,16 @@ impl TIP20Token {
         to.validate()?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.validate_inbound_or_block(originator, from, &to, amount, None, B256::ZERO)? {
-            return Ok(true);
+        if self.storage.spec().is_t6() {
+            if to.target == RECEIVE_POLICY_GUARD_ADDRESS {
+                return Err(ReceivePolicyGuardError::address_reserved().into());
+            }
+            if TIP403Registry::new()
+                .validate_receive_policy(self.address, receive_policy_sender, to.target)?
+                .is_some()
+            {
+                return Err(TIP20Error::policy_forbids().into());
+            }
         }
 
         self._transfer(from, &to, amount)?;
@@ -1127,7 +1137,7 @@ impl TIP20Token {
             self.check_and_update_spending_limit(from, amount)?;
         }
 
-        if self.validate_inbound_or_block(from, from, &to, amount, None, memo)? {
+        if self.validate_inbound_or_block(from, &to, amount, None, memo)? {
             return Ok(None);
         }
 
@@ -1165,14 +1175,7 @@ impl TIP20Token {
             return Err(TIP20Error::policy_forbids().into());
         }
 
-        if self.validate_inbound_or_block(
-            msg_sender,
-            msg_sender,
-            &to,
-            amount,
-            Some(total_supply),
-            memo,
-        )? {
+        if self.validate_inbound_or_block(msg_sender, &to, amount, Some(total_supply), memo)? {
             return Ok(None);
         }
 
@@ -1274,14 +1277,12 @@ impl TIP20Token {
         self.emit_event(to.build_transfer_event(from, amount))
     }
 
-    /// Validates the receive policy of `to.target` against `originator`. If blocked, moves funds
-    /// from `transfer_from` into the guard account and stores a claim receipt attributed to
-    /// `originator`; returns `true`. Returns `false` when the inbound is authorized and the caller
-    /// should proceed with the normal transfer or mint.
+    /// Validates the receive policy of `to.target`. If blocked, moves the funds into the guard
+    /// account and stores a claim receipt; returns `true`. Returns `false` when the inbound is
+    /// authorized and the caller should proceed with the normal transfer or mint.
     pub(crate) fn validate_inbound_or_block(
         &mut self,
         originator: Address,
-        transfer_from: Address,
         to: &Recipient,
         amount: U256,
         mint_total_supply: Option<U256>,
@@ -1307,7 +1308,7 @@ impl TIP20Token {
             self.emit_event(TIP20Event::mint(guard.target, amount))?;
             InboundKind::MINT
         } else {
-            self._transfer(transfer_from, &guard, amount)?;
+            self._transfer(originator, &guard, amount)?;
             InboundKind::TRANSFER
         };
         ReceivePolicyGuard::new()

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     signature_verifier::SignatureVerifier,
     storage::{Handler, Mapping},
     storage_credits::StorageCredits,
-    tip20::{ITIP20, Recipient, TIP20Token, is_tip20_prefix},
+    tip20::{ITIP20, Recipient, TIP20Token, TransferPolicyCheck, is_tip20_prefix},
     tip403_registry::AuthRole,
 };
 use alloy::{
@@ -161,11 +161,23 @@ impl TIP20ChannelReserve {
             return Err(TIP20ChannelReserveError::channel_already_exists().into());
         }
 
-        token.ensure_authorized_as(&[(
-            Recipient::resolve(call.payee)?.target,
-            AuthRole::Recipient,
-        )])?;
-        token.system_transfer_from(self.address, msg_sender, U256::from(call.deposit))?;
+        if self.storage.spec().is_t9() {
+            token.channel_reserve_transfer(
+                msg_sender,
+                self.address,
+                U256::from(call.deposit),
+                TransferPolicyCheck::Logical {
+                    from: msg_sender,
+                    to: Recipient::resolve(call.payee)?.target,
+                },
+            )?;
+        } else {
+            token.ensure_authorized_as(&[(
+                Recipient::resolve(call.payee)?.target,
+                AuthRole::Recipient,
+            )])?;
+            token.system_transfer_from(self.address, msg_sender, U256::from(call.deposit))?;
+        }
 
         self.write_channel_state_spending_credit(
             msg_sender,
@@ -229,18 +241,30 @@ impl TIP20ChannelReserve {
             .expect("cumulative amount already checked to be increasing");
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
-        token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
 
         state.settled = cumulative;
         self.channel_states[channel_id].write(state)?;
 
-        token.transfer(
-            self.address,
-            ITIP20::transferCall {
-                to: call.descriptor.payee,
-                amount: U256::from(delta),
-            },
-        )?;
+        if self.storage.spec().is_t9() {
+            token.channel_reserve_transfer(
+                self.address,
+                call.descriptor.payee,
+                U256::from(delta),
+                TransferPolicyCheck::Logical {
+                    from: call.descriptor.payer,
+                    to: Recipient::resolve(call.descriptor.payee)?.target,
+                },
+            )?;
+        } else {
+            token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
+            token.transfer(
+                self.address,
+                ITIP20::transferCall {
+                    to: call.descriptor.payee,
+                    amount: U256::from(delta),
+                },
+            )?;
+        }
 
         self.emit_event(TIP20ChannelReserveEvent::Settled(
             ITIP20ChannelReserve::Settled {
@@ -286,15 +310,27 @@ impl TIP20ChannelReserve {
 
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
-            token.ensure_authorized_as(&[(
-                Recipient::resolve(call.descriptor.payee)?.target,
-                AuthRole::Recipient,
-            )])?;
-            token.system_transfer_from(
-                self.address,
-                msg_sender,
-                U256::from(call.additionalDeposit),
-            )?;
+            if self.storage.spec().is_t9() {
+                token.channel_reserve_transfer(
+                    msg_sender,
+                    self.address,
+                    U256::from(call.additionalDeposit),
+                    TransferPolicyCheck::Logical {
+                        from: msg_sender,
+                        to: Recipient::resolve(call.descriptor.payee)?.target,
+                    },
+                )?;
+            } else {
+                token.ensure_authorized_as(&[(
+                    Recipient::resolve(call.descriptor.payee)?.target,
+                    AuthRole::Recipient,
+                )])?;
+                token.system_transfer_from(
+                    self.address,
+                    msg_sender,
+                    U256::from(call.additionalDeposit),
+                )?;
+            }
         }
         if had_close_request {
             state.close_requested_at = 0;
@@ -404,23 +440,44 @@ impl TIP20ChannelReserve {
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
         if !delta.is_zero() {
-            token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
-            token.transfer(
-                self.address,
-                ITIP20::transferCall {
-                    to: call.descriptor.payee,
-                    amount: U256::from(delta),
-                },
-            )?;
+            if self.storage.spec().is_t9() {
+                token.channel_reserve_transfer(
+                    self.address,
+                    call.descriptor.payee,
+                    U256::from(delta),
+                    TransferPolicyCheck::Logical {
+                        from: call.descriptor.payer,
+                        to: Recipient::resolve(call.descriptor.payee)?.target,
+                    },
+                )?;
+            } else {
+                token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
+                token.transfer(
+                    self.address,
+                    ITIP20::transferCall {
+                        to: call.descriptor.payee,
+                        amount: U256::from(delta),
+                    },
+                )?;
+            }
         }
         if !refund.is_zero() {
-            token.transfer(
-                self.address,
-                ITIP20::transferCall {
-                    to: call.descriptor.payer,
-                    amount: U256::from(refund),
-                },
-            )?;
+            if self.storage.spec().is_t9() {
+                token.channel_reserve_transfer(
+                    self.address,
+                    call.descriptor.payer,
+                    U256::from(refund),
+                    TransferPolicyCheck::Bypass,
+                )?;
+            } else {
+                token.transfer(
+                    self.address,
+                    ITIP20::transferCall {
+                        to: call.descriptor.payer,
+                        amount: U256::from(refund),
+                    },
+                )?;
+            }
         }
 
         self.emit_event(TIP20ChannelReserveEvent::ChannelClosed(
@@ -463,13 +520,23 @@ impl TIP20ChannelReserve {
 
         self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
         if !refund.is_zero() {
-            TIP20Token::from_address(call.descriptor.token)?.transfer(
-                self.address,
-                ITIP20::transferCall {
-                    to: call.descriptor.payer,
-                    amount: U256::from(refund),
-                },
-            )?;
+            let mut token = TIP20Token::from_address(call.descriptor.token)?;
+            if self.storage.spec().is_t9() {
+                token.channel_reserve_transfer(
+                    self.address,
+                    call.descriptor.payer,
+                    U256::from(refund),
+                    TransferPolicyCheck::Bypass,
+                )?;
+            } else {
+                token.transfer(
+                    self.address,
+                    ITIP20::transferCall {
+                        to: call.descriptor.payer,
+                        amount: U256::from(refund),
+                    },
+                )?;
+            }
         }
         self.emit_event(TIP20ChannelReserveEvent::ChannelClosed(
             ITIP20ChannelReserve::ChannelClosed {
@@ -886,6 +953,46 @@ mod tests {
         )
     }
 
+    fn install_recipient_whitelist_policy(
+        token: &mut TIP20Token,
+        admin: Address,
+        recipients: &[Address],
+    ) -> Result<()> {
+        let mut registry = TIP403Registry::new();
+        registry.initialize()?;
+        let recipient_policy = registry.create_policy(
+            admin,
+            ITIP403Registry::createPolicyCall {
+                admin,
+                policyType: ITIP403Registry::PolicyType::WHITELIST,
+            },
+        )?;
+        for &recipient in recipients {
+            registry.modify_policy_whitelist(
+                admin,
+                ITIP403Registry::modifyPolicyWhitelistCall {
+                    policyId: recipient_policy,
+                    account: recipient,
+                    allowed: true,
+                },
+            )?;
+        }
+        let compound_policy = registry.create_compound_policy(
+            admin,
+            ITIP403Registry::createCompoundPolicyCall {
+                senderPolicyId: 1,
+                recipientPolicyId: recipient_policy,
+                mintRecipientPolicyId: 1,
+            },
+        )?;
+        token.change_transfer_policy_id(
+            admin,
+            ITIP20::changeTransferPolicyIdCall {
+                newPolicyId: compound_policy,
+            },
+        )
+    }
+
     #[test]
     fn test_selector_coverage() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T7);
@@ -1168,6 +1275,214 @@ mod tests {
             );
             assert_eq!(res.unwrap_err(), TIP20Error::policy_forbids().into());
 
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t9_recipient_restricted_token_supports_channel_capture_and_refund() -> eyre::Result<()>
+    {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        let payer_signer = PrivateKeySigner::random();
+        let payer = payer_signer.address();
+        let payee = Address::random();
+        let stranger = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(1_000u128))
+                .apply()?;
+            install_recipient_whitelist_policy(&mut token, payer, &[payee])?;
+
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+
+            // The reserve is not an authorized recipient, but the logical payer -> payee path is.
+            let salt = B256::random();
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            let channel_id = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+
+            let digest =
+                reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                    channelId: channel_id,
+                    cumulativeAmount: U96::from(40),
+                })?;
+            let signature =
+                Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&digest)?.as_bytes());
+            reserve.settle(
+                payee,
+                ITIP20ChannelReserve::settleCall {
+                    descriptor: descriptor.clone(),
+                    cumulativeAmount: U96::from(40),
+                    signature,
+                },
+            )?;
+            reserve.close(
+                payee,
+                ITIP20ChannelReserve::closeCall {
+                    descriptor,
+                    cumulativeAmount: U96::from(40),
+                    captureAmount: U96::from(40),
+                    signature: Bytes::new(),
+                },
+            )?;
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(960u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payee })?,
+                U256::from(40u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: TIP20_CHANNEL_RESERVE_ADDRESS,
+                })?,
+                U256::ZERO
+            );
+
+            // The channel path does not weaken ordinary transfer restrictions.
+            let result = token.transfer(
+                payer,
+                ITIP20::transferCall {
+                    to: stranger,
+                    amount: U256::from(1u128),
+                },
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+
+            // A caller cannot use the reserve to route value to an unauthorized payee.
+            seed_expiring_nonce_hash(&mut reserve)?;
+            let result = reserve.open(
+                payer,
+                open_call(
+                    stranger,
+                    Address::ZERO,
+                    token.address(),
+                    1,
+                    B256::random(),
+                    Address::ZERO,
+                ),
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t9_recipient_restricted_token_supports_unilateral_withdraw() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        let payer = Address::random();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(100u128))
+                .apply()?;
+            install_recipient_whitelist_policy(&mut token, payer, &[payee])?;
+
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+            reserve.storage.set_timestamp(U256::from(1_000u64));
+            let salt = B256::random();
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+
+            reserve.request_close(
+                payer,
+                ITIP20ChannelReserve::requestCloseCall {
+                    descriptor: descriptor.clone(),
+                },
+            )?;
+            reserve
+                .storage
+                .set_timestamp(U256::from(1_000u64 + CLOSE_GRACE_PERIOD));
+            reserve.withdraw(payer, ITIP20ChannelReserve::withdrawCall { descriptor })?;
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(100u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: TIP20_CHANNEL_RESERVE_ADDRESS,
+                })?,
+                U256::ZERO
+            );
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_pre_t9_recipient_restricted_token_cannot_fund_reserve() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let payer = Address::random();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(100u128))
+                .apply()?;
+            install_recipient_whitelist_policy(&mut token, payer, &[payee])?;
+
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+            seed_expiring_nonce_hash(&mut reserve)?;
+            let result = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    B256::random(),
+                    Address::ZERO,
+                ),
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
             Ok(())
         })
     }

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -845,7 +845,7 @@ mod tests {
             TIP20Setup, VIRTUAL_MASTER, assert_full_coverage, check_selector_coverage,
             register_virtual_master,
         },
-        tip403_registry::{ITIP403Registry, TIP403Registry},
+        tip403_registry::{ALLOW_ALL_POLICY_ID, ITIP403Registry, TIP403Registry},
     };
     use alloy::{
         primitives::{Bytes, Signature},
@@ -1016,7 +1016,7 @@ mod tests {
         let payee = Address::random();
 
         StorageCtx::enter(&mut storage, || {
-            let token = TIP20Setup::path_usd(payer)
+            let mut token = TIP20Setup::path_usd(payer)
                 .with_issuer(payer)
                 .with_mint(payer, U256::from(100u128))
                 .apply()?;
@@ -1289,7 +1289,7 @@ mod tests {
         let stranger = Address::random();
 
         StorageCtx::enter(&mut storage, || {
-            let mut token = TIP20Setup::path_usd(payer)
+            let token = TIP20Setup::path_usd(payer)
                 .with_issuer(payer)
                 .with_mint(payer, U256::from(1_000u128))
                 .apply()?;
@@ -1386,6 +1386,97 @@ mod tests {
                 ),
             );
             assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t9_capture_applies_payee_receive_policy_to_logical_payer() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        let payer_signer = PrivateKeySigner::random();
+        let payer = payer_signer.address();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(1_000u128))
+                .apply()?;
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+
+            let salt = B256::random();
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            let channel_id = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+
+            // The payee rejects only the logical payer. The physical reserve sender remains
+            // authorized, so this distinguishes the two identities during capture.
+            let mut registry = TIP403Registry::new();
+            registry.initialize()?;
+            let sender_policy = registry.create_policy(
+                payee,
+                ITIP403Registry::createPolicyCall {
+                    admin: payee,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
+            registry.set_receive_policy(
+                payee,
+                ITIP403Registry::setReceivePolicyCall {
+                    senderPolicyId: sender_policy,
+                    tokenFilterId: ALLOW_ALL_POLICY_ID,
+                    recoveryAuthority: Address::ZERO,
+                },
+            )?;
+
+            let cumulative = U96::from(40);
+            let digest =
+                reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                    channelId: channel_id,
+                    cumulativeAmount: cumulative,
+                })?;
+            let signature =
+                Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&digest)?.as_bytes());
+            reserve.settle(
+                payee,
+                ITIP20ChannelReserve::settleCall {
+                    descriptor,
+                    cumulativeAmount: cumulative,
+                    signature,
+                },
+            )?;
+
+            assert_eq!(token.get_balance(payer)?, U256::from(900u128));
+            assert_eq!(token.get_balance(payee)?, U256::ZERO);
+            assert_eq!(
+                token.get_balance(TIP20_CHANNEL_RESERVE_ADDRESS)?,
+                U256::from(60u128)
+            );
+            assert_eq!(
+                token.get_balance(crate::RECEIVE_POLICY_GUARD_ADDRESS)?,
+                U256::from(40u128)
+            );
 
             Ok(())
         })

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -242,9 +242,6 @@ impl TIP20ChannelReserve {
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
-        state.settled = cumulative;
-        self.channel_states[channel_id].write(state)?;
-
         if self.storage.spec().is_t9() {
             token.channel_reserve_transfer(
                 self.address,
@@ -265,6 +262,9 @@ impl TIP20ChannelReserve {
                 },
             )?;
         }
+
+        state.settled = cumulative;
+        self.channel_states[channel_id].write(state)?;
 
         self.emit_event(TIP20ChannelReserveEvent::Settled(
             ITIP20ChannelReserve::Settled {

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -1016,7 +1016,7 @@ mod tests {
         let payee = Address::random();
 
         StorageCtx::enter(&mut storage, || {
-            let mut token = TIP20Setup::path_usd(payer)
+            let token = TIP20Setup::path_usd(payer)
                 .with_issuer(payer)
                 .with_mint(payer, U256::from(100u128))
                 .apply()?;
@@ -1289,7 +1289,7 @@ mod tests {
         let stranger = Address::random();
 
         StorageCtx::enter(&mut storage, || {
-            let token = TIP20Setup::path_usd(payer)
+            let mut token = TIP20Setup::path_usd(payer)
                 .with_issuer(payer)
                 .with_mint(payer, U256::from(1_000u128))
                 .apply()?;
@@ -1467,14 +1467,24 @@ mod tests {
                 },
             )?;
 
-            assert_eq!(token.get_balance(payer)?, U256::from(900u128));
-            assert_eq!(token.get_balance(payee)?, U256::ZERO);
             assert_eq!(
-                token.get_balance(TIP20_CHANNEL_RESERVE_ADDRESS)?,
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(900u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payee })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: TIP20_CHANNEL_RESERVE_ADDRESS,
+                })?,
                 U256::from(60u128)
             );
             assert_eq!(
-                token.get_balance(crate::RECEIVE_POLICY_GUARD_ADDRESS)?,
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: crate::RECEIVE_POLICY_GUARD_ADDRESS,
+                })?,
                 U256::from(40u128)
             );
 

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -161,7 +161,7 @@ impl TIP20ChannelReserve {
             return Err(TIP20ChannelReserveError::channel_already_exists().into());
         }
 
-        if self.storage.spec().is_t10() {
+        if self.storage.spec().is_t11() {
             token.ensure_transfer_authorized(msg_sender, Recipient::resolve(call.payee)?.target)?;
             token.channel_reserve_transfer(
                 msg_sender,
@@ -240,7 +240,7 @@ impl TIP20ChannelReserve {
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
-        if self.storage.spec().is_t10() {
+        if self.storage.spec().is_t11() {
             token.ensure_transfer_authorized(
                 call.descriptor.payer,
                 Recipient::resolve(call.descriptor.payee)?.target,
@@ -257,7 +257,7 @@ impl TIP20ChannelReserve {
         } else {
             token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
 
-            // Preserve the pre-T10 fallible-operation order. Although a later transfer failure
+            // Preserve the pre-T11 fallible-operation order. Although a later transfer failure
             // reverts this write, moving it changes consensus-visible gas on legacy forks.
             state.settled = cumulative;
             self.channel_states[channel_id].write(state)?;
@@ -315,7 +315,7 @@ impl TIP20ChannelReserve {
 
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
-            if self.storage.spec().is_t10() {
+            if self.storage.spec().is_t11() {
                 token.ensure_transfer_authorized(
                     msg_sender,
                     Recipient::resolve(call.descriptor.payee)?.target,
@@ -442,7 +442,7 @@ impl TIP20ChannelReserve {
             .checked_sub(capture)
             .expect("capture amount already checked against deposit");
 
-        if self.storage.spec().is_t10() {
+        if self.storage.spec().is_t11() {
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if !delta.is_zero() {
                 token.ensure_transfer_authorized(
@@ -469,7 +469,7 @@ impl TIP20ChannelReserve {
             // rejections therefore leave the channel available for retry.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
         } else {
-            // Preserve the pre-T10 fallible-operation order and gas behavior.
+            // Preserve the pre-T11 fallible-operation order and gas behavior.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
@@ -532,7 +532,7 @@ impl TIP20ChannelReserve {
             .checked_sub(state.settled)
             .expect("settled is always <= deposit");
 
-        if self.storage.spec().is_t10() {
+        if self.storage.spec().is_t11() {
             if !refund.is_zero() {
                 let mut token = TIP20Token::from_address(call.descriptor.token)?;
                 token.channel_reserve_transfer(
@@ -546,7 +546,7 @@ impl TIP20ChannelReserve {
             // withdrawal has no fallible token delivery to wait for.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
         } else {
-            // Preserve the pre-T10 fallible-operation order and gas behavior.
+            // Preserve the pre-T11 fallible-operation order and gas behavior.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
             if !refund.is_zero() {
                 TIP20Token::from_address(call.descriptor.token)?.transfer(
@@ -1300,9 +1300,9 @@ mod tests {
     }
 
     #[test]
-    fn test_t10_recipient_restricted_token_supports_channel_capture_and_refund() -> eyre::Result<()>
+    fn test_t11_recipient_restricted_token_supports_channel_capture_and_refund() -> eyre::Result<()>
     {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();
         let payee = Address::random();
@@ -1429,8 +1429,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t10_blocked_capture_reverts_and_remains_retryable() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+    fn test_t11_blocked_capture_reverts_and_remains_retryable() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();
         let payee = Address::random();
@@ -1581,8 +1581,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t10_recipient_restricted_token_supports_unilateral_withdraw() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+    fn test_t11_recipient_restricted_token_supports_unilateral_withdraw() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
         let payer = Address::random();
         let payee = Address::random();
 
@@ -1645,8 +1645,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t10_blocked_refund_reverts_and_remains_retryable() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+    fn test_t11_blocked_refund_reverts_and_remains_retryable() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
         let payer = Address::random();
         let payee = Address::random();
 
@@ -1784,7 +1784,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_t10_recipient_restricted_token_cannot_fund_reserve() -> eyre::Result<()> {
+    fn test_pre_t11_recipient_restricted_token_cannot_fund_reserve() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         let payer = Address::random();
         let payee = Address::random();
@@ -1816,7 +1816,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_t10_settle_preserves_state_write_before_transfer_failure() -> eyre::Result<()> {
+    fn test_pre_t11_settle_preserves_state_write_before_transfer_failure() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     signature_verifier::SignatureVerifier,
     storage::{Handler, Mapping},
     storage_credits::StorageCredits,
-    tip20::{ITIP20, Recipient, TIP20Token, TransferPolicyCheck, is_tip20_prefix},
+    tip20::{ITIP20, Recipient, TIP20Token, is_tip20_prefix},
     tip403_registry::AuthRole,
 };
 use alloy::{
@@ -162,14 +162,12 @@ impl TIP20ChannelReserve {
         }
 
         if self.storage.spec().is_t9() {
+            token.ensure_transfer_authorized(msg_sender, Recipient::resolve(call.payee)?.target)?;
             token.channel_reserve_transfer(
                 msg_sender,
                 self.address,
                 U256::from(call.deposit),
-                TransferPolicyCheck::Logical {
-                    from: msg_sender,
-                    to: Recipient::resolve(call.payee)?.target,
-                },
+                msg_sender,
             )?;
         } else {
             token.ensure_authorized_as(&[(
@@ -243,14 +241,15 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
         if self.storage.spec().is_t9() {
+            token.ensure_transfer_authorized(
+                call.descriptor.payer,
+                Recipient::resolve(call.descriptor.payee)?.target,
+            )?;
             token.channel_reserve_transfer(
                 self.address,
                 call.descriptor.payee,
                 U256::from(delta),
-                TransferPolicyCheck::Logical {
-                    from: call.descriptor.payer,
-                    to: Recipient::resolve(call.descriptor.payee)?.target,
-                },
+                call.descriptor.payer,
             )?;
         } else {
             token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
@@ -311,14 +310,15 @@ impl TIP20ChannelReserve {
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if self.storage.spec().is_t9() {
+                token.ensure_transfer_authorized(
+                    msg_sender,
+                    Recipient::resolve(call.descriptor.payee)?.target,
+                )?;
                 token.channel_reserve_transfer(
                     msg_sender,
                     self.address,
                     U256::from(call.additionalDeposit),
-                    TransferPolicyCheck::Logical {
-                        from: msg_sender,
-                        to: Recipient::resolve(call.descriptor.payee)?.target,
-                    },
+                    msg_sender,
                 )?;
             } else {
                 token.ensure_authorized_as(&[(
@@ -441,14 +441,15 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
         if !delta.is_zero() {
             if self.storage.spec().is_t9() {
+                token.ensure_transfer_authorized(
+                    call.descriptor.payer,
+                    Recipient::resolve(call.descriptor.payee)?.target,
+                )?;
                 token.channel_reserve_transfer(
                     self.address,
                     call.descriptor.payee,
                     U256::from(delta),
-                    TransferPolicyCheck::Logical {
-                        from: call.descriptor.payer,
-                        to: Recipient::resolve(call.descriptor.payee)?.target,
-                    },
+                    call.descriptor.payer,
                 )?;
             } else {
                 token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
@@ -467,7 +468,7 @@ impl TIP20ChannelReserve {
                     self.address,
                     call.descriptor.payer,
                     U256::from(refund),
-                    TransferPolicyCheck::Bypass,
+                    self.address,
                 )?;
             } else {
                 token.transfer(
@@ -526,7 +527,7 @@ impl TIP20ChannelReserve {
                     self.address,
                     call.descriptor.payer,
                     U256::from(refund),
-                    TransferPolicyCheck::Bypass,
+                    self.address,
                 )?;
             } else {
                 token.transfer(

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -161,7 +161,7 @@ impl TIP20ChannelReserve {
             return Err(TIP20ChannelReserveError::channel_already_exists().into());
         }
 
-        if self.storage.spec().is_t9() {
+        if self.storage.spec().is_t10() {
             token.ensure_transfer_authorized(msg_sender, Recipient::resolve(call.payee)?.target)?;
             token.channel_reserve_transfer(
                 msg_sender,
@@ -240,7 +240,7 @@ impl TIP20ChannelReserve {
 
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
-        if self.storage.spec().is_t9() {
+        if self.storage.spec().is_t10() {
             token.ensure_transfer_authorized(
                 call.descriptor.payer,
                 Recipient::resolve(call.descriptor.payee)?.target,
@@ -257,7 +257,7 @@ impl TIP20ChannelReserve {
         } else {
             token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
 
-            // Preserve the pre-T9 fallible-operation order. Although a later transfer failure
+            // Preserve the pre-T10 fallible-operation order. Although a later transfer failure
             // reverts this write, moving it changes consensus-visible gas on legacy forks.
             state.settled = cumulative;
             self.channel_states[channel_id].write(state)?;
@@ -315,7 +315,7 @@ impl TIP20ChannelReserve {
 
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
-            if self.storage.spec().is_t9() {
+            if self.storage.spec().is_t10() {
                 token.ensure_transfer_authorized(
                     msg_sender,
                     Recipient::resolve(call.descriptor.payee)?.target,
@@ -442,7 +442,7 @@ impl TIP20ChannelReserve {
             .checked_sub(capture)
             .expect("capture amount already checked against deposit");
 
-        if self.storage.spec().is_t9() {
+        if self.storage.spec().is_t10() {
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if !delta.is_zero() {
                 token.ensure_transfer_authorized(
@@ -469,7 +469,7 @@ impl TIP20ChannelReserve {
             // rejections therefore leave the channel available for retry.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
         } else {
-            // Preserve the pre-T9 fallible-operation order and gas behavior.
+            // Preserve the pre-T10 fallible-operation order and gas behavior.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
@@ -532,7 +532,7 @@ impl TIP20ChannelReserve {
             .checked_sub(state.settled)
             .expect("settled is always <= deposit");
 
-        if self.storage.spec().is_t9() {
+        if self.storage.spec().is_t10() {
             if !refund.is_zero() {
                 let mut token = TIP20Token::from_address(call.descriptor.token)?;
                 token.channel_reserve_transfer(
@@ -546,7 +546,7 @@ impl TIP20ChannelReserve {
             // withdrawal has no fallible token delivery to wait for.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
         } else {
-            // Preserve the pre-T9 fallible-operation order and gas behavior.
+            // Preserve the pre-T10 fallible-operation order and gas behavior.
             self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
             if !refund.is_zero() {
                 TIP20Token::from_address(call.descriptor.token)?.transfer(
@@ -1300,9 +1300,9 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_recipient_restricted_token_supports_channel_capture_and_refund() -> eyre::Result<()>
+    fn test_t10_recipient_restricted_token_supports_channel_capture_and_refund() -> eyre::Result<()>
     {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();
         let payee = Address::random();
@@ -1429,8 +1429,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_blocked_capture_reverts_and_remains_retryable() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+    fn test_t10_blocked_capture_reverts_and_remains_retryable() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();
         let payee = Address::random();
@@ -1581,8 +1581,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_recipient_restricted_token_supports_unilateral_withdraw() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+    fn test_t10_recipient_restricted_token_supports_unilateral_withdraw() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
         let payer = Address::random();
         let payee = Address::random();
 
@@ -1645,8 +1645,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_blocked_refund_reverts_and_remains_retryable() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+    fn test_t10_blocked_refund_reverts_and_remains_retryable() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
         let payer = Address::random();
         let payee = Address::random();
 
@@ -1784,8 +1784,8 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_t9_recipient_restricted_token_cannot_fund_reserve() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+    fn test_pre_t10_recipient_restricted_token_cannot_fund_reserve() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         let payer = Address::random();
         let payee = Address::random();
 
@@ -1816,8 +1816,8 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_t9_settle_preserves_state_write_before_transfer_failure() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+    fn test_pre_t10_settle_preserves_state_write_before_transfer_failure() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();
         let payee = Address::random();

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -167,7 +167,7 @@ impl TIP20ChannelReserve {
             token.ensure_receive_policy_authorized(msg_sender, payee)?;
             token.channel_reserve_transfer(
                 msg_sender,
-                self.address,
+                Recipient::direct(self.address),
                 U256::from(call.deposit),
                 msg_sender,
             )?;
@@ -243,13 +243,11 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
         if self.storage.spec().is_t11() {
-            token.ensure_transfer_authorized(
-                call.descriptor.payer,
-                Recipient::resolve(call.descriptor.payee)?.target,
-            )?;
+            let payee = Recipient::resolve(call.descriptor.payee)?;
+            token.ensure_transfer_authorized(call.descriptor.payer, payee.target)?;
             token.channel_reserve_transfer(
                 self.address,
-                call.descriptor.payee,
+                payee,
                 U256::from(delta),
                 call.descriptor.payer,
             )?;
@@ -323,7 +321,7 @@ impl TIP20ChannelReserve {
                 token.ensure_receive_policy_authorized(msg_sender, payee)?;
                 token.channel_reserve_transfer(
                     msg_sender,
-                    self.address,
+                    Recipient::direct(self.address),
                     U256::from(call.additionalDeposit),
                     msg_sender,
                 )?;
@@ -446,13 +444,11 @@ impl TIP20ChannelReserve {
         if self.storage.spec().is_t11() {
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if !delta.is_zero() {
-                token.ensure_transfer_authorized(
-                    call.descriptor.payer,
-                    Recipient::resolve(call.descriptor.payee)?.target,
-                )?;
+                let payee = Recipient::resolve(call.descriptor.payee)?;
+                token.ensure_transfer_authorized(call.descriptor.payer, payee.target)?;
                 token.channel_reserve_transfer(
                     self.address,
-                    call.descriptor.payee,
+                    payee,
                     U256::from(delta),
                     call.descriptor.payer,
                 )?;
@@ -460,7 +456,7 @@ impl TIP20ChannelReserve {
             if !refund.is_zero() {
                 token.channel_reserve_transfer(
                     self.address,
-                    call.descriptor.payer,
+                    Recipient::resolve(call.descriptor.payer)?,
                     U256::from(refund),
                     self.address,
                 )?;
@@ -538,7 +534,7 @@ impl TIP20ChannelReserve {
                 let mut token = TIP20Token::from_address(call.descriptor.token)?;
                 token.channel_reserve_transfer(
                     self.address,
-                    call.descriptor.payer,
+                    Recipient::resolve(call.descriptor.payer)?,
                     U256::from(refund),
                     self.address,
                 )?;
@@ -981,29 +977,20 @@ mod tests {
     ) -> Result<()> {
         let mut registry = TIP403Registry::new();
         registry.initialize()?;
-        let recipient_policy = registry.create_policy(
+        let recipient_policy = registry.create_policy_with_accounts(
             admin,
-            ITIP403Registry::createPolicyCall {
+            ITIP403Registry::createPolicyWithAccountsCall {
                 admin,
                 policyType: ITIP403Registry::PolicyType::WHITELIST,
+                accounts: recipients.to_vec(),
             },
         )?;
-        for &recipient in recipients {
-            registry.modify_policy_whitelist(
-                admin,
-                ITIP403Registry::modifyPolicyWhitelistCall {
-                    policyId: recipient_policy,
-                    account: recipient,
-                    allowed: true,
-                },
-            )?;
-        }
         let compound_policy = registry.create_compound_policy(
             admin,
             ITIP403Registry::createCompoundPolicyCall {
-                senderPolicyId: 1,
+                senderPolicyId: ALLOW_ALL_POLICY_ID,
                 recipientPolicyId: recipient_policy,
-                mintRecipientPolicyId: 1,
+                mintRecipientPolicyId: ALLOW_ALL_POLICY_ID,
             },
         )?;
         token.change_transfer_policy_id(
@@ -1012,6 +999,31 @@ mod tests {
                 newPolicyId: compound_policy,
             },
         )
+    }
+
+    fn install_receive_sender_blacklist(
+        receiver: Address,
+        blocked_sender: Address,
+    ) -> Result<(TIP403Registry, u64)> {
+        let mut registry = TIP403Registry::new();
+        registry.initialize()?;
+        let sender_policy = registry.create_policy_with_accounts(
+            receiver,
+            ITIP403Registry::createPolicyWithAccountsCall {
+                admin: receiver,
+                policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                accounts: vec![blocked_sender],
+            },
+        )?;
+        registry.set_receive_policy(
+            receiver,
+            ITIP403Registry::setReceivePolicyCall {
+                senderPolicyId: sender_policy,
+                tokenFilterId: ALLOW_ALL_POLICY_ID,
+                recoveryAuthority: Address::ZERO,
+            },
+        )?;
+        Ok((registry, sender_policy))
     }
 
     #[test]
@@ -1443,24 +1455,7 @@ mod tests {
             let mut reserve = TIP20ChannelReserve::new();
             reserve.initialize()?;
 
-            let mut registry = TIP403Registry::new();
-            registry.initialize()?;
-            let sender_policy = registry.create_policy(
-                payee,
-                ITIP403Registry::createPolicyCall {
-                    admin: payee,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
-            registry.set_receive_policy(
-                payee,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: sender_policy,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
-                },
-            )?;
+            let (mut registry, sender_policy) = install_receive_sender_blacklist(payee, payer)?;
 
             let salt = B256::random();
             seed_expiring_nonce_hash(&mut reserve)?;
@@ -1566,24 +1561,7 @@ mod tests {
 
             // Receive policies remain mutable after funding. The payee now rejects only the
             // logical payer, while the physical reserve sender remains authorized.
-            let mut registry = TIP403Registry::new();
-            registry.initialize()?;
-            let sender_policy = registry.create_policy(
-                payee,
-                ITIP403Registry::createPolicyCall {
-                    admin: payee,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
-            registry.set_receive_policy(
-                payee,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: sender_policy,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
-                },
-            )?;
+            let (mut registry, sender_policy) = install_receive_sender_blacklist(payee, payer)?;
 
             let cumulative = U96::from(40);
             let digest =
@@ -1791,30 +1769,8 @@ mod tests {
 
             // Originator recovery would make a guarded reserve-originated refund unclaimable.
             // Channel refunds reject the policy instead and leave channel state intact.
-            let mut registry = TIP403Registry::new();
-            registry.initialize()?;
-            let sender_policy = registry.create_policy(
-                payer,
-                ITIP403Registry::createPolicyCall {
-                    admin: payer,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-            set_blacklisted(
-                &mut registry,
-                payer,
-                sender_policy,
-                TIP20_CHANNEL_RESERVE_ADDRESS,
-                true,
-            )?;
-            registry.set_receive_policy(
-                payer,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: sender_policy,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
-                },
-            )?;
+            let (mut registry, sender_policy) =
+                install_receive_sender_blacklist(payer, TIP20_CHANNEL_RESERVE_ADDRESS)?;
 
             let close_result = reserve.close(
                 payee,

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -1503,7 +1503,7 @@ mod tests {
             let result = reserve.top_up(
                 payer,
                 ITIP20ChannelReserve::topUpCall {
-                    descriptor: descriptor.clone(),
+                    descriptor,
                     additionalDeposit: U96::from(1),
                 },
             );

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -162,7 +162,9 @@ impl TIP20ChannelReserve {
         }
 
         if self.storage.spec().is_t11() {
-            token.ensure_transfer_authorized(msg_sender, Recipient::resolve(call.payee)?.target)?;
+            let payee = Recipient::resolve(call.payee)?.target;
+            token.ensure_transfer_authorized(msg_sender, payee)?;
+            token.ensure_receive_policy_authorized(msg_sender, payee)?;
             token.channel_reserve_transfer(
                 msg_sender,
                 self.address,
@@ -316,10 +318,9 @@ impl TIP20ChannelReserve {
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if self.storage.spec().is_t11() {
-                token.ensure_transfer_authorized(
-                    msg_sender,
-                    Recipient::resolve(call.descriptor.payee)?.target,
-                )?;
+                let payee = Recipient::resolve(call.descriptor.payee)?.target;
+                token.ensure_transfer_authorized(msg_sender, payee)?;
+                token.ensure_receive_policy_authorized(msg_sender, payee)?;
                 token.channel_reserve_transfer(
                     msg_sender,
                     self.address,
@@ -1429,6 +1430,103 @@ mod tests {
     }
 
     #[test]
+    fn test_t11_funding_checks_payee_receive_policy() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
+        let payer = Address::random();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(1_000u128))
+                .apply()?;
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+
+            let mut registry = TIP403Registry::new();
+            registry.initialize()?;
+            let sender_policy = registry.create_policy(
+                payee,
+                ITIP403Registry::createPolicyCall {
+                    admin: payee,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
+            registry.set_receive_policy(
+                payee,
+                ITIP403Registry::setReceivePolicyCall {
+                    senderPolicyId: sender_policy,
+                    tokenFilterId: ALLOW_ALL_POLICY_ID,
+                    recoveryAuthority: Address::ZERO,
+                },
+            )?;
+
+            let salt = B256::random();
+            seed_expiring_nonce_hash(&mut reserve)?;
+            let result = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(1_000u128)
+            );
+
+            set_blacklisted(&mut registry, payee, sender_policy, payer, false)?;
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            let channel_id = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+
+            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
+            let result = reserve.top_up(
+                payer,
+                ITIP20ChannelReserve::topUpCall {
+                    descriptor: descriptor.clone(),
+                    additionalDeposit: U96::from(1),
+                },
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+            assert_eq!(
+                reserve
+                    .get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                        channelId: channel_id,
+                    })?
+                    .deposit,
+                U96::from(100)
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_t11_blocked_capture_reverts_and_remains_retryable() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
         let payer_signer = PrivateKeySigner::random();
@@ -1466,8 +1564,8 @@ mod tests {
                 expiring_nonce_hash,
             );
 
-            // The payee rejects only the logical payer. The physical reserve sender remains
-            // authorized, so this distinguishes the two identities during capture.
+            // Receive policies remain mutable after funding. The payee now rejects only the
+            // logical payer, while the physical reserve sender remains authorized.
             let mut registry = TIP403Registry::new();
             registry.initialize()?;
             let sender_policy = registry.create_policy(

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -251,8 +251,17 @@ impl TIP20ChannelReserve {
                 U256::from(delta),
                 call.descriptor.payer,
             )?;
+
+            state.settled = cumulative;
+            self.channel_states[channel_id].write(state)?;
         } else {
             token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
+
+            // Preserve the pre-T9 fallible-operation order. Although a later transfer failure
+            // reverts this write, moving it changes consensus-visible gas on legacy forks.
+            state.settled = cumulative;
+            self.channel_states[channel_id].write(state)?;
+
             token.transfer(
                 self.address,
                 ITIP20::transferCall {
@@ -261,9 +270,6 @@ impl TIP20ChannelReserve {
                 },
             )?;
         }
-
-        state.settled = cumulative;
-        self.channel_states[channel_id].write(state)?;
 
         self.emit_event(TIP20ChannelReserveEvent::Settled(
             ITIP20ChannelReserve::Settled {
@@ -436,11 +442,9 @@ impl TIP20ChannelReserve {
             .checked_sub(capture)
             .expect("capture amount already checked against deposit");
 
-        self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
-
-        let mut token = TIP20Token::from_address(call.descriptor.token)?;
-        if !delta.is_zero() {
-            if self.storage.spec().is_t9() {
+        if self.storage.spec().is_t9() {
+            let mut token = TIP20Token::from_address(call.descriptor.token)?;
+            if !delta.is_zero() {
                 token.ensure_transfer_authorized(
                     call.descriptor.payer,
                     Recipient::resolve(call.descriptor.payee)?.target,
@@ -451,7 +455,25 @@ impl TIP20ChannelReserve {
                     U256::from(delta),
                     call.descriptor.payer,
                 )?;
-            } else {
+            }
+            if !refund.is_zero() {
+                token.channel_reserve_transfer(
+                    self.address,
+                    call.descriptor.payer,
+                    U256::from(refund),
+                    self.address,
+                )?;
+            }
+
+            // Commit terminal channel state only after both deliveries succeed. TIP-1028
+            // rejections therefore leave the channel available for retry.
+            self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
+        } else {
+            // Preserve the pre-T9 fallible-operation order and gas behavior.
+            self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
+            let mut token = TIP20Token::from_address(call.descriptor.token)?;
+
+            if !delta.is_zero() {
                 token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
                 token.transfer(
                     self.address,
@@ -461,16 +483,7 @@ impl TIP20ChannelReserve {
                     },
                 )?;
             }
-        }
-        if !refund.is_zero() {
-            if self.storage.spec().is_t9() {
-                token.channel_reserve_transfer(
-                    self.address,
-                    call.descriptor.payer,
-                    U256::from(refund),
-                    self.address,
-                )?;
-            } else {
+            if !refund.is_zero() {
                 token.transfer(
                     self.address,
                     ITIP20::transferCall {
@@ -519,18 +532,24 @@ impl TIP20ChannelReserve {
             .checked_sub(state.settled)
             .expect("settled is always <= deposit");
 
-        self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
-        if !refund.is_zero() {
-            let mut token = TIP20Token::from_address(call.descriptor.token)?;
-            if self.storage.spec().is_t9() {
+        if self.storage.spec().is_t9() {
+            if !refund.is_zero() {
+                let mut token = TIP20Token::from_address(call.descriptor.token)?;
                 token.channel_reserve_transfer(
                     self.address,
                     call.descriptor.payer,
                     U256::from(refund),
                     self.address,
                 )?;
-            } else {
-                token.transfer(
+            }
+            // Commit terminal state only after a nonzero refund succeeds. A zero-refund
+            // withdrawal has no fallible token delivery to wait for.
+            self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
+        } else {
+            // Preserve the pre-T9 fallible-operation order and gas behavior.
+            self.delete_channel_state_and_credit_payer(channel_id, call.descriptor.payer)?;
+            if !refund.is_zero() {
+                TIP20Token::from_address(call.descriptor.token)?.transfer(
                     self.address,
                     ITIP20::transferCall {
                         to: call.descriptor.payer,
@@ -1323,6 +1342,14 @@ mod tests {
                 expiring_nonce_hash,
             );
 
+            reserve.top_up(
+                payer,
+                ITIP20ChannelReserve::topUpCall {
+                    descriptor: descriptor.clone(),
+                    additionalDeposit: U96::from(20),
+                },
+            )?;
+
             let digest =
                 reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
                     channelId: channel_id,
@@ -1338,23 +1365,32 @@ mod tests {
                     signature,
                 },
             )?;
+
+            // Exercise a positive capture delta and a refund in the same close.
+            let close_digest =
+                reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                    channelId: channel_id,
+                    cumulativeAmount: U96::from(60),
+                })?;
+            let close_signature =
+                Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&close_digest)?.as_bytes());
             reserve.close(
                 payee,
                 ITIP20ChannelReserve::closeCall {
                     descriptor,
-                    cumulativeAmount: U96::from(40),
-                    captureAmount: U96::from(40),
-                    signature: Bytes::new(),
+                    cumulativeAmount: U96::from(60),
+                    captureAmount: U96::from(60),
+                    signature: close_signature,
                 },
             )?;
 
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall { account: payer })?,
-                U256::from(960u128)
+                U256::from(940u128)
             );
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall { account: payee })?,
-                U256::from(40u128)
+                U256::from(60u128)
             );
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall {
@@ -1393,7 +1429,7 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_capture_applies_payee_receive_policy_to_logical_payer() -> eyre::Result<()> {
+    fn test_t9_blocked_capture_reverts_and_remains_retryable() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         let payer_signer = PrivateKeySigner::random();
         let payer = payer_signer.address();
@@ -1459,14 +1495,15 @@ mod tests {
                 })?;
             let signature =
                 Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&digest)?.as_bytes());
-            reserve.settle(
+            let result = reserve.settle(
                 payee,
                 ITIP20ChannelReserve::settleCall {
-                    descriptor,
+                    descriptor: descriptor.clone(),
                     cumulativeAmount: cumulative,
-                    signature,
+                    signature: signature.clone(),
                 },
-            )?;
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
 
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall { account: payer })?,
@@ -1480,13 +1517,63 @@ mod tests {
                 token.balance_of(ITIP20::balanceOfCall {
                     account: TIP20_CHANNEL_RESERVE_ADDRESS,
                 })?,
-                U256::from(60u128)
+                U256::from(100u128)
             );
             assert_eq!(
                 token.balance_of(ITIP20::balanceOfCall {
                     account: crate::RECEIVE_POLICY_GUARD_ADDRESS,
                 })?,
+                U256::ZERO
+            );
+            assert_eq!(
+                reserve
+                    .get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                        channelId: channel_id
+                    })?
+                    .settled,
+                U96::ZERO
+            );
+
+            let close_result = reserve.close(
+                payee,
+                ITIP20ChannelReserve::closeCall {
+                    descriptor: descriptor.clone(),
+                    cumulativeAmount: cumulative,
+                    captureAmount: cumulative,
+                    signature: signature.clone(),
+                },
+            );
+            assert_eq!(
+                close_result.unwrap_err(),
+                TIP20Error::policy_forbids().into()
+            );
+            let state = reserve.get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                channelId: channel_id,
+            })?;
+            assert_eq!(state.deposit, U96::from(100));
+            assert_eq!(state.settled, U96::ZERO);
+
+            // Once the payee accepts the logical payer, the same voucher can settle.
+            set_blacklisted(&mut registry, payee, sender_policy, payer, false)?;
+            reserve.settle(
+                payee,
+                ITIP20ChannelReserve::settleCall {
+                    descriptor,
+                    cumulativeAmount: cumulative,
+                    signature,
+                },
+            )?;
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payee })?,
                 U256::from(40u128)
+            );
+            assert_eq!(
+                reserve
+                    .get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                        channelId: channel_id
+                    })?
+                    .settled,
+                cumulative
             );
 
             Ok(())
@@ -1558,6 +1645,145 @@ mod tests {
     }
 
     #[test]
+    fn test_t9_blocked_refund_reverts_and_remains_retryable() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+        let payer = Address::random();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(1_000u128))
+                .apply()?;
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+            reserve.storage.set_timestamp(U256::from(1_000u64));
+
+            let salt = B256::random();
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            let channel_id = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+            reserve.request_close(
+                payer,
+                ITIP20ChannelReserve::requestCloseCall {
+                    descriptor: descriptor.clone(),
+                },
+            )?;
+            reserve
+                .storage
+                .set_timestamp(U256::from(1_000u64 + CLOSE_GRACE_PERIOD));
+
+            // Originator recovery would make a guarded reserve-originated refund unclaimable.
+            // Channel refunds reject the policy instead and leave channel state intact.
+            let mut registry = TIP403Registry::new();
+            registry.initialize()?;
+            let sender_policy = registry.create_policy(
+                payer,
+                ITIP403Registry::createPolicyCall {
+                    admin: payer,
+                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                },
+            )?;
+            set_blacklisted(
+                &mut registry,
+                payer,
+                sender_policy,
+                TIP20_CHANNEL_RESERVE_ADDRESS,
+                true,
+            )?;
+            registry.set_receive_policy(
+                payer,
+                ITIP403Registry::setReceivePolicyCall {
+                    senderPolicyId: sender_policy,
+                    tokenFilterId: ALLOW_ALL_POLICY_ID,
+                    recoveryAuthority: Address::ZERO,
+                },
+            )?;
+
+            let close_result = reserve.close(
+                payee,
+                ITIP20ChannelReserve::closeCall {
+                    descriptor: descriptor.clone(),
+                    cumulativeAmount: U96::ZERO,
+                    captureAmount: U96::ZERO,
+                    signature: Bytes::new(),
+                },
+            );
+            assert_eq!(
+                close_result.unwrap_err(),
+                TIP20Error::policy_forbids().into()
+            );
+
+            let result = reserve.withdraw(
+                payer,
+                ITIP20ChannelReserve::withdrawCall {
+                    descriptor: descriptor.clone(),
+                },
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+            assert_eq!(
+                reserve
+                    .get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                        channelId: channel_id
+                    })?
+                    .deposit,
+                U96::from(100)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(900u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: crate::RECEIVE_POLICY_GUARD_ADDRESS,
+                })?,
+                U256::ZERO
+            );
+
+            set_blacklisted(
+                &mut registry,
+                payer,
+                sender_policy,
+                TIP20_CHANNEL_RESERVE_ADDRESS,
+                false,
+            )?;
+            reserve.withdraw(payer, ITIP20ChannelReserve::withdrawCall { descriptor })?;
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(1_000u128)
+            );
+            assert!(
+                reserve
+                    .get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                        channelId: channel_id
+                    })?
+                    .deposit
+                    .is_zero()
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_pre_t9_recipient_restricted_token_cannot_fund_reserve() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
         let payer = Address::random();
@@ -1585,6 +1811,78 @@ mod tests {
                 ),
             );
             assert_eq!(result.unwrap_err(), TIP20Error::policy_forbids().into());
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_pre_t9_settle_preserves_state_write_before_transfer_failure() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T8);
+        let payer_signer = PrivateKeySigner::random();
+        let payer = payer_signer.address();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let mut token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_role(payer, TIP20Token::pause_role())
+                .with_mint(payer, U256::from(100u128))
+                .apply()?;
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+
+            let salt = B256::random();
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            let channel_id = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+            let cumulative = U96::from(40);
+            let digest =
+                reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                    channelId: channel_id,
+                    cumulativeAmount: cumulative,
+                })?;
+            let signature =
+                Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&digest)?.as_bytes());
+
+            token.pause(payer, ITIP20::pauseCall {})?;
+            let result = reserve.settle(
+                payee,
+                ITIP20ChannelReserve::settleCall {
+                    descriptor,
+                    cumulativeAmount: cumulative,
+                    signature,
+                },
+            );
+            assert_eq!(result.unwrap_err(), TIP20Error::contract_paused().into());
+
+            // Direct unit calls do not apply EVM rollback, exposing the intermediate write and
+            // pinning its position before the failing transfer. On-chain the whole call reverts.
+            assert_eq!(
+                reserve
+                    .get_channel_state(ITIP20ChannelReserve::getChannelStateCall {
+                        channelId: channel_id
+                    })?
+                    .settled,
+                cumulative
+            );
             Ok(())
         })
     }

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -117,7 +117,7 @@ Before `settle` or the capture leg of `close` moves a nonzero amount, the reserv
 2. require the descriptor payer to be currently authorized as a sender;
 3. require the resolved descriptor payee to be currently authorized as a recipient;
 4. enforce token pause state, recipient validity, and applicable TIP-1028 handling for the actual
-   payee; and
+   payee, using the descriptor payer as the inbound originator while debiting reserve custody; and
 5. move the physical amount from reserve to the descriptor payee without separately evaluating the
    reserve as the policy sender.
 

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -1,0 +1,252 @@
+---
+id: TIP-1095
+title: Policy-Aware Channel Reserve Transfers
+description: Applies TIP-403 policy to the logical payer-payee path of TIP-1034 channels while preserving unilateral refunds.
+authors: Georgios Konstantopoulos
+status: Draft
+related: TIP-20, TIP-403, TIP-1015, TIP-1028, TIP-1034, TIP-1035
+protocolVersion: T9
+---
+
+# TIP-1095: Policy-Aware Channel Reserve Transfers
+
+## Abstract
+
+This TIP makes TIP-1034 channels compatible with TIP-20 tokens whose TIP-403 recipient policy
+allows a payee but does not allow the channel reserve or payer. Channel funding and captures enforce
+policy against the logical `payer -> payee` payment, rather than the intermediate custody movement.
+Descriptor-bound refunds bypass TIP-403 recipient authorization so the payer retains unilateral
+recovery, while pause state and address-level receive policies continue to apply.
+
+## Motivation
+
+TIP-1015 supports closed-loop credits by allowing any holder to send while restricting transfer
+recipients to one or more vendors. TIP-1034 currently cannot use such a token without broadening its
+recipient policy:
+
+```text
+funding:    payer   -> channel reserve
+capture:    reserve -> payee
+refund:     reserve -> payer
+```
+
+The token sees these physical custody movements. A vendor-only recipient policy rejects funding
+because the reserve is not a vendor and rejects refunds because the payer is not a vendor.
+Whitelisting the reserve and every payer would permit peer-to-peer transfers among those recipients,
+which defeats the closed-loop policy.
+
+The channel descriptor and reserve state already identify the logical payer, payee, captured amount,
+and refund amount. The reserve can therefore enforce policy on the underlying payment while treating
+its own custody movements as an implementation detail. This preserves the issuer's intended
+`payer -> payee` restriction without requiring a new TIP-403 policy type.
+
+## Assumptions
+
+1. `TIP20_CHANNEL_RESERVE` is the canonical TIP-1034 precompile and its implementation is part of
+   the trusted protocol.
+2. A channel's payer and payee are immutable because both are bound into `channelId` and every
+   post-open operation supplies the same authenticated descriptor.
+3. The reserve can invoke a native TIP-20 movement path that is not exposed through the TIP-20 ABI.
+4. TIP-1028 address-level receive policies remain independent from token-level TIP-403 policy.
+5. Token pause state remains authoritative for all channel movements, including refunds. A paused
+   token can therefore delay channel exits until it is unpaused.
+
+## Threat Model
+
+- **Payer:** May choose arbitrary channel fields and attempt to use reserve custody to pay a
+  recipient forbidden by the token policy. The reserve MUST validate the logical payer/payee path
+  before funding or capture.
+- **Payee or operator:** May submit valid vouchers and choose a permitted capture amount, but MUST
+  NOT redirect captures or refunds away from descriptor-bound recipients.
+- **Token issuer:** Controls the token's transfer policy and pause roles. Policy changes may prevent
+  new captures, but MUST NOT redirect reserve custody or prevent a TIP-403-only payer refund.
+- **TIP-1034 reserve:** Is trusted to derive refund recipients and amounts exclusively from channel
+  state. No public or internal caller-controlled entrypoint may request an arbitrary policy-bypassed
+  transfer.
+- **TIP-1028 receive-policy administrator:** May block or reroute inbound funds according to
+  TIP-1028. This TIP does not bypass that authority.
+
+---
+
+# Specification
+
+## Logical And Physical Transfers
+
+For TIP-1034 operations, implementations MUST distinguish:
+
+- the **physical transfer**, which moves a TIP-20 balance into or out of reserve custody; and
+- the **logical transfer**, which represents the channel payment from `payer` to `payee`.
+
+TIP-403 authorization MUST follow this table after activation:
+
+| Operation | Physical transfer | TIP-403 authorization |
+|---|---|---|
+| `open` | `payer -> reserve` | `payer -> payee` |
+| Nonzero `topUp` | `payer -> reserve` | `payer -> payee` |
+| `settle` capture | `reserve -> payee` | `payer -> payee` |
+| `close` capture | `reserve -> payee` | `payer -> payee` |
+| `close` refund | `reserve -> payer` | Bypassed |
+| `withdraw` refund | `reserve -> payer` | Bypassed |
+
+For virtual payees, recipient authorization MUST use the resolved master address, matching ordinary
+TIP-20 recipient-policy behavior.
+
+This TIP does not change TIP-403 policy evaluation for ordinary TIP-20 transfers, minting, the
+stablecoin DEX, fee collection, or any precompile other than the TIP-1034 reserve.
+
+## Funding
+
+Before `open` or a nonzero `topUp` moves funds, the reserve MUST:
+
+1. resolve the descriptor payee as a TIP-20 recipient;
+2. require the payer to be authorized as a sender under the token's active policy;
+3. require the resolved payee to be authorized as a recipient under that policy;
+4. enforce token pause state, payer balance, payer access-key spending limits, recipient validity,
+   and applicable TIP-1028 handling for the physical reserve recipient; and
+5. move the physical amount from payer to reserve without separately requiring the reserve to be an
+   authorized TIP-403 recipient.
+
+A forbidden payee MUST cause funding to revert even though the reserve itself receives the physical
+balance. A forbidden payer MUST likewise be unable to fund or top up a channel.
+
+## Captures
+
+Before `settle` or the capture leg of `close` moves a nonzero amount, the reserve MUST:
+
+1. perform all existing channel, caller, bound, and voucher checks;
+2. require the descriptor payer to be currently authorized as a sender;
+3. require the resolved descriptor payee to be currently authorized as a recipient;
+4. enforce token pause state, recipient validity, and applicable TIP-1028 handling for the actual
+   payee; and
+5. move the physical amount from reserve to the descriptor payee without separately evaluating the
+   reserve as the policy sender.
+
+The reserve MUST NOT treat every reserve-originated transfer as authorized. Captures remain bound to
+the descriptor payee and the logical policy path. Consequently, a payer cannot open a channel with
+an unauthorized payee and use settlement as a transfer-policy bypass.
+
+## Refunds
+
+The refund leg of `close` and the payer-only `withdraw` path MUST bypass TIP-403 sender and recipient
+authorization. This bypass is valid only when all of the following are true:
+
+1. the physical sender is `TIP20_CHANNEL_RESERVE`;
+2. the recipient is the descriptor payer;
+3. the amount equals the refund derived from authenticated channel state; and
+4. the operation deletes or terminally closes that channel according to TIP-1034.
+
+Refunds MUST continue to enforce token pause state, physical recipient validity, balance
+conservation, and TIP-1028 address-level receive policy. If TIP-1028 blocks an inbound refund, the
+existing receive-policy guard behavior applies.
+
+The payer's `requestClose` followed by `withdraw` MUST remain unilateral. No token-policy
+administrator, payee, or operator action may be required solely because the payer is not an
+authorized TIP-403 recipient.
+
+## Native TIP-20 Integration
+
+The TIP-20 implementation MUST provide an internal-only movement primitive for the channel reserve.
+It MUST accept physical endpoints and exactly one of these policy modes:
+
+```text
+Logical(from, to)  enforce TIP-403 against the supplied logical endpoints
+Bypass             skip TIP-403 for a descriptor-bound refund
+```
+
+The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
+neither endpoint is `TIP20_CHANNEL_RESERVE`, and MUST reject `Bypass` unless the physical sender is
+`TIP20_CHANNEL_RESERVE`.
+
+All validation other than the explicitly selected TIP-403 mode MUST match native TIP-20 transfer
+behavior. Successful movements MUST update rewards and balances and emit the same physical
+`Transfer` events as the corresponding custody movement. Virtual-recipient forwarding events MUST
+remain unchanged.
+
+## Activation And Existing Channels
+
+The behavior activates at T9. Before T9, channel reserve operations retain TIP-1034's original
+physical transfer-policy checks.
+
+After activation, the new rules apply to both newly opened and already active channels. No channel
+state migration is required because payer, payee, token, and accounting state are already available
+from the descriptor and packed channel state.
+
+## Interface And Storage Compatibility
+
+This TIP introduces no public ABI, event, channel identity, voucher, or storage-layout changes.
+Existing TIP-1034 clients and indexers remain compatible.
+
+# Tooling
+
+Wallets and MPP clients require no protocol-interface changes. Token-issuance tooling SHOULD explain
+that a TIP-1015 recipient whitelist containing a service payee can support TIP-1034 after T9 without
+also whitelisting the reserve or every payer.
+
+Integration tests for restricted credits SHOULD exercise direct transfer rejection, channel
+funding, capture, payee close with refund, and unilateral payer withdrawal.
+
+# Observability
+
+No new events are required. Existing TIP-20 `Transfer` events expose physical custody movement, and
+TIP-1034 `ChannelOpened`, `Settled`, and `ChannelClosed` events expose the logical payer, payee,
+capture, and refund amounts.
+
+Operators diagnosing a failed channel operation SHOULD inspect both the channel event history and
+the token's current TIP-403 and TIP-1028 policies.
+
+# Invariants
+
+1. Ordinary holder-to-holder transfers remain forbidden when the active recipient policy forbids
+   the recipient.
+2. Funding succeeds only when the logical `payer -> payee` path is authorized.
+3. Captures succeed only when the logical `payer -> payee` path is authorized at capture time.
+4. Neither reserve custody nor a channel voucher can route captured value to a payee forbidden by
+   TIP-403.
+5. A refund can go only to the descriptor payer and cannot exceed `deposit - captureAmount` for
+   `close` or `deposit - settled` for `withdraw`.
+6. A payer can recover the refundable balance through `requestClose` and `withdraw` without being
+   an authorized TIP-403 recipient.
+7. Policy bypass is unreachable through the public TIP-20 ABI and cannot be selected for a
+   non-reserve physical sender.
+8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
+   movement.
+9. Channel and token fund-conservation invariants remain unchanged.
+10. Pre-T9 execution retains the original physical transfer-policy behavior.
+
+## Alternatives Considered
+
+### Whitelist The Reserve And Payers
+
+Adding the reserve and every payer to a recipient whitelist permits funding and refunds, but it also
+permits ordinary transfers to those payer addresses. This weakens closed-loop credit semantics and
+requires unbounded policy administration.
+
+### Exempt Every Reserve-Originated Transfer
+
+A sender-based reserve exemption would allow a payer to name an arbitrary payee and route funds
+through settlement, bypassing the token's recipient policy. This TIP instead distinguishes captures
+from refunds using authenticated channel state.
+
+### Extend TIP-1015 With Pair-Aware Policies
+
+A pair-aware policy could express sender-dependent recipient rules, but it would add policy types,
+registry state, issuer configuration, and evaluation overhead for a custody issue that TIP-1034 can
+resolve from state it already authenticates.
+
+### Administrator-Assisted Refunds
+
+An issuer could atomically whitelist a payer, close the channel, and remove the payer. That makes
+refund liveness depend on the issuer and does not preserve the payer-only unilateral withdrawal.
+
+### Charge-Only Credits
+
+Applications can omit TIP-1034 and use direct charges. This remains valid, but it unnecessarily
+prevents restricted credits from using efficient streaming sessions when the reserve can safely
+separate logical payments from physical custody.
+
+## References
+
+- [TIP-1015: Compound Transfer Policies](tip-1015.md)
+- [TIP-1028: Address-Level Receive Policies](tip-1028.md)
+- [TIP-1034: TIP-20 Channel Reserve Precompile](tip-1034.md)
+- [TIP-1035: Implicit Approval List](tip-1035.md)

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -12,263 +12,134 @@ protocolVersion: T11
 
 ## Abstract
 
-This TIP makes TIP-1034 channels compatible with TIP-20 tokens whose TIP-403 recipient policy
-allows a payee but does not allow the channel reserve or payer. Channel funding and captures enforce
-policy against the logical `payer -> payee` payment, rather than the intermediate custody movement.
-Descriptor-bound refunds bypass TIP-403 recipient authorization so the payer retains unilateral
-recovery, while pause state and address-level receive policies continue to apply.
+This TIP lets recipient-restricted TIP-20 tokens use TIP-1034 channels without authorizing the
+channel reserve or every payer as a recipient. Funding and capture apply TIP-403 to the logical
+`payer -> payee` payment. Refunds return funds to the payer without TIP-403 authorization.
+
+Token pause state and TIP-1028 receive policies still apply to every movement.
 
 ## Motivation
 
-TIP-1015 supports closed-loop credits by allowing any holder to send while restricting transfer
-recipients to one or more vendors. TIP-1034 currently cannot use such a token without broadening its
-recipient policy:
+A channel moves tokens through reserve custody:
 
 ```text
-funding:    payer   -> channel reserve
-capture:    reserve -> payee
-refund:     reserve -> payer
+funding: payer   -> reserve
+capture: reserve -> payee
+refund:  reserve -> payer
 ```
 
-The token sees these physical custody movements. A vendor-only recipient policy rejects funding
-because the reserve is not a vendor and rejects refunds because the payer is not a vendor.
-Whitelisting the reserve and every payer would permit peer-to-peer transfers among those recipients,
-which defeats the closed-loop policy.
+A recipient policy that allows only the payee rejects funding because the reserve is not allowed,
+and rejects refunds because the payer is not allowed. Allowing the reserve and every payer would
+weaken the policy by making those addresses valid recipients for ordinary transfers.
 
-The channel descriptor and reserve state already identify the logical payer, payee, captured amount,
-and refund amount. The reserve can therefore enforce policy on the underlying payment while treating
-its own custody movements as an implementation detail. This preserves the issuer's intended
-`payer -> payee` restriction without requiring a new TIP-403 policy type.
+The channel already authenticates its payer, payee, and balances. TIP-403 can therefore apply to
+the payment the channel represents instead of its intermediate custody movements. A blanket
+exemption for reserve transfers would be unsafe because it could send captured funds to a forbidden
+payee.
 
 ## Assumptions
 
-1. `TIP20_CHANNEL_RESERVE` is the canonical TIP-1034 precompile and its implementation is part of
-   the trusted protocol.
-2. A channel's payer and payee are immutable because both are bound into `channelId` and every
-   post-open operation supplies the same authenticated descriptor.
-3. The reserve can invoke a native TIP-20 movement path that is not exposed through the TIP-20 ABI.
-4. TIP-1028 address-level receive policies remain independent from token-level TIP-403 policy.
-   Channel movements respect those policies by reverting rejected delivery instead of creating a
-   guarded receipt that channel accounting cannot represent.
-5. Token pause state remains authoritative for all channel movements, including refunds. A paused
-   token can therefore delay channel exits until it is unpaused.
+- The TIP-1034 reserve is trusted protocol code. Its descriptor binds an immutable payer and payee
+  to each channel.
+- The reserve can use an internal TIP-20 transfer function that is unavailable through the
+  public TIP-20 ABI.
+- TIP-1028 receive policies and token pause state remain independent of TIP-403 authorization.
 
 ## Threat Model
 
-- **Payer:** May choose arbitrary channel fields and attempt to use reserve custody to pay a
-  recipient forbidden by the token policy. The reserve MUST validate the logical payer/payee path
-  before funding or capture.
-- **Payee or operator:** May submit valid vouchers and choose a permitted capture amount, but MUST
-  NOT redirect captures or refunds away from descriptor-bound recipients.
-- **Token issuer:** Controls the token's transfer policy and pause roles. Policy changes may prevent
-  new captures, but MUST NOT redirect reserve custody or prevent a TIP-403-only payer refund.
-- **TIP-1034 reserve:** Is trusted to derive refund recipients and amounts exclusively from channel
-  state. No public or internal caller-controlled entrypoint may request an arbitrary policy-bypassed
-  transfer.
-- **TIP-1028 receive-policy administrator:** May reject an inbound channel movement according to
-  TIP-1028. This TIP does not bypass that authority, but does not create guarded channel receipts.
+- Channel participants may choose channel fields and submit valid vouchers, but cannot redirect a
+  capture or refund away from the descriptor-bound address.
+- The token issuer may change TIP-403 policy or pause the token. This may delay a channel operation,
+  but cannot redirect reserve custody.
+- A TIP-1028 policy may reject a capture or refund. The operation must remain retryable.
 
 ---
 
 # Specification
 
-## Logical And Physical Transfers
+After T11, TIP-403 authorization for channel operations is:
 
-For TIP-1034 operations, implementations MUST distinguish:
-
-- the **physical transfer**, which moves a TIP-20 balance into or out of reserve custody; and
-- the **logical transfer**, which represents the channel payment from `payer` to `payee`.
-
-TIP-403 authorization MUST follow this table after activation:
-
-| Operation | Physical transfer | TIP-403 authorization |
+| Operation | Physical movement | TIP-403 authorization |
 |---|---|---|
-| `open` | `payer -> reserve` | `payer -> payee` |
-| Nonzero `topUp` | `payer -> reserve` | `payer -> payee` |
-| `settle` capture | `reserve -> payee` | `payer -> payee` |
-| `close` capture | `reserve -> payee` | `payer -> payee` |
-| `close` refund | `reserve -> payer` | Bypassed |
-| `withdraw` refund | `reserve -> payer` | Bypassed |
+| `open`, nonzero `topUp` | `payer -> reserve` | `payer -> payee` |
+| `settle`, capture in `close` | `reserve -> payee` | `payer -> payee` |
+| refund in `close`, `withdraw` | `reserve -> payer` | bypassed |
 
-For virtual payees, recipient authorization MUST use the resolved master address, matching ordinary
-TIP-20 recipient-policy behavior.
+For a virtual payee, authorization uses its resolved master address, as in an ordinary TIP-20
+transfer.
 
-This TIP does not change TIP-403 policy evaluation for ordinary TIP-20 transfers, minting, the
-stablecoin DEX, fee collection, or any precompile other than the TIP-1034 reserve.
+## Funding and Capture
 
-## Funding
+Before funding or capture, the reserve must check the descriptor payer as the TIP-403 sender and
+the resolved descriptor payee as the TIP-403 recipient under the token's current policy. It then
+moves the physical balance without separately applying TIP-403 to the reserve address.
 
-Before `open` or a nonzero `topUp` moves funds, the reserve MUST:
+All existing channel checks still apply. Token pause state, balances, access-key limits, recipient
+validity, and TIP-1028 policy must be enforced as they are for native TIP-20 transfers.
 
-1. resolve the descriptor payee as a TIP-20 recipient;
-2. require the payer to be authorized as a sender under the token's active policy;
-3. require the resolved payee to be authorized as a recipient under that policy;
-4. enforce token pause state, payer balance, payer access-key spending limits, recipient validity,
-   and the reserve's applicable TIP-1028 policy, reverting if delivery is rejected; and
-5. move the physical amount from payer to reserve without separately requiring the reserve to be an
-   authorized TIP-403 recipient.
-
-A forbidden payee MUST cause funding to revert even though the reserve itself receives the physical
-balance. A forbidden payer MUST likewise be unable to fund or top up a channel.
-
-## Captures
-
-Before `settle` or the capture leg of `close` moves a nonzero amount, the reserve MUST:
-
-1. perform all existing channel, caller, bound, and voucher checks;
-2. require the descriptor payer to be currently authorized as a sender;
-3. require the resolved descriptor payee to be currently authorized as a recipient;
-4. enforce token pause state, recipient validity, and the actual payee's applicable TIP-1028
-   policy using the descriptor payer as the policy sender, reverting if delivery is rejected; and
-5. move the physical amount from reserve to the descriptor payee without separately evaluating the
-   reserve as the policy sender.
-
-The reserve MUST NOT treat every reserve-originated transfer as authorized. Captures remain bound to
-the descriptor payee and the logical policy path. Consequently, a payer cannot open a channel with
-an unauthorized payee and use settlement as a transfer-policy bypass.
+A failed capture must not advance cumulative settlement or close the channel.
 
 ## Refunds
 
-The refund leg of `close` and the payer-only `withdraw` path MUST bypass TIP-403 sender and recipient
-authorization. This bypass is valid only when all of the following are true:
+The refund in `close` and the payer-only `withdraw` path bypass TIP-403 only when:
 
-1. the physical sender is `TIP20_CHANNEL_RESERVE`;
-2. the recipient is the descriptor payer;
-3. the amount equals the refund derived from authenticated channel state; and
-4. the operation deletes or terminally closes that channel according to TIP-1034.
+- the physical sender is the channel reserve;
+- the recipient is the descriptor payer; and
+- the amount is the refund derived from authenticated channel state.
 
-Refunds MUST continue to enforce token pause state, physical recipient validity, balance
-conservation, and TIP-1028 address-level receive policy using `TIP20_CHANNEL_RESERVE` as the policy
-sender. If TIP-1028 rejects an inbound refund, the operation MUST revert without deleting the
-channel or creating a guarded receipt. The payer can update its receive policy and retry the close
-or withdrawal.
+Pause state, recipient validity, and TIP-1028 policy still apply. If a refund is rejected, the
+operation must revert without deleting the channel or moving funds, so the payer can update its
+receive policy and retry.
 
-The payer's `requestClose` followed by `withdraw` MUST remain unilateral. No token-policy
-administrator, payee, or operator action may be required solely because the payer is not an
-authorized TIP-403 recipient.
+`requestClose` followed by `withdraw` remains unilateral. The payer does not need the issuer,
+payee, or operator to authorize the refund under TIP-403.
 
-## Native TIP-20 Integration
+## TIP-20 Integration
 
-The channel reserve MUST perform the logical payer and payee TIP-403 checks directly in the funding
-and capture operations before moving custody. Descriptor-bound refund operations MUST omit those
-checks only after deriving the payer and refund amount from authenticated channel state.
+The transfer function used by the reserve must be internal-only and must reject transfers where
+neither endpoint is the channel reserve. Funding and capture use the descriptor payer as the sender
+for TIP-1028 evaluation; refunds use the reserve.
 
-The TIP-20 implementation MUST provide an internal-only custody-movement primitive for the channel
-reserve. It accepts the physical endpoints and the sender identity used for TIP-1028 receive-policy
-evaluation, but does not select or evaluate a TIP-403 policy mode. Funding and capture MUST supply
-the descriptor payer as the TIP-1028 policy sender. Refunds MUST supply
-`TIP20_CHANNEL_RESERVE`, preserving the ordinary physical sender identity for receive-policy
-evaluation.
+TIP-1028 rejection must revert instead of creating a `ReceivePolicyGuard` receipt, because channel
+accounting cannot represent guarded funds. Successful movements update balances and rewards and
+emit the same physical `Transfer` events as ordinary TIP-20 movements.
 
-Before moving custody, the primitive MUST evaluate the destination's TIP-1028 policy. A rejected
-channel movement MUST revert with `PolicyForbids()` and MUST NOT transfer funds to
-`ReceivePolicyGuard` or create a claim receipt. `settle` MUST update cumulative settlement only
-after a successful capture. At T11, `close` and `withdraw` MUST delete terminal channel state only
-after every nonzero capture and refund succeeds.
+## Activation and Compatibility
 
-The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
-neither endpoint is `TIP20_CHANNEL_RESERVE`. The trusted reserve implementation MUST invoke it only
-after applying the operation-specific rules above.
+This behavior activates at T11 and applies to both new and existing channels. Before T11, TIP-1034
+keeps its original physical transfer-policy checks.
 
-All validation other than the TIP-403 checks applied by the reserve MUST match native TIP-20
-transfer behavior. Successful movements MUST update rewards and balances and emit the same physical
-`Transfer` events as the corresponding custody movement. Virtual-recipient forwarding events MUST
-remain unchanged.
-
-## Activation And Existing Channels
-
-The behavior activates at T11. Before T11, channel reserve operations retain TIP-1034's original
-physical transfer-policy checks.
-
-After activation, the new rules apply to both newly opened and already active channels. No channel
-state migration is required because payer, payee, token, and accounting state are already available
-from the descriptor and packed channel state.
-
-## Interface And Storage Compatibility
-
-This TIP introduces no public ABI, event, channel identity, voucher, or storage-layout changes.
-Existing TIP-1034 clients and indexers remain compatible.
+No channel migration is required. This TIP changes no public ABI, channel ID, voucher, event, or
+storage layout. It does not change TIP-403 behavior outside the channel reserve.
 
 # Tooling
 
-Wallets and MPP clients require no protocol-interface or session-format changes. Token-issuance
-tooling SHOULD explain that a TIP-1015 recipient whitelist containing a service payee can support
-TIP-1034 after T11 without also whitelisting the reserve or every payer. An MPP server whose
-settlement is rejected by the payee's current TIP-1028 policy SHOULD stop accepting new spend for
-that channel and retry only after the policy allows delivery; the channel remains recoverable.
-
-Integration tests for restricted credits SHOULD exercise direct transfer rejection, channel
-funding and top-up, settlement, payee close with a positive capture and refund, unilateral payer
-withdrawal, blocked capture retry, and blocked refund retry.
+N/A. Existing TIP-1034 clients and session formats are unchanged.
 
 # Observability
 
-No new events are required. Existing TIP-20 `Transfer` events expose physical custody movement, and
-TIP-1034 `ChannelOpened`, `Settled`, and `ChannelClosed` events expose the logical payer, payee,
-capture, and refund amounts.
-
-Operators diagnosing a failed channel operation SHOULD inspect both the channel event history and
-the token's current TIP-403 and TIP-1028 policies. A rejected channel movement emits no
-`TransferBlocked` event because the operation reverts before guard custody is created.
+N/A. TIP-20 `Transfer` events continue to show physical custody movements. TIP-1034 channel events
+continue to show the logical payer, payee, capture, and refund.
 
 # Invariants
 
-1. Ordinary holder-to-holder transfers remain forbidden when the active recipient policy forbids
-   the recipient.
-2. Funding succeeds only when the logical `payer -> payee` path is authorized.
-3. Captures succeed only when the logical `payer -> payee` path is authorized at capture time.
-4. Neither reserve custody nor a channel voucher can route captured value to a payee forbidden by
-   TIP-403.
-5. A refund can go only to the descriptor payer and cannot exceed `deposit - captureAmount` for
-   `close` or `deposit - settled` for `withdraw`.
-6. A payer can recover the refundable balance through `requestClose` and `withdraw` without being
-   an authorized TIP-403 recipient.
-7. TIP-403-free custody movement is unreachable through the public TIP-20 ABI and is used without
-   logical payer-payee checks only for descriptor-bound, reserve-originated refunds.
-8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
-   movement; a TIP-1028 rejection leaves channel accounting and reserve custody unchanged.
-9. Channel and token fund-conservation invariants remain unchanged.
-10. Pre-T11 execution retains the original physical transfer-policy behavior.
-11. No channel movement creates a `ReceivePolicyGuard` receipt or marks guarded funds as captured,
-    settled, or refunded.
+- Ordinary TIP-20 transfers remain subject to the token's TIP-403 policy.
+- Funding and capture succeed only while the logical `payer -> payee` transfer is authorized.
+- Captured funds can go only to the descriptor payee.
+- A refund can go only to the descriptor payer and cannot exceed the refundable channel balance.
+- The payer can recover refundable funds without being an authorized TIP-403 recipient.
+- The TIP-403 bypass is unavailable through the public TIP-20 ABI and is used only for
+  reserve refunds whose recipient and amount come from channel state.
+- Pause state and TIP-1028 apply to every physical movement. Rejection leaves balances and channel
+  accounting unchanged and creates no guarded receipt.
+- Token and channel balance conservation is unchanged.
+- Pre-T11 execution is unchanged.
 
 ## Success Criteria
 
-This TIP is successful when a recipient-restricted TIP-20 can fund, top up, settle, close, and
-refund a channel without authorizing the reserve or payer as TIP-403 recipients; ordinary forbidden
-transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T11
-execution ordering and public interfaces remain unchanged.
-
-## Alternatives Considered
-
-### Whitelist The Reserve And Payers
-
-Adding the reserve and every payer to a recipient whitelist permits funding and refunds, but it also
-permits ordinary transfers to those payer addresses. This weakens closed-loop credit semantics and
-requires unbounded policy administration.
-
-### Exempt Every Reserve-Originated Transfer
-
-A sender-based reserve exemption would allow a payer to name an arbitrary payee and route funds
-through settlement, bypassing the token's recipient policy. This TIP instead distinguishes captures
-from refunds using authenticated channel state.
-
-### Extend TIP-1015 With Pair-Aware Policies
-
-A pair-aware policy could express sender-dependent recipient rules, but it would add policy types,
-registry state, issuer configuration, and evaluation overhead for a custody issue that TIP-1034 can
-resolve from state it already authenticates.
-
-### Administrator-Assisted Refunds
-
-An issuer could atomically whitelist a payer, close the channel, and remove the payer. That makes
-refund liveness depend on the issuer and does not preserve the payer-only unilateral withdrawal.
-
-### Charge-Only Credits
-
-Applications can omit TIP-1034 and use direct charges. This remains valid, but it unnecessarily
-prevents restricted credits from using efficient streaming sessions when the reserve can safely
-separate logical payments from physical custody.
+A recipient-restricted token can fund, top up, settle, close, and refund a channel without
+authorizing the reserve or payer as recipients, while forbidden ordinary transfers and forbidden
+channel payees remain rejected.
 
 ## References
 

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -74,6 +74,10 @@ Before funding or capture, the reserve must check the descriptor payer as the TI
 the resolved descriptor payee as the TIP-403 recipient under the token's current policy. It then
 moves the physical balance without separately applying TIP-403 to the reserve address.
 
+Before `open` or a nonzero `topUp` moves funds, the reserve must also check that the payee's current
+TIP-1028 policy accepts the channel token from the payer. This check does not lock the policy. If
+the payee later changes it, capture may fail until the payee accepts the payment again.
+
 All existing channel checks still apply. Token pause state, balances, access-key limits, recipient
 validity, and TIP-1028 policy must be enforced as they are for native TIP-20 transfers.
 
@@ -97,8 +101,8 @@ payee, or operator to authorize the refund under TIP-403.
 ## TIP-20 Integration
 
 The transfer function used by the reserve must be internal-only and must reject transfers where
-neither endpoint is the channel reserve. Funding and capture use the descriptor payer as the sender
-for TIP-1028 evaluation; refunds use the reserve.
+neither endpoint is the channel reserve. Funding preflights the payee's policy, capture uses the
+descriptor payer as the TIP-1028 sender, and refunds use the reserve.
 
 TIP-1028 rejection must revert instead of creating a `ReceivePolicyGuard` receipt, because channel
 accounting cannot represent guarded funds. Successful movements update balances and rewards and
@@ -125,6 +129,7 @@ continue to show the logical payer, payee, capture, and refund.
 
 - Ordinary TIP-20 transfers remain subject to the token's TIP-403 policy.
 - Funding and capture succeed only while the logical `payer -> payee` transfer is authorized.
+- Funding requires the payee's current TIP-1028 policy to accept the token from the payer.
 - Captured funds can go only to the descriptor payee.
 - A refund can go only to the descriptor payer and cannot exceed the refundable channel balance.
 - The payer can recover refundable funds without being an authorized TIP-403 recipient.

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -48,6 +48,8 @@ its own custody movements as an implementation detail. This preserves the issuer
    post-open operation supplies the same authenticated descriptor.
 3. The reserve can invoke a native TIP-20 movement path that is not exposed through the TIP-20 ABI.
 4. TIP-1028 address-level receive policies remain independent from token-level TIP-403 policy.
+   Channel movements respect those policies by reverting rejected delivery instead of creating a
+   guarded receipt that channel accounting cannot represent.
 5. Token pause state remains authoritative for all channel movements, including refunds. A paused
    token can therefore delay channel exits until it is unpaused.
 
@@ -63,8 +65,8 @@ its own custody movements as an implementation detail. This preserves the issuer
 - **TIP-1034 reserve:** Is trusted to derive refund recipients and amounts exclusively from channel
   state. No public or internal caller-controlled entrypoint may request an arbitrary policy-bypassed
   transfer.
-- **TIP-1028 receive-policy administrator:** May block or reroute inbound funds according to
-  TIP-1028. This TIP does not bypass that authority.
+- **TIP-1028 receive-policy administrator:** May reject an inbound channel movement according to
+  TIP-1028. This TIP does not bypass that authority, but does not create guarded channel receipts.
 
 ---
 
@@ -102,7 +104,7 @@ Before `open` or a nonzero `topUp` moves funds, the reserve MUST:
 2. require the payer to be authorized as a sender under the token's active policy;
 3. require the resolved payee to be authorized as a recipient under that policy;
 4. enforce token pause state, payer balance, payer access-key spending limits, recipient validity,
-   and applicable TIP-1028 handling for the physical reserve recipient; and
+   and the reserve's applicable TIP-1028 policy, reverting if delivery is rejected; and
 5. move the physical amount from payer to reserve without separately requiring the reserve to be an
    authorized TIP-403 recipient.
 
@@ -116,8 +118,8 @@ Before `settle` or the capture leg of `close` moves a nonzero amount, the reserv
 1. perform all existing channel, caller, bound, and voucher checks;
 2. require the descriptor payer to be currently authorized as a sender;
 3. require the resolved descriptor payee to be currently authorized as a recipient;
-4. enforce token pause state, recipient validity, and applicable TIP-1028 handling for the actual
-   payee, using the descriptor payer as the inbound originator while debiting reserve custody; and
+4. enforce token pause state, recipient validity, and the actual payee's applicable TIP-1028
+   policy using the descriptor payer as the policy sender, reverting if delivery is rejected; and
 5. move the physical amount from reserve to the descriptor payee without separately evaluating the
    reserve as the policy sender.
 
@@ -136,8 +138,10 @@ authorization. This bypass is valid only when all of the following are true:
 4. the operation deletes or terminally closes that channel according to TIP-1034.
 
 Refunds MUST continue to enforce token pause state, physical recipient validity, balance
-conservation, and TIP-1028 address-level receive policy. If TIP-1028 blocks an inbound refund, the
-existing receive-policy guard behavior applies.
+conservation, and TIP-1028 address-level receive policy using `TIP20_CHANNEL_RESERVE` as the policy
+sender. If TIP-1028 rejects an inbound refund, the operation MUST revert without deleting the
+channel or creating a guarded receipt. The payer can update its receive policy and retry the close
+or withdrawal.
 
 The payer's `requestClose` followed by `withdraw` MUST remain unilateral. No token-policy
 administrator, payee, or operator action may be required solely because the payer is not an
@@ -152,9 +156,15 @@ checks only after deriving the payer and refund amount from authenticated channe
 The TIP-20 implementation MUST provide an internal-only custody-movement primitive for the channel
 reserve. It accepts the physical endpoints and the sender identity used for TIP-1028 receive-policy
 evaluation, but does not select or evaluate a TIP-403 policy mode. Funding and capture MUST supply
-the descriptor payer as the TIP-1028 originator. Refunds MUST supply
+the descriptor payer as the TIP-1028 policy sender. Refunds MUST supply
 `TIP20_CHANNEL_RESERVE`, preserving the ordinary physical sender identity for receive-policy
-handling.
+evaluation.
+
+Before moving custody, the primitive MUST evaluate the destination's TIP-1028 policy. A rejected
+channel movement MUST revert with `PolicyForbids()` and MUST NOT transfer funds to
+`ReceivePolicyGuard` or create a claim receipt. `settle` MUST update cumulative settlement only
+after a successful capture. At T9, `close` and `withdraw` MUST delete terminal channel state only
+after every nonzero capture and refund succeeds.
 
 The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
 neither endpoint is `TIP20_CHANNEL_RESERVE`. The trusted reserve implementation MUST invoke it only
@@ -181,12 +191,15 @@ Existing TIP-1034 clients and indexers remain compatible.
 
 # Tooling
 
-Wallets and MPP clients require no protocol-interface changes. Token-issuance tooling SHOULD explain
-that a TIP-1015 recipient whitelist containing a service payee can support TIP-1034 after T9 without
-also whitelisting the reserve or every payer.
+Wallets and MPP clients require no protocol-interface or session-format changes. Token-issuance
+tooling SHOULD explain that a TIP-1015 recipient whitelist containing a service payee can support
+TIP-1034 after T9 without also whitelisting the reserve or every payer. An MPP server whose
+settlement is rejected by the payee's current TIP-1028 policy SHOULD stop accepting new spend for
+that channel and retry only after the policy allows delivery; the channel remains recoverable.
 
 Integration tests for restricted credits SHOULD exercise direct transfer rejection, channel
-funding, capture, payee close with refund, and unilateral payer withdrawal.
+funding and top-up, settlement, payee close with a positive capture and refund, unilateral payer
+withdrawal, blocked capture retry, and blocked refund retry.
 
 # Observability
 
@@ -195,7 +208,8 @@ TIP-1034 `ChannelOpened`, `Settled`, and `ChannelClosed` events expose the logic
 capture, and refund amounts.
 
 Operators diagnosing a failed channel operation SHOULD inspect both the channel event history and
-the token's current TIP-403 and TIP-1028 policies.
+the token's current TIP-403 and TIP-1028 policies. A rejected channel movement emits no
+`TransferBlocked` event because the operation reverts before guard custody is created.
 
 # Invariants
 
@@ -212,9 +226,18 @@ the token's current TIP-403 and TIP-1028 policies.
 7. TIP-403-free custody movement is unreachable through the public TIP-20 ABI and is used without
    logical payer-payee checks only for descriptor-bound, reserve-originated refunds.
 8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
-   movement.
+   movement; a TIP-1028 rejection leaves channel accounting and reserve custody unchanged.
 9. Channel and token fund-conservation invariants remain unchanged.
 10. Pre-T9 execution retains the original physical transfer-policy behavior.
+11. No channel movement creates a `ReceivePolicyGuard` receipt or marks guarded funds as captured,
+    settled, or refunded.
+
+## Success Criteria
+
+This TIP is successful when a recipient-restricted TIP-20 can fund, top up, settle, close, and
+refund a channel without authorizing the reserve or payer as TIP-403 recipients; ordinary forbidden
+transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T9
+execution ordering and public interfaces remain unchanged.
 
 ## Alternatives Considered
 

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -113,8 +113,11 @@ physical `Transfer` events as ordinary TIP-20 movements.
 This behavior activates at T11 and applies to both new and existing channels. Before T11, TIP-1034
 keeps its original physical transfer-policy checks.
 
-No channel migration is required. This TIP changes no public ABI, channel ID, voucher, event, or
-storage layout. It does not change TIP-403 behavior outside the channel reserve.
+No on-chain channel migration is required. Existing channels continue to work, but a payee that
+previously allowed the channel reserve in its TIP-1028 policy may need to allow the channel payer
+after T11. Otherwise, future settlements or captures can revert until the policy is updated.
+This TIP changes no public ABI, channel ID, voucher, event, or storage layout, and does not change
+TIP-403 behavior outside the channel reserve.
 
 # Tooling
 

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -145,20 +145,23 @@ authorized TIP-403 recipient.
 
 ## Native TIP-20 Integration
 
-The TIP-20 implementation MUST provide an internal-only movement primitive for the channel reserve.
-It MUST accept physical endpoints and exactly one of these policy modes:
+The channel reserve MUST perform the logical payer and payee TIP-403 checks directly in the funding
+and capture operations before moving custody. Descriptor-bound refund operations MUST omit those
+checks only after deriving the payer and refund amount from authenticated channel state.
 
-```text
-Logical(from, to)  enforce TIP-403 against the supplied logical endpoints
-Bypass             skip TIP-403 for a descriptor-bound refund
-```
+The TIP-20 implementation MUST provide an internal-only custody-movement primitive for the channel
+reserve. It accepts the physical endpoints and the sender identity used for TIP-1028 receive-policy
+evaluation, but does not select or evaluate a TIP-403 policy mode. Funding and capture MUST supply
+the descriptor payer as the TIP-1028 originator. Refunds MUST supply
+`TIP20_CHANNEL_RESERVE`, preserving the ordinary physical sender identity for receive-policy
+handling.
 
 The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
-neither endpoint is `TIP20_CHANNEL_RESERVE`, and MUST reject `Bypass` unless the physical sender is
-`TIP20_CHANNEL_RESERVE`.
+neither endpoint is `TIP20_CHANNEL_RESERVE`. The trusted reserve implementation MUST invoke it only
+after applying the operation-specific rules above.
 
-All validation other than the explicitly selected TIP-403 mode MUST match native TIP-20 transfer
-behavior. Successful movements MUST update rewards and balances and emit the same physical
+All validation other than the TIP-403 checks applied by the reserve MUST match native TIP-20
+transfer behavior. Successful movements MUST update rewards and balances and emit the same physical
 `Transfer` events as the corresponding custody movement. Virtual-recipient forwarding events MUST
 remain unchanged.
 
@@ -206,8 +209,8 @@ the token's current TIP-403 and TIP-1028 policies.
    `close` or `deposit - settled` for `withdraw`.
 6. A payer can recover the refundable balance through `requestClose` and `withdraw` without being
    an authorized TIP-403 recipient.
-7. Policy bypass is unreachable through the public TIP-20 ABI and cannot be selected for a
-   non-reserve physical sender.
+7. TIP-403-free custody movement is unreachable through the public TIP-20 ABI and is used without
+   logical payer-payee checks only for descriptor-bound, reserve-originated refunds.
 8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
    movement.
 9. Channel and token fund-conservation invariants remain unchanged.

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -5,7 +5,7 @@ description: Applies TIP-403 policy to the logical payer-payee path of TIP-1034 
 authors: Georgios Konstantopoulos
 status: Draft
 related: TIP-20, TIP-403, TIP-1015, TIP-1028, TIP-1034, TIP-1035
-protocolVersion: T9
+protocolVersion: T10
 ---
 
 # TIP-1095: Policy-Aware Channel Reserve Transfers
@@ -163,7 +163,7 @@ evaluation.
 Before moving custody, the primitive MUST evaluate the destination's TIP-1028 policy. A rejected
 channel movement MUST revert with `PolicyForbids()` and MUST NOT transfer funds to
 `ReceivePolicyGuard` or create a claim receipt. `settle` MUST update cumulative settlement only
-after a successful capture. At T9, `close` and `withdraw` MUST delete terminal channel state only
+after a successful capture. At T10, `close` and `withdraw` MUST delete terminal channel state only
 after every nonzero capture and refund succeeds.
 
 The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
@@ -177,7 +177,7 @@ remain unchanged.
 
 ## Activation And Existing Channels
 
-The behavior activates at T9. Before T9, channel reserve operations retain TIP-1034's original
+The behavior activates at T10. Before T10, channel reserve operations retain TIP-1034's original
 physical transfer-policy checks.
 
 After activation, the new rules apply to both newly opened and already active channels. No channel
@@ -193,7 +193,7 @@ Existing TIP-1034 clients and indexers remain compatible.
 
 Wallets and MPP clients require no protocol-interface or session-format changes. Token-issuance
 tooling SHOULD explain that a TIP-1015 recipient whitelist containing a service payee can support
-TIP-1034 after T9 without also whitelisting the reserve or every payer. An MPP server whose
+TIP-1034 after T10 without also whitelisting the reserve or every payer. An MPP server whose
 settlement is rejected by the payee's current TIP-1028 policy SHOULD stop accepting new spend for
 that channel and retry only after the policy allows delivery; the channel remains recoverable.
 
@@ -228,7 +228,7 @@ the token's current TIP-403 and TIP-1028 policies. A rejected channel movement e
 8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
    movement; a TIP-1028 rejection leaves channel accounting and reserve custody unchanged.
 9. Channel and token fund-conservation invariants remain unchanged.
-10. Pre-T9 execution retains the original physical transfer-policy behavior.
+10. Pre-T10 execution retains the original physical transfer-policy behavior.
 11. No channel movement creates a `ReceivePolicyGuard` receipt or marks guarded funds as captured,
     settled, or refunded.
 
@@ -236,7 +236,7 @@ the token's current TIP-403 and TIP-1028 policies. A rejected channel movement e
 
 This TIP is successful when a recipient-restricted TIP-20 can fund, top up, settle, close, and
 refund a channel without authorizing the reserve or payer as TIP-403 recipients; ordinary forbidden
-transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T9
+transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T10
 execution ordering and public interfaces remain unchanged.
 
 ## Alternatives Considered

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -140,12 +140,6 @@ continue to show the logical payer, payee, capture, and refund.
 - Token and channel balance conservation is unchanged.
 - Pre-T11 execution is unchanged.
 
-## Success Criteria
-
-A recipient-restricted token can fund, top up, settle, close, and refund a channel without
-authorizing the reserve or payer as recipients, while forbidden ordinary transfers and forbidden
-channel payees remain rejected.
-
 ## References
 
 - [TIP-1015: Compound Transfer Policies](tip-1015.md)

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -5,7 +5,7 @@ description: Applies TIP-403 policy to the logical payer-payee path of TIP-1034 
 authors: Georgios Konstantopoulos
 status: Draft
 related: TIP-20, TIP-403, TIP-1015, TIP-1028, TIP-1034, TIP-1035
-protocolVersion: T10
+protocolVersion: T11
 ---
 
 # TIP-1095: Policy-Aware Channel Reserve Transfers
@@ -163,7 +163,7 @@ evaluation.
 Before moving custody, the primitive MUST evaluate the destination's TIP-1028 policy. A rejected
 channel movement MUST revert with `PolicyForbids()` and MUST NOT transfer funds to
 `ReceivePolicyGuard` or create a claim receipt. `settle` MUST update cumulative settlement only
-after a successful capture. At T10, `close` and `withdraw` MUST delete terminal channel state only
+after a successful capture. At T11, `close` and `withdraw` MUST delete terminal channel state only
 after every nonzero capture and refund succeeds.
 
 The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
@@ -177,7 +177,7 @@ remain unchanged.
 
 ## Activation And Existing Channels
 
-The behavior activates at T10. Before T10, channel reserve operations retain TIP-1034's original
+The behavior activates at T11. Before T11, channel reserve operations retain TIP-1034's original
 physical transfer-policy checks.
 
 After activation, the new rules apply to both newly opened and already active channels. No channel
@@ -193,7 +193,7 @@ Existing TIP-1034 clients and indexers remain compatible.
 
 Wallets and MPP clients require no protocol-interface or session-format changes. Token-issuance
 tooling SHOULD explain that a TIP-1015 recipient whitelist containing a service payee can support
-TIP-1034 after T10 without also whitelisting the reserve or every payer. An MPP server whose
+TIP-1034 after T11 without also whitelisting the reserve or every payer. An MPP server whose
 settlement is rejected by the payee's current TIP-1028 policy SHOULD stop accepting new spend for
 that channel and retry only after the policy allows delivery; the channel remains recoverable.
 
@@ -228,7 +228,7 @@ the token's current TIP-403 and TIP-1028 policies. A rejected channel movement e
 8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
    movement; a TIP-1028 rejection leaves channel accounting and reserve custody unchanged.
 9. Channel and token fund-conservation invariants remain unchanged.
-10. Pre-T10 execution retains the original physical transfer-policy behavior.
+10. Pre-T11 execution retains the original physical transfer-policy behavior.
 11. No channel movement creates a `ReceivePolicyGuard` receipt or marks guarded funds as captured,
     settled, or refunded.
 
@@ -236,7 +236,7 @@ the token's current TIP-403 and TIP-1028 policies. A rejected channel movement e
 
 This TIP is successful when a recipient-restricted TIP-20 can fund, top up, settle, close, and
 refund a channel without authorizing the reserve or payer as TIP-403 recipients; ordinary forbidden
-transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T10
+transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T11
 execution ordering and public interfaces remain unchanged.
 
 ## Alternatives Considered

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -105,8 +105,8 @@ neither endpoint is the channel reserve. Funding preflights the payee's policy, 
 descriptor payer as the TIP-1028 sender, and refunds use the reserve.
 
 TIP-1028 rejection must revert instead of creating a `ReceivePolicyGuard` receipt, because channel
-accounting cannot represent guarded funds. Successful movements update balances and rewards and
-emit the same physical `Transfer` events as ordinary TIP-20 movements.
+accounting cannot represent guarded funds. Successful movements update balances and emit the same
+physical `Transfer` events as ordinary TIP-20 movements.
 
 ## Activation and Compatibility
 

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -125,8 +125,20 @@ N/A. Existing TIP-1034 clients and session formats are unchanged.
 
 # Observability
 
-N/A. TIP-20 `Transfer` events continue to show physical custody movements. TIP-1034 channel events
-continue to show the logical payer, payee, capture, and refund.
+No new events are added. Existing TIP-20 `Transfer` events and TIP-1034 channel events
+remain sufficient for monitoring and debugging, but they represent different sides of a channel
+movement:
+
+| Existing events | What it records | Interpretation |
+|---|---|---|
+| TIP-20 `Transfer` event | Physical token movement and custody | For settlement and capture, the physical path is `channel reserve -> payee`. It does not identify the payer used for policy authorization |
+| TIP-1034 channel events | Logical channel parties and accounting | Use the payer, payee, and operation-specific amount fields to correlate the movement with the logical payment |
+
+Before this TIP, settlement and capture presented the channel reserve as the sender to the payee's
+receive policy. Under this TIP, authorization uses the `payer -> payee` path while the physical
+movement and `Transfer` event remain `channel reserve -> payee`. Consequently, an unchanged policy
+can change whether settlement or capture succeeds, and a `Transfer` from the channel reserve to
+the payee does not by itself mean that the channel reserve was authorized as the policy sender.
 
 # Invariants
 

--- a/tips/verify/src/TIP20ChannelReserve.sol
+++ b/tips/verify/src/TIP20ChannelReserve.sol
@@ -7,6 +7,9 @@ import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 
 /// @title TIP20ChannelReserve
 /// @notice Reference contract for the TIP-1034 channel model.
+/// @dev TIP-1095's policy-aware custody movement is native-only and cannot be reproduced through
+/// the public TIP-20 ABI used by this informative Solidity reference. The precompile applies
+/// TIP-403 to the logical payer-payee path and bypasses TIP-403 only for descriptor-bound refunds.
 contract TIP20ChannelReserve is ITIP20ChannelReserve {
 
     error TransferFailed();
@@ -88,7 +91,8 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         );
 
         // The reference contract keeps ERC-20-style allowance flow for local verification.
-        // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
+        // The enshrined precompile uses native movement and, after TIP-1095, applies TIP-403 to
+        // msg.sender -> payee instead of this physical msg.sender -> reserve custody edge.
         bool success = ITIP20(token).transferFrom(msg.sender, address(this), deposit);
         if (!success) revert TransferFailed();
 
@@ -134,6 +138,8 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         channel.settled = cumulativeAmount;
         channelStates[channelId] = _encodeChannelState(channel);
 
+        // TIP-1095 applies TIP-403 to descriptor.payer -> descriptor.payee. This public-ABI
+        // approximation still applies the token's ordinary physical reserve -> payee policy.
         bool success = ITIP20(descriptor.token).transfer(descriptor.payee, delta);
         if (!success) revert TransferFailed();
 
@@ -154,7 +160,7 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
             channel.deposit += additionalDeposit;
 
             // The reference contract keeps ERC-20-style allowance flow for local verification.
-            // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
+            // The enshrined precompile uses TIP-1095 logical payer -> payee authorization.
             bool success =
                 ITIP20(descriptor.token).transferFrom(msg.sender, address(this), additionalDeposit);
             if (!success) revert TransferFailed();
@@ -229,6 +235,8 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         }
 
         if (refund > 0) {
+            // TIP-1095 bypasses TIP-403 for this descriptor-bound refund while retaining pause and
+            // address-level receive-policy handling. The public ABI cannot model that bypass.
             bool payerTransferSucceeded =
                 ITIP20(descriptor.token).transfer(descriptor.payer, refund);
             if (!payerTransferSucceeded) revert TransferFailed();
@@ -253,6 +261,7 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         delete channelStates[channelId];
 
         if (refund > 0) {
+            // TIP-1095 bypasses TIP-403 only for this payer-only, state-derived refund.
             bool success = ITIP20(descriptor.token).transfer(descriptor.payer, refund);
             if (!success) revert TransferFailed();
         }

--- a/tips/verify/src/TIP20ChannelReserve.sol
+++ b/tips/verify/src/TIP20ChannelReserve.sol
@@ -11,6 +11,7 @@ import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 /// the public TIP-20 ABI used by this informative Solidity reference. The precompile applies
 /// TIP-403 to the logical payer-payee path, bypasses TIP-403 only for descriptor-bound refunds,
 /// and reverts TIP-1028-rejected channel movements instead of creating guarded receipts.
+/// Funding checks the payee's current TIP-1028 policy, but does not lock it against later changes.
 contract TIP20ChannelReserve is ITIP20ChannelReserve {
 
     error TransferFailed();

--- a/tips/verify/src/TIP20ChannelReserve.sol
+++ b/tips/verify/src/TIP20ChannelReserve.sol
@@ -9,7 +9,8 @@ import { ITIP20 } from "tempo-std/interfaces/ITIP20.sol";
 /// @notice Reference contract for the TIP-1034 channel model.
 /// @dev TIP-1095's policy-aware custody movement is native-only and cannot be reproduced through
 /// the public TIP-20 ABI used by this informative Solidity reference. The precompile applies
-/// TIP-403 to the logical payer-payee path and bypasses TIP-403 only for descriptor-bound refunds.
+/// TIP-403 to the logical payer-payee path, bypasses TIP-403 only for descriptor-bound refunds,
+/// and reverts TIP-1028-rejected channel movements instead of creating guarded receipts.
 contract TIP20ChannelReserve is ITIP20ChannelReserve {
 
     error TransferFailed();
@@ -138,8 +139,9 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         channel.settled = cumulativeAmount;
         channelStates[channelId] = _encodeChannelState(channel);
 
-        // TIP-1095 applies TIP-403 to descriptor.payer -> descriptor.payee. This public-ABI
-        // approximation still applies the token's ordinary physical reserve -> payee policy.
+        // TIP-1095 applies TIP-403 and TIP-1028 to descriptor.payer -> descriptor.payee and reverts
+        // rejected delivery. This public-ABI approximation still uses ordinary physical transfer
+        // behavior, including ReceivePolicyGuard redirection.
         bool success = ITIP20(descriptor.token).transfer(descriptor.payee, delta);
         if (!success) revert TransferFailed();
 
@@ -235,8 +237,8 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         }
 
         if (refund > 0) {
-            // TIP-1095 bypasses TIP-403 for this descriptor-bound refund while retaining pause and
-            // address-level receive-policy handling. The public ABI cannot model that bypass.
+            // TIP-1095 bypasses TIP-403 for this descriptor-bound refund but reverts when the
+            // payer's TIP-1028 policy rejects the reserve. The public ABI cannot model that path.
             bool payerTransferSucceeded =
                 ITIP20(descriptor.token).transfer(descriptor.payer, refund);
             if (!payerTransferSucceeded) revert TransferFailed();
@@ -261,7 +263,8 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         delete channelStates[channelId];
 
         if (refund > 0) {
-            // TIP-1095 bypasses TIP-403 only for this payer-only, state-derived refund.
+            // TIP-1095 bypasses TIP-403 only for this payer-only, state-derived refund and reverts
+            // TIP-1028 rejection without deleting native channel state.
             bool success = ITIP20(descriptor.token).transfer(descriptor.payer, refund);
             if (!success) revert TransferFailed();
         }


### PR DESCRIPTION
Adds TIP-1095 for T12 so recipient-restricted TIP-20 credits can use TIP-1034 without whitelisting the reserve or every payer.

Enforces TIP-403 on the logical payer-payee path and bypasses it only for descriptor-bound refunds, preserving unilateral withdrawal and ordinary transfer restrictions.