### PR TITLE
chore(zone-factory): add max Tempo gas rate slot

### DIFF
--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -411,6 +411,7 @@ mod tests {
             );
             assert!(portal.is_access_enforced.read()?);
             assert!(portal.is_gateway_enforced.read()?);
+            assert_eq!(portal.max_tempo_gas_rate.read()?, 0);
 
             // Pin the native storage handlers to the canonical Solidity layout.
             assert_eq!(
@@ -437,6 +438,7 @@ mod tests {
                 StorageCtx.sload(created.portal, U256::from(21))?,
                 U256::from(0x0101)
             );
+            assert_eq!(portal.max_tempo_gas_rate.slot(), U256::from(22));
             Ok(())
         })
     }

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -8,7 +8,7 @@ use crate::{
     error::Result,
     storage::{Handler, Mapping},
 };
-use alloy::primitives::{Address, B256, Bytes, U256, hex};
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256, hex};
 use revm::state::Bytecode;
 use tempo_contracts::precompiles::{
     IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZonePortalRole,
@@ -79,6 +79,10 @@ pub struct ZonePortalStorage {
     role: Mapping<Address, u8>,
     is_access_enforced: bool,
     is_gateway_enforced: bool,
+    /// Reserved remainder of the enforcement modes slot.
+    _reserved: FixedBytes<30>,
+    /// Maximum Tempo gas rate, stored in `PORTAL_MAX_TEMPO_GAS_RATE_SLOT`.
+    max_tempo_gas_rate: u128,
 }
 
 impl ZonePortalStorage {


### PR DESCRIPTION
Adds the ZonePortal `maxTempoGasRate` storage handler at the dedicated slot 22 introduced by the [Zones Solidity implementation](https://github.com/tempoxyz/zones/blob/199ff70fb80e2d91cdad58e6f395ab0ef6d702fa/specs/ref-impls/src/tempo/ZonePortal.sol#L160-L168). Pins the slot in the native layout regression test.

Prompted by: @0xrusowsky