### PR TITLE
fix(ci): allow sync app to update workflows

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -22,6 +22,7 @@ jobs:
           app-id: ${{ vars.SYNC_APP_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
           permission-contents: write
+          permission-workflows: write
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
         with:


### PR DESCRIPTION
Allows fork sync jobs to update workflow files when upstream changes them, preventing GitHub from rejecting the force-push.

Prompted by: @sds