### PR TITLE
refactor(tip-1095): inline channel policy checks

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -920,14 +920,14 @@ impl TIP20Token {
     /// endpoint must be the canonical channel reserve. The reserve checks the logical payer-payee
     /// path before funding and capture, and derives refunds from authenticated channel state.
     ///
-    /// `receive_policy_originator` is the sender presented to TIP-1028. It may differ from the
-    /// physical balance owner when reserve custody pays a channel's payee.
+    /// `originator` is the sender presented to TIP-1028. It may differ from the physical balance
+    /// owner when reserve custody pays a channel's payee.
     pub(crate) fn channel_reserve_transfer(
         &mut self,
         from: Address,
         to: Address,
         amount: U256,
-        receive_policy_originator: Address,
+        originator: Address,
     ) -> Result<bool> {
         if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
             return Err(TIP20Error::unauthorized().into());
@@ -938,14 +938,7 @@ impl TIP20Token {
         to.validate()?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.validate_inbound_or_block(
-            receive_policy_originator,
-            from,
-            &to,
-            amount,
-            None,
-            B256::ZERO,
-        )? {
+        if self.validate_inbound_or_block(originator, from, &to, amount, None, B256::ZERO)? {
             return Ok(true);
         }
 

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -48,18 +48,6 @@ use tracing::trace;
 /// u128::MAX as U256
 pub const U128_MAX: U256 = uint!(0xffffffffffffffffffffffffffffffff_U256);
 
-/// TIP-403 subjects used for a physical TIP-20 balance movement.
-///
-/// Most transfers enforce policy against the physical balance owner and recipient. Protocol
-/// custody may instead enforce a logical payment path, or bypass TIP-403 for a descriptor-bound
-/// refund while retaining all other transfer validation.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum TransferPolicyCheck {
-    Physical,
-    Logical { from: Address, to: Address },
-    Bypass,
-}
-
 /// Validates that the given token's currency is `"USD"`.
 ///
 /// # Errors
@@ -926,32 +914,40 @@ impl TIP20Token {
         Ok(true)
     }
 
-    /// Moves channel-reserve custody while applying policy to the logical payment path.
+    /// Moves channel-reserve custody after the reserve applies operation-specific TIP-403 rules.
     ///
     /// This is an internal TIP-1034 integration, not an ABI entrypoint. At least one physical
-    /// endpoint must be the canonical channel reserve. `Bypass` is valid only for reserve-originated
-    /// refunds; the reserve derives their recipient and amount from authenticated channel state.
+    /// endpoint must be the canonical channel reserve. The reserve checks the logical payer-payee
+    /// path before funding and capture, and derives refunds from authenticated channel state.
+    ///
+    /// `receive_policy_originator` is the sender presented to TIP-1028. It may differ from the
+    /// physical balance owner when reserve custody pays a channel's payee.
     pub(crate) fn channel_reserve_transfer(
         &mut self,
         from: Address,
         to: Address,
         amount: U256,
-        policy_check: TransferPolicyCheck,
+        receive_policy_originator: Address,
     ) -> Result<bool> {
         if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
             return Err(TIP20Error::unauthorized().into());
         }
-        if matches!(policy_check, TransferPolicyCheck::Bypass)
-            && from != TIP20_CHANNEL_RESERVE_ADDRESS
-        {
-            return Err(TIP20Error::unauthorized().into());
-        }
 
-        let Some(to) =
-            self.validate_transfer_with_policy(None, from, to, amount, B256::ZERO, policy_check)?
-        else {
+        let to = Recipient::resolve(to)?;
+        self.check_not_paused()?;
+        to.validate()?;
+        self.check_and_update_spending_limit(from, amount)?;
+
+        if self.validate_inbound_or_block(
+            receive_policy_originator,
+            from,
+            &to,
+            amount,
+            None,
+            B256::ZERO,
+        )? {
             return Ok(true);
-        };
+        }
 
         self._transfer(from, &to, amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(amount) {
@@ -1127,40 +1123,10 @@ impl TIP20Token {
         amount: U256,
         memo: B256,
     ) -> Result<Option<Recipient>> {
-        self.validate_transfer_with_policy(
-            spender,
-            from,
-            to,
-            amount,
-            memo,
-            TransferPolicyCheck::Physical,
-        )
-    }
-
-    /// Validates a physical balance movement with an explicit TIP-403 policy path.
-    fn validate_transfer_with_policy(
-        &mut self,
-        spender: Option<Address>,
-        from: Address,
-        to: Address,
-        amount: U256,
-        memo: B256,
-        policy_check: TransferPolicyCheck,
-    ) -> Result<Option<Recipient>> {
         let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
-        let inbound_originator = match policy_check {
-            TransferPolicyCheck::Logical { from, .. } => from,
-            TransferPolicyCheck::Physical | TransferPolicyCheck::Bypass => from,
-        };
-        match policy_check {
-            TransferPolicyCheck::Physical => self.ensure_transfer_authorized(from, to.target)?,
-            TransferPolicyCheck::Logical { from, to } => {
-                self.ensure_transfer_authorized(from, to)?
-            }
-            TransferPolicyCheck::Bypass => {}
-        }
+        self.ensure_transfer_authorized(from, to.target)?;
 
         if let Some(spender) = spender {
             self.consume_allowance(from, spender, amount)?;
@@ -1168,7 +1134,7 @@ impl TIP20Token {
             self.check_and_update_spending_limit(from, amount)?;
         }
 
-        if self.validate_inbound_or_block(inbound_originator, from, &to, amount, None, memo)? {
+        if self.validate_inbound_or_block(from, from, &to, amount, None, memo)? {
             return Ok(None);
         }
 

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     signature_verifier::SignatureVerifier,
     storage::{Handler, Mapping},
     storage_credits::StorageCredits,
-    tip20::{ITIP20, Recipient, TIP20Token, TransferPolicyCheck, is_tip20_prefix},
+    tip20::{ITIP20, Recipient, TIP20Token, is_tip20_prefix},
     tip403_registry::AuthRole,
 };
 use alloy::{
@@ -162,14 +162,12 @@ impl TIP20ChannelReserve {
         }
 
         if self.storage.spec().is_t9() {
+            token.ensure_transfer_authorized(msg_sender, Recipient::resolve(call.payee)?.target)?;
             token.channel_reserve_transfer(
                 msg_sender,
                 self.address,
                 U256::from(call.deposit),
-                TransferPolicyCheck::Logical {
-                    from: msg_sender,
-                    to: Recipient::resolve(call.payee)?.target,
-                },
+                msg_sender,
             )?;
         } else {
             token.ensure_authorized_as(&[(
@@ -243,14 +241,15 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
         if self.storage.spec().is_t9() {
+            token.ensure_transfer_authorized(
+                call.descriptor.payer,
+                Recipient::resolve(call.descriptor.payee)?.target,
+            )?;
             token.channel_reserve_transfer(
                 self.address,
                 call.descriptor.payee,
                 U256::from(delta),
-                TransferPolicyCheck::Logical {
-                    from: call.descriptor.payer,
-                    to: Recipient::resolve(call.descriptor.payee)?.target,
-                },
+                call.descriptor.payer,
             )?;
         } else {
             token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
@@ -311,14 +310,15 @@ impl TIP20ChannelReserve {
             state.deposit = next_deposit;
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if self.storage.spec().is_t9() {
+                token.ensure_transfer_authorized(
+                    msg_sender,
+                    Recipient::resolve(call.descriptor.payee)?.target,
+                )?;
                 token.channel_reserve_transfer(
                     msg_sender,
                     self.address,
                     U256::from(call.additionalDeposit),
-                    TransferPolicyCheck::Logical {
-                        from: msg_sender,
-                        to: Recipient::resolve(call.descriptor.payee)?.target,
-                    },
+                    msg_sender,
                 )?;
             } else {
                 token.ensure_authorized_as(&[(
@@ -441,14 +441,15 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
         if !delta.is_zero() {
             if self.storage.spec().is_t9() {
+                token.ensure_transfer_authorized(
+                    call.descriptor.payer,
+                    Recipient::resolve(call.descriptor.payee)?.target,
+                )?;
                 token.channel_reserve_transfer(
                     self.address,
                     call.descriptor.payee,
                     U256::from(delta),
-                    TransferPolicyCheck::Logical {
-                        from: call.descriptor.payer,
-                        to: Recipient::resolve(call.descriptor.payee)?.target,
-                    },
+                    call.descriptor.payer,
                 )?;
             } else {
                 token.ensure_authorized_as(&[(call.descriptor.payer, AuthRole::Sender)])?;
@@ -467,7 +468,7 @@ impl TIP20ChannelReserve {
                     self.address,
                     call.descriptor.payer,
                     U256::from(refund),
-                    TransferPolicyCheck::Bypass,
+                    self.address,
                 )?;
             } else {
                 token.transfer(
@@ -526,7 +527,7 @@ impl TIP20ChannelReserve {
                     self.address,
                     call.descriptor.payer,
                     U256::from(refund),
-                    TransferPolicyCheck::Bypass,
+                    self.address,
                 )?;
             } else {
                 token.transfer(

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -145,20 +145,23 @@ authorized TIP-403 recipient.
 
 ## Native TIP-20 Integration
 
-The TIP-20 implementation MUST provide an internal-only movement primitive for the channel reserve.
-It MUST accept physical endpoints and exactly one of these policy modes:
+The channel reserve MUST perform the logical payer and payee TIP-403 checks directly in the funding
+and capture operations before moving custody. Descriptor-bound refund operations MUST omit those
+checks only after deriving the payer and refund amount from authenticated channel state.
 
-```text
-Logical(from, to)  enforce TIP-403 against the supplied logical endpoints
-Bypass             skip TIP-403 for a descriptor-bound refund
-```
+The TIP-20 implementation MUST provide an internal-only custody-movement primitive for the channel
+reserve. It accepts the physical endpoints and the sender identity used for TIP-1028 receive-policy
+evaluation, but does not select or evaluate a TIP-403 policy mode. Funding and capture MUST supply
+the descriptor payer as the TIP-1028 originator. Refunds MUST supply
+`TIP20_CHANNEL_RESERVE`, preserving the ordinary physical sender identity for receive-policy
+handling.
 
 The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
-neither endpoint is `TIP20_CHANNEL_RESERVE`, and MUST reject `Bypass` unless the physical sender is
-`TIP20_CHANNEL_RESERVE`.
+neither endpoint is `TIP20_CHANNEL_RESERVE`. The trusted reserve implementation MUST invoke it only
+after applying the operation-specific rules above.
 
-All validation other than the explicitly selected TIP-403 mode MUST match native TIP-20 transfer
-behavior. Successful movements MUST update rewards and balances and emit the same physical
+All validation other than the TIP-403 checks applied by the reserve MUST match native TIP-20
+transfer behavior. Successful movements MUST update rewards and balances and emit the same physical
 `Transfer` events as the corresponding custody movement. Virtual-recipient forwarding events MUST
 remain unchanged.
 
@@ -206,8 +209,8 @@ the token's current TIP-403 and TIP-1028 policies.
    `close` or `deposit - settled` for `withdraw`.
 6. A payer can recover the refundable balance through `requestClose` and `withdraw` without being
    an authorized TIP-403 recipient.
-7. Policy bypass is unreachable through the public TIP-20 ABI and cannot be selected for a
-   non-reserve physical sender.
+7. TIP-403-free custody movement is unreachable through the public TIP-20 ABI and is used without
+   logical payer-payee checks only for descriptor-bound, reserve-originated refunds.
 8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
    movement.
 9. Channel and token fund-conservation invariants remain unchanged.


### PR DESCRIPTION
Refactors #6957 so TIP-403 authorization is explicit in the channel-reserve operations instead of selected through `TransferPolicyCheck`. Funding and capture validate the descriptor payer and payee before moving custody, while state-derived refunds continue to omit TIP-403. `channel_reserve_transfer` is reduced to reserve endpoint validation, standard token checks, TIP-1028 handling, and balance movement. TIP-1095 is updated to match.

Stacked on #6957.