### PR TITLE
fix(consensus): more reliable finalized block RPC delivery

### DIFF
--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -274,7 +274,6 @@ where
                 mailbox_size: self.mailbox_size,
                 subblocks: subblocks.as_ref().map(|s| s.mailbox()),
                 marshal: marshal_mailbox.clone(),
-                feed: feed_mailbox.clone(),
                 scheme_provider: scheme_provider.clone(),
                 time_to_collect_notarizations: self.time_to_collect_notarizations,
                 time_to_retry_nullify_broadcast: self.time_to_retry_nullify_broadcast,
@@ -326,6 +325,7 @@ where
             peer_manager_mailbox,
 
             feed,
+            feed_mailbox,
 
             subblocks,
         })
@@ -381,6 +381,7 @@ where
     peer_manager_mailbox: peer_manager::Mailbox,
 
     feed: crate::feed::Actor<TContext>,
+    feed_mailbox: crate::feed::Mailbox,
 
     subblocks: Option<subblocks::Actor<TContext>>,
 }
@@ -498,7 +499,10 @@ where
                 self.epoch_manager_mailbox,
                 Reporters::from((
                     self.executor_mailbox,
-                    Reporters::from((self.dkg_manager_mailbox.clone(), self.peer_manager_mailbox)),
+                    Reporters::from((
+                        self.dkg_manager_mailbox.clone(),
+                        Reporters::from((self.peer_manager_mailbox, self.feed_mailbox)),
+                    )),
                 )),
             )),
             self.broadcast_mailbox,

--- a/crates/consensus/src/epoch/manager/actor.rs
+++ b/crates/consensus/src/epoch/manager/actor.rs
@@ -338,7 +338,7 @@ where
                 relay: self.config.application.clone(),
                 reporter: Reporters::<_, crate::subblocks::Mailbox, _>::from((
                     self.config.subblocks.clone(),
-                    Reporters::from((self.config.marshal.clone(), self.config.feed.clone())),
+                    self.config.marshal.clone(),
                 )),
                 partition: format!(
                     "{partition_prefix}_consensus_epoch_{epoch}",

--- a/crates/consensus/src/epoch/manager/mod.rs
+++ b/crates/consensus/src/epoch/manager/mod.rs
@@ -14,7 +14,7 @@ use commonware_runtime::{
 };
 use rand_08::{CryptoRng, Rng};
 
-use crate::{epoch::scheme_provider::SchemeProvider, feed, subblocks};
+use crate::{epoch::scheme_provider::SchemeProvider, subblocks};
 
 pub(crate) struct Config<TBlocker> {
     pub(crate) application: crate::consensus::application::Mailbox,
@@ -26,7 +26,6 @@ pub(crate) struct Config<TBlocker> {
     pub(crate) mailbox_size: usize,
     pub(crate) subblocks: Option<subblocks::Mailbox>,
     pub(crate) marshal: crate::alias::marshal::Mailbox,
-    pub(crate) feed: feed::Mailbox,
     pub(crate) scheme_provider: SchemeProvider,
     pub(crate) time_to_collect_notarizations: Duration,
     pub(crate) time_to_retry_nullify_broadcast: Duration,

--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -1,105 +1,37 @@
 //! Feed actor implementation.
 //!
-//! This actor:
-//! - Receives consensus activity (notarizations, finalizations)
-//! - Updates shared state (accessible by RPC handlers)
-//! - Broadcasts events to subscribers
-//!
-//! Block resolution uses [`marshal::Mailbox::subscribe_by_digest`] to wait for the block
-//! to become available, avoiding a race where the block hasn't been stored yet
-//! when the activity arrives.
-//!
-//! The actor always polls the oldest (lowest-round) pending subscription so
-//! that events are emitted in order. Notarizations are dropped when a finalization
-//!  at a higher-or-equal round is pending, since the finalization supersedes them.
+//! The actor receives finalized blocks from marshal, publishes those with a
+//! direct finalization certificate, updates the shared RPC state, and
+//! broadcasts them to subscribers.
 
 use alloy_primitives::hex;
 use commonware_codec::Encode;
-use commonware_consensus::{
-    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
-    types::{Epoch, Round, View},
-};
-use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
-use commonware_macros::select;
+use commonware_consensus::Heightable as _;
 use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell};
-use commonware_utils::channel::oneshot;
-use eyre::eyre;
-use futures::{FutureExt, StreamExt};
-use std::{
-    collections::BTreeMap,
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-    time::{SystemTime, UNIX_EPOCH},
-};
+use futures::StreamExt;
+use std::time::{SystemTime, UNIX_EPOCH};
 use tempo_node::rpc::consensus::{CertifiedBlock, Event};
-use tracing::{debug, error, info_span, instrument, warn, warn_span};
+use tracing::{debug, error, info_span, instrument};
 
 use super::state::FeedStateHandle;
-use crate::{
-    alias::marshal,
-    consensus::{Digest, block::Block},
-    utils::OptionFuture,
-};
+use crate::{alias::marshal, consensus::block::Block};
 
-/// Type alias for the activity type used by the feed actor.
-pub(super) type FeedActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
-
-/// Receiver for activity messages.
-pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<FeedActivity>;
-
-/// A pending block subscription paired with its originating activity.
-///
-/// Resolves to `(Round, FeedActivity, Block)` when the block becomes available.
-struct PendingSubscription {
-    round: Round,
-    activity: Option<FeedActivity>,
-    block_rx: oneshot::Receiver<Block>,
-}
-
-impl PendingSubscription {
-    fn new(round: Round, activity: FeedActivity, block_rx: oneshot::Receiver<Block>) -> Self {
-        Self {
-            round,
-            activity: Some(activity),
-            block_rx,
-        }
-    }
-}
-
-impl Future for PendingSubscription {
-    type Output = eyre::Result<(Round, FeedActivity, Block)>;
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.block_rx.poll_unpin(cx) {
-            Poll::Ready(Ok(block)) => {
-                let activity = self.activity.take().expect("polled after completion");
-                Poll::Ready(Ok((self.round, activity, block)))
-            }
-            Poll::Ready(Err(_)) => Poll::Ready(Err(eyre::eyre!("block subscription cancelled"))),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
+/// Receiver for finalized blocks.
+pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<Block>;
 
 pub(crate) struct Actor<TContext> {
     /// Runtime context.
     context: ContextCell<TContext>,
-    /// Receiver for activity messages.
+    /// Receiver for finalized blocks.
     receiver: Receiver,
     /// Shared state handle.
     state: FeedStateHandle,
-    /// Marshal mailbox for block lookups.
+    /// Marshal mailbox for finalization certificate lookups.
     marshal: marshal::Mailbox,
-    /// Pending block subscriptions keyed by round. Since finalizations
-    /// must be delivered, pending subscriptions are bound by the marshal.
-    pending: BTreeMap<Round, PendingSubscription>,
 }
 
 impl<TContext: Spawner> Actor<TContext> {
     /// Create a new feed actor.
-    ///
-    /// The actor receives Activity messages via `receiver` and updates the shared `state`.
     pub(crate) fn new(
         context: TContext,
         marshal: marshal::Mailbox,
@@ -113,7 +45,6 @@ impl<TContext: Spawner> Actor<TContext> {
             receiver,
             state,
             marshal,
-            pending: BTreeMap::new(),
         }
     }
 
@@ -122,148 +53,46 @@ impl<TContext: Spawner> Actor<TContext> {
         spawn_cell!(self.context, self.run())
     }
 
-    /// Run the actor's main loop.
-    ///
-    /// The loop races the oldest pending block subscription
-    /// against incoming activity so events are emitted in order.
     async fn run(mut self) {
-        let reason = loop {
-            // We need a mutable reference to poll pending subscription. Thus if a new activity arrives,
-            // we also need to re-insert this popped subscription.
-            let mut oldest = OptionFuture::from(self.pending.pop_first().map(|(_, p)| p));
-
-            select!(
-                result = &mut oldest => {
-                    match result {
-                        Ok((_, activity, block)) => self.handle_activity(activity, block),
-                        Err(error) => warn_span!("feed_actor").in_scope(||
-                            warn!(%error, "did not get pending block")
-                        ),
-                    }
-                },
-
-                activity = self.receiver.next() => {
-                    let Some(activity) = activity else {
-                        break eyre!("mailbox closed");
-                    };
-
-                    if let Some(p) = oldest.take() {
-                        self.pending.insert(p.round, p);
-                    }
-                    self.subscribe(activity).await;
-                },
-            );
-        };
-
-        info_span!("feed_actor").in_scope(|| error!(%reason, "shutting down"));
-    }
-
-    async fn subscribe(&mut self, activity: FeedActivity) {
-        let (round, payload) = match &activity {
-            Activity::Notarization(n) => (n.proposal.round, n.proposal.payload),
-            Activity::Finalization(f) => (f.proposal.round, f.proposal.payload),
-            _ => return,
-        };
-
-        // Prune & filter incoming activity.
-        // - Incoming Finalization. Prune older subscriptions as we only care about latest information
-        // - Incoming Notarization. Only accept if ahead of the latest Finalization.
-        match &activity {
-            Activity::Finalization(_) => self.pending.retain(|&r, p| {
-                matches!(&p.activity, Some(Activity::Finalization(_))) || r > round
-            }),
-            Activity::Notarization(_)
-                if self
-                    .state
-                    .read()
-                    .latest_finalized
-                    .as_ref()
-                    .map(|f| Round::new(Epoch::new(f.epoch), View::new(f.view)))
-                    .is_none_or(|f| f < round) => {}
-
-            _ => return,
+        while let Some(block) = self.receiver.next().await {
+            self.handle_block(block).await;
         }
 
-        let block_rx = self.marshal.subscribe_by_digest(Some(round), payload).await;
-        let pending = PendingSubscription::new(round, activity, block_rx);
-        self.pending.insert(round, pending);
+        info_span!("feed_actor").in_scope(|| error!("mailbox closed; shutting down"));
     }
 
-    #[instrument(skip_all, fields(activity = ?activity))]
-    fn handle_activity(&self, activity: FeedActivity, consensus_block: Block) {
-        let block = consensus_block.into_execution_block();
-        let (round, digest, certificate) = match activity.clone() {
-            Activity::Notarization(notarization) => (
-                notarization.proposal.round,
-                notarization.proposal.payload.0,
-                notarization.encode(),
-            ),
-            Activity::Finalization(finalization) => (
-                finalization.proposal.round,
-                finalization.proposal.payload.0,
-                finalization.encode(),
-            ),
-            _ => return,
+    #[instrument(skip_all, fields(height = %block.height(), digest = %block.digest()))]
+    async fn handle_block(&self, block: Block) {
+        let height = block.height();
+        let Some(finalization) = self.marshal.get_finalization(height).await else {
+            debug!(
+                height = height.get(),
+                "skipping finalized block without a direct finalization certificate"
+            );
+            return;
         };
+        let round = finalization.proposal.round;
 
-        let certified = CertifiedBlock {
+        let finalized = CertifiedBlock {
             epoch: round.epoch().get(),
             view: round.view().get(),
-            block,
-            digest,
-            certificate: hex::encode(certificate),
+            block: block.into_execution_block(),
+            digest: finalization.proposal.payload.0,
+            certificate: hex::encode(finalization.encode()),
         };
 
-        let mut state = self.state.write();
-        let latest_finalized_round = state
-            .latest_finalized
-            .as_ref()
-            .map(|b| Round::new(Epoch::new(b.epoch), View::new(b.view)));
+        self.state.write().latest_finalized = Some(finalized.clone());
 
-        let latest_notarized_round = state
-            .latest_notarized
-            .as_ref()
-            .map(|b| Round::new(Epoch::new(b.epoch), View::new(b.view)));
-
-        // Update state and broadcast events
-        let height = certified.block.inner.number;
         let subscribers = self.state.events_tx().receiver_count();
-        match activity {
-            Activity::Notarization(_) => {
-                if latest_notarized_round.is_none_or(|previous| round > previous) {
-                    debug!(subscribers, height, "sending new notarized event");
-                    let _ = self.state.events_tx().send(Event::Notarized {
-                        block: certified.clone(),
-                        seen: now_millis(),
-                    });
-                }
-
-                if latest_finalized_round.is_none_or(|r| r < round)
-                    && latest_notarized_round.is_none_or(|r| r < round)
-                {
-                    state.latest_notarized = Some(certified);
-                }
-            }
-
-            Activity::Finalization(_) => {
-                if latest_finalized_round.is_none_or(|previous| round > previous) {
-                    debug!(subscribers, height, "sending new finalized event");
-                    let _ = self.state.events_tx().send(Event::Finalized {
-                        block: certified.clone(),
-                        seen: now_millis(),
-                    });
-                }
-
-                if latest_finalized_round.is_none_or(|r| r < round) {
-                    if latest_notarized_round.is_none_or(|r| r < round) {
-                        state.latest_notarized = None;
-                    }
-
-                    state.latest_finalized = Some(certified);
-                }
-            }
-            _ => {}
-        }
+        debug!(
+            subscribers,
+            height = height.get(),
+            "sending finalized block event"
+        );
+        let _ = self.state.events_tx().send(Event::Finalized {
+            block: finalized,
+            seen: now_millis(),
+        });
     }
 }
 

--- a/crates/consensus/src/feed/ingress.rs
+++ b/crates/consensus/src/feed/ingress.rs
@@ -1,20 +1,16 @@
-//! Mailbox for sending consensus activity to the feed actor.
+//! Mailbox for sending marshal updates to the feed actor.
 
-use commonware_consensus::{
-    Reporter,
-    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
-};
-use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_consensus::{Reporter, marshal::Update};
+use commonware_utils::Acknowledgement as _;
 use futures::channel::mpsc;
 use tracing::error;
 
-use super::actor::FeedActivity;
-use crate::consensus::Digest;
+use crate::consensus::block::Block;
 
 /// Sender half of the feed channel.
-pub(super) type Sender = mpsc::UnboundedSender<FeedActivity>;
+pub(super) type Sender = mpsc::UnboundedSender<Block>;
 
-/// Mailbox for sending consensus activity to the feed actor.
+/// Mailbox for sending finalized marshal blocks to the feed actor.
 #[derive(Clone, Debug)]
 pub(crate) struct Mailbox {
     sender: Sender,
@@ -27,11 +23,77 @@ impl Mailbox {
 }
 
 impl Reporter for Mailbox {
-    type Activity = Activity<Scheme<PublicKey, MinSig>, Digest>;
+    type Activity = Update<Block>;
 
-    async fn report(&mut self, activity: Self::Activity) {
-        if self.sender.unbounded_send(activity).is_err() {
-            error!("failed sending activity to feed because it is no longer running");
+    async fn report(&mut self, update: Self::Activity) {
+        let Update::Block(block, acknowledgement) = update else {
+            return;
+        };
+
+        // The feed is best-effort and must never hold up marshal's durable
+        // finalized-block stream.
+        acknowledgement.acknowledge();
+
+        if self.sender.unbounded_send(block).is_err() {
+            error!("failed sending finalized block to feed because it is no longer running");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Header;
+    use commonware_consensus::{
+        Heightable as _, Reporter as _,
+        marshal::Update,
+        types::{Epoch, Round, View},
+    };
+    use commonware_utils::{Acknowledgement as _, acknowledgement::Exact};
+    use futures::{FutureExt as _, StreamExt as _, executor::block_on};
+    use reth_node_core::primitives::SealedBlock;
+    use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
+
+    use super::Mailbox;
+    use crate::consensus::block::Block;
+
+    #[test]
+    fn forwards_only_acknowledged_blocks() {
+        block_on(async {
+            let (sender, mut receiver) = futures::channel::mpsc::unbounded();
+            let mut mailbox = Mailbox::new(sender);
+            let block = Block::from_execution_block(
+                SealedBlock::seal_slow(TempoBlock {
+                    header: TempoHeader {
+                        inner: Header {
+                            number: 1,
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    body: BlockBody::default(),
+                }),
+                None,
+            )
+            .expect("test block should not contain BAL side data");
+
+            mailbox
+                .report(Update::Tip(
+                    Round::new(Epoch::zero(), View::new(1)),
+                    block.height(),
+                    block.digest(),
+                ))
+                .await;
+
+            let (acknowledgement, acknowledged) = Exact::handle();
+            mailbox
+                .report(Update::Block(block.clone(), acknowledgement))
+                .await;
+
+            acknowledged
+                .await
+                .expect("feed should immediately acknowledge the block");
+            assert_eq!(receiver.next().await, Some(block));
+            assert!(receiver.next().now_or_never().is_none());
+        });
     }
 }

--- a/crates/consensus/src/feed/mod.rs
+++ b/crates/consensus/src/feed/mod.rs
@@ -1,8 +1,9 @@
 //! Feed module for consensus event tracking and RPC.
 //!
 //! Architecture:
-//! - `Mailbox` implements `Reporter` and sends Activity to the actor
-//! - `Actor` processes Activity and updates shared [`FeedStateHandle`]
+//! - `Mailbox` implements `Reporter` for marshal updates and immediately
+//!   acknowledges finalized blocks before forwarding them to the actor
+//! - `Actor` publishes finalized blocks and updates shared [`FeedStateHandle`]
 //! - [`FeedStateHandle`] implements `ConsensusFeed` for RPC access
 //!
 //! This design ensures RPC traffic cannot block consensus activity processing.

--- a/crates/consensus/src/feed/state.rs
+++ b/crates/consensus/src/feed/state.rs
@@ -3,7 +3,7 @@
 use crate::alias::marshal;
 use alloy_primitives::hex;
 use commonware_codec::Encode;
-use commonware_consensus::types::{Epoch, Height, Round, View};
+use commonware_consensus::types::Height;
 use parking_lot::RwLock;
 use std::sync::{Arc, OnceLock};
 use tempo_node::rpc::consensus::{
@@ -16,8 +16,6 @@ const BROADCAST_CHANNEL_SIZE: usize = 1024;
 
 /// Internal shared state for the feed.
 pub(super) struct FeedState {
-    /// Latest notarized block.
-    pub(super) latest_notarized: Option<CertifiedBlock>,
     /// Latest finalized block.
     pub(super) latest_finalized: Option<CertifiedBlock>,
 }
@@ -25,7 +23,7 @@ pub(super) struct FeedState {
 /// Handle to shared feed state.
 ///
 /// This handle can be cloned and used by both:
-/// - The feed actor (to update state when processing Activity)
+/// - The feed actor (to update state when processing finalized blocks)
 /// - RPC handlers (implements `ConsensusFeed`)
 #[derive(Clone)]
 pub struct FeedStateHandle {
@@ -43,7 +41,6 @@ impl FeedStateHandle {
         let (events_tx, _) = broadcast::channel(BROADCAST_CHANNEL_SIZE);
         Self {
             state: Arc::new(RwLock::new(FeedState {
-                latest_notarized: None,
                 latest_finalized: None,
             })),
             marshal: Arc::new(OnceLock::new()),
@@ -59,11 +56,6 @@ impl FeedStateHandle {
     /// Get the broadcast sender for events.
     pub(super) fn events_tx(&self) -> &broadcast::Sender<Event> {
         &self.events_tx
-    }
-
-    /// Get read access to the internal state.
-    pub(super) fn read(&self) -> parking_lot::RwLockReadGuard<'_, FeedState> {
-        self.state.read()
     }
 
     /// Get write access to the internal state.
@@ -91,7 +83,6 @@ impl std::fmt::Debug for FeedStateHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let state = self.state.read();
         f.debug_struct("FeedStateHandle")
-            .field("latest_notarized", &state.latest_notarized)
             .field("latest_finalized", &state.latest_finalized)
             .field("marshal_set", &self.marshal.get().is_some())
             .field("subscriber_count", &self.events_tx.receiver_count())
@@ -134,30 +125,9 @@ impl ConsensusFeed for FeedStateHandle {
     }
 
     async fn get_latest(&self) -> ConsensusState {
-        let (finalized, mut notarized) = {
-            let state = self.state.read();
-            (
-                state.latest_finalized.clone(),
-                state.latest_notarized.clone(),
-            )
-        };
-
-        let finalized_round = finalized
-            .as_ref()
-            .map(|f| Round::new(Epoch::new(f.epoch), View::new(f.view)));
-
-        let notarized_round = notarized
-            .as_ref()
-            .map(|n| Round::new(Epoch::new(n.epoch), View::new(n.view)));
-
-        // Only include the notarization if it is ahead.
-        if finalized_round.is_some_and(|f| notarized_round.is_none_or(|n| n <= f)) {
-            notarized = None;
-        }
-
         ConsensusState {
-            finalized,
-            notarized,
+            finalized: self.state.read().latest_finalized.clone(),
+            notarized: None,
         }
     }
 

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -22,18 +22,17 @@ use tempo_node::rpc::consensus::{CertifiedBlock, Event};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, instrument, warn};
 
-use super::{Config, ExecutionProvider, Feed, Mailbox, Marshal, ingress::Message};
+use super::{Config, ExecutionProvider, Mailbox, Marshal, ingress::Message};
 use crate::consensus::{Block, Digest};
 
-pub(super) fn try_init<TContext, P, M, F>(
+pub(super) fn try_init<TContext, P, M>(
     context: TContext,
-    config: Config<P, M, F>,
-) -> eyre::Result<(Driver<TContext, P, M, F>, Mailbox)>
+    config: Config<P, M>,
+) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
-    F: Feed + 'static,
 {
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = Mailbox(tx);
@@ -107,21 +106,20 @@ where
     Ok((actor, mailbox))
 }
 
-pub(crate) struct Driver<TContext, P, M, F> {
+pub(crate) struct Driver<TContext, P, M> {
     context: ContextCell<TContext>,
-    config: Config<P, M, F>,
+    config: Config<P, M>,
     mailbox: mpsc::UnboundedReceiver<Message>,
     startup_execution_boundary: Height,
     current_epoch: Epoch,
     network_scheme: Arc<Scheme<PublicKey, MinSig>>,
 }
 
-impl<C, P, M, F> Driver<C, P, M, F>
+impl<C, P, M> Driver<C, P, M>
 where
     C: Clock + Rng + CryptoRng + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
-    F: Feed + 'static,
 {
     pub(crate) fn start(mut self) -> commonware_runtime::Handle<()> {
         spawn_cell!(self.context, self.run())
@@ -293,8 +291,7 @@ where
         let activity = Activity::Finalization(finalization);
 
         let _ = self.config.marshal.certified(round, consensus_block).await;
-        self.config.marshal.report(activity.clone()).await;
-        self.config.feed.report(activity).await;
+        self.config.marshal.report(activity).await;
         Ok(())
     }
 

--- a/crates/consensus/src/follow/driver/mod.rs
+++ b/crates/consensus/src/follow/driver/mod.rs
@@ -1,7 +1,7 @@
 //! Follower finalization driver.
 //!
-//! Validates finalized blocks received from upstream and reports them to marshal and the consensus
-//! feed.
+//! Validates finalized blocks received from upstream and reports them to marshal.
+//! Marshal's finalized block updates independently drive the consensus feed.
 
 use std::future::Future;
 
@@ -28,7 +28,6 @@ use tempo_primitives::TempoHeader;
 use crate::{
     consensus::{Block, Digest},
     epoch::SchemeProvider,
-    feed,
 };
 
 mod actor;
@@ -42,7 +41,7 @@ pub(super) use ingress::Mailbox;
 
 type ConsensusActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 
-pub(super) struct Config<P, M, F> {
+pub(super) struct Config<P, M> {
     pub(super) execution_provider: P,
     pub(super) scheme_provider: SchemeProvider,
     pub(super) network_identity: NetworkIdentity,
@@ -50,20 +49,18 @@ pub(super) struct Config<P, M, F> {
     pub(super) last_finalized_height: Height,
 
     pub(super) marshal: M,
-    pub(super) feed: F,
 
     pub(super) epoch_strategy: FixedEpocher,
 }
 
-pub(super) fn try_init<TContext, P, M, F>(
+pub(super) fn try_init<TContext, P, M>(
     context: TContext,
-    config: Config<P, M, F>,
-) -> eyre::Result<(Driver<TContext, P, M, F>, Mailbox)>
+    config: Config<P, M>,
+) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
-    F: Feed + 'static,
 {
     actor::try_init(context, config)
 }
@@ -80,11 +77,6 @@ pub(super) trait Marshal: Send + Sync {
     fn certified(&self, round: Round, block: Block) -> impl Future<Output = bool> + Send;
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send;
     fn hint_finalized(&self, height: Height) -> impl Future<Output = ()> + Send;
-}
-
-/// Consensus-feed operation used by the follower driver.
-pub(super) trait Feed: Send + Sync {
-    fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send;
 }
 
 impl<N> ExecutionProvider for BlockchainProvider<N>
@@ -123,13 +115,6 @@ impl Marshal for crate::alias::marshal::Mailbox {
         async move { mailbox.certified(round, block).await }
     }
 
-    fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
-        let mut mailbox = self.clone();
-        async move { commonware_consensus::Reporter::report(&mut mailbox, activity).await }
-    }
-}
-
-impl Feed for feed::Mailbox {
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
         let mut mailbox = self.clone();
         async move { commonware_consensus::Reporter::report(&mut mailbox, activity).await }

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -19,7 +19,7 @@ use tempo_node::rpc::consensus::Event;
 use super::{Config, try_init};
 use crate::epoch::SchemeProvider;
 use utils::{
-    EPOCH_LENGTH, StubExecutionProvider, StubFeed, StubMarshal, dkg_fixture, make_block,
+    EPOCH_LENGTH, StubExecutionProvider, StubMarshal, dkg_fixture, make_block,
     make_certified_block, make_finalization,
 };
 
@@ -62,7 +62,6 @@ fn startup_uses_previous_execution_boundary() {
                 },
                 last_finalized_height: finalized_height,
                 marshal: StubMarshal::default(),
-                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         );
@@ -91,7 +90,6 @@ fn startup_propagates_finalized_block_read_failure() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
-                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -118,7 +116,6 @@ fn startup_requires_execution_boundary_header() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
-                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -137,7 +134,6 @@ fn valid_finalization_is_certified_and_reported() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
-        let feed = StubFeed::default();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
             Config {
@@ -149,7 +145,6 @@ fn valid_finalization_is_certified_and_reported() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
-                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -173,7 +168,6 @@ fn valid_finalization_is_certified_and_reported() {
         assert_eq!(certified[0].0, finalization.proposal.round);
         assert_eq!(certified[0].1, block);
         assert_eq!(marshal.report_count(), 1);
-        assert_eq!(feed.report_count(), 1);
         assert!(marshal.hints().is_empty());
     });
 }
@@ -187,7 +181,6 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
         let provider = StubExecutionProvider::default();
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
-        let feed = StubFeed::default();
         let schemes = SchemeProvider::new();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
@@ -200,7 +193,6 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
-                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -228,7 +220,6 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
         wait_until(&context, || marshal.certified().len() == 1).await;
 
         assert_eq!(marshal.report_count(), 1);
-        assert_eq!(feed.report_count(), 1);
         assert!(marshal.hints().is_empty());
     });
 }
@@ -243,7 +234,6 @@ fn invalid_finalization_hints_current_epoch_boundary() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
-        let feed = StubFeed::default();
         let strategy = FixedEpocher::new(EPOCH_LENGTH);
         let expected_boundary = strategy
             .last(Epoch::zero())
@@ -260,7 +250,6 @@ fn invalid_finalization_hints_current_epoch_boundary() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
-                feed: feed.clone(),
                 epoch_strategy: strategy,
             },
         )
@@ -283,7 +272,6 @@ fn invalid_finalization_hints_current_epoch_boundary() {
         assert_eq!(marshal.hints(), vec![expected_boundary]);
         assert!(marshal.certified().is_empty());
         assert_eq!(marshal.report_count(), 0);
-        assert_eq!(feed.report_count(), 0);
     });
 }
 
@@ -296,7 +284,6 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
 
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
-        let feed = StubFeed::default();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
             Config {
@@ -308,7 +295,6 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
-                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -331,7 +317,6 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
 
         assert!(marshal.certified().is_empty());
         assert_eq!(marshal.report_count(), 0);
-        assert_eq!(feed.report_count(), 0);
         assert!(marshal.hints().is_empty());
 
         let block = make_block(3, None);
@@ -347,7 +332,6 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
 
         assert_eq!(marshal.certified()[0].1, block);
         assert_eq!(marshal.report_count(), 1);
-        assert_eq!(feed.report_count(), 1);
     });
 }
 
@@ -361,7 +345,6 @@ fn scheme_before_network_identity_epoch_is_required() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
-        let feed = StubFeed::default();
         let schemes = SchemeProvider::new();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
@@ -374,7 +357,6 @@ fn scheme_before_network_identity_epoch_is_required() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
-                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -402,7 +384,6 @@ fn scheme_before_network_identity_epoch_is_required() {
 
         assert!(marshal.certified().is_empty());
         assert_eq!(marshal.report_count(), 0);
-        assert_eq!(feed.report_count(), 0);
         assert!(marshal.hints().is_empty());
     });
 }
@@ -433,7 +414,6 @@ fn boundary_update_registers_scheme_before_acknowledging() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
-                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -473,7 +453,6 @@ fn non_boundary_update_is_acknowledged_without_registering_a_scheme() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
-                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -527,7 +506,6 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
                 },
                 last_finalized_height,
                 marshal: marshal.clone(),
-                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -544,14 +522,13 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
 }
 
 #[test_traced]
-fn non_finalized_event_is_ignored() {
+fn non_finalized_events_are_ignored() {
     deterministic::Runner::default().start(|mut context| async move {
         let fixture = dkg_fixture(&mut context, Epoch::zero());
         let startup_block = make_block(0, Some(&fixture.outcome));
         let provider = StubExecutionProvider::default();
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
-        let feed = StubFeed::default();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
             Config {
@@ -563,7 +540,6 @@ fn non_finalized_event_is_ignored() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
-                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -578,11 +554,11 @@ fn non_finalized_event_is_ignored() {
         };
         let mut reporter = mailbox.to_event_reporter();
         reporter.report(event).await;
+
         context.sleep(Duration::from_millis(1)).await;
 
         assert!(marshal.certified().is_empty());
         assert_eq!(marshal.report_count(), 0);
-        assert_eq!(feed.report_count(), 0);
         assert!(marshal.hints().is_empty());
     });
 }

--- a/crates/consensus/src/follow/driver/test/utils.rs
+++ b/crates/consensus/src/follow/driver/test/utils.rs
@@ -36,7 +36,7 @@ use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::rpc::consensus::CertifiedBlock;
 use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
 
-use super::super::{ConsensusActivity, ExecutionProvider, Feed, Marshal};
+use super::super::{ConsensusActivity, ExecutionProvider, Marshal};
 use crate::consensus::{Block, Digest};
 
 pub(super) const EPOCH_LENGTH: NonZeroU64 = NonZeroU64::new(10).expect("epoch length is nonzero");
@@ -236,24 +236,6 @@ impl Marshal for StubMarshal {
 
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
         self.inner.reports.lock().push(activity);
-        async {}
-    }
-}
-
-#[derive(Clone, Default)]
-pub(super) struct StubFeed {
-    reports: Arc<Mutex<Vec<ConsensusActivity>>>,
-}
-
-impl StubFeed {
-    pub(super) fn report_count(&self) -> usize {
-        self.reports.lock().len()
-    }
-}
-
-impl Feed for StubFeed {
-    fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
-        self.reports.lock().push(activity);
         async {}
     }
 }

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -180,7 +180,6 @@ impl<TUpstream> Config<TUpstream> {
                 network_identity: self.network_identity,
                 last_finalized_height,
                 marshal: marshal_mailbox,
-                feed: feed_mailbox,
                 epoch_strategy: epoch_strategy.clone(),
             },
         )
@@ -199,6 +198,7 @@ impl<TUpstream> Config<TUpstream> {
             executor: executor_actor,
             executor_mailbox,
             feed: feed_actor,
+            feed_mailbox,
             broadcast,
             upstream: self.upstream,
         })
@@ -218,7 +218,6 @@ where
             NodeTypesWithDBAdapter<TempoNode, reth_ethereum::provider::db::DatabaseEnv>,
         >,
         crate::alias::marshal::Mailbox,
-        feed::Mailbox,
     >,
     driver_mailbox: driver::Mailbox,
     resolver: Resolver<TContext>,
@@ -234,6 +233,7 @@ where
     >,
     executor_mailbox: executor::Mailbox,
     feed: feed::Actor<TContext>,
+    feed_mailbox: feed::Mailbox,
     broadcast: buffered::Mailbox<PublicKey, Block>,
     upstream: TUpstreamActor,
 }
@@ -270,6 +270,7 @@ where
             executor,
             executor_mailbox,
             feed,
+            feed_mailbox,
             broadcast,
             ..
         } = self;
@@ -281,7 +282,7 @@ where
             marshal.start(
                 Reporters::from((
                     executor_mailbox.clone(),
-                    driver_mailbox.to_marshal_reporter(),
+                    Reporters::from((driver_mailbox.to_marshal_reporter(), feed_mailbox)),
                 )),
                 broadcast,
                 (resolver_rx, resolver_mailbox),

--- a/crates/e2e/src/tests/consensus_rpc.rs
+++ b/crates/e2e/src/tests/consensus_rpc.rs
@@ -59,30 +59,25 @@ async fn consensus_subscribe_and_query_finalization() {
 
     let finalized_height = initial_height;
 
-    loop {
-        let event = tokio::time::timeout(Duration::from_secs(10), subscription.next())
-            .await
-            .unwrap()
-            .unwrap()
-            .unwrap();
+    let event = tokio::time::timeout(Duration::from_secs(10), subscription.next())
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
 
-        match event {
-            Event::Notarized { .. } => panic!("feed must not publish notarizations"),
-            Event::Finalized { block, .. } => {
-                let height = block.block.inner.number;
-                assert!(height > finalized_height);
+    let Event::Finalized { block, .. } = event else {
+        panic!("feed must not publish nullifications or notarizations");
+    };
 
-                let queried_block = http_client
-                    .get_finalization(Query::Height(height))
-                    .await
-                    .unwrap();
+    let height = block.block.inner.number;
+    assert!(height > finalized_height);
 
-                assert_eq!(queried_block, block);
-                break;
-            }
-            Event::Nullified { .. } => panic!("feed must not publish nullifications"),
-        }
-    }
+    let queried_block = http_client
+        .get_finalization(Query::Height(height))
+        .await
+        .unwrap();
+
+    assert_eq!(queried_block, block);
 
     let _ = http_client.get_finalization(Query::Latest).await.unwrap();
 

--- a/crates/e2e/src/tests/consensus_rpc.rs
+++ b/crates/e2e/src/tests/consensus_rpc.rs
@@ -57,12 +57,9 @@ async fn consensus_subscribe_and_query_finalization() {
 
     let http_client = HttpClientBuilder::default().build(&http_url).unwrap();
 
-    let mut saw_notarized = false;
-    let mut saw_finalized = false;
-    let mut notarized_height = initial_height;
-    let mut finalized_height = initial_height;
+    let finalized_height = initial_height;
 
-    while !saw_notarized || !saw_finalized {
+    loop {
         let event = tokio::time::timeout(Duration::from_secs(10), subscription.next())
             .await
             .unwrap()
@@ -70,13 +67,7 @@ async fn consensus_subscribe_and_query_finalization() {
             .unwrap();
 
         match event {
-            Event::Notarized { block, .. } => {
-                let height = block.block.inner.number;
-                assert!(height > notarized_height);
-
-                notarized_height = height;
-                saw_notarized = true;
-            }
+            Event::Notarized { .. } => panic!("feed must not publish notarizations"),
             Event::Finalized { block, .. } => {
                 let height = block.block.inner.number;
                 assert!(height > finalized_height);
@@ -87,11 +78,9 @@ async fn consensus_subscribe_and_query_finalization() {
                     .unwrap();
 
                 assert_eq!(queried_block, block);
-
-                finalized_height = height;
-                saw_finalized = true;
+                break;
             }
-            Event::Nullified { .. } => {}
+            Event::Nullified { .. } => panic!("feed must not publish nullifications"),
         }
     }
 
@@ -100,6 +89,7 @@ async fn consensus_subscribe_and_query_finalization() {
     let state = http_client.get_latest().await.unwrap();
 
     assert!(state.finalized.is_some());
+    assert!(state.notarized.is_none());
 
     drop(done_tx);
     executor_handle.join().unwrap();

--- a/crates/e2e/src/tests/follow.rs
+++ b/crates/e2e/src/tests/follow.rs
@@ -303,23 +303,6 @@ impl MetricScope for Follower {
     }
 }
 
-/// Polls the feed until `query` resolves successfully.
-///
-/// Height queries resolve once marshal has stored both the certificate and
-/// block for that height.
-async fn wait_for_finalization<TContext: Clock>(
-    context: &TContext,
-    feed: &FeedStateHandle,
-    query: Query,
-) {
-    while !matches!(
-        feed.get_finalization(query.clone()).await,
-        Response::Success(..)
-    ) {
-        context.sleep(Duration::from_millis(100)).await;
-    }
-}
-
 #[test_traced]
 fn follower_bootstraps_from_validator() {
     let _ = tempo_eyre::install();
@@ -350,7 +333,12 @@ fn follower_bootstraps_from_validator() {
         // The marshal floor only advances with actually processed blocks, so
         // the follower backfills the gap between its startup floor (genesis
         // for a fresh node) and the join point via gap repair.
-        wait_for_finalization(&context, &follower.feed, Query::Height(1)).await;
+        while !matches!(
+            follower.feed.get_finalization(Query::Height(1)).await,
+            Response::Success(..)
+        ) {
+            context.sleep(Duration::from_millis(100)).await;
+        }
     });
 }
 
@@ -379,20 +367,20 @@ fn follower_syncs_historical_state() {
         follower.connect_peers(&validators).await;
 
         wait_for_height(&context, &follower, follower_target_height).await;
-        wait_for_finalization(&context, &follower.feed, Query::Latest).await;
 
         // The follower syncs directly to the observed finalization rather than
-        // targeting an epoch boundary. Marshal may still backfill historical
-        // boundary certificates as part of its normal gap repair.
-        // The feed and Reth finalized tip show that the follower caught up
-        // independently of those certificates.
-        let reported_finalized_height = follower
-            .feed
-            .get_finalization(Query::Latest)
-            .await
-            .unwrap()
-            .block
-            .number();
+        // targeting an epoch boundary. The feed follows marshal's ordered block
+        // delivery, so wait for gap repair to advance it to the target.
+        let reported_finalized_height = loop {
+            if let Response::Success(block) = follower.feed.get_finalization(Query::Latest).await {
+                let height = block.block.number();
+                if height >= follower_target_height {
+                    break height;
+                }
+            }
+
+            context.sleep(Duration::from_millis(100)).await;
+        };
 
         let provider = &follower.execution_node.node.provider;
         let synced_height = loop {

--- a/crates/node/src/rpc/consensus/mod.rs
+++ b/crates/node/src/rpc/consensus/mod.rs
@@ -63,11 +63,11 @@ pub trait TempoConsensusApi {
 
     /// Get the current consensus state snapshot.
     ///
-    /// Returns the latest finalized block and the latest notarized block (if not yet finalized).
+    /// Returns the latest finalized block. The notarized field is retained for compatibility.
     #[method(name = "getLatest")]
     async fn get_latest(&self) -> RpcResult<ConsensusState>;
 
-    /// Subscribe to all consensus events (Notarized, Finalized, Nullified).
+    /// Subscribe to finalized block events.
     #[subscription(name = "subscribe" => "event", unsubscribe = "unsubscribe", item = Event)]
     async fn subscribe_events(&self) -> jsonrpsee::core::SubscriptionResult;
 }

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -87,7 +87,7 @@ impl Display for Query {
 pub struct ConsensusState {
     /// The latest finalized block (if any).
     pub finalized: Option<CertifiedBlock>,
-    /// The latest notarized block (if any, and not yet finalized).
+    /// Reserved for backwards compatibility. The feed does not track notarizations.
     pub notarized: Option<CertifiedBlock>,
 }
 
@@ -131,7 +131,7 @@ pub trait ConsensusFeed: Send + Sync + 'static {
         query: Query,
     ) -> impl Future<Output = Response<CertifiedBlock>> + Send;
 
-    /// Get the current consensus state (latest finalized + latest notarized).
+    /// Get the current consensus state.
     fn get_latest(&self) -> impl Future<Output = ConsensusState> + Send;
 
     /// Subscribe to consensus events.


### PR DESCRIPTION
Fixes finalized block head of line delivery by leaching off of the marshal actor instead of manually reconciling blocks and certificates.

This patch also removes publication of `(notarization, block)` pairs. The reason is simple: notarizations are not reliable and can be re-orged at a moments notice - but there is no functionality to back-trace the ancestors from the re-orged block for validator-followers.

All services (followers, zones) are mindful of this and thus only follow the more reliable finalizations.