### PR TITLE
fix(precompiles): validate zone before creation gas charge

### DIFF
--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -30,6 +30,7 @@ pub struct HashMapStorageProvider {
     is_static: bool,
     gas_params: GasParams,
     gas_tracker: GasTracker,
+    deducted_gas: u64,
     tip1060_storage_credits_enabled: bool,
     counter_sload: u64,
     counter_sstore: u64,
@@ -83,6 +84,7 @@ impl HashMapStorageProvider {
             is_static: false,
             gas_params: GasParams::new_spec(spec.into()),
             gas_tracker: GasTracker::new(u64::MAX, u64::MAX, 0),
+            deducted_gas: 0,
             tip1060_storage_credits_enabled: spec.is_t7(),
             counter_sload: 0,
             counter_sstore: 0,
@@ -103,6 +105,11 @@ impl HashMapStorageProvider {
         self.amsterdam_eip8037_enabled = enabled;
         self.gas_params = GasParams::new_spec(self.spec.into());
         self
+    }
+
+    /// Returns gas explicitly deducted through [`PrecompileStorageProvider::deduct_gas`].
+    pub fn deducted_gas(&self) -> u64 {
+        self.deducted_gas
     }
 }
 
@@ -204,7 +211,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
             .unwrap_or(U256::ZERO))
     }
 
-    fn deduct_gas(&mut self, _gas: u64) -> Result<(), TempoPrecompileError> {
+    fn deduct_gas(&mut self, gas: u64) -> Result<(), TempoPrecompileError> {
+        self.deducted_gas = self
+            .deducted_gas
+            .checked_add(gas)
+            .ok_or(TempoPrecompileError::OutOfGas)?;
         Ok(())
     }
 

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -99,8 +99,6 @@ impl ZoneFactory {
         msg_sender: Address,
         call: IZoneFactory::createZoneCall,
     ) -> Result<IZoneFactory::createZoneReturn> {
-        self.storage.deduct_gas(ZONE_CREATION_GAS)?;
-
         if msg_sender != self.owner()? {
             return Err(ZoneFactoryError::not_owner().into());
         }
@@ -130,11 +128,16 @@ impl ZoneFactory {
         let token_symbol = token.symbol()?;
         let token_currency = token.currency()?;
 
-        self.next_zone_id.write(
-            zone_id
-                .checked_add(1)
-                .ok_or(TempoPrecompileError::under_overflow())?,
-        )?;
+        let next_zone_id = zone_id
+            .checked_add(1)
+            .ok_or(TempoPrecompileError::under_overflow())?;
+
+        // Only charge the fixed creation cost after all fallible read-only validation has passed.
+        // This remains before the first mutation, so an out-of-gas error cannot partially create
+        // a zone.
+        self.storage.deduct_gas(ZONE_CREATION_GAS)?;
+
+        self.next_zone_id.write(next_zone_id)?;
         // TIP-1091 deliberately etches the canonical runtime unconditionally. The 96-bit portal
         // prefix makes pre-existing state computationally infeasible to target with CREATE2.
         ZonePortalStorage::new(portal).initialize(zone_id, &call.params)?;
@@ -625,12 +628,17 @@ mod tests {
     }
 
     #[test]
-    fn owner_and_input_validation_revert_before_mutation() -> eyre::Result<()> {
+    fn create_zone_validates_before_charging_creation_gas() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
             TIP20Setup::path_usd(ADMIN).apply()?;
-            let mut factory = factory_with_owner(OWNER)?;
+            factory_with_owner(OWNER)?;
+            Ok(())
+        })?;
+        let gas_before_create = storage.deducted_gas();
 
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            let mut factory = ZoneFactory::new();
             let err = factory
                 .create_zone(
                     ADMIN,
@@ -645,7 +653,34 @@ mod tests {
             );
             assert_eq!(factory.next_zone_id()?, 1);
 
+            let mut params = create_params(PATH_USD_ADDRESS);
+            params.threshold = 0;
+            let err = factory
+                .create_zone(OWNER, IZoneFactory::createZoneCall { params })
+                .unwrap_err();
+            assert_eq!(
+                err,
+                TempoPrecompileError::from(ZoneFactoryError::invalid_sequencer_set())
+            );
+            assert_eq!(factory.next_zone_id()?, 1);
             Ok(())
-        })
+        })?;
+        assert_eq!(storage.deducted_gas(), gas_before_create);
+
+        StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+            let mut factory = ZoneFactory::new();
+            factory.create_zone(
+                OWNER,
+                IZoneFactory::createZoneCall {
+                    params: create_params(PATH_USD_ADDRESS),
+                },
+            )?;
+            Ok(())
+        })?;
+        assert_eq!(
+            storage.deducted_gas(),
+            gas_before_create + ZONE_CREATION_GAS
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
Fixes https://linear.app/tempoxyz/issue/SIGP-320

Moves the fixed 15M Zone creation charge after all fallible read-only validation and immediately before the first mutation. Invalid requests no longer pay the deployment floor, while successful creations retain it; regression coverage records explicit mock gas deductions for both paths.

Tests: `rustup run nightly cargo test -p tempo-precompiles --lib`; `rustup run nightly cargo clippy -p tempo-precompiles --lib -- -D warnings`; `rustup run nightly cargo fmt --all -- --check`.