### PR TITLE
fix(consensus): publish feed events from finalized tips

### DIFF
--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -10,7 +10,7 @@ use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell};
 use futures::StreamExt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tempo_node::rpc::consensus::CertifiedBlock;
-use tracing::{debug, error, info_span, instrument};
+use tracing::{debug, error, info_span, instrument, warn};
 
 use super::{ingress::FinalizedTip, state::FeedStateHandle};
 use crate::alias::marshal;
@@ -63,15 +63,15 @@ impl<TContext: Spawner> Actor<TContext> {
     #[instrument(skip_all, fields(height = %tip.height, digest = %tip.digest))]
     async fn handle_tip(&self, tip: FinalizedTip) {
         let Some(finalization) = self.marshal.get_finalization(tip.height).await else {
-            debug!("skipping finalized tip without a certificate");
+            warn!("finalized tip without a persisted certificate");
             return;
         };
         let Some(block) = self.marshal.get_block(tip.height).await else {
-            debug!("skipping finalized tip without persisted block");
+            warn!("finalized tip without a persisted block");
             return;
         };
 
-        let finalized = CertifiedBlock {
+        let certified = CertifiedBlock {
             epoch: tip.round.epoch().get(),
             view: tip.round.view().get(),
             digest: tip.digest.0,
@@ -79,8 +79,8 @@ impl<TContext: Spawner> Actor<TContext> {
             certificate: hex::encode(finalization.encode()),
         };
 
-        let subscribers = self.state.publish_finalized(finalized, now_millis());
-        debug!(subscribers, "sending new finalized event");
+        let subscribers = self.state.publish_certified(certified, now_millis());
+        debug!(subscribers, "published new certified block");
     }
 }
 

--- a/crates/consensus/src/feed/actor.rs
+++ b/crates/consensus/src/feed/actor.rs
@@ -1,28 +1,27 @@
 //! Feed actor implementation.
 //!
-//! The actor receives finalized blocks from marshal, publishes those with a
-//! direct finalization certificate, updates the shared RPC state, and
+//! The actor receives finalized-tip updates from marshal, resolves their
+//! persisted blocks and certificates, updates the shared RPC state, and
 //! broadcasts them to subscribers.
 
 use alloy_primitives::hex;
 use commonware_codec::Encode;
-use commonware_consensus::Heightable as _;
 use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell};
 use futures::StreamExt;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tempo_node::rpc::consensus::{CertifiedBlock, Event};
+use tempo_node::rpc::consensus::CertifiedBlock;
 use tracing::{debug, error, info_span, instrument};
 
-use super::state::FeedStateHandle;
-use crate::{alias::marshal, consensus::block::Block};
+use super::{ingress::FinalizedTip, state::FeedStateHandle};
+use crate::alias::marshal;
 
-/// Receiver for finalized blocks.
-pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<Block>;
+/// Receiver for finalized tips.
+pub(super) type Receiver = futures::channel::mpsc::UnboundedReceiver<FinalizedTip>;
 
 pub(crate) struct Actor<TContext> {
     /// Runtime context.
     context: ContextCell<TContext>,
-    /// Receiver for finalized blocks.
+    /// Receiver for finalized tips.
     receiver: Receiver,
     /// Shared state handle.
     state: FeedStateHandle,
@@ -32,7 +31,7 @@ pub(crate) struct Actor<TContext> {
 
 impl<TContext: Spawner> Actor<TContext> {
     /// Create a new feed actor.
-    pub(crate) fn new(
+    pub(super) fn new(
         context: TContext,
         marshal: marshal::Mailbox,
         receiver: Receiver,
@@ -54,45 +53,34 @@ impl<TContext: Spawner> Actor<TContext> {
     }
 
     async fn run(mut self) {
-        while let Some(block) = self.receiver.next().await {
-            self.handle_block(block).await;
+        while let Some(tip) = self.receiver.next().await {
+            self.handle_tip(tip).await;
         }
 
         info_span!("feed_actor").in_scope(|| error!("mailbox closed; shutting down"));
     }
 
-    #[instrument(skip_all, fields(height = %block.height(), digest = %block.digest()))]
-    async fn handle_block(&self, block: Block) {
-        let height = block.height();
-        let Some(finalization) = self.marshal.get_finalization(height).await else {
-            debug!(
-                height = height.get(),
-                "skipping finalized block without a direct finalization certificate"
-            );
+    #[instrument(skip_all, fields(height = %tip.height, digest = %tip.digest))]
+    async fn handle_tip(&self, tip: FinalizedTip) {
+        let Some(finalization) = self.marshal.get_finalization(tip.height).await else {
+            debug!("skipping finalized tip without a certificate");
             return;
         };
-        let round = finalization.proposal.round;
+        let Some(block) = self.marshal.get_block(tip.height).await else {
+            debug!("skipping finalized tip without persisted block");
+            return;
+        };
 
         let finalized = CertifiedBlock {
-            epoch: round.epoch().get(),
-            view: round.view().get(),
+            epoch: tip.round.epoch().get(),
+            view: tip.round.view().get(),
+            digest: tip.digest.0,
             block: block.into_execution_block(),
-            digest: finalization.proposal.payload.0,
             certificate: hex::encode(finalization.encode()),
         };
 
-        self.state.write().latest_finalized = Some(finalized.clone());
-
-        let subscribers = self.state.events_tx().receiver_count();
-        debug!(
-            subscribers,
-            height = height.get(),
-            "sending finalized block event"
-        );
-        let _ = self.state.events_tx().send(Event::Finalized {
-            block: finalized,
-            seen: now_millis(),
-        });
+        let subscribers = self.state.publish_finalized(finalized, now_millis());
+        debug!(subscribers, "sending new finalized event");
     }
 }
 

--- a/crates/consensus/src/feed/ingress.rs
+++ b/crates/consensus/src/feed/ingress.rs
@@ -1,14 +1,26 @@
 //! Mailbox for sending marshal updates to the feed actor.
 
-use commonware_consensus::{Reporter, marshal::Update};
+use commonware_consensus::{
+    Reporter,
+    marshal::Update,
+    types::{Height, Round},
+};
 use commonware_utils::Acknowledgement as _;
 use futures::channel::mpsc;
 use tracing::error;
 
-use crate::consensus::block::Block;
+use crate::consensus::{Digest, block::Block};
+
+/// A newly observed directly finalized tip.
+#[derive(Clone, Copy, Debug)]
+pub(super) struct FinalizedTip {
+    pub(super) round: Round,
+    pub(super) height: Height,
+    pub(super) digest: Digest,
+}
 
 /// Sender half of the feed channel.
-pub(super) type Sender = mpsc::UnboundedSender<Block>;
+pub(super) type Sender = mpsc::UnboundedSender<FinalizedTip>;
 
 /// Mailbox for sending finalized marshal blocks to the feed actor.
 #[derive(Clone, Debug)]
@@ -26,16 +38,20 @@ impl Reporter for Mailbox {
     type Activity = Update<Block>;
 
     async fn report(&mut self, update: Self::Activity) {
-        let Update::Block(block, acknowledgement) = update else {
-            return;
+        let tip = match update {
+            Update::Tip(round, height, digest) => FinalizedTip {
+                round,
+                height,
+                digest,
+            },
+            Update::Block(_, ack) => {
+                ack.acknowledge();
+                return;
+            }
         };
 
-        // The feed is best-effort and must never hold up marshal's durable
-        // finalized-block stream.
-        acknowledgement.acknowledge();
-
-        if self.sender.unbounded_send(block).is_err() {
-            error!("failed sending finalized block to feed because it is no longer running");
+        if self.sender.unbounded_send(tip).is_err() {
+            error!("failed sending finalized tip to feed because it is no longer running");
         }
     }
 }
@@ -57,7 +73,7 @@ mod tests {
     use crate::consensus::block::Block;
 
     #[test]
-    fn forwards_only_acknowledged_blocks() {
+    fn forwards_tips_and_acknowledges_blocks() {
         block_on(async {
             let (sender, mut receiver) = futures::channel::mpsc::unbounded();
             let mut mailbox = Mailbox::new(sender);
@@ -84,15 +100,17 @@ mod tests {
                 ))
                 .await;
 
+            let tip = receiver.next().await.expect("tip should be forwarded");
+            assert_eq!(tip.round, Round::new(Epoch::zero(), View::new(1)));
+            assert_eq!(tip.height, block.height());
+            assert_eq!(tip.digest, block.digest());
+
             let (acknowledgement, acknowledged) = Exact::handle();
-            mailbox
-                .report(Update::Block(block.clone(), acknowledgement))
-                .await;
+            mailbox.report(Update::Block(block, acknowledgement)).await;
 
             acknowledged
                 .await
                 .expect("feed should immediately acknowledge the block");
-            assert_eq!(receiver.next().await, Some(block));
             assert!(receiver.next().now_or_never().is_none());
         });
     }

--- a/crates/consensus/src/feed/mod.rs
+++ b/crates/consensus/src/feed/mod.rs
@@ -1,9 +1,10 @@
 //! Feed module for consensus event tracking and RPC.
 //!
 //! Architecture:
-//! - `Mailbox` implements `Reporter` for marshal updates and immediately
-//!   acknowledges finalized blocks before forwarding them to the actor
-//! - `Actor` publishes finalized blocks and updates shared [`FeedStateHandle`]
+//! - `Mailbox` implements `Reporter` for marshal updates, forwards finalized
+//!   tips, and immediately acknowledges gap-free block updates
+//! - `Actor` resolves and publishes finalized tips and updates shared
+//!   [`FeedStateHandle`]
 //! - [`FeedStateHandle`] implements `ConsensusFeed` for RPC access
 //!
 //! This design ensures RPC traffic cannot block consensus activity processing.

--- a/crates/consensus/src/feed/state.rs
+++ b/crates/consensus/src/feed/state.rs
@@ -53,14 +53,16 @@ impl FeedStateHandle {
         let _ = self.marshal.set(marshal);
     }
 
-    /// Get the broadcast sender for events.
-    pub(super) fn events_tx(&self) -> &broadcast::Sender<Event> {
-        &self.events_tx
-    }
+    /// Update the latest finalized block and broadcast it to RPC subscribers.
+    pub(crate) fn publish_finalized(&self, finalized: CertifiedBlock, seen: u64) -> usize {
+        self.state.write().latest_finalized = Some(finalized.clone());
+        let subscribers = self.events_tx.receiver_count();
+        let _ = self.events_tx.send(Event::Finalized {
+            block: finalized,
+            seen,
+        });
 
-    /// Get write access to the internal state.
-    pub(super) fn write(&self) -> parking_lot::RwLockWriteGuard<'_, FeedState> {
-        self.state.write()
+        subscribers
     }
 
     /// Get the marshal mailbox, logging if not yet set.

--- a/crates/consensus/src/feed/state.rs
+++ b/crates/consensus/src/feed/state.rs
@@ -54,14 +54,10 @@ impl FeedStateHandle {
     }
 
     /// Update the latest finalized block and broadcast it to RPC subscribers.
-    pub(crate) fn publish_finalized(&self, finalized: CertifiedBlock, seen: u64) -> usize {
-        self.state.write().latest_finalized = Some(finalized.clone());
+    pub(crate) fn publish_certified(&self, block: CertifiedBlock, seen: u64) -> usize {
+        self.state.write().latest_finalized = Some(block.clone());
         let subscribers = self.events_tx.receiver_count();
-        let _ = self.events_tx.send(Event::Finalized {
-            block: finalized,
-            seen,
-        });
-
+        let _ = self.events_tx.send(Event::Finalized { block, seen });
         subscribers
     }
 

--- a/crates/consensus/src/follow/driver/mod.rs
+++ b/crates/consensus/src/follow/driver/mod.rs
@@ -1,7 +1,7 @@
 //! Follower finalization driver.
 //!
 //! Validates finalized blocks received from upstream and reports them to marshal.
-//! Marshal's finalized block updates independently drive the consensus feed.
+//! Marshal's finalized tip updates independently drive the consensus feed.
 
 use std::future::Future;
 


### PR DESCRIPTION
Drive the feed from marshal tip updates. A node syncing doesn't starve downstream consumer from observing a newer digest