### PR TITLE
deps: update reth from main (2026-07-28)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8607,7 +8607,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8634,7 +8634,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8646,7 +8646,6 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.4",
- "rayon",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -8654,7 +8653,6 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
- "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
  "revm",
@@ -8667,7 +8665,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8687,7 +8685,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8700,7 +8698,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8784,7 +8782,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8794,7 +8792,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8847,7 +8845,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8863,7 +8861,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8877,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8890,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8915,7 +8913,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8944,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8970,7 +8968,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9000,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9015,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9040,7 +9038,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9064,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9088,7 +9086,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9123,7 +9121,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9180,7 +9178,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9207,7 +9205,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9230,7 +9228,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9257,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9296,11 +9294,11 @@ dependencies = [
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
+ "reth-storage-overlay",
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
  "reth-trie-common",
- "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm",
@@ -9314,7 +9312,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9344,7 +9342,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9362,7 +9360,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9378,7 +9376,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9401,7 +9399,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9412,7 +9410,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9440,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9462,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9503,7 +9501,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "clap",
  "eyre",
@@ -9526,7 +9524,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9542,7 +9540,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9558,7 +9556,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9571,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9601,7 +9599,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9615,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9625,7 +9623,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9634,6 +9632,7 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
+ "fixed-cache",
  "futures-util",
  "metrics",
  "rayon",
@@ -9650,7 +9649,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9670,7 +9669,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9688,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9701,7 +9700,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9720,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9758,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9772,7 +9771,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "serde",
  "serde_json",
@@ -9782,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9808,7 +9807,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bytes",
  "futures",
@@ -9828,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9845,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bindgen",
  "cc",
@@ -9854,7 +9853,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "futures",
  "libc",
@@ -9868,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9877,7 +9876,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9891,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9920,6 +9919,7 @@ dependencies = [
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
+ "reth-evm",
  "reth-evm-ethereum",
  "reth-fs-util",
  "reth-metrics",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9974,7 +9974,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10027,7 +10027,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10044,7 +10044,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10121,11 +10121,11 @@ dependencies = [
  "reth-rpc-layer",
  "reth-stages",
  "reth-static-file",
+ "reth-storage-overlay",
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -10136,7 +10136,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10264,7 +10264,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10288,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "bytes",
  "eyre",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10329,7 +10329,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10353,7 +10353,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10365,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10388,7 +10388,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10431,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10464,6 +10464,7 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
+ "reth-storage-overlay",
  "reth-tasks",
  "reth-tokio-util",
  "reth-trie",
@@ -10479,7 +10480,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10506,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10522,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10537,7 +10538,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10614,7 +10615,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10644,7 +10645,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10687,7 +10688,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10707,7 +10708,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10738,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10785,7 +10786,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10836,7 +10837,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10850,7 +10851,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10881,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10932,7 +10933,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10960,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10974,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10994,7 +10995,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11009,7 +11010,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11035,7 +11036,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11050,9 +11051,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "reth-storage-overlay"
+version = "2.4.1"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "metrics",
+ "parking_lot",
+ "rayon",
+ "reth-chain-state",
+ "reth-errors",
+ "reth-ethereum-primitives",
+ "reth-metrics",
+ "reth-primitives-traits",
+ "reth-prune-types",
+ "reth-stages-types",
+ "reth-storage-api",
+ "reth-storage-errors",
+ "reth-tasks",
+ "reth-trie",
+ "reth-trie-common",
+ "reth-trie-db",
+ "tracing",
+]
+
+[[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11073,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11089,7 +11116,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11099,7 +11126,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "clap",
  "eyre",
@@ -11119,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11138,7 +11165,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11181,7 +11208,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11206,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11233,14 +11260,11 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
- "metrics",
- "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
- "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11252,7 +11276,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11277,7 +11301,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=84f4c98#84f4c989cb29c14af6a7bdcc0a97e4844f1cd3da"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "84f4c98", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`84f4c98...fc3f7da`](https://github.com/paradigmxyz/reth/compare/84f4c98...fc3f7da)

🔗 Amp thread: https://ampcode.com/threads/T-019fa6e6-358d-769d-a560-e7c7433eb193
**Storage**
- Extracted the `reth-storage-overlay` crate ([#26506](https://github.com/paradigmxyz/reth/pull/26506)).

**Perf**
- Shared the sender recovery cache across transaction paths ([#26494](https://github.com/paradigmxyz/reth/pull/26494)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019fa6e6-4989-703d-b9be-8c6eddc2de10
- Migrated all Git-sourced Reth workspace dependencies from revision `84f4c98` to `fc3f7da` to align Tempo with the newer Reth SDK snapshot; dependency features and configuration remain unchanged.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/30327506200)
