### PR TITLE
fix(follower): republish upstream blocks to feed

### DIFF
--- a/crates/consensus/src/feed/state.rs
+++ b/crates/consensus/src/feed/state.rs
@@ -53,6 +53,17 @@ impl FeedStateHandle {
         let _ = self.marshal.set(marshal);
     }
 
+    /// Update the latest finalized block and broadcast it to RPC subscribers.
+    pub(crate) fn publish_finalized(&self, finalized: CertifiedBlock, seen: u64) -> usize {
+        self.state.write().latest_finalized = Some(finalized.clone());
+        let subscribers = self.events_tx.receiver_count();
+        let _ = self.events_tx.send(Event::Finalized {
+            block: finalized,
+            seen,
+        });
+        subscribers
+    }
+
     /// Get the broadcast sender for events.
     pub(super) fn events_tx(&self) -> &broadcast::Sender<Event> {
         &self.events_tx

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -22,17 +22,18 @@ use tempo_node::rpc::consensus::{CertifiedBlock, Event};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, instrument, warn};
 
-use super::{Config, ExecutionProvider, Mailbox, Marshal, ingress::Message};
+use super::{Config, ExecutionProvider, Feed, Mailbox, Marshal, ingress::Message};
 use crate::consensus::{Block, Digest};
 
-pub(super) fn try_init<TContext, P, M>(
+pub(super) fn try_init<TContext, P, M, F>(
     context: TContext,
-    config: Config<P, M>,
-) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
+    config: Config<P, M, F>,
+) -> eyre::Result<(Driver<TContext, P, M, F>, Mailbox)>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    F: Feed + 'static,
 {
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = Mailbox(tx);
@@ -106,20 +107,21 @@ where
     Ok((actor, mailbox))
 }
 
-pub(crate) struct Driver<TContext, P, M> {
+pub(crate) struct Driver<TContext, P, M, F> {
     context: ContextCell<TContext>,
-    config: Config<P, M>,
+    config: Config<P, M, F>,
     mailbox: mpsc::UnboundedReceiver<Message>,
     startup_execution_boundary: Height,
     current_epoch: Epoch,
     network_scheme: Arc<Scheme<PublicKey, MinSig>>,
 }
 
-impl<C, P, M> Driver<C, P, M>
+impl<C, P, M, F> Driver<C, P, M, F>
 where
     C: Clock + Rng + CryptoRng + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    F: Feed + 'static,
 {
     pub(crate) fn start(mut self) -> commonware_runtime::Handle<()> {
         spawn_cell!(self.context, self.run())
@@ -288,9 +290,14 @@ where
         }
 
         let round = finalization.round();
-        let activity = Activity::Finalization(finalization);
+        let activity = Activity::Finalization(finalization.clone());
 
-        let _ = self.config.marshal.certified(round, consensus_block).await;
+        let _ = self
+            .config
+            .marshal
+            .certified(round, consensus_block.clone())
+            .await;
+        self.config.feed.report(consensus_block, finalization);
         self.config.marshal.report(activity).await;
         Ok(())
     }

--- a/crates/consensus/src/follow/driver/mod.rs
+++ b/crates/consensus/src/follow/driver/mod.rs
@@ -1,12 +1,15 @@
 //! Follower finalization driver.
 //!
-//! Validates finalized blocks received from upstream and reports them to marshal.
-//! Marshal's finalized block updates independently drive the consensus feed.
+//! Validates finalized blocks received from upstream and reports them to marshal
+//! and the local consensus feed.
 
 use std::future::Future;
 
 use commonware_consensus::{
-    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Activity},
+    simplex::{
+        scheme::bls12381_threshold::vrf::Scheme,
+        types::{Activity, Finalization},
+    },
     types::{FixedEpocher, Height, Round},
 };
 use commonware_cryptography::{
@@ -30,6 +33,8 @@ use crate::{
     epoch::SchemeProvider,
 };
 
+use super::feed as follower_feed;
+
 mod actor;
 mod ingress;
 
@@ -40,8 +45,9 @@ pub(super) use actor::Driver;
 pub(super) use ingress::Mailbox;
 
 type ConsensusActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
+type ConsensusFinalization = Finalization<Scheme<PublicKey, MinSig>, Digest>;
 
-pub(super) struct Config<P, M> {
+pub(super) struct Config<P, M, F> {
     pub(super) execution_provider: P,
     pub(super) scheme_provider: SchemeProvider,
     pub(super) network_identity: NetworkIdentity,
@@ -49,20 +55,27 @@ pub(super) struct Config<P, M> {
     pub(super) last_finalized_height: Height,
 
     pub(super) marshal: M,
+    pub(super) feed: F,
 
     pub(super) epoch_strategy: FixedEpocher,
 }
 
-pub(super) fn try_init<TContext, P, M>(
+pub(super) fn try_init<TContext, P, M, F>(
     context: TContext,
-    config: Config<P, M>,
-) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
+    config: Config<P, M, F>,
+) -> eyre::Result<(Driver<TContext, P, M, F>, Mailbox)>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    F: Feed + 'static,
 {
     actor::try_init(context, config)
+}
+
+/// Local feed operation used to republish certified blocks received upstream.
+pub(super) trait Feed: Send + Sync {
+    fn report(&self, block: Block, finalization: ConsensusFinalization);
 }
 
 /// Finalized execution-layer state needed to establish the driver's trusted boundary.
@@ -118,5 +131,11 @@ impl Marshal for crate::alias::marshal::Mailbox {
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
         let mut mailbox = self.clone();
         async move { commonware_consensus::Reporter::report(&mut mailbox, activity).await }
+    }
+}
+
+impl Feed for follower_feed::Mailbox {
+    fn report(&self, block: Block, finalization: ConsensusFinalization) {
+        self.report(block, finalization);
     }
 }

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -19,7 +19,7 @@ use tempo_node::rpc::consensus::Event;
 use super::{Config, try_init};
 use crate::epoch::SchemeProvider;
 use utils::{
-    EPOCH_LENGTH, StubExecutionProvider, StubMarshal, dkg_fixture, make_block,
+    EPOCH_LENGTH, StubExecutionProvider, StubFeed, StubMarshal, dkg_fixture, make_block,
     make_certified_block, make_finalization,
 };
 
@@ -62,6 +62,7 @@ fn startup_uses_previous_execution_boundary() {
                 },
                 last_finalized_height: finalized_height,
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         );
@@ -90,6 +91,7 @@ fn startup_propagates_finalized_block_read_failure() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -116,6 +118,7 @@ fn startup_requires_execution_boundary_header() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -134,6 +137,7 @@ fn valid_finalization_is_certified_and_reported() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
+        let feed = StubFeed::default();
         let (actor, mailbox) = try_init(
             context.with_label("driver"),
             Config {
@@ -145,6 +149,7 @@ fn valid_finalization_is_certified_and_reported() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: feed.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -162,13 +167,62 @@ fn valid_finalization_is_certified_and_reported() {
 
         let mut reporter = mailbox.to_event_reporter();
         reporter.report(event).await;
-        wait_until(&context, || marshal.certified().len() == 1).await;
+        wait_until(&context, || {
+            marshal.certified().len() == 1 && feed.blocks().len() == 1
+        })
+        .await;
 
         let certified = marshal.certified();
         assert_eq!(certified[0].0, finalization.proposal.round);
         assert_eq!(certified[0].1, block);
         assert_eq!(marshal.report_count(), 1);
+        assert_eq!(feed.blocks(), vec![block]);
         assert!(marshal.hints().is_empty());
+    });
+}
+
+#[test_traced]
+fn valid_finalization_reaches_feed_when_marshal_reporting_stalls() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+
+        let marshal = StubMarshal::default();
+        marshal.block_reports();
+        let feed = StubFeed::default();
+        let (actor, mailbox) = try_init(
+            context.with_label("driver"),
+            Config {
+                execution_provider: provider,
+                scheme_provider: SchemeProvider::new(),
+                network_identity: NetworkIdentity {
+                    from_epoch: 0,
+                    identity: *fixture.outcome.network_identity(),
+                },
+                last_finalized_height: Height::zero(),
+                marshal,
+                feed: feed.clone(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+            },
+        )
+        .expect("driver should initialize");
+
+        actor.start();
+
+        let block = make_block(1, None);
+        let finalization = make_finalization(&block, Epoch::zero(), &fixture.schemes);
+        let mut reporter = mailbox.to_event_reporter();
+        reporter
+            .report(Event::Finalized {
+                block: make_certified_block(block.clone(), &finalization),
+                seen: 0,
+            })
+            .await;
+
+        wait_until(&context, || feed.blocks().len() == 1).await;
+        assert_eq!(feed.blocks(), vec![block]);
     });
 }
 
@@ -193,6 +247,7 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -250,6 +305,7 @@ fn invalid_finalization_hints_current_epoch_boundary() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -295,6 +351,7 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -357,6 +414,7 @@ fn scheme_before_network_identity_epoch_is_required() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -414,6 +472,7 @@ fn boundary_update_registers_scheme_before_acknowledging() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -453,6 +512,7 @@ fn non_boundary_update_is_acknowledged_without_registering_a_scheme() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -506,6 +566,7 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
                 },
                 last_finalized_height,
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -540,6 +601,7 @@ fn non_finalized_events_are_ignored() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                feed: StubFeed::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )

--- a/crates/consensus/src/follow/driver/test/utils.rs
+++ b/crates/consensus/src/follow/driver/test/utils.rs
@@ -36,7 +36,7 @@ use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::rpc::consensus::CertifiedBlock;
 use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
 
-use super::super::{ConsensusActivity, ExecutionProvider, Marshal};
+use super::super::{ConsensusActivity, ConsensusFinalization, ExecutionProvider, Feed, Marshal};
 use crate::consensus::{Block, Digest};
 
 pub(super) const EPOCH_LENGTH: NonZeroU64 = NonZeroU64::new(10).expect("epoch length is nonzero");
@@ -193,6 +193,7 @@ struct StubMarshalInner {
     hints: Mutex<Vec<Height>>,
     certified: Mutex<Vec<(Round, Block)>>,
     reports: Mutex<Vec<ConsensusActivity>>,
+    block_reports: AtomicBool,
 }
 
 impl StubMarshal {
@@ -215,6 +216,10 @@ impl StubMarshal {
     pub(super) fn report_count(&self) -> usize {
         self.inner.reports.lock().len()
     }
+
+    pub(super) fn block_reports(&self) {
+        self.inner.block_reports.store(true, Ordering::SeqCst);
+    }
 }
 
 impl Marshal for StubMarshal {
@@ -236,6 +241,28 @@ impl Marshal for StubMarshal {
 
     fn report(&self, activity: ConsensusActivity) -> impl Future<Output = ()> + Send {
         self.inner.reports.lock().push(activity);
-        async {}
+        let block = self.inner.block_reports.load(Ordering::SeqCst);
+        async move {
+            if block {
+                std::future::pending().await
+            }
+        }
+    }
+}
+
+#[derive(Clone, Default)]
+pub(super) struct StubFeed {
+    blocks: Arc<Mutex<Vec<Block>>>,
+}
+
+impl StubFeed {
+    pub(super) fn blocks(&self) -> Vec<Block> {
+        self.blocks.lock().clone()
+    }
+}
+
+impl Feed for StubFeed {
+    fn report(&self, block: Block, _finalization: ConsensusFinalization) {
+        self.blocks.lock().push(block);
     }
 }

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -180,7 +180,7 @@ impl<TUpstream> Config<TUpstream> {
                 network_identity: self.network_identity,
                 last_finalized_height,
                 marshal: marshal_mailbox,
-                feed: feed_mailbox.clone(),
+                feed: feed_mailbox,
                 epoch_strategy: epoch_strategy.clone(),
             },
         )

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -30,12 +30,12 @@ use tempo_chainspec::NetworkIdentity;
 use tempo_node::{TempoFullNode, TempoPayloadTypes, node::TempoNode};
 use tracing::{info, info_span};
 
-use super::{driver, executor, resolver, resolver::Resolver, stubs};
+use super::{driver, executor, feed, resolver, resolver::Resolver, stubs};
 use crate::{
     alias,
     consensus::{Digest, block::Block},
     epoch::SchemeProvider,
-    feed::{self, FeedStateHandle},
+    feed::FeedStateHandle,
     follow::upstream,
     storage,
 };
@@ -180,6 +180,7 @@ impl<TUpstream> Config<TUpstream> {
                 network_identity: self.network_identity,
                 last_finalized_height,
                 marshal: marshal_mailbox,
+                feed: feed_mailbox.clone(),
                 epoch_strategy: epoch_strategy.clone(),
             },
         )
@@ -198,7 +199,6 @@ impl<TUpstream> Config<TUpstream> {
             executor: executor_actor,
             executor_mailbox,
             feed: feed_actor,
-            feed_mailbox,
             broadcast,
             upstream: self.upstream,
         })
@@ -218,6 +218,7 @@ where
             NodeTypesWithDBAdapter<TempoNode, reth_ethereum::provider::db::DatabaseEnv>,
         >,
         crate::alias::marshal::Mailbox,
+        feed::Mailbox,
     >,
     driver_mailbox: driver::Mailbox,
     resolver: Resolver<TContext>,
@@ -233,7 +234,6 @@ where
     >,
     executor_mailbox: executor::Mailbox,
     feed: feed::Actor<TContext>,
-    feed_mailbox: feed::Mailbox,
     broadcast: buffered::Mailbox<PublicKey, Block>,
     upstream: TUpstreamActor,
 }
@@ -270,7 +270,6 @@ where
             executor,
             executor_mailbox,
             feed,
-            feed_mailbox,
             broadcast,
             ..
         } = self;
@@ -282,7 +281,7 @@ where
             marshal.start(
                 Reporters::from((
                     executor_mailbox.clone(),
-                    Reporters::from((driver_mailbox.to_marshal_reporter(), feed_mailbox)),
+                    driver_mailbox.to_marshal_reporter(),
                 )),
                 broadcast,
                 (resolver_rx, resolver_mailbox),

--- a/crates/consensus/src/follow/feed.rs
+++ b/crates/consensus/src/follow/feed.rs
@@ -42,6 +42,7 @@ pub(super) struct Actor<TContext> {
     context: ContextCell<TContext>,
     receiver: mpsc::UnboundedReceiver<Certified>,
     state: FeedStateHandle,
+    last_published_height: Option<commonware_consensus::types::Height>,
 }
 
 impl<TContext: Spawner> Actor<TContext> {
@@ -58,8 +59,15 @@ impl<TContext: Spawner> Actor<TContext> {
     }
 
     #[instrument(skip_all, fields(height = %block.height(), digest = %block.digest()))]
-    fn publish(&self, block: Block, finalization: ConsensusFinalization) {
+    fn publish(&mut self, block: Block, finalization: ConsensusFinalization) {
         let height = block.height();
+        if self
+            .last_published_height
+            .is_some_and(|last_height| height <= last_height)
+        {
+            return;
+        }
+        self.last_published_height = Some(height);
         let round = finalization.proposal.round;
         let finalized = CertifiedBlock {
             epoch: round.epoch().get(),
@@ -90,6 +98,7 @@ pub(super) fn init<TContext: Spawner>(
             context: ContextCell::new(context),
             receiver,
             state,
+            last_published_height: None,
         },
         Mailbox(sender),
     )

--- a/crates/consensus/src/follow/feed.rs
+++ b/crates/consensus/src/follow/feed.rs
@@ -1,0 +1,103 @@
+//! Local RPC feed for follower mode.
+//!
+//! Unlike the validator feed, this feed receives complete, verified
+//! `(block, finalization)` pairs from the upstream driver. It does not depend
+//! on marshal updates for live delivery.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use alloy_primitives::hex;
+use commonware_codec::Encode as _;
+use commonware_consensus::{
+    Heightable as _,
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
+};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell};
+use futures::{StreamExt as _, channel::mpsc};
+use tempo_node::rpc::consensus::CertifiedBlock;
+use tracing::{debug, error, info_span, instrument};
+
+use crate::{
+    alias::marshal,
+    consensus::{Block, Digest},
+    feed::FeedStateHandle,
+};
+
+pub(super) type ConsensusFinalization = Finalization<Scheme<PublicKey, MinSig>, Digest>;
+type Certified = (Block, ConsensusFinalization);
+
+#[derive(Clone, Debug)]
+pub(super) struct Mailbox(mpsc::UnboundedSender<Certified>);
+
+impl Mailbox {
+    pub(super) fn report(&self, block: Block, finalization: ConsensusFinalization) {
+        if self.0.unbounded_send((block, finalization)).is_err() {
+            error!("failed sending certified block to follower feed");
+        }
+    }
+}
+
+pub(super) struct Actor<TContext> {
+    context: ContextCell<TContext>,
+    receiver: mpsc::UnboundedReceiver<Certified>,
+    state: FeedStateHandle,
+}
+
+impl<TContext: Spawner> Actor<TContext> {
+    pub(super) fn start(mut self) -> Handle<()> {
+        spawn_cell!(self.context, self.run())
+    }
+
+    async fn run(&mut self) {
+        while let Some((block, finalization)) = self.receiver.next().await {
+            self.publish(block, finalization);
+        }
+
+        info_span!("follower_feed_actor").in_scope(|| error!("mailbox closed; shutting down"));
+    }
+
+    #[instrument(skip_all, fields(height = %block.height(), digest = %block.digest()))]
+    fn publish(&self, block: Block, finalization: ConsensusFinalization) {
+        let height = block.height();
+        let round = finalization.proposal.round;
+        let finalized = CertifiedBlock {
+            epoch: round.epoch().get(),
+            view: round.view().get(),
+            block: block.into_execution_block(),
+            digest: finalization.proposal.payload.0,
+            certificate: hex::encode(finalization.encode()),
+        };
+
+        let subscribers = self.state.publish_finalized(finalized, now_millis());
+        debug!(
+            subscribers,
+            height = height.get(),
+            "sending follower finalized block event"
+        );
+    }
+}
+
+pub(super) fn init<TContext: Spawner>(
+    context: TContext,
+    marshal: marshal::Mailbox,
+    state: FeedStateHandle,
+) -> (Actor<TContext>, Mailbox) {
+    state.set_marshal(marshal);
+    let (sender, receiver) = mpsc::unbounded();
+    (
+        Actor {
+            context: ContextCell::new(context),
+            receiver,
+            state,
+        },
+        Mailbox(sender),
+    )
+}
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/crates/consensus/src/follow/feed.rs
+++ b/crates/consensus/src/follow/feed.rs
@@ -45,11 +45,11 @@ pub(super) struct Actor<TContext> {
 }
 
 impl<TContext: Spawner> Actor<TContext> {
-    pub(super) fn start(mut self) -> Handle<()> {
+    pub(super) fn start(self) -> Handle<()> {
         spawn_cell!(self.context, self.run())
     }
 
-    async fn run(&mut self) {
+    async fn run(mut self) {
         while let Some((block, finalization)) = self.receiver.next().await {
             self.publish(block, finalization);
         }

--- a/crates/consensus/src/follow/feed.rs
+++ b/crates/consensus/src/follow/feed.rs
@@ -46,7 +46,7 @@ pub(super) struct Actor<TContext> {
 }
 
 impl<TContext: Spawner> Actor<TContext> {
-    pub(super) fn start(self) -> Handle<()> {
+    pub(super) fn start(mut self) -> Handle<()> {
         spawn_cell!(self.context, self.run())
     }
 

--- a/crates/consensus/src/follow/mod.rs
+++ b/crates/consensus/src/follow/mod.rs
@@ -6,6 +6,7 @@
 mod driver;
 pub mod engine;
 pub(crate) mod executor;
+mod feed;
 pub(crate) mod resolver;
 mod stubs;
 pub mod upstream;


### PR DESCRIPTION
Adds a dedicated follower feed that republishes verified upstream `(block, finalization)` pairs directly to the existing shared feed state. The validator feed remains marshal-driven.

Adds a regression test proving follower feed delivery still occurs when marshal activity reporting stalls.

Validation: `cargo +nightly fmt --all --check`; `git diff --check`.
Focused Rust tests were blocked by HTTP 401 fetching the pinned Commonware revision.

Prompted by: @SuperFluffy