### PR TITLE
feat(ci): allow release validation dispatch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ name: Lint
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:
@@ -58,7 +59,7 @@ jobs:
   crate-checks:
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 60
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -3,6 +3,7 @@ name: Specs
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 permissions: {}
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
Allows the release orchestrator to run lint, test, and specs against an exact release-branch commit without opening a temporary pull request. Dispatch runs include the full crate-check lint partition.

Prompted by: @joshieDo