### PR TITLE
test(contracts): verify ZonePortal bytecode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,20 @@ jobs:
             echo "Generated genesis matches test-genesis.json"
           fi
 
+  zone-portal-bytecode:
+    name: ZonePortal bytecode
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1.7.0
+      - name: Verify ZonePortal bytecode
+        run: ./scripts/verify-zone-portal-bytecode.sh
+
   test:
     name: test (${{ matrix.partition }}/2)
     needs: check-precompiles
@@ -289,6 +303,7 @@ jobs:
       - cli
       - msrv
       - genesis
+      - zone-portal-bytecode
     timeout-minutes: 30
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/crates/contracts/ZONES_REVISION
+++ b/crates/contracts/ZONES_REVISION
@@ -1,0 +1,1 @@
+199ff70fb80e2d91cdad58e6f395ab0ef6d702fa

--- a/crates/contracts/src/zones.rs
+++ b/crates/contracts/src/zones.rs
@@ -3,6 +3,9 @@
 use alloy_primitives::{Bytes, bytes};
 
 /// Canonical ZonePortal implementation deployed runtime.
+///
+/// Built from the Zones revision pinned in `../ZONES_REVISION`. Run
+/// `scripts/verify-zone-portal-bytecode.sh` to reproduce and verify it.
 pub const ZONE_PORTAL_RUNTIME: Bytes = bytes!(
     "0x60c0806040526004361015610012575f80fd5b5f60a0525f3560e01c9081625d97ef1461339857508062ebfdb41461330357806309a0a23414612fd45780630e18b68114612f395780630e86bbdc1461"
     "2eb25780630f3804b814612e3c57806310cea85714612df4578063129c824014612dbd5780631950dd1114612d985780631b32199b14612d725780632678224714612d4857806327c71b5014612cb757"

--- a/scripts/verify-zone-portal-bytecode.sh
+++ b/scripts/verify-zone-portal-bytecode.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+zones_revision="$(tr -d '[:space:]' < "$repo_root/crates/contracts/ZONES_REVISION")"
+workdir="$(mktemp -d)"
+anvil_log="$workdir/anvil.log"
+
+cleanup() {
+  if [[ -n "${anvil_pid:-}" ]]; then
+    kill "$anvil_pid" 2>/dev/null || true
+    wait "$anvil_pid" 2>/dev/null || true
+  fi
+  rm -rf "$workdir"
+}
+trap cleanup EXIT
+
+git clone --quiet https://github.com/tempoxyz/zones.git "$workdir/zones"
+git -C "$workdir/zones" checkout --quiet "$zones_revision"
+git -C "$workdir/zones" submodule update --init --recursive --quiet
+
+anvil --silent >"$anvil_log" 2>&1 &
+anvil_pid=$!
+rpc_url="http://127.0.0.1:8545"
+for _ in {1..50}; do
+  if cast block-number --rpc-url "$rpc_url" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+cast block-number --rpc-url "$rpc_url" >/dev/null
+
+deployment="$({
+  cd "$workdir/zones/specs/ref-impls"
+  forge create src/tempo/ZonePortal.sol:ZonePortal \
+    --broadcast \
+    --json \
+    --rpc-url "$rpc_url" \
+    --private-key ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+})"
+portal_address="$(jq -r '.deployedTo' <<<"$deployment")"
+local_runtime="$(cast code "$portal_address" --rpc-url "$rpc_url" | tr '[:upper:]' '[:lower:]')"
+tempo_runtime="$({
+  sed -n '/pub const ZONE_PORTAL_RUNTIME/,/^);/p' \
+    "$repo_root/crates/contracts/src/zones.rs" \
+    | grep -oE '"[0-9a-fx]+"' \
+    | tr -d '"\n'
+} | tr '[:upper:]' '[:lower:]')"
+
+without_metadata() {
+  local bytecode="${1#0x}"
+  local metadata_length=$((16#${bytecode: -4} + 2))
+  echo "0x${bytecode:0:${#bytecode} - metadata_length * 2}"
+}
+
+local_executable="$(without_metadata "$local_runtime")"
+tempo_executable="$(without_metadata "$tempo_runtime")"
+
+if [[ "$local_executable" != "$tempo_executable" ]]; then
+  echo "ZonePortal executable mismatch for zones@$zones_revision" >&2
+  echo "local: $(cast keccak "$local_executable")" >&2
+  echo "tempo: $(cast keccak "$tempo_executable")" >&2
+  exit 1
+fi
+
+echo "ZonePortal executable matches zones@$zones_revision ($(cast keccak "$tempo_executable"))"


### PR DESCRIPTION
Pins the Zones revision used for the embedded ZonePortal runtime and adds a CI check that deploys that source locally with Forge before comparing its executable runtime bytecode (excluding Solidity metadata).

Prompted by: @0xalpharush