### PR TITLE
fix(ci): allow scheduled fork syncs

### DIFF
--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   sync:
-    if: ${{ github.repository != 'tempoxyz/tempo' && github.event_name != 'schedule' }}
+    if: ${{ github.repository != 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     steps:
       - name: Generate GitHub App token


### PR DESCRIPTION
Restores scheduled runs for `sync-from-upstream.yml` in forks by reverting that file’s repository/schedule gate from #6972. Other scheduled workflows remain restricted to `tempoxyz/tempo`.

Supersedes #6974 with a single commit rebased onto the latest `main`.

Prompted by: @sds