### PR TITLE
refactor(alloy): expose lightweight Tempo simulation env

### DIFF
--- a/.changelog/lightweight-alloy-revm.md
+++ b/.changelog/lightweight-alloy-revm.md
@@ -1,0 +1,5 @@
+---
+tempo-alloy: patch
+---
+
+Added a lightweight `revm` feature for Tempo transaction simulation without enabling the full Reth compatibility dependency set.

--- a/.changelog/lightweight-alloy-revm.md
+++ b/.changelog/lightweight-alloy-revm.md
@@ -1,5 +1,0 @@
----
-tempo-alloy: patch
----
-
-Added a lightweight `revm` feature for Tempo transaction simulation without enabling the full Reth compatibility dependency set.

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [dependencies]
 tempo-contracts = { workspace = true, features = ["rpc"] }
-tempo-primitives = { workspace = true, features = ["serde", "rpc"] }
+tempo-primitives = { workspace = true, features = ["serde"] }
 tempo-chainspec = { workspace = true, default-features = false }
 tempo-evm = { workspace = true, optional = true }
 tempo-revm = { workspace = true, optional = true }
@@ -71,7 +71,7 @@ reth = [
     "dep:reth-primitives-traits",
     "dep:reth-rpc-convert",
     "dep:reth-rpc-eth-types",
-    "tempo-primitives/reth",
+    "tempo-primitives/rpc",
     "tempo-chainspec/reth",
 ]
 asm-keccak = [

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -63,9 +63,10 @@ tokio.workspace = true
 
 [features]
 default = []
+revm = ["dep:tempo-revm"]
 reth = [
+    "revm",
     "dep:tempo-evm",
-    "dep:tempo-revm",
     "dep:reth-evm",
     "dep:reth-primitives-traits",
     "dep:reth-rpc-convert",

--- a/crates/alloy/src/rpc/mod.rs
+++ b/crates/alloy/src/rpc/mod.rs
@@ -9,6 +9,9 @@ pub use request::{FeeToken, TempoCallBuilderExt, TempoTransactionRequest};
 mod receipt;
 pub use receipt::TempoTransactionReceipt;
 
+#[cfg(feature = "revm")]
+mod revm_compat;
+
 #[cfg(feature = "reth")]
 mod reth_compat;
 

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -1,8 +1,7 @@
 use crate::rpc::{TempoHeaderResponse, TempoTransactionRequest};
 use alloy_consensus::{EthereumTxEnvelope, TxEip4844, error::ValueError};
 use alloy_network::{NetworkTransactionBuilder, TxSigner};
-use alloy_primitives::{Address, B256, Bytes, Signature};
-use core::num::NonZeroU64;
+use alloy_primitives::Signature;
 use reth_evm::EvmEnv;
 use reth_primitives_traits::SealedHeader;
 use reth_rpc_convert::{
@@ -11,18 +10,8 @@ use reth_rpc_convert::{
 use reth_rpc_eth_types::EthApiError;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_evm::TempoBlockEnv;
-use tempo_primitives::{
-    SignatureType, TempoHeader, TempoSignature, TempoTxEnvelope, TempoTxType,
-    transaction::{Call, RecoveredTempoAuthorization},
-};
-use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
-
-/// Non-zero transaction identifier used only for RPC simulations.
-///
-/// RPC requests are not final signed transactions, so gas filling and other request normalization
-/// can make a simulated signing payload differ from the eventual submitted transaction. Use a
-/// fixed sentinel instead of deriving a misleading future channel id from the simulated payload.
-const RPC_SIMULATION_UNIQUE_TX_IDENTIFIER: B256 = B256::new(*b"TEMPO_RPC_SIMULATION_MPP_CONTEXT");
+use tempo_primitives::{TempoHeader, TempoSignature, TempoTxEnvelope, TempoTxType};
+use tempo_revm::TempoTxEnv;
 
 impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
     fn try_into_sim_tx(self) -> Result<TempoTxEnvelope, ValueError<Self>> {
@@ -105,207 +94,9 @@ impl TryIntoTxEnv<TempoTxEnv, TempoHardfork, TempoBlockEnv> for TempoTransaction
         self,
         evm_env: &EvmEnv<TempoHardfork, TempoBlockEnv>,
     ) -> Result<TempoTxEnv, Self::Err> {
-        let caller_addr = self.inner.from.unwrap_or_default();
-        let is_aa = self.has_aa_fields();
-
-        let fee_payer = if self.fee_payer_signature.is_some() {
-            // Try to recover the fee payer address from the signature.
-            // If recovery fails (e.g. dummy signature during gas estimation / fill),
-            // keep it unresolved so estimation/fill can continue with sender-paid semantics.
-            let recovered = self
-                .clone()
-                .build_aa()
-                .ok()
-                .and_then(|tx| tx.recover_fee_payer(caller_addr).ok());
-            Some(recovered)
-        } else {
-            None
-        };
-
-        let Self {
-            inner,
-            fee_token,
-            calls,
-            key_type,
-            key_data,
-            key_id,
-            tempo_authorization_list,
-            nonce_key,
-            key_authorization,
-            valid_before,
-            valid_after,
-            fee_payer_signature: _,
-        } = self;
-
-        Ok(TempoTxEnv {
-            fee_token,
-            is_system_tx: false,
-            unique_tx_identifier: Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER),
-            fee_payer,
-            tempo_tx_env: if is_aa {
-                // Create mock signature for gas estimation
-                // If key_type is not provided, default to secp256k1
-                // For Keychain signatures, use the caller's address as the root key address
-                let key_type = key_type.unwrap_or(SignatureType::Secp256k1);
-                let mock_signature = create_mock_tempo_sig(
-                    &key_type,
-                    key_data.as_ref(),
-                    key_id,
-                    caller_addr,
-                    evm_env.spec_id().is_t1c(),
-                );
-
-                let mut calls = calls;
-                if let Some(to) = &inner.to {
-                    calls.push(Call {
-                        to: *to,
-                        value: inner.value.unwrap_or_default(),
-                        input: inner.input.clone().into_input().unwrap_or_default(),
-                    });
-                }
-                if calls.is_empty() {
-                    return Err(EthApiError::InvalidParams("empty calls list".to_string()));
-                }
-
-                Some(Box::new(TempoBatchCallEnv {
-                    aa_calls: calls,
-                    signature: mock_signature,
-                    tempo_authorization_list: tempo_authorization_list
-                        .into_iter()
-                        .map(RecoveredTempoAuthorization::new)
-                        .collect(),
-                    nonce_key: nonce_key.unwrap_or_default(),
-                    key_authorization,
-                    signature_hash: B256::ZERO,
-                    tx_hash: B256::ZERO,
-                    valid_before: valid_before.map(NonZeroU64::get),
-                    valid_after: valid_after.map(NonZeroU64::get),
-                    subblock_transaction: false,
-                    override_key_id: key_id,
-                    expiring_nonce_idx: None,
-                }))
-            } else {
-                None
-            },
-            inner: inner.try_into_tx_env(evm_env)?,
-        })
-    }
-}
-
-/// Creates a mock AA signature for gas estimation based on key type hints
-///
-/// - `key_type`: The primitive signature type (secp256k1, P256, WebAuthn)
-/// - `key_data`: Type-specific data (e.g., WebAuthn size)
-/// - `key_id`: If Some, wraps the signature in a Keychain wrapper (+3,000 gas for key validation)
-/// - `caller_addr`: The transaction caller address (used as root key address for Keychain)
-/// - `is_t1c`: Whether T1C is active — determines keychain signature version (V1 pre-T1C, V2 post-T1C)
-fn create_mock_tempo_sig(
-    key_type: &SignatureType,
-    key_data: Option<&Bytes>,
-    key_id: Option<Address>,
-    caller_addr: alloy_primitives::Address,
-    is_t1c: bool,
-) -> TempoSignature {
-    use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
-
-    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
-
-    if key_id.is_some() {
-        // For Keychain signatures, the root_key_address is the caller (account owner).
-        let keychain_sig = if is_t1c {
-            KeychainSignature::new(caller_addr, inner_sig)
-        } else {
-            KeychainSignature::new_v1(caller_addr, inner_sig)
-        };
-        TempoSignature::Keychain(keychain_sig)
-    } else {
-        TempoSignature::Primitive(inner_sig)
-    }
-}
-
-/// Creates a mock primitive signature for gas estimation
-fn create_mock_primitive_signature(
-    sig_type: &SignatureType,
-    key_data: Option<Bytes>,
-) -> tempo_primitives::transaction::tt_signature::PrimitiveSignature {
-    use tempo_primitives::transaction::tt_signature::{
-        P256SignatureWithPreHash, PrimitiveSignature, WebAuthnSignature,
-    };
-
-    match sig_type {
-        SignatureType::Secp256k1 => {
-            // Create a dummy secp256k1 signature (65 bytes)
-            PrimitiveSignature::Secp256k1(Signature::new(
-                alloy_primitives::U256::ZERO,
-                alloy_primitives::U256::ZERO,
-                false,
-            ))
-        }
-        SignatureType::P256 => {
-            // Create a dummy P256 signature
-            PrimitiveSignature::P256(P256SignatureWithPreHash {
-                r: alloy_primitives::B256::ZERO,
-                s: alloy_primitives::B256::ZERO,
-                pub_key_x: alloy_primitives::B256::ZERO,
-                pub_key_y: alloy_primitives::B256::ZERO,
-                pre_hash: false,
-            })
-        }
-        SignatureType::WebAuthn => {
-            // Create a dummy WebAuthn signature with the specified size
-            // key_data contains the total size of webauthn_data (excluding 128 bytes for public keys)
-            // Default: 800 bytes if no key_data provided
-
-            // Base clientDataJSON template (50 bytes): {"type":"webauthn.get","challenge":"","origin":""}
-            // Authenticator data (37 bytes): 32 rpIdHash + 1 flags + 4 signCount
-            // Minimum total: 87 bytes
-            const BASE_CLIENT_JSON: &str = r#"{"type":"webauthn.get","challenge":"","origin":""}"#;
-            const AUTH_DATA_SIZE: usize = 37;
-            const MIN_WEBAUTHN_SIZE: usize = AUTH_DATA_SIZE + BASE_CLIENT_JSON.len(); // 87 bytes
-            const DEFAULT_WEBAUTHN_SIZE: usize = 800; // Default when no key_data provided
-            const MAX_WEBAUTHN_SIZE: usize = 8192; // Maximum realistic WebAuthn signature size
-
-            // Parse size from key_data, or use default
-            let size = if let Some(data) = key_data.as_ref() {
-                match data.len() {
-                    1 => data[0] as usize,
-                    2 => u16::from_be_bytes([data[0], data[1]]) as usize,
-                    4 => u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize,
-                    _ => DEFAULT_WEBAUTHN_SIZE, // Fallback default
-                }
-            } else {
-                DEFAULT_WEBAUTHN_SIZE // Default size when no key_data provided
-            };
-
-            // Clamp size to safe bounds to prevent DoS via unbounded allocation
-            let size = size.clamp(MIN_WEBAUTHN_SIZE, MAX_WEBAUTHN_SIZE);
-
-            // Construct authenticatorData (37 bytes)
-            let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
-            webauthn_data[32] = 0x01; // UP flag set
-
-            // Construct clientDataJSON with padding in origin field if needed
-            let additional_bytes = size - MIN_WEBAUTHN_SIZE;
-            let client_json = if additional_bytes > 0 {
-                // Add padding bytes to origin field
-                // {"type":"webauthn.get","challenge":"","origin":"XXXXX"}
-                let padding = "x".repeat(additional_bytes);
-                format!(r#"{{"type":"webauthn.get","challenge":"","origin":"{padding}"}}"#,)
-            } else {
-                BASE_CLIENT_JSON.to_string()
-            };
-
-            webauthn_data.extend_from_slice(client_json.as_bytes());
-            let webauthn_data = Bytes::from(webauthn_data);
-
-            PrimitiveSignature::WebAuthn(WebAuthnSignature {
-                webauthn_data,
-                r: alloy_primitives::B256::ZERO,
-                s: alloy_primitives::B256::ZERO,
-                pub_key_x: alloy_primitives::B256::ZERO,
-                pub_key_y: alloy_primitives::B256::ZERO,
-            })
-        }
+        let inner = self.inner.clone().try_into_tx_env(evm_env)?;
+        self.try_into_tempo_tx_env(TempoTxEnv::from(inner), evm_env.spec_id().is_t1c())
+            .map_err(|err| EthApiError::InvalidParams(err.to_string()))
     }
 }
 
@@ -338,13 +129,16 @@ impl FromConsensusHeader<TempoHeader> for TempoHeaderResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_primitives::{TxKind, address};
+    use crate::rpc::revm_compat::{
+        RPC_SIMULATION_UNIQUE_TX_IDENTIFIER, create_mock_primitive_signature,
+    };
+    use alloy_primitives::{Address, B256, Bytes, TxKind, address};
     use alloy_rpc_types_eth::TransactionRequest;
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use reth_rpc_convert::TryIntoTxEnv;
     use tempo_primitives::{
-        TempoTransaction,
+        SignatureType, TempoTransaction,
         transaction::{Call, FEE_PAYER_SIGNATURE_MARKER, tt_signature::PrimitiveSignature},
     };
 

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -1,0 +1,233 @@
+use super::TempoTransactionRequest;
+use alloy_consensus::error::ValueError;
+use alloy_primitives::{Address, B256, Bytes, Signature};
+use core::num::NonZeroU64;
+use tempo_primitives::{
+    SignatureType, TempoSignature,
+    transaction::{Call, RecoveredTempoAuthorization},
+};
+use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
+
+/// Non-zero transaction identifier used only for RPC simulations.
+///
+/// RPC requests are not final signed transactions, so gas filling and other request normalization
+/// can make a simulated signing payload differ from the eventual submitted transaction. Use a
+/// fixed sentinel instead of deriving a misleading future channel id from the simulated payload.
+pub(super) const RPC_SIMULATION_UNIQUE_TX_IDENTIFIER: B256 =
+    B256::new(*b"TEMPO_RPC_SIMULATION_MPP_CONTEXT");
+
+impl TempoTransactionRequest {
+    /// Applies this request's Tempo-specific fields to a normalized simulation transaction env.
+    ///
+    /// The caller owns normalization of the inner Ethereum transaction env (fees, gas limit,
+    /// nonce, and call defaults). This method owns Tempo AA simulation semantics, including mock
+    /// signatures, access-key identity, sponsorship, authorizations, and expiring nonces.
+    pub fn try_into_tempo_tx_env(
+        self,
+        mut tx_env: TempoTxEnv,
+        is_t1c: bool,
+    ) -> Result<TempoTxEnv, ValueError<Self>> {
+        let caller_addr = self.inner.from.unwrap_or_default();
+        let is_aa = self.has_aa_fields();
+
+        if is_aa && self.calls.is_empty() && self.inner.to.is_none() {
+            return Err(ValueError::new(self, "empty calls list"));
+        }
+
+        let fee_payer = if self.fee_payer_signature.is_some() {
+            // Try to recover the fee payer address from the signature. A dummy or incomplete
+            // simulation request retains the failed recovery for normal validation downstream.
+            let recovered = self
+                .clone()
+                .build_aa()
+                .ok()
+                .and_then(|tx| tx.recover_fee_payer(caller_addr).ok());
+            Some(recovered)
+        } else {
+            None
+        };
+
+        let Self {
+            inner,
+            fee_token,
+            calls,
+            key_type,
+            key_data,
+            key_id,
+            tempo_authorization_list,
+            nonce_key,
+            key_authorization,
+            valid_before,
+            valid_after,
+            fee_payer_signature: _,
+        } = self;
+
+        tx_env.fee_token = fee_token;
+        tx_env.is_system_tx = false;
+        tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
+        tx_env.fee_payer = fee_payer;
+        tx_env.tempo_tx_env = if is_aa {
+            let key_type = key_type.unwrap_or(SignatureType::Secp256k1);
+            let mock_signature =
+                create_mock_tempo_sig(&key_type, key_data.as_ref(), key_id, caller_addr, is_t1c);
+
+            let mut calls = calls;
+            if let Some(to) = &inner.to {
+                calls.push(Call {
+                    to: *to,
+                    value: inner.value.unwrap_or_default(),
+                    input: inner.input.clone().into_input().unwrap_or_default(),
+                });
+            }
+
+            Some(Box::new(TempoBatchCallEnv {
+                aa_calls: calls,
+                signature: mock_signature,
+                tempo_authorization_list: tempo_authorization_list
+                    .into_iter()
+                    .map(RecoveredTempoAuthorization::new)
+                    .collect(),
+                nonce_key: nonce_key.unwrap_or_default(),
+                key_authorization,
+                signature_hash: B256::ZERO,
+                tx_hash: B256::ZERO,
+                valid_before: valid_before.map(NonZeroU64::get),
+                valid_after: valid_after.map(NonZeroU64::get),
+                subblock_transaction: false,
+                override_key_id: key_id,
+                expiring_nonce_idx: None,
+            }))
+        } else {
+            None
+        };
+
+        Ok(tx_env)
+    }
+}
+
+/// Creates a mock AA signature for gas estimation based on key type hints.
+pub(super) fn create_mock_tempo_sig(
+    key_type: &SignatureType,
+    key_data: Option<&Bytes>,
+    key_id: Option<Address>,
+    caller_addr: Address,
+    is_t1c: bool,
+) -> TempoSignature {
+    use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
+
+    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
+
+    if key_id.is_some() {
+        let keychain_sig = if is_t1c {
+            KeychainSignature::new(caller_addr, inner_sig)
+        } else {
+            KeychainSignature::new_v1(caller_addr, inner_sig)
+        };
+        TempoSignature::Keychain(keychain_sig)
+    } else {
+        TempoSignature::Primitive(inner_sig)
+    }
+}
+
+/// Creates a mock primitive signature for gas estimation.
+pub(super) fn create_mock_primitive_signature(
+    sig_type: &SignatureType,
+    key_data: Option<Bytes>,
+) -> tempo_primitives::transaction::tt_signature::PrimitiveSignature {
+    use tempo_primitives::transaction::tt_signature::{
+        P256SignatureWithPreHash, PrimitiveSignature, WebAuthnSignature,
+    };
+
+    match sig_type {
+        SignatureType::Secp256k1 => PrimitiveSignature::Secp256k1(Signature::new(
+            alloy_primitives::U256::ZERO,
+            alloy_primitives::U256::ZERO,
+            false,
+        )),
+        SignatureType::P256 => PrimitiveSignature::P256(P256SignatureWithPreHash {
+            r: B256::ZERO,
+            s: B256::ZERO,
+            pub_key_x: B256::ZERO,
+            pub_key_y: B256::ZERO,
+            pre_hash: false,
+        }),
+        SignatureType::WebAuthn => {
+            // Base clientDataJSON template (50 bytes) plus 37 bytes of authenticator data.
+            const BASE_CLIENT_JSON: &str = r#"{"type":"webauthn.get","challenge":"","origin":""}"#;
+            const AUTH_DATA_SIZE: usize = 37;
+            const MIN_WEBAUTHN_SIZE: usize = AUTH_DATA_SIZE + BASE_CLIENT_JSON.len();
+            const DEFAULT_WEBAUTHN_SIZE: usize = 800;
+            const MAX_WEBAUTHN_SIZE: usize = 8192;
+
+            let size = if let Some(data) = key_data.as_ref() {
+                match data.len() {
+                    1 => data[0] as usize,
+                    2 => u16::from_be_bytes([data[0], data[1]]) as usize,
+                    4 => u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize,
+                    _ => DEFAULT_WEBAUTHN_SIZE,
+                }
+            } else {
+                DEFAULT_WEBAUTHN_SIZE
+            }
+            .clamp(MIN_WEBAUTHN_SIZE, MAX_WEBAUTHN_SIZE);
+
+            let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
+            webauthn_data[32] = 0x01;
+
+            let additional_bytes = size - MIN_WEBAUTHN_SIZE;
+            let client_json = if additional_bytes > 0 {
+                let padding = "x".repeat(additional_bytes);
+                format!(r#"{{"type":"webauthn.get","challenge":"","origin":"{padding}"}}"#,)
+            } else {
+                BASE_CLIENT_JSON.to_string()
+            };
+            webauthn_data.extend_from_slice(client_json.as_bytes());
+
+            PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                webauthn_data: Bytes::from(webauthn_data),
+                r: B256::ZERO,
+                s: B256::ZERO,
+                pub_key_x: B256::ZERO,
+                pub_key_y: B256::ZERO,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{TxKind, address};
+    use alloy_rpc_types_eth::TransactionRequest;
+
+    #[test]
+    fn access_key_request_populates_typed_simulation_env() {
+        let root = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let key_id = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let target = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                from: Some(root),
+                to: Some(TxKind::Call(target)),
+                ..Default::default()
+            },
+            key_type: Some(SignatureType::Secp256k1),
+            key_id: Some(key_id),
+            ..Default::default()
+        };
+
+        let env = request
+            .try_into_tempo_tx_env(TempoTxEnv::default(), true)
+            .expect("valid simulation request");
+        let aa = env.tempo_tx_env.expect("AA simulation env");
+
+        assert_eq!(aa.override_key_id, Some(key_id));
+        assert_eq!(aa.aa_calls.len(), 1);
+        assert_eq!(aa.aa_calls[0].to, TxKind::Call(target));
+        assert!(matches!(aa.signature, TempoSignature::Keychain(_)));
+        assert_eq!(
+            env.unique_tx_identifier,
+            Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER)
+        );
+    }
+}

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -35,8 +35,9 @@ impl TempoTransactionRequest {
         }
 
         let fee_payer = if self.fee_payer_signature.is_some() {
-            // Try to recover the fee payer address from the signature. A dummy or incomplete
-            // simulation request retains the failed recovery for normal validation downstream.
+            // Try to recover the fee payer address from the signature.
+            // If recovery fails (e.g. dummy signature during gas estimation / fill),
+            // keep it unresolved so estimation/fill can continue with sender-paid semantics.
             let recovered = self
                 .clone()
                 .build_aa()
@@ -67,6 +68,9 @@ impl TempoTransactionRequest {
         tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
         tx_env.fee_payer = fee_payer;
         tx_env.tempo_tx_env = if is_aa {
+            // Create a mock signature for gas estimation.
+            // If key_type is not provided, default to secp256k1.
+            // For Keychain signatures, use the caller's address as the root key address.
             let key_type = key_type.unwrap_or(SignatureType::Secp256k1);
             let mock_signature =
                 create_mock_tempo_sig(&key_type, key_data.as_ref(), key_id, caller_addr, is_t1c);
@@ -106,6 +110,13 @@ impl TempoTransactionRequest {
 }
 
 /// Creates a mock AA signature for gas estimation based on key type hints.
+///
+/// - `key_type`: The primitive signature type (secp256k1, P256, WebAuthn)
+/// - `key_data`: Type-specific data (e.g., WebAuthn size)
+/// - `key_id`: If Some, wraps the signature in a Keychain wrapper (+3,000 gas for key validation)
+/// - `caller_addr`: The transaction caller address (used as root key address for Keychain)
+/// - `is_t1c`: Whether T1C is active — determines keychain signature version (V1 pre-T1C, V2
+///   post-T1C)
 pub(super) fn create_mock_tempo_sig(
     key_type: &SignatureType,
     key_data: Option<&Bytes>,
@@ -118,6 +129,7 @@ pub(super) fn create_mock_tempo_sig(
     let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
 
     if key_id.is_some() {
+        // For Keychain signatures, the root_key_address is the caller (account owner).
         let keychain_sig = if is_t1c {
             KeychainSignature::new(caller_addr, inner_sig)
         } else {
@@ -139,11 +151,13 @@ pub(super) fn create_mock_primitive_signature(
     };
 
     match sig_type {
+        // Create a dummy secp256k1 signature (65 bytes).
         SignatureType::Secp256k1 => PrimitiveSignature::Secp256k1(Signature::new(
             alloy_primitives::U256::ZERO,
             alloy_primitives::U256::ZERO,
             false,
         )),
+        // Create a dummy P256 signature.
         SignatureType::P256 => PrimitiveSignature::P256(P256SignatureWithPreHash {
             r: B256::ZERO,
             s: B256::ZERO,
@@ -152,13 +166,21 @@ pub(super) fn create_mock_primitive_signature(
             pre_hash: false,
         }),
         SignatureType::WebAuthn => {
-            // Base clientDataJSON template (50 bytes) plus 37 bytes of authenticator data.
+            // Create a dummy WebAuthn signature with the specified size.
+            // key_data contains the total size of webauthn_data (excluding 128 bytes for public
+            // keys). Default: 800 bytes if no key_data is provided.
+
+            // Base clientDataJSON template (50 bytes):
+            // {"type":"webauthn.get","challenge":"","origin":""}
+            // Authenticator data (37 bytes): 32 rpIdHash + 1 flags + 4 signCount.
+            // Minimum total: 87 bytes.
             const BASE_CLIENT_JSON: &str = r#"{"type":"webauthn.get","challenge":"","origin":""}"#;
             const AUTH_DATA_SIZE: usize = 37;
-            const MIN_WEBAUTHN_SIZE: usize = AUTH_DATA_SIZE + BASE_CLIENT_JSON.len();
-            const DEFAULT_WEBAUTHN_SIZE: usize = 800;
-            const MAX_WEBAUTHN_SIZE: usize = 8192;
+            const MIN_WEBAUTHN_SIZE: usize = AUTH_DATA_SIZE + BASE_CLIENT_JSON.len(); // 87 bytes
+            const DEFAULT_WEBAUTHN_SIZE: usize = 800; // Default when no key_data provided
+            const MAX_WEBAUTHN_SIZE: usize = 8192; // Maximum realistic WebAuthn signature size
 
+            // Parse size from key_data, or use the default.
             let size = if let Some(data) = key_data.as_ref() {
                 match data.len() {
                     1 => data[0] as usize,
@@ -169,13 +191,18 @@ pub(super) fn create_mock_primitive_signature(
             } else {
                 DEFAULT_WEBAUTHN_SIZE
             }
+            // Clamp size to safe bounds to prevent DoS via unbounded allocation.
             .clamp(MIN_WEBAUTHN_SIZE, MAX_WEBAUTHN_SIZE);
 
+            // Construct authenticatorData (37 bytes).
             let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
-            webauthn_data[32] = 0x01;
+            webauthn_data[32] = 0x01; // UP flag set
 
+            // Construct clientDataJSON with padding in the origin field if needed.
             let additional_bytes = size - MIN_WEBAUTHN_SIZE;
             let client_json = if additional_bytes > 0 {
+                // Add padding bytes to origin field:
+                // {"type":"webauthn.get","challenge":"","origin":"XXXXX"}
                 let padding = "x".repeat(additional_bytes);
                 format!(r#"{{"type":"webauthn.get","challenge":"","origin":"{padding}"}}"#,)
             } else {

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -118,8 +118,9 @@ cp -R "$REPO_ROOT/crates/chainspec"  "$TMP_WORK_DIR/chainspec"
 cp -R "$REPO_ROOT/crates/alloy"      "$TMP_WORK_DIR/alloy"
 
 # ── 1. Delete compat modules ──────────────────────────────────────────────────
-log "Deleting reth_compat modules …"
+log "Deleting node-internal compatibility modules …"
 rm -rf "$TMP_WORK_DIR/primitives/src/reth_compat"
+rm -f  "$TMP_WORK_DIR/alloy/src/rpc/revm_compat.rs"
 rm -f  "$TMP_WORK_DIR/alloy/src/rpc/reth_compat.rs"
 
 # ── 2. Strip reth/compat references from source ──────────────────────────────
@@ -219,9 +220,11 @@ for feat in reth reth-codec serde-bincode-compat rpc; do
         err "Feature '$feat' still defined in tempo-primitives Cargo.toml"
 done
 
-# Alloy: no reth feature
-grep -qE "^\s*reth\s*=" "$TMP_WORK_DIR/alloy/Cargo.toml" && \
-    err "Feature 'reth' still defined in tempo-alloy Cargo.toml"
+# Alloy: no node-internal compatibility features
+for feat in revm reth; do
+    grep -qE "^\s*${feat}\s*=" "$TMP_WORK_DIR/alloy/Cargo.toml" && \
+        err "Feature '$feat' still defined in tempo-alloy Cargo.toml"
+done
 
 # Source: no forbidden references
 (
@@ -233,6 +236,8 @@ grep -qE "^\s*reth\s*=" "$TMP_WORK_DIR/alloy/Cargo.toml" && \
 
 grep -rq 'feature = "reth"' "$TMP_WORK_DIR/alloy/src/" && \
     err "reth-gated code still in tempo-alloy source"
+grep -rq 'feature = "revm"' "$TMP_WORK_DIR/alloy/src/" && \
+    err "revm-gated code still in tempo-alloy source"
 
 # Exclude hardfork.rs: the tempo_hardfork! macro generates #[cfg(feature = "reth")]
 # blocks that are dead code when the reth feature is absent (suppressed via check-cfg).

--- a/scripts/sanitize_source.py
+++ b/scripts/sanitize_source.py
@@ -292,15 +292,24 @@ def sanitize_chainspec(chainspec_dir):
 def sanitize_alloy(alloy_dir):
     """Strip node-internal code from tempo-alloy source files.
 
-    The reth_compat.rs file is already deleted by the shell script (publish-crates.sh).
-    This function removes the cfg-gated `mod reth_compat;` declaration from rpc/mod.rs
-    so the crate compiles without the file.
+    The revm_compat.rs and reth_compat.rs files are already deleted by the shell
+    script (publish-crates.sh). This function removes their cfg-gated module
+    declarations from rpc/mod.rs so the crate compiles without those files.
     """
     src = f"{alloy_dir}/src"
 
-    # Delete the cfg-gated `mod reth_compat;` block from rpc/mod.rs
-    delete_lines(f"{src}/rpc/mod.rs", r'^#\[cfg\(feature = "reth"\)\]\nmod reth_compat;\n', expected=1)
-    print(f"  rpc/mod.rs: deleted mod reth_compat declaration", file=sys.stderr)
+    # Delete the cfg-gated compatibility module blocks from rpc/mod.rs
+    delete_lines(
+        f"{src}/rpc/mod.rs",
+        r'^#\[cfg\(feature = "revm"\)\]\nmod revm_compat;\n',
+        expected=1,
+    )
+    delete_lines(
+        f"{src}/rpc/mod.rs",
+        r'^#\[cfg\(feature = "reth"\)\]\nmod reth_compat;\n',
+        expected=1,
+    )
+    print(f"  rpc/mod.rs: deleted revm/reth compatibility declarations", file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/scripts/sanitize_toml.py
+++ b/scripts/sanitize_toml.py
@@ -396,8 +396,8 @@ def main():
         internal_deps = ws_path_deps - publish_keep
         text = strip_dep_lines(text, lambda n: n in internal_deps)
 
-        # Strip the `reth` feature block
-        text = strip_feature_blocks(text, ['reth'])
+        # Strip node-internal compatibility feature blocks
+        text = strip_feature_blocks(text, ['revm', 'reth'])
 
         # Strip "rpc" from tempo-primitives features (rpc feature is stripped during publish)
         text = re.sub(r', "rpc"', '', text)


### PR DESCRIPTION
Extracts the lightweight Tempo simulation environment from #6965 so downstream consumers can select `tempo-alloy/revm` without enabling Reth RPC compatibility and its broader dependency set. The `reth` feature continues to include `revm`, preserving existing node behavior.

This PR was prepared with Codex assistance.

Prompted by: @joshieDo
