### PR TITLE
fix(ci): pin changelog action release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -26,7 +26,7 @@ jobs:
 
       - run: curl -fsSL https://ampcode.com/install.sh | bash
 
-      - uses: wevm/changelogs/check@74f07b39c7c85773575e32472dfd5298ec6baaf4 # master
+      - uses: wevm/changelogs/check@59d4d403a10ad3072d4f1354c5fe0ac0c34e8a15 # v0.8.2
         with:
           ai: 'amp -x'
           ecosystem: rust


### PR DESCRIPTION
Pins `wevm/changelogs/check` to its `v0.8.2` release SHA and updates the version comment to match. This resolves the zizmor hash-pin mismatch that failed the GitHub Actions scan.

We should not be pinning to a moving target branch like `master`. It's prone to this kind of churn and is a security risk.

Prompted by: @sds