### PR TITLE
fix(consensus): prevent feed head-of-line stalls

### DIFF
--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -9,9 +9,9 @@
 //! to become available, avoiding a race where the block hasn't been stored yet
 //! when the activity arrives.
 //!
-//! The actor always polls the oldest (lowest-round) pending subscription so
-//! that events are emitted in order. Notarizations are dropped when a finalization
-//!  at a higher-or-equal round is pending, since the finalization supersedes them.
+//! All pending subscriptions are polled concurrently so one unresolved block
+//! cannot prevent newer finalizations from advancing the feed. When a finalization
+//! resolves, pending activity at lower-or-equal rounds is discarded.
 
 use alloy_primitives::hex;
 use commonware_codec::Encode;
@@ -22,14 +22,12 @@ use commonware_consensus::{
 use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_macros::select;
 use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell};
-use commonware_utils::channel::oneshot;
+use commonware_utils::futures::{AbortablePool, Aborter};
 use eyre::eyre;
-use futures::{FutureExt, StreamExt};
+use futures::StreamExt;
 use std::{
     collections::BTreeMap,
     future::Future,
-    pin::Pin,
-    task::{Context, Poll},
     time::{SystemTime, UNIX_EPOCH},
 };
 use tempo_node::rpc::consensus::{CertifiedBlock, Event};
@@ -39,7 +37,6 @@ use super::state::FeedStateHandle;
 use crate::{
     alias::marshal,
     consensus::{Digest, block::Block},
-    utils::OptionFuture,
 };
 
 /// Type alias for the activity type used by the feed actor.
@@ -48,37 +45,108 @@ pub(super) type FeedActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 /// Receiver for activity messages.
 pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<FeedActivity>;
 
-/// A pending block subscription paired with its originating activity.
-///
-/// Resolves to `(Round, FeedActivity, Block)` when the block becomes available.
-struct PendingSubscription {
-    round: Round,
-    activity: Option<FeedActivity>,
-    block_rx: oneshot::Receiver<Block>,
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PendingKind {
+    Notarization,
+    Finalization,
 }
 
-impl PendingSubscription {
-    fn new(round: Round, activity: FeedActivity, block_rx: oneshot::Receiver<Block>) -> Self {
+struct PendingEntry {
+    id: u64,
+    kind: PendingKind,
+    _aborter: Aborter,
+}
+
+type Resolution<A, B> = (u64, Round, A, eyre::Result<B>);
+
+/// Concurrent block subscriptions indexed by their consensus round.
+///
+/// The index owns abort handles so superseded subscriptions can be cancelled
+/// while the pool yields whichever block resolution completes first.
+struct PendingSubscriptions<A, B> {
+    next_id: u64,
+    entries: BTreeMap<Round, PendingEntry>,
+    resolutions: AbortablePool<Resolution<A, B>>,
+}
+
+impl<A, B> Default for PendingSubscriptions<A, B>
+where
+    A: Send,
+    B: Send,
+{
+    fn default() -> Self {
         Self {
-            round,
-            activity: Some(activity),
-            block_rx,
+            next_id: 0,
+            entries: BTreeMap::new(),
+            resolutions: AbortablePool::default(),
         }
     }
 }
 
-impl Future for PendingSubscription {
-    type Output = eyre::Result<(Round, FeedActivity, Block)>;
+impl<A, B> PendingSubscriptions<A, B>
+where
+    A: Send + 'static,
+    B: Send + 'static,
+{
+    fn insert(
+        &mut self,
+        round: Round,
+        kind: PendingKind,
+        activity: A,
+        resolution: impl Future<Output = eyre::Result<B>> + Send + 'static,
+    ) {
+        let id = self.next_id;
+        self.next_id = self
+            .next_id
+            .checked_add(1)
+            .expect("subscription id overflow");
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.block_rx.poll_unpin(cx) {
-            Poll::Ready(Ok(block)) => {
-                let activity = self.activity.take().expect("polled after completion");
-                Poll::Ready(Ok((self.round, activity, block)))
+        let aborter = self.resolutions.push(async move {
+            let result = resolution.await;
+            (id, round, activity, result)
+        });
+
+        self.entries.insert(
+            round,
+            PendingEntry {
+                id,
+                kind,
+                _aborter: aborter,
+            },
+        );
+    }
+
+    /// Wait for the next current subscription to resolve.
+    ///
+    /// Completions from cancelled or replaced subscriptions are ignored.
+    async fn next_completed(&mut self) -> (Round, A, eyre::Result<B>) {
+        loop {
+            let Ok((id, round, activity, result)) = self.resolutions.next_completed().await else {
+                continue;
+            };
+
+            if self.entries.get(&round).is_none_or(|entry| entry.id != id) {
+                continue;
             }
-            Poll::Ready(Err(_)) => Poll::Ready(Err(eyre::eyre!("block subscription cancelled"))),
-            Poll::Pending => Poll::Pending,
+
+            self.entries.remove(&round);
+            return (round, activity, result);
         }
+    }
+
+    fn retain(&mut self, mut predicate: impl FnMut(Round, PendingKind) -> bool) {
+        self.entries
+            .retain(|&round, entry| predicate(round, entry.kind));
+    }
+
+    fn remove_through(&mut self, round: Round) {
+        self.entries
+            .retain(|&pending_round, _| pending_round > round);
+    }
+
+    #[cfg(test)]
+    fn is_empty(&self) -> bool {
+        self.entries.is_empty()
     }
 }
 
@@ -91,9 +159,8 @@ pub(crate) struct Actor<TContext> {
     state: FeedStateHandle,
     /// Marshal mailbox for block lookups.
     marshal: marshal::Mailbox,
-    /// Pending block subscriptions keyed by round. Since finalizations
-    /// must be delivered, pending subscriptions are bound by the marshal.
-    pending: BTreeMap<Round, PendingSubscription>,
+    /// Pending block subscriptions polled concurrently.
+    pending: PendingSubscriptions<FeedActivity, Block>,
 }
 
 impl<TContext: Spawner> Actor<TContext> {
@@ -113,7 +180,7 @@ impl<TContext: Spawner> Actor<TContext> {
             receiver,
             state,
             marshal,
-            pending: BTreeMap::new(),
+            pending: PendingSubscriptions::default(),
         }
     }
 
@@ -123,19 +190,19 @@ impl<TContext: Spawner> Actor<TContext> {
     }
 
     /// Run the actor's main loop.
-    ///
-    /// The loop races the oldest pending block subscription
-    /// against incoming activity so events are emitted in order.
     async fn run(mut self) {
         let reason = loop {
-            // We need a mutable reference to poll pending subscription. Thus if a new activity arrives,
-            // we also need to re-insert this popped subscription.
-            let mut oldest = OptionFuture::from(self.pending.pop_first().map(|(_, p)| p));
-
             select!(
-                result = &mut oldest => {
+                (round, activity, result) = self.pending.next_completed() => {
                     match result {
-                        Ok((_, activity, block)) => self.handle_activity(activity, block),
+                        Ok(block) => {
+                            let is_finalization = matches!(&activity, Activity::Finalization(_));
+                            self.handle_activity(activity, block);
+
+                            if is_finalization {
+                                self.pending.remove_through(round);
+                            }
+                        }
                         Err(error) => warn_span!("feed_actor").in_scope(||
                             warn!(%error, "did not get pending block")
                         ),
@@ -147,10 +214,7 @@ impl<TContext: Spawner> Actor<TContext> {
                         break eyre!("mailbox closed");
                     };
 
-                    if let Some(p) = oldest.take() {
-                        self.pending.insert(p.round, p);
-                    }
-                    self.subscribe(activity).await;
+                    self.subscribe(activity);
                 },
             );
         };
@@ -158,20 +222,29 @@ impl<TContext: Spawner> Actor<TContext> {
         info_span!("feed_actor").in_scope(|| error!(%reason, "shutting down"));
     }
 
-    async fn subscribe(&mut self, activity: FeedActivity) {
-        let (round, payload) = match &activity {
-            Activity::Notarization(n) => (n.proposal.round, n.proposal.payload),
-            Activity::Finalization(f) => (f.proposal.round, f.proposal.payload),
+    fn subscribe(&mut self, activity: FeedActivity) {
+        let (round, payload, kind) = match &activity {
+            Activity::Notarization(n) => (
+                n.proposal.round,
+                n.proposal.payload,
+                PendingKind::Notarization,
+            ),
+            Activity::Finalization(f) => (
+                f.proposal.round,
+                f.proposal.payload,
+                PendingKind::Finalization,
+            ),
             _ => return,
         };
 
         // Prune & filter incoming activity.
-        // - Incoming Finalization. Prune older subscriptions as we only care about latest information
+        // - Incoming Finalization. Prune older notarizations; resolved finalizations prune
+        //   all lower-or-equal pending activity.
         // - Incoming Notarization. Only accept if ahead of the latest Finalization.
         match &activity {
-            Activity::Finalization(_) => self.pending.retain(|&r, p| {
-                matches!(&p.activity, Some(Activity::Finalization(_))) || r > round
-            }),
+            Activity::Finalization(_) => self
+                .pending
+                .retain(|r, kind| matches!(kind, PendingKind::Finalization) || r > round),
             Activity::Notarization(_)
                 if self
                     .state
@@ -184,9 +257,13 @@ impl<TContext: Spawner> Actor<TContext> {
             _ => return,
         }
 
-        let block_rx = self.marshal.subscribe_by_digest(Some(round), payload).await;
-        let pending = PendingSubscription::new(round, activity, block_rx);
-        self.pending.insert(round, pending);
+        let marshal = self.marshal.clone();
+        self.pending.insert(round, kind, activity, async move {
+            let block_rx = marshal.subscribe_by_digest(Some(round), payload).await;
+            block_rx
+                .await
+                .map_err(|_| eyre!("block subscription cancelled"))
+        });
     }
 
     #[instrument(skip_all, fields(activity = ?activity))]
@@ -273,4 +350,49 @@ fn now_millis() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{channel::oneshot, executor::block_on};
+
+    #[test]
+    fn newer_subscription_completes_while_oldest_is_unresolved() {
+        block_on(async {
+            let older_round = Round::new(Epoch::new(1), View::new(10));
+            let newer_round = Round::new(Epoch::new(1), View::new(11));
+            let (older_tx, older_rx) = oneshot::channel::<u64>();
+            let (newer_tx, newer_rx) = oneshot::channel::<u64>();
+            let mut pending = PendingSubscriptions::default();
+
+            // Keep the older sender alive without delivering a block to reproduce
+            // a marshal subscription that never completes.
+            pending.insert(
+                older_round,
+                PendingKind::Finalization,
+                "older",
+                async move { older_rx.await.map_err(eyre::Report::new) },
+            );
+            pending.insert(
+                newer_round,
+                PendingKind::Finalization,
+                "newer",
+                async move { newer_rx.await.map_err(eyre::Report::new) },
+            );
+
+            newer_tx.send(11).unwrap();
+            let (round, activity, block) = pending.next_completed().await;
+
+            assert_eq!(round, newer_round);
+            assert_eq!(activity, "newer");
+            assert_eq!(block.unwrap(), 11);
+
+            pending.remove_through(round);
+            assert!(pending.is_empty());
+
+            drop(pending);
+            assert!(older_tx.send(10).is_err());
+        });
+    }
 }

--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -45,26 +45,32 @@ pub(super) type FeedActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 /// Receiver for activity messages.
 pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<FeedActivity>;
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy)]
 enum PendingKind {
     Notarization,
     Finalization,
 }
 
 struct PendingEntry {
-    id: u64,
+    generation: u64,
     kind: PendingKind,
-    _aborter: Aborter,
+    /// Dropping this handle cancels the corresponding in-flight block resolution.
+    _cancel_on_drop: Aborter,
 }
 
-type Resolution<A, B> = (u64, Round, A, eyre::Result<B>);
+struct Resolution<A, B> {
+    generation: u64,
+    round: Round,
+    activity: A,
+    block: eyre::Result<B>,
+}
 
 /// Concurrent block subscriptions indexed by their consensus round.
 ///
 /// The index owns abort handles so superseded subscriptions can be cancelled
 /// while the pool yields whichever block resolution completes first.
 struct PendingSubscriptions<A, B> {
-    next_id: u64,
+    next_generation: u64,
     entries: BTreeMap<Round, PendingEntry>,
     resolutions: AbortablePool<Resolution<A, B>>,
 }
@@ -76,7 +82,7 @@ where
 {
     fn default() -> Self {
         Self {
-            next_id: 0,
+            next_generation: 0,
             entries: BTreeMap::new(),
             resolutions: AbortablePool::default(),
         }
@@ -95,23 +101,28 @@ where
         activity: A,
         resolution: impl Future<Output = eyre::Result<B>> + Send + 'static,
     ) {
-        let id = self.next_id;
-        self.next_id = self
-            .next_id
+        let generation = self.next_generation;
+        self.next_generation = self
+            .next_generation
             .checked_add(1)
-            .expect("subscription id overflow");
+            .expect("subscription generation overflow");
 
         let aborter = self.resolutions.push(async move {
-            let result = resolution.await;
-            (id, round, activity, result)
+            let block = resolution.await;
+            Resolution {
+                generation,
+                round,
+                activity,
+                block,
+            }
         });
 
         self.entries.insert(
             round,
             PendingEntry {
-                id,
+                generation,
                 kind,
-                _aborter: aborter,
+                _cancel_on_drop: aborter,
             },
         );
     }
@@ -121,16 +132,20 @@ where
     /// Completions from cancelled or replaced subscriptions are ignored.
     async fn next_completed(&mut self) -> (Round, A, eyre::Result<B>) {
         loop {
-            let Ok((id, round, activity, result)) = self.resolutions.next_completed().await else {
+            let Ok(resolution) = self.resolutions.next_completed().await else {
                 continue;
             };
 
-            if self.entries.get(&round).is_none_or(|entry| entry.id != id) {
+            if self
+                .entries
+                .get(&resolution.round)
+                .is_none_or(|entry| entry.generation != resolution.generation)
+            {
                 continue;
             }
 
-            self.entries.remove(&round);
-            return (round, activity, result);
+            self.entries.remove(&resolution.round);
+            return (resolution.round, resolution.activity, resolution.block);
         }
     }
 

--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -11,7 +11,8 @@
 //!
 //! All pending subscriptions are polled concurrently so one unresolved block
 //! cannot prevent newer finalizations from advancing the feed. When a finalization
-//! resolves, pending activity at lower-or-equal rounds is discarded.
+//! resolves, pending activity at lower-or-equal rounds is discarded. A resolved
+//! notarization discards only lower-or-equal notarizations.
 
 use alloy_primitives::hex;
 use commonware_codec::Encode;
@@ -45,7 +46,7 @@ pub(super) type FeedActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 /// Receiver for activity messages.
 pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<FeedActivity>;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum PendingKind {
     Notarization,
     Finalization,
@@ -100,7 +101,28 @@ where
         kind: PendingKind,
         activity: A,
         resolution: impl Future<Output = eyre::Result<B>> + Send + 'static,
-    ) {
+    ) -> bool {
+        // Do not restart an identical pending subscription. A finalization
+        // supersedes a notarization at the same round, but never the reverse.
+        if self
+            .entries
+            .get(&round)
+            .is_some_and(|entry| entry.kind == kind || entry.kind == PendingKind::Finalization)
+        {
+            return false;
+        }
+
+        // A pending finalization supersedes notarizations at lower-or-equal
+        // rounds even when those notarizations arrive later.
+        if kind == PendingKind::Notarization
+            && self
+                .entries
+                .range(round..)
+                .any(|(_, entry)| entry.kind == PendingKind::Finalization)
+        {
+            return false;
+        }
+
         let generation = self.next_generation;
         self.next_generation = self
             .next_generation
@@ -125,6 +147,7 @@ where
                 _cancel_on_drop: aborter,
             },
         );
+        true
     }
 
     /// Wait for the next current subscription to resolve.
@@ -149,20 +172,33 @@ where
         }
     }
 
-    fn retain(&mut self, mut predicate: impl FnMut(Round, PendingKind) -> bool) {
-        self.entries
-            .retain(|&round, entry| predicate(round, entry.kind));
-    }
-
     fn remove_through(&mut self, round: Round) {
         self.entries
             .retain(|&pending_round, _| pending_round > round);
+    }
+
+    fn remove_notarizations_through(&mut self, round: Round) {
+        self.entries.retain(|&pending_round, entry| {
+            entry.kind == PendingKind::Finalization || pending_round > round
+        });
     }
 
     #[cfg(test)]
     fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
+}
+
+/// Returns whether an activity can still advance the published feed state.
+fn can_advance_state(
+    kind: PendingKind,
+    round: Round,
+    latest_finalized: Option<Round>,
+    latest_notarized: Option<Round>,
+) -> bool {
+    latest_finalized.is_none_or(|latest| round > latest)
+        && (kind == PendingKind::Finalization
+            || latest_notarized.is_none_or(|latest| round > latest))
 }
 
 pub(crate) struct Actor<TContext> {
@@ -216,6 +252,8 @@ impl<TContext: Spawner> Actor<TContext> {
 
                             if is_finalization {
                                 self.pending.remove_through(round);
+                            } else {
+                                self.pending.remove_notarizations_through(round);
                             }
                         }
                         Err(error) => warn_span!("feed_actor").in_scope(||
@@ -252,24 +290,29 @@ impl<TContext: Spawner> Actor<TContext> {
             _ => return,
         };
 
+        let (latest_finalized, latest_notarized) = {
+            let state = self.state.read();
+            let round =
+                |block: &CertifiedBlock| Round::new(Epoch::new(block.epoch), View::new(block.view));
+            (
+                state.latest_finalized.as_ref().map(round),
+                state.latest_notarized.as_ref().map(round),
+            )
+        };
+
+        // A stale activity can never update state or emit an event. Avoid
+        // registering a marshal subscription that may remain unresolved.
+        if !can_advance_state(kind, round, latest_finalized, latest_notarized) {
+            return;
+        }
+
         // Prune & filter incoming activity.
         // - Incoming Finalization. Prune older notarizations; resolved finalizations prune
         //   all lower-or-equal pending activity.
-        // - Incoming Notarization. Only accept if ahead of the latest Finalization.
-        match &activity {
-            Activity::Finalization(_) => self
-                .pending
-                .retain(|r, kind| matches!(kind, PendingKind::Finalization) || r > round),
-            Activity::Notarization(_)
-                if self
-                    .state
-                    .read()
-                    .latest_finalized
-                    .as_ref()
-                    .map(|f| Round::new(Epoch::new(f.epoch), View::new(f.view)))
-                    .is_none_or(|f| f < round) => {}
-
-            _ => return,
+        // - Incoming Notarization. PendingSubscriptions rejects it if a higher-or-equal
+        //   finalization is already pending.
+        if kind == PendingKind::Finalization {
+            self.pending.remove_notarizations_through(round);
         }
 
         let marshal = self.marshal.clone();
@@ -370,7 +413,7 @@ fn now_millis() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{channel::oneshot, executor::block_on};
+    use futures::{FutureExt, channel::oneshot, executor::block_on, pin_mut};
 
     #[test]
     fn newer_subscription_completes_while_oldest_is_unresolved() {
@@ -383,22 +426,30 @@ mod tests {
 
             // Keep the older sender alive without delivering a block to reproduce
             // a marshal subscription that never completes.
-            pending.insert(
+            assert!(pending.insert(
                 older_round,
                 PendingKind::Finalization,
                 "older",
                 async move { older_rx.await.map_err(eyre::Report::new) },
-            );
-            pending.insert(
+            ));
+            assert!(pending.insert(
                 newer_round,
                 PendingKind::Finalization,
                 "newer",
                 async move { newer_rx.await.map_err(eyre::Report::new) },
-            );
+            ));
 
-            newer_tx.send(11).unwrap();
-            let (round, activity, block) = pending.next_completed().await;
+            // Arm both resolutions while the oldest remains unresolved, then
+            // make only the newer block available.
+            let completed = {
+                let next = pending.next_completed();
+                pin_mut!(next);
+                assert!(futures::poll!(next.as_mut()).is_pending());
 
+                newer_tx.send(11).unwrap();
+                next.await
+            };
+            let (round, activity, block) = completed;
             assert_eq!(round, newer_round);
             assert_eq!(activity, "newer");
             assert_eq!(block.unwrap(), 11);
@@ -406,8 +457,150 @@ mod tests {
             pending.remove_through(round);
             assert!(pending.is_empty());
 
-            drop(pending);
+            // The actor polls the pool before accepting more activity, which
+            // drains the aborted resolution and drops its marshal receiver.
+            assert!(pending.next_completed().now_or_never().is_none());
             assert!(older_tx.send(10).is_err());
         });
+    }
+
+    #[test]
+    fn pending_finalization_cannot_be_replaced_by_notarization() {
+        block_on(async {
+            let earlier_round = Round::new(Epoch::new(1), View::new(9));
+            let round = Round::new(Epoch::new(1), View::new(10));
+            let later_round = Round::new(Epoch::new(1), View::new(11));
+            let (finalization_tx, finalization_rx) = oneshot::channel::<u64>();
+            let (same_round_tx, same_round_rx) = oneshot::channel::<u64>();
+            let (earlier_tx, earlier_rx) = oneshot::channel::<u64>();
+            let (later_tx, later_rx) = oneshot::channel::<u64>();
+            let mut pending = PendingSubscriptions::default();
+
+            assert!(pending.insert(
+                round,
+                PendingKind::Finalization,
+                "finalization",
+                async move { finalization_rx.await.map_err(eyre::Report::new) },
+            ));
+            assert!(!pending.insert(
+                round,
+                PendingKind::Notarization,
+                "same-round notarization",
+                async move { same_round_rx.await.map_err(eyre::Report::new) },
+            ));
+            assert!(!pending.insert(
+                earlier_round,
+                PendingKind::Notarization,
+                "earlier notarization",
+                async move { earlier_rx.await.map_err(eyre::Report::new) },
+            ));
+            assert!(pending.insert(
+                later_round,
+                PendingKind::Notarization,
+                "later notarization",
+                async move { later_rx.await.map_err(eyre::Report::new) },
+            ));
+
+            assert!(same_round_tx.send(10).is_err());
+            assert!(earlier_tx.send(9).is_err());
+
+            later_tx.send(11).unwrap();
+            let (completed_round, activity, block) = pending.next_completed().await;
+            assert_eq!(completed_round, later_round);
+            assert_eq!(activity, "later notarization");
+            assert_eq!(block.unwrap(), 11);
+
+            finalization_tx.send(10).unwrap();
+            let (completed_round, activity, block) = pending.next_completed().await;
+            assert_eq!(completed_round, round);
+            assert_eq!(activity, "finalization");
+            assert_eq!(block.unwrap(), 10);
+        });
+    }
+
+    #[test]
+    fn newer_notarization_cancels_only_superseded_notarizations() {
+        block_on(async {
+            let finalization_round = Round::new(Epoch::new(1), View::new(9));
+            let older_round = Round::new(Epoch::new(1), View::new(10));
+            let newer_round = Round::new(Epoch::new(1), View::new(11));
+            let (finalization_tx, finalization_rx) = oneshot::channel::<u64>();
+            let (older_tx, older_rx) = oneshot::channel::<u64>();
+            let (newer_tx, newer_rx) = oneshot::channel::<u64>();
+            let mut pending = PendingSubscriptions::default();
+
+            assert!(pending.insert(
+                finalization_round,
+                PendingKind::Finalization,
+                "finalization",
+                async move { finalization_rx.await.map_err(eyre::Report::new) },
+            ));
+            assert!(pending.insert(
+                older_round,
+                PendingKind::Notarization,
+                "older notarization",
+                async move { older_rx.await.map_err(eyre::Report::new) },
+            ));
+            assert!(pending.insert(
+                newer_round,
+                PendingKind::Notarization,
+                "newer notarization",
+                async move { newer_rx.await.map_err(eyre::Report::new) },
+            ));
+
+            newer_tx.send(11).unwrap();
+            let (completed_round, activity, block) = pending.next_completed().await;
+            assert_eq!(completed_round, newer_round);
+            assert_eq!(activity, "newer notarization");
+            assert_eq!(block.unwrap(), 11);
+
+            pending.remove_notarizations_through(completed_round);
+            assert!(pending.next_completed().now_or_never().is_none());
+            assert!(older_tx.send(10).is_err());
+
+            finalization_tx.send(9).unwrap();
+            let (completed_round, activity, block) = pending.next_completed().await;
+            assert_eq!(completed_round, finalization_round);
+            assert_eq!(activity, "finalization");
+            assert_eq!(block.unwrap(), 9);
+        });
+    }
+
+    #[test]
+    fn stale_activity_cannot_advance_state() {
+        let round_10 = Round::new(Epoch::new(1), View::new(10));
+        let round_11 = Round::new(Epoch::new(1), View::new(11));
+        let round_12 = Round::new(Epoch::new(1), View::new(12));
+
+        assert!(!can_advance_state(
+            PendingKind::Finalization,
+            round_10,
+            Some(round_10),
+            None,
+        ));
+        assert!(can_advance_state(
+            PendingKind::Finalization,
+            round_11,
+            Some(round_10),
+            Some(round_12),
+        ));
+        assert!(!can_advance_state(
+            PendingKind::Notarization,
+            round_11,
+            Some(round_10),
+            Some(round_11),
+        ));
+        assert!(!can_advance_state(
+            PendingKind::Notarization,
+            round_11,
+            Some(round_11),
+            None,
+        ));
+        assert!(can_advance_state(
+            PendingKind::Notarization,
+            round_12,
+            Some(round_10),
+            Some(round_11),
+        ));
     }
 }


### PR DESCRIPTION
Prevents one unresolved marshal block subscription from head-of-line blocking later consensus feed finalizations. Block subscriptions now resolve concurrently, and a completed finalization cancels lower-or-equal pending activity so followers can advance without a timer-based scan. Adds a deterministic regression for an unresolved oldest subscription and a newer available block.