### PR TITLE
fix(follower): republish upstream blocks to feed

### DIFF
--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -62,7 +62,9 @@ use reth_network_api::Peers;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
 use std::{sync::Arc, thread};
 use tempo_chainspec::spec::TempoChainSpec;
-use tempo_consensus::{feed as consensus_feed, run_consensus_stack, run_follow_stack};
+use tempo_consensus::{
+    feed as consensus_feed, follow::feed as follower_feed, run_consensus_stack, run_follow_stack,
+};
 use tempo_evm::{TempoEvmConfig, consensus::TempoConsensus};
 use tempo_faucet::faucet::{TempoFaucetExt, TempoFaucetExtApiServer};
 pub use tempo_node::{
@@ -265,9 +267,11 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
     let cl_feed_state = consensus_feed::FeedStateHandle::new();
+    let follower_feed_state = follower_feed::FeedStateHandle::new();
 
     let shutdown_token_clone = shutdown_token.clone();
     let cl_feed_state_clone = cl_feed_state.clone();
+    let follower_feed_state_clone = follower_feed_state.clone();
 
     let consensus_handle = thread::spawn(move || {
         // Exit early if we are not executing `tempo node` command.
@@ -356,7 +360,7 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
                     args.consensus,
                     follow_url,
                     Arc::new(node),
-                    cl_feed_state_clone,
+                    follower_feed_state_clone,
                 ))
             } else {
                 Either::Right(run_consensus_stack(
@@ -449,6 +453,7 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
             url => Some(url.to_string()),
         };
 
+        let is_following = args.follow.is_some();
         let NodeHandle {
             node,
             node_exit_future,
@@ -490,9 +495,15 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
                     }
 
                     if has_consensus_engine {
-                        let consensus_rpc = TempoConsensusRpc::new(cl_feed_state);
-                        ctx.modules.merge_configured(consensus_rpc.into_rpc())
-                            .wrap_err("failed to register consensus rpc module")?;
+                        if is_following {
+                            let consensus_rpc = TempoConsensusRpc::new(follower_feed_state);
+                            ctx.modules.merge_configured(consensus_rpc.into_rpc())
+                                .wrap_err("failed to register follower consensus rpc module")?;
+                        } else {
+                            let consensus_rpc = TempoConsensusRpc::new(cl_feed_state);
+                            ctx.modules.merge_configured(consensus_rpc.into_rpc())
+                                .wrap_err("failed to register consensus rpc module")?;
+                        }
                     }
 
                     Ok(())

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -22,17 +22,18 @@ use tempo_node::rpc::consensus::{CertifiedBlock, Event};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, instrument, warn};
 
-use super::{Config, ExecutionProvider, Mailbox, Marshal, ingress::Message};
+use super::{Config, ExecutionProvider, Feed, Mailbox, Marshal, ingress::Message};
 use crate::consensus::{Block, Digest};
 
-pub(super) fn try_init<TContext, P, M>(
+pub(super) fn try_init<TContext, P, M, F>(
     context: TContext,
-    config: Config<P, M>,
-) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
+    config: Config<P, M, F>,
+) -> eyre::Result<(Driver<TContext, P, M, F>, Mailbox)>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    F: Feed + 'static,
 {
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = Mailbox(tx);
@@ -106,20 +107,21 @@ where
     Ok((actor, mailbox))
 }
 
-pub(crate) struct Driver<TContext, P, M> {
+pub(crate) struct Driver<TContext, P, M, F> {
     context: ContextCell<TContext>,
-    config: Config<P, M>,
+    config: Config<P, M, F>,
     mailbox: mpsc::UnboundedReceiver<Message>,
     startup_execution_boundary: Height,
     current_epoch: Epoch,
     network_scheme: Arc<Scheme<PublicKey, MinSig>>,
 }
 
-impl<C, P, M> Driver<C, P, M>
+impl<C, P, M, F> Driver<C, P, M, F>
 where
     C: Clock + Rng + CryptoRng + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    F: Feed + 'static,
 {
     pub(crate) fn start(mut self) -> commonware_runtime::Handle<()> {
         spawn_cell!(self.context, self.run())
@@ -288,9 +290,14 @@ where
         }
 
         let round = finalization.round();
-        let activity = Activity::Finalization(finalization);
+        let activity = Activity::Finalization(finalization.clone());
 
-        let _ = self.config.marshal.certified(round, consensus_block).await;
+        let _ = self
+            .config
+            .marshal
+            .certified(round, consensus_block.clone())
+            .await;
+        self.config.feed.report(consensus_block, finalization);
         self.config.marshal.report(activity).await;
         Ok(())
     }

--- a/crates/consensus/src/follow/driver/mod.rs
+++ b/crates/consensus/src/follow/driver/mod.rs
@@ -1,12 +1,15 @@
 //! Follower finalization driver.
 //!
-//! Validates finalized blocks received from upstream and reports them to marshal.
-//! Marshal's finalized block updates independently drive the consensus feed.
+//! Validates finalized blocks received from upstream and reports them to marshal
+//! and the local consensus feed.
 
 use std::future::Future;
 
 use commonware_consensus::{
-    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
+    simplex::{
+        scheme::bls12381_threshold::vrf::Scheme,
+        types::{Activity, Finalization},
+    },
     types::{FixedEpocher, Height, Round},
 };
 use commonware_cryptography::{
@@ -30,6 +33,8 @@ use crate::{
     epoch::SchemeProvider,
 };
 
+use super::feed as follower_feed;
+
 mod actor;
 mod ingress;
 
@@ -40,8 +45,9 @@ pub(super) use actor::Driver;
 pub(super) use ingress::Mailbox;
 
 type ConsensusActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
+type ConsensusFinalization = Finalization<Scheme<PublicKey, MinSig>, Digest>;
 
-pub(super) struct Config<P, M> {
+pub(super) struct Config<P, M, F> {
     pub(super) execution_provider: P,
     pub(super) scheme_provider: SchemeProvider,
     pub(super) network_identity: NetworkIdentity,
@@ -49,20 +55,27 @@ pub(super) struct Config<P, M> {
     pub(super) last_finalized_height: Height,
 
     pub(super) marshal: M,
+    pub(super) feed: F,
 
     pub(super) epoch_strategy: FixedEpocher,
 }
 
-pub(super) fn try_init<TContext, P, M>(
+pub(super) fn try_init<TContext, P, M, F>(
     context: TContext,
-    config: Config<P, M>,
-) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
+    config: Config<P, M, F>,
+) -> eyre::Result<(Driver<TContext, P, M, F>, Mailbox)>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    F: Feed + 'static,
 {
     actor::try_init(context, config)
+}
+
+/// Local feed operation used to republish certified blocks received upstream.
+pub(super) trait Feed: Send + Sync {
+    fn report(&self, block: Block, finalization: ConsensusFinalization);
 }
 
 /// Finalized execution-layer state needed to establish the driver's trusted boundary.
@@ -118,5 +131,11 @@ impl Marshal for crate::alias::marshal::Mailbox {
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
         let mut mailbox = self.clone();
         async move { commonware_consensus::Reporter::report(&mut mailbox, activity).await }
+    }
+}
+
+impl Feed for follower_feed::Mailbox {
+    fn report(&self, block: Block, finalization: ConsensusFinalization) {
+        self.report(block, finalization);
     }
 }

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -19,7 +19,7 @@ use tempo_node::rpc::consensus::Event;
 use super::{Config, try_init};
 use crate::epoch::SchemeProvider;
 use utils::{
-    EPOCH_LENGTH, StubExecutionProvider, StubMarshal, dkg_fixture, make_block,
+    EPOCH_LENGTH, StubExecutionProvider, StubFeed, StubMarshal, dkg_fixture, make_block,
     make_certified_block, make_finalization,
 };
 
@@ -62,6 +62,7 @@ fn startup_uses_previous_execution_boundary() {
                 },
                 last_finalized_height: finalized_height,
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         );
@@ -90,6 +91,7 @@ fn startup_propagates_finalized_block_read_failure() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -116,6 +118,7 @@ fn startup_requires_execution_boundary_header() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -134,6 +137,7 @@ fn valid_finalization_is_certified_and_reported() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
+        let feed = StubFeed::default();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
             Config {
@@ -145,6 +149,7 @@ fn valid_finalization_is_certified_and_reported() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -162,13 +167,62 @@ fn valid_finalization_is_certified_and_reported() {
 
         let mut reporter = mailbox.to_event_reporter();
         reporter.report(event).await;
-        wait_until(&context, || marshal.certified().len() == 1).await;
+        wait_until(&context, || {
+            marshal.certified().len() == 1 && feed.blocks().len() == 1
+        })
+        .await;
 
         let certified = marshal.certified();
         assert_eq!(certified[0].0, finalization.proposal.round);
         assert_eq!(certified[0].1, block);
         assert_eq!(marshal.report_count(), 1);
+        assert_eq!(feed.blocks(), vec![block]);
         assert!(marshal.hints().is_empty());
+    });
+}
+
+#[test_traced]
+fn valid_finalization_reaches_feed_when_marshal_reporting_stalls() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+
+        let marshal = StubMarshal::default();
+        marshal.block_reports();
+        let feed = StubFeed::default();
+        let (actor, mailbox) = try_init(
+            context.with_label("driver"),
+            Config {
+                execution_provider: provider,
+                scheme_provider: SchemeProvider::new(),
+                network_identity: NetworkIdentity {
+                    from_epoch: 0,
+                    identity: *fixture.outcome.network_identity(),
+                },
+                last_finalized_height: Height::zero(),
+                marshal,
+                feed: feed.clone(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+            },
+        )
+        .expect("driver should initialize");
+
+        actor.start();
+
+        let block = make_block(1, None);
+        let finalization = make_finalization(&block, Epoch::zero(), &fixture.schemes);
+        let mut reporter = mailbox.to_event_reporter();
+        reporter
+            .report(Event::Finalized {
+                block: make_certified_block(block.clone(), &finalization),
+                seen: 0,
+            })
+            .await;
+
+        wait_until(&context, || feed.blocks().len() == 1).await;
+        assert_eq!(feed.blocks(), vec![block]);
     });
 }
 
@@ -193,6 +247,7 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -250,6 +305,7 @@ fn invalid_finalization_hints_current_epoch_boundary() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -295,6 +351,7 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -357,6 +414,7 @@ fn scheme_before_network_identity_epoch_is_required() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -414,6 +472,7 @@ fn boundary_update_registers_scheme_before_acknowledging() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -453,6 +512,7 @@ fn non_boundary_update_is_acknowledged_without_registering_a_scheme() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -506,6 +566,7 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
                 },
                 last_finalized_height,
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -540,6 +601,7 @@ fn non_finalized_events_are_ignored() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )

--- a/crates/consensus/src/follow/driver/test/utils.rs
+++ b/crates/consensus/src/follow/driver/test/utils.rs
@@ -36,7 +36,7 @@ use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::rpc::consensus::CertifiedBlock;
 use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
 
-use super::super::{ConsensusActivity, ExecutionProvider, Marshal};
+use super::super::{ConsensusActivity, ConsensusFinalization, ExecutionProvider, Feed, Marshal};
 use crate::consensus::{Block, Digest};
 
 pub(super) const EPOCH_LENGTH: NonZeroU64 = NonZeroU64::new(10).expect("epoch length is nonzero");
@@ -193,6 +193,7 @@ struct StubMarshalInner {
     hints: Mutex<Vec<Height>>,
     certified: Mutex<Vec<(Round, Block)>>,
     reports: Mutex<Vec<ConsensusActivity>>,
+    block_reports: AtomicBool,
 }
 
 impl StubMarshal {
@@ -215,6 +216,10 @@ impl StubMarshal {
     pub(super) fn report_count(&self) -> usize {
         self.inner.reports.lock().len()
     }
+
+    pub(super) fn block_reports(&self) {
+        self.inner.block_reports.store(true, Ordering::SeqCst);
+    }
 }
 
 impl Marshal for StubMarshal {
@@ -236,6 +241,28 @@ impl Marshal for StubMarshal {
 
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
         self.inner.reports.lock().push(activity);
-        async {}
+        let block = self.inner.block_reports.load(Ordering::SeqCst);
+        async move {
+            if block {
+                std::future::pending().await
+            }
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct StubFeed {
+    blocks: Arc<Mutex<Vec<Block>>>,
+}
+
+impl StubFeed {
+    pub(super) fn blocks(&self) -> Vec<Block> {
+        self.blocks.lock().clone()
+    }
+}
+
+impl Feed for StubFeed {
+    fn report(&self, block: Block, _finalization: ConsensusFinalization) {
+        self.blocks.lock().push(block);
     }
 }

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -30,12 +30,11 @@ use tempo_chainspec::NetworkIdentity;
 use tempo_node::{TempoFullNode, TempoPayloadTypes, node::TempoNode};
 use tracing::{info, info_span};
 
-use super::{driver, executor, resolver, resolver::Resolver, stubs};
+use super::{driver, executor, feed, resolver, resolver::Resolver, stubs};
 use crate::{
     alias,
     consensus::{Digest, block::Block},
     epoch::SchemeProvider,
-    feed::{self, FeedStateHandle},
     follow::upstream,
     storage,
 };
@@ -47,7 +46,7 @@ pub struct Config<TUpstream> {
     pub execution_node: Arc<TempoFullNode>,
 
     /// Feed state handle for RPC serving.
-    pub feed_state: FeedStateHandle,
+    pub feed_state: feed::FeedStateHandle,
 
     /// Partition prefix for storage.
     pub partition_prefix: String,
@@ -180,6 +179,7 @@ impl<TUpstream> Config<TUpstream> {
                 network_identity: self.network_identity,
                 last_finalized_height,
                 marshal: marshal_mailbox,
+                feed: feed_mailbox.clone(),
                 epoch_strategy: epoch_strategy.clone(),
             },
         )
@@ -198,7 +198,6 @@ impl<TUpstream> Config<TUpstream> {
             executor: executor_actor,
             executor_mailbox,
             feed: feed_actor,
-            feed_mailbox,
             broadcast,
             upstream: self.upstream,
         })
@@ -218,6 +217,7 @@ where
             NodeTypesWithDBAdapter<TempoNode, reth_ethereum::provider::db::DatabaseEnv>,
         >,
         crate::alias::marshal::Mailbox,
+        feed::Mailbox,
     >,
     driver_mailbox: driver::Mailbox,
     resolver: Resolver<TContext>,
@@ -233,7 +233,6 @@ where
     >,
     executor_mailbox: executor::Mailbox,
     feed: feed::Actor<TContext>,
-    feed_mailbox: feed::Mailbox,
     broadcast: buffered::Mailbox<PublicKey, Block>,
     upstream: TUpstreamActor,
 }
@@ -270,7 +269,6 @@ where
             executor,
             executor_mailbox,
             feed,
-            feed_mailbox,
             broadcast,
             ..
         } = self;
@@ -282,7 +280,7 @@ where
             marshal.start(
                 Reporters::from((
                     executor_mailbox.clone(),
-                    Reporters::from((driver_mailbox.to_marshal_reporter(), feed_mailbox)),
+                    driver_mailbox.to_marshal_reporter(),
                 )),
                 broadcast,
                 (resolver_rx, resolver_mailbox),

--- a/crates/consensus/src/follow/feed.rs
+++ b/crates/consensus/src/follow/feed.rs
@@ -1,0 +1,212 @@
+//! Local RPC feed for follower mode.
+//!
+//! Unlike the validator feed, this feed receives complete, verified
+//! `(block, finalization)` pairs from the upstream driver. It does not depend
+//! on marshal updates for live delivery.
+
+use std::{
+    sync::{Arc, OnceLock},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use alloy_primitives::hex;
+use commonware_codec::Encode as _;
+use commonware_consensus::{
+    Heightable as _,
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
+    types::Height,
+};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell};
+use futures::{StreamExt as _, channel::mpsc};
+use parking_lot::RwLock;
+use tempo_node::rpc::consensus::{
+    CertifiedBlock, ConsensusFeed, ConsensusState, Event, Query, types::Response,
+};
+use tokio::sync::broadcast;
+use tracing::{Level, debug, error, info_span, instrument};
+
+use crate::{
+    alias::marshal,
+    consensus::{Block, Digest},
+};
+
+pub(super) type ConsensusFinalization = Finalization<Scheme<PublicKey, MinSig>, Digest>;
+type Certified = (Block, ConsensusFinalization);
+const BROADCAST_CHANNEL_SIZE: usize = 1024;
+
+#[derive(Default)]
+struct FeedState {
+    latest_finalized: Option<CertifiedBlock>,
+}
+
+#[derive(Clone)]
+pub struct FeedStateHandle {
+    state: Arc<RwLock<FeedState>>,
+    marshal: Arc<OnceLock<marshal::Mailbox>>,
+    events_tx: broadcast::Sender<Event>,
+}
+
+impl FeedStateHandle {
+    pub fn new() -> Self {
+        let (events_tx, _) = broadcast::channel(BROADCAST_CHANNEL_SIZE);
+        Self {
+            state: Arc::new(RwLock::new(FeedState::default())),
+            marshal: Arc::new(OnceLock::new()),
+            events_tx,
+        }
+    }
+
+    fn set_marshal(&self, marshal: marshal::Mailbox) {
+        let _ = self.marshal.set(marshal);
+    }
+
+    fn publish(&self, finalized: CertifiedBlock, seen: u64) -> usize {
+        self.state.write().latest_finalized = Some(finalized.clone());
+        let subscribers = self.events_tx.receiver_count();
+        let _ = self.events_tx.send(Event::Finalized {
+            block: finalized,
+            seen,
+        });
+        subscribers
+    }
+
+    fn marshal(&self) -> Option<marshal::Mailbox> {
+        self.marshal.get().cloned()
+    }
+}
+
+impl Default for FeedStateHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for FeedStateHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FollowerFeedStateHandle")
+            .field("latest_finalized", &self.state.read().latest_finalized)
+            .field("marshal_set", &self.marshal.get().is_some())
+            .field("subscriber_count", &self.events_tx.receiver_count())
+            .finish()
+    }
+}
+
+impl ConsensusFeed for FeedStateHandle {
+    #[instrument(skip_all, fields(%query), ret(level = Level::DEBUG, Display))]
+    async fn get_finalization(&self, query: Query) -> Response<CertifiedBlock> {
+        match query {
+            Query::Latest => self
+                .state
+                .read()
+                .latest_finalized
+                .clone()
+                .map_or(Response::Missing("certifications"), Response::Success),
+            Query::Height(height) => 'process: {
+                let Some(marshal) = self.marshal() else {
+                    break 'process Response::NotReady;
+                };
+                let height = Height::new(height);
+                let Some(finalization) = marshal.get_finalization(height).await else {
+                    break 'process Response::Missing("certificate");
+                };
+                let Some(block) = marshal.get_block(height).await else {
+                    break 'process Response::Missing("block");
+                };
+                Response::Success(CertifiedBlock {
+                    epoch: finalization.proposal.round.epoch().get(),
+                    view: finalization.proposal.round.view().get(),
+                    block: block.into_execution_block(),
+                    digest: finalization.proposal.payload.0,
+                    certificate: hex::encode(finalization.encode()),
+                })
+            }
+        }
+    }
+
+    async fn get_latest(&self) -> ConsensusState {
+        ConsensusState {
+            finalized: self.state.read().latest_finalized.clone(),
+            notarized: None,
+        }
+    }
+
+    async fn subscribe(&self) -> Option<broadcast::Receiver<Event>> {
+        Some(self.events_tx.subscribe())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct Mailbox(mpsc::UnboundedSender<Certified>);
+
+impl Mailbox {
+    pub(super) fn report(&self, block: Block, finalization: ConsensusFinalization) {
+        if self.0.unbounded_send((block, finalization)).is_err() {
+            error!("failed sending certified block to follower feed");
+        }
+    }
+}
+
+pub(super) struct Actor<TContext> {
+    context: ContextCell<TContext>,
+    receiver: mpsc::UnboundedReceiver<Certified>,
+    state: FeedStateHandle,
+}
+
+impl<TContext: Spawner> Actor<TContext> {
+    pub(super) fn start(mut self) -> Handle<()> {
+        spawn_cell!(self.context, self.run())
+    }
+
+    async fn run(&mut self) {
+        while let Some((block, finalization)) = self.receiver.next().await {
+            self.publish(block, finalization);
+        }
+
+        info_span!("follower_feed_actor").in_scope(|| error!("mailbox closed; shutting down"));
+    }
+
+    #[instrument(skip_all, fields(height = %block.height(), digest = %block.digest()))]
+    fn publish(&self, block: Block, finalization: ConsensusFinalization) {
+        let height = block.height();
+        let round = finalization.proposal.round;
+        let finalized = CertifiedBlock {
+            epoch: round.epoch().get(),
+            view: round.view().get(),
+            block: block.into_execution_block(),
+            digest: finalization.proposal.payload.0,
+            certificate: hex::encode(finalization.encode()),
+        };
+
+        let subscribers = self.state.publish(finalized, now_millis());
+        debug!(
+            subscribers,
+            height = height.get(),
+            "sending follower finalized block event"
+        );
+    }
+}
+
+pub(super) fn init<TContext: Spawner>(
+    context: TContext,
+    marshal: marshal::Mailbox,
+    state: FeedStateHandle,
+) -> (Actor<TContext>, Mailbox) {
+    state.set_marshal(marshal);
+    let (sender, receiver) = mpsc::unbounded();
+    (
+        Actor {
+            context: ContextCell::new(context),
+            receiver,
+            state,
+        },
+        Mailbox(sender),
+    )
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/consensus/src/follow/mod.rs
+++ b/crates/consensus/src/follow/mod.rs
@@ -6,6 +6,7 @@
 mod driver;
 pub mod engine;
 pub(crate) mod executor;
+pub mod feed;
 pub(crate) mod resolver;
 mod stubs;
 pub mod upstream;

--- a/crates/consensus/src/follow/upstream/in_process.rs
+++ b/crates/consensus/src/follow/upstream/in_process.rs
@@ -13,7 +13,7 @@ use futures::{
 use reth_provider::{BlockReader as _, BlockSource};
 use tempo_node::{
     TempoFullNode,
-    rpc::consensus::{CertifiedBlock, ConsensusFeed as _, Event, Query},
+    rpc::consensus::{CertifiedBlock, ConsensusFeed, Event, Query},
 };
 use tokio::{
     select,
@@ -24,18 +24,17 @@ use tracing::{debug, debug_span, info, instrument};
 
 use crate::{
     consensus::{Block, Digest},
-    feed::FeedStateHandle,
     utils::OptionFuture,
 };
 
 use super::ingress::{Mailbox, Message};
 
-pub struct Config {
+pub struct Config<F> {
     pub execution_node: Arc<TempoFullNode>,
-    pub feed: FeedStateHandle,
+    pub feed: F,
 }
 
-pub fn init<TContext>(context: TContext, config: Config) -> (Actor<TContext>, Mailbox) {
+pub fn init<TContext, F>(context: TContext, config: Config<F>) -> (Actor<TContext, F>, Mailbox) {
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = Mailbox::new(tx);
 
@@ -51,17 +50,18 @@ pub fn init<TContext>(context: TContext, config: Config) -> (Actor<TContext>, Ma
     (actor, mailbox)
 }
 
-pub struct Actor<TContext> {
+pub struct Actor<TContext, F> {
     context: ContextCell<TContext>,
-    config: Config,
+    config: Config<F>,
     event_stream: Fuse<BoxStream<'static, Result<Event, BroadcastStreamRecvError>>>,
     mailbox: mpsc::UnboundedReceiver<Message>,
     waiters: Vec<Message>,
 }
 
-impl<TContext> Actor<TContext>
+impl<TContext, F> Actor<TContext, F>
 where
     TContext: Clock + Metrics + Spawner,
+    F: Clone + ConsensusFeed + Send + Sync + 'static,
 {
     pub(crate) fn start(
         mut self,
@@ -139,8 +139,8 @@ where
 }
 
 #[instrument(skip_all, fields(%height), err)]
-async fn get_finalization(
-    client: FeedStateHandle,
+async fn get_finalization<F: ConsensusFeed>(
+    client: F,
     height: Height,
     response: oneshot::Sender<Option<CertifiedBlock>>,
 ) -> eyre::Result<()> {

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -172,7 +172,7 @@ pub async fn run_follow_stack(
     config: Args,
     upstream_url: String,
     execution_node: Arc<TempoFullNode>,
-    feed_state: feed::FeedStateHandle,
+    feed_state: follow::feed::FeedStateHandle,
 ) -> eyre::Result<()> {
     let chain_spec = execution_node.chain_spec();
 

--- a/crates/e2e/src/execution_runtime.rs
+++ b/crates/e2e/src/execution_runtime.rs
@@ -235,6 +235,8 @@ pub struct ExecutionNodeConfig {
     pub validator_key: Option<B256>,
     /// Feed state handle for consensus RPC (if validator).
     pub feed_state: Option<FeedStateHandle>,
+    /// Feed state handle for consensus RPC (if follower).
+    pub follower_feed_state: Option<tempo_consensus::follow::feed::FeedStateHandle>,
     /// Share the engine's sparse trie pipeline with the payload builder.
     pub share_sparse_trie_with_payload_builder: bool,
 }
@@ -250,6 +252,7 @@ impl ExecutionNodeConfig {
             secret_key: B256::random(),
             validator_key: None,
             feed_state: None,
+            follower_feed_state: None,
             share_sparse_trie_with_payload_builder: false,
         }
     }
@@ -866,6 +869,7 @@ pub async fn launch_execution_node<P: AsRef<Path>>(
         secret_key,
         validator_key,
         feed_state,
+        follower_feed_state,
         share_sparse_trie_with_payload_builder,
     } = config;
     let node_config = NodeConfig::new(Arc::new(chain_spec))
@@ -909,6 +913,10 @@ pub async fn launch_execution_node<P: AsRef<Path>>(
     .node(tempo_node)
     .extend_rpc_modules(move |ctx| {
         if let Some(feed_state) = feed_state {
+            ctx.modules
+                .merge_configured(TempoConsensusRpc::new(feed_state).into_rpc())?;
+        }
+        if let Some(feed_state) = follower_feed_state {
             ctx.modules
                 .merge_configured(TempoConsensusRpc::new(feed_state).into_rpc())?;
         }

--- a/crates/e2e/src/tests/follow.rs
+++ b/crates/e2e/src/tests/follow.rs
@@ -24,8 +24,11 @@ use futures::{channel::oneshot, future::join_all};
 use jsonrpsee::{core::client::ClientT as _, http_client::HttpClientBuilder, rpc_params};
 use rand_core::CryptoRngCore;
 use reth_ethereum::provider::BlockIdReader as _;
-use tempo_consensus::{feed::FeedStateHandle, follow};
-use tempo_node::rpc::consensus::{ConsensusFeed as _, Query, types::Response};
+use tempo_consensus::{
+    feed::FeedStateHandle,
+    follow::{self, feed::FeedStateHandle as FollowerFeedStateHandle},
+};
+use tempo_node::rpc::consensus::{ConsensusFeed, ConsensusFeed as _, Query, types::Response};
 
 static EPOCH_LENGTH: u64 = 10;
 
@@ -91,12 +94,16 @@ async fn follower_rpc_survives_execution_node_handle_drop() {
 }
 
 trait FeedStateProvider {
-    fn feed_state(&self) -> FeedStateHandle;
+    type Feed: Clone + ConsensusFeed + Send + Sync + 'static;
+
+    fn feed_state(&self) -> Self::Feed;
 
     fn execution_node(&self) -> Arc<tempo_node::TempoFullNode>;
 }
 
 impl<TContext: Clock> FeedStateProvider for TestingNode<TContext> {
+    type Feed = FeedStateHandle;
+
     fn feed_state(&self) -> FeedStateHandle {
         self.consensus_config.feed_state.clone()
     }
@@ -112,7 +119,9 @@ impl<TContext: Clock> FeedStateProvider for TestingNode<TContext> {
 }
 
 impl FeedStateProvider for Follower {
-    fn feed_state(&self) -> FeedStateHandle {
+    type Feed = FollowerFeedStateHandle;
+
+    fn feed_state(&self) -> Self::Feed {
         self.feed.clone()
     }
 
@@ -122,7 +131,9 @@ impl FeedStateProvider for Follower {
 }
 
 impl<T: FeedStateProvider> FeedStateProvider for &T {
-    fn feed_state(&self) -> FeedStateHandle {
+    type Feed = T::Feed;
+
+    fn feed_state(&self) -> Self::Feed {
         (*self).feed_state()
     }
 
@@ -198,14 +209,15 @@ impl FollowerBuilder {
         });
 
         let partition_prefix = partition_prefix.unwrap_or_else(|| name.clone());
-        let feed_state = FeedStateHandle::new();
+        let feed_state = FollowerFeedStateHandle::new();
         let upstream_execution_node = upstream.execution_node();
         let upstream_feed_state = upstream.feed_state();
 
         let config = crate::ExecutionNodeConfig {
             secret_key: alloy_primitives::B256::random(),
             validator_key: None,
-            feed_state: Some(feed_state.clone()),
+            feed_state: None,
+            follower_feed_state: Some(feed_state.clone()),
             share_sparse_trie_with_payload_builder: false,
         };
 
@@ -278,7 +290,7 @@ impl FollowerBuilder {
 
 struct Follower {
     name: String,
-    feed: FeedStateHandle,
+    feed: FollowerFeedStateHandle,
     execution_node: ExecutionNode,
     _handle: Handle<eyre::Result<()>>,
 }


### PR DESCRIPTION
Adds a self-contained follower feed and follower feed state that republishes verified upstream `(block, finalization)` pairs directly to follower RPC subscribers. The validator feed and its state remain unchanged.

Production and E2E RPC setup now select the validator or follower state explicitly; the in-process test upstream accepts either state implementation.

Validation: `cargo +nightly fmt --all --check`; `cargo metadata --no-deps --offline`; `git diff --check`.
Focused Rust tests were blocked by HTTP 401 fetching the pinned Commonware revision.

Prompted by: @SuperFluffy