### PR TITLE
fix(ci): use client ID input for sync app

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -19,7 +19,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ vars.SYNC_APP_ID }}
+          client-id: ${{ vars.SYNC_APP_ID }}
           private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-workflows: write


### PR DESCRIPTION
Uses the supported `client-id` input for the sync GitHub App token while retaining the existing repository variable value. This removes the deprecation warning emitted by `actions/create-github-app-token`.

Prompted by: @sds