### PR TITLE
chore(precompiles): expose `Slot` address and context

### DIFF
--- a/crates/precompiles/src/storage/types/slot.rs
+++ b/crates/precompiles/src/storage/types/slot.rs
@@ -105,6 +105,18 @@ impl<T> Slot<T> {
         self.slot
     }
 
+    /// Returns the address whose storage this slot accesses.
+    #[inline]
+    pub const fn address(&self) -> Address {
+        self.address
+    }
+
+    /// Returns the layout context used to load and store the underlying type.
+    #[inline]
+    pub const fn ctx(&self) -> LayoutCtx {
+        self.ctx
+    }
+
     /// Returns the byte offset within the slot (for packed fields).
     ///
     /// Returns `Some(offset)` if this is a packed slot, `None` if it's a full slot.


### PR DESCRIPTION
Adds public `address()` and `ctx()` getters to `Slot<T>` so callers can inspect its storage target and complete layout context.

Prompted by: @0xrusowsky