### PR TITLE
fix(ci): restrict scheduled jobs to upstream repo

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -67,6 +67,7 @@ permissions: {}
 jobs:
   resolve-refs:
     name: resolve-refs
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -37,6 +37,7 @@ permissions: {}
 jobs:
   resolve-refs:
     name: resolve-refs
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -56,6 +56,7 @@ permissions: {}
 jobs:
   resolve-refs:
     name: resolve-refs
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   build-and-push:
     name: Build and Push Docker Images
-    if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository != 'tempoxyz/tempo') }}
+    if: ${{ (github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo') && !(github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository != 'tempoxyz/tempo') }}
     runs-on: depot-ubuntu-latest-16
     permissions:
       actions: read

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -17,6 +17,7 @@ permissions: {}
 
 jobs:
   scan:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@512158c4e90e42eef8aa7fc3fc3186a79b5b4648 # main
     permissions:
       actions: read

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   stale:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   sync:
-    if: ${{ github.repository != 'tempoxyz/tempo' }}
+    if: ${{ github.repository != 'tempoxyz/tempo' && github.event_name != 'schedule' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token

--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -30,6 +30,7 @@ env:
 jobs:
   update:
     name: Update reth dependencies
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
Skips scheduled jobs in forks while preserving push, pull-request, and manual workflow runs. The upstream-sync workflow remains manually dispatchable in forks.

This prevents forks from running schedules copied from the upstream repository, which can cause issues.

Prompted by: @sds