### PR TITLE
fix(ci): restrict release PR workflow to upstream

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -11,6 +11,7 @@ permissions: {}
 jobs:
   release-pr:
     name: Release PR
+    if: ${{ github.repository == 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     environment: release-pr
     permissions: {}


### PR DESCRIPTION
Guards the release PR job so pushes to `main` only execute it in `tempoxyz/tempo`, preventing forks from attempting release automation.

Prompted by: @sds