### PR TITLE
fix(transaction-pool): classify keychain cardinality errors

### DIFF
--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -691,9 +691,9 @@ impl PoolTransactionError for TempoPoolTransactionError {
             | Self::InvalidValidBefore { .. }
             | Self::InvalidValidAfter { .. }
             | Self::AccessKeyExpired { .. }
-            | Self::KeyAuthorizationExpired { .. }
-            | Self::Keychain(_) => false,
+            | Self::KeyAuthorizationExpired { .. } => false,
             Self::SubblockNonceKey
+            | Self::Keychain(_)
             | Self::TooManyAuthorizations { .. }
             | Self::TooManyCalls { .. }
             | Self::CallInputTooLarge { .. }
@@ -1156,7 +1156,7 @@ mod tests {
                 },
                 false,
             ),
-            (TempoPoolTransactionError::Keychain("test error"), false),
+            (TempoPoolTransactionError::Keychain("test error"), true),
             (
                 TempoPoolTransactionError::Evm(TempoInvalidTransaction::NonceManagerError(
                     "nonce error".to_string(),

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -491,6 +491,29 @@ impl TempoPooledTransaction {
     }
 }
 
+/// Keychain-specific transaction pool rejection reasons.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum KeychainError {
+    /// A key authorization contains too many call scopes.
+    #[error("too many call scopes in key authorization")]
+    TooManyCallScopes,
+    /// A call scope contains too many selector rules.
+    #[error("too many selector rules in call scope")]
+    TooManySelectorRules,
+    /// A selector rule contains too many recipients.
+    #[error("too many recipients in selector rule")]
+    TooManyRecipients,
+}
+
+impl KeychainError {
+    /// Returns whether the error warrants peer penalization.
+    const fn is_bad_transaction(&self) -> bool {
+        match self {
+            Self::TooManyCallScopes | Self::TooManySelectorRules | Self::TooManyRecipients => true,
+        }
+    }
+}
+
 /// Tempo-specific transaction pool rejection reasons.
 ///
 /// These errors can be returned by RPC after transaction submission when the
@@ -536,12 +559,11 @@ pub enum TempoPoolTransactionError {
     /// A pool-only keychain authorization limit failed.
     ///
     /// Thrown during AA field-limit validation for key authorizations whose call
-    /// scopes, selector rules, or selector recipients exceed pool DoS limits. The
-    /// static string identifies the specific exceeded limit.
+    /// scopes, selector rules, or selector recipients exceed pool DoS limits.
     #[error(
         "Keychain signature validation failed: {0}, please see https://docs.tempo.xyz/errors/tx/Keychain for more"
     )]
-    Keychain(&'static str),
+    Keychain(#[from] KeychainError),
 
     /// A pool transaction attempted to use the subblock nonce-key prefix.
     ///
@@ -687,13 +709,13 @@ impl PoolTransactionError for TempoPoolTransactionError {
     fn is_bad_transaction(&self) -> bool {
         match self {
             Self::Evm(err) => err.is_bad_transaction(),
+            Self::Keychain(err) => err.is_bad_transaction(),
             Self::ExceedsNonPaymentLimit
             | Self::InvalidValidBefore { .. }
             | Self::InvalidValidAfter { .. }
             | Self::AccessKeyExpired { .. }
             | Self::KeyAuthorizationExpired { .. } => false,
             Self::SubblockNonceKey
-            | Self::Keychain(_)
             | Self::TooManyAuthorizations { .. }
             | Self::TooManyCalls { .. }
             | Self::CallInputTooLarge { .. }
@@ -1156,7 +1178,18 @@ mod tests {
                 },
                 false,
             ),
-            (TempoPoolTransactionError::Keychain("test error"), true),
+            (
+                TempoPoolTransactionError::Keychain(KeychainError::TooManyCallScopes),
+                true,
+            ),
+            (
+                TempoPoolTransactionError::Keychain(KeychainError::TooManySelectorRules),
+                true,
+            ),
+            (
+                TempoPoolTransactionError::Keychain(KeychainError::TooManyRecipients),
+                true,
+            ),
             (
                 TempoPoolTransactionError::Evm(TempoInvalidTransaction::NonceManagerError(
                     "nonce error".to_string(),

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -822,7 +822,7 @@ mod tests {
     use tempo_primitives::{
         Block, TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType,
         transaction::{
-            TempoTransaction,
+            CallScope, KeyAuthorization, SelectorRule, SignatureType, TempoTransaction,
             envelope::TEMPO_SYSTEM_TX_SIGNATURE,
             tempo_transaction::Call,
             tt_signature::{PrimitiveSignature, TempoSignature},
@@ -2726,6 +2726,60 @@ mod tests {
             is_paused.unwrap(),
             "Paused validator token should be detected by is_fee_token_paused BEFORE reaching has_enough_liquidity"
         );
+    }
+
+    #[test]
+    fn test_keychain_cardinality_limits_are_bad_transactions() {
+        use reth_transaction_pool::error::PoolTransactionError;
+
+        let cases = [
+            (
+                MAX_KEYCHAIN_CALL_SCOPES as usize + 1,
+                1,
+                0,
+                "too many call scopes in key authorization",
+            ),
+            (
+                1,
+                MAX_KEYCHAIN_SELECTOR_RULES_PER_SCOPE as usize + 1,
+                0,
+                "too many selector rules in call scope",
+            ),
+            (
+                1,
+                1,
+                MAX_KEYCHAIN_RECIPIENTS_PER_SELECTOR as usize + 1,
+                "too many recipients in selector rule",
+            ),
+        ];
+
+        for (scope_count, rule_count, recipient_count, expected_message) in cases {
+            let rule = SelectorRule {
+                selector: [0; 4],
+                recipients: vec![Address::random(); recipient_count],
+            };
+            let scope = CallScope {
+                target: Address::random(),
+                selector_rules: vec![rule; rule_count],
+            };
+            let key_authorization =
+                KeyAuthorization::unrestricted(42431, SignatureType::Secp256k1, Address::random())
+                    .with_allowed_calls(vec![scope; scope_count])
+                    .into_signed(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+            let transaction = TxBuilder::aa(Address::random())
+                .key_authorization(key_authorization)
+                .build();
+            let validator = setup_validator(&transaction, 0);
+
+            let err = validator
+                .ensure_aa_field_limits(&transaction)
+                .expect_err("over-limit key authorization must be rejected");
+            assert!(
+                matches!(&err, TempoPoolTransactionError::Keychain(message) if *message == expected_message),
+                "unexpected keychain cardinality error: {err}"
+            );
+            assert!(err.is_bad_transaction());
+        }
     }
 
     #[tokio::test]

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1,7 +1,7 @@
 use crate::{
     amm::AmmLiquidityCache,
     state_cache::{StateCache, StateCacheDb},
-    transaction::{TempoPoolTransactionError, TempoPooledTransaction},
+    transaction::{KeychainError, TempoPoolTransactionError, TempoPooledTransaction},
 };
 
 use alloy_consensus::constants::KECCAK_EMPTY;
@@ -306,23 +306,17 @@ where
 
             if let Some(scopes) = &key_auth.allowed_calls {
                 if scopes.len() > MAX_KEYCHAIN_CALL_SCOPES as usize {
-                    return Err(TempoPoolTransactionError::Keychain(
-                        "too many call scopes in key authorization",
-                    ));
+                    return Err(KeychainError::TooManyCallScopes.into());
                 }
 
                 for scope in scopes {
                     if scope.selector_rules.len() > MAX_KEYCHAIN_SELECTOR_RULES_PER_SCOPE as usize {
-                        return Err(TempoPoolTransactionError::Keychain(
-                            "too many selector rules in call scope",
-                        ));
+                        return Err(KeychainError::TooManySelectorRules.into());
                     }
 
                     for rule in &scope.selector_rules {
                         if rule.recipients.len() > MAX_KEYCHAIN_RECIPIENTS_PER_SELECTOR as usize {
-                            return Err(TempoPoolTransactionError::Keychain(
-                                "too many recipients in selector rule",
-                            ));
+                            return Err(KeychainError::TooManyRecipients.into());
                         }
                     }
                 }
@@ -2737,23 +2731,26 @@ mod tests {
                 MAX_KEYCHAIN_CALL_SCOPES as usize + 1,
                 1,
                 0,
+                KeychainError::TooManyCallScopes,
                 "too many call scopes in key authorization",
             ),
             (
                 1,
                 MAX_KEYCHAIN_SELECTOR_RULES_PER_SCOPE as usize + 1,
                 0,
+                KeychainError::TooManySelectorRules,
                 "too many selector rules in call scope",
             ),
             (
                 1,
                 1,
                 MAX_KEYCHAIN_RECIPIENTS_PER_SELECTOR as usize + 1,
+                KeychainError::TooManyRecipients,
                 "too many recipients in selector rule",
             ),
         ];
 
-        for (scope_count, rule_count, recipient_count, expected_message) in cases {
+        for (scope_count, rule_count, recipient_count, expected_error, expected_message) in cases {
             let rule = SelectorRule {
                 selector: [0; 4],
                 recipients: vec![Address::random(); recipient_count],
@@ -2774,10 +2771,11 @@ mod tests {
             let err = validator
                 .ensure_aa_field_limits(&transaction)
                 .expect_err("over-limit key authorization must be rejected");
-            assert!(
-                matches!(&err, TempoPoolTransactionError::Keychain(message) if *message == expected_message),
-                "unexpected keychain cardinality error: {err}"
-            );
+            let TempoPoolTransactionError::Keychain(keychain_error) = &err else {
+                panic!("unexpected keychain cardinality error: {err}");
+            };
+            assert_eq!(keychain_error, &expected_error);
+            assert_eq!(keychain_error.to_string(), expected_message);
             assert!(err.is_bad_transaction());
         }
     }


### PR DESCRIPTION
Builds on #6885 by @ArshLabs and preserves their original commit.

Classifies oversized key authorization cardinality failures as bad transactions so peers are penalized and repeated hashes are cached. Replaces stringly typed keychain errors with an exhaustive enum, keeping existing messages while making peer-penalty behavior explicit per variant.