### PR TITLE
feat(xtask): add deploy-zone-runtimes for factory-free deployment

### DIFF
--- a/.changelog/deploy-zone-runtimes.md
+++ b/.changelog/deploy-zone-runtimes.md
@@ -1,0 +1,5 @@
+---
+tempo-xtask: minor
+---
+
+Added `cargo xtask deploy-zone-runtimes`, which deploys the ZonePortal implementation, verifier, and shared messenger runtimes from just a private key and an RPC URL, for testing without the native ZoneFactory.

--- a/scripts/deploy-zone-runtimes.sh
+++ b/scripts/deploy-zone-runtimes.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Deploy the shared Zone runtimes (ZonePortal implementation, verifier, messenger) without the
+# native ZoneFactory. Needs only a private key and an RPC URL.
+#
+#   PRIVATE_KEY=0x... ./scripts/deploy-zone-runtimes.sh
+#   PRIVATE_KEY=0x... ETH_RPC_URL=https://rpc.moderato.tempo.xyz ./scripts/deploy-zone-runtimes.sh
+#
+# The runtimes land at CREATE-derived addresses, not the canonical protocol addresses that the T10
+# hardfork etches — an EOA cannot write to those. Creating a usable zone still requires the native
+# factory; the portal implementation rejects `initialize` from any other caller.
+
+set -e
+
+if [ -z "$PRIVATE_KEY" ]; then
+  echo "PRIVATE_KEY must be set (hex encoded, funded on the target chain)" >&2
+  exit 1
+fi
+
+# Use existing ETH_RPC_URL or default to localhost
+if [ -z "$ETH_RPC_URL" ]; then
+  export ETH_RPC_URL="http://localhost:8545"
+fi
+
+exec cargo run --quiet -p tempo-xtask -- deploy-zone-runtimes \
+  --rpc-url "$ETH_RPC_URL" \
+  --private-key "$PRIVATE_KEY" \
+  "$@"

--- a/scripts/deploy-zone-runtimes.sh
+++ b/scripts/deploy-zone-runtimes.sh
@@ -7,8 +7,10 @@
 #   PRIVATE_KEY=0x... ETH_RPC_URL=https://rpc.moderato.tempo.xyz ./scripts/deploy-zone-runtimes.sh
 #
 # The runtimes land at CREATE-derived addresses, not the canonical protocol addresses that the T10
-# hardfork etches — an EOA cannot write to those. Creating a usable zone still requires the native
-# factory; the portal implementation rejects `initialize` from any other caller.
+# hardfork etches — an EOA cannot write to those. No real portal can reference these copies either:
+# portal proxies hardcode the canonical implementation, and the factory fixes every portal's
+# messenger and verifier to the canonical addresses. Use genesis or the T10 boundary for a usable
+# zone; this script is for exercising the contracts standalone.
 
 set -e
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -32,6 +32,7 @@ alloy = { workspace = true, features = [
   "provider-ws",
   "reqwest",
   "reqwest-rustls-tls",
+  "rpc-types",
   "signers",
   "signer-local",
   "signer-mnemonic",

--- a/xtask/src/deploy_zone_runtimes.rs
+++ b/xtask/src/deploy_zone_runtimes.rs
@@ -7,15 +7,26 @@
 //!
 //! This command deploys ordinary copies of the same runtime bytecode at CREATE-derived addresses
 //! using nothing but a private key and an RPC URL. That works on any network, whether or not T10
-//! is active, and is useful for inspecting or exercising the zone contracts directly.
+//! is active, and is useful for exercising or inspecting the contracts standalone: reading the
+//! verifier, poking the messenger, or confirming the runtimes deploy and match the expected bytes.
 //!
 //! ## What this cannot do
 //!
-//! It cannot stand up a working *zone*. A live portal is an ERC-1167 proxy whose storage the
-//! factory initializes, and the implementation gates its one-time `initialize` on the caller being
-//! the factory: calling it from an EOA reverts `NotFactory()` immediately. Since the gate is the
-//! canonical [`ZONE_FACTORY_ADDRESS`], nothing an EOA can do satisfies it on a real network. Zone
-//! creation therefore still requires `createZone` on a chain where T10 is active.
+//! It cannot stand up a working *zone*, and no real portal can reference these copies. Every
+//! address a zone resolves is fixed to a canonical one:
+//!
+//! * a portal proxy hardcodes [`ZONE_PORTAL_IMPL_ADDRESS`] in its 45-byte runtime
+//!   (`ZONE_PORTAL_PROXY_RUNTIME`), so it always delegates to the canonical implementation;
+//! * the factory writes [`ZONE_MESSENGER_ADDRESS`] and [`ZONE_VERIFIER_ADDRESS`] into portal
+//!   storage from constants, and `CreateZoneParams` has no fields for them, so a zone creator
+//!   cannot point a portal at a different messenger or verifier;
+//! * the implementation gates its one-time `initialize` on the caller being the factory, reverting
+//!   `NotFactory()` for an EOA, so a hand-rolled proxy cannot be initialized either.
+//!
+//! Getting these runtimes to their canonical addresses therefore requires either the genesis
+//! allocation (`cargo xtask generate-genesis` etches them when T10 is active at genesis) or the T10
+//! boundary install on a live chain. There is no EOA-only path, and no `anvil_setCode`-style escape
+//! hatch on a Tempo node.
 
 use alloy::{
     network::{EthereumWallet, TransactionBuilder as _},
@@ -119,9 +130,10 @@ impl DeployZoneRuntimes {
             println!("  {label:<25} {address}  ({canonical})");
         }
         println!(
-            "\nThese are CREATE-derived addresses, not the canonical ones the T10 boundary etches.\n\
-             Creating a usable zone still needs the native factory at {ZONE_FACTORY_ADDRESS}: the\n\
-             portal implementation rejects `initialize` from any other caller with NotFactory()."
+            "\nThese are CREATE-derived addresses, not the canonical ones the T10 boundary etches,\n\
+             and no real portal can reference them: proxies hardcode the canonical implementation,\n\
+             and the factory at {ZONE_FACTORY_ADDRESS} fixes each portal's messenger and verifier to\n\
+             the canonical addresses. Use genesis or the T10 boundary for a usable zone."
         );
 
         Ok(())

--- a/xtask/src/deploy_zone_runtimes.rs
+++ b/xtask/src/deploy_zone_runtimes.rs
@@ -1,0 +1,224 @@
+//! Deploy the shared Zone runtimes manually, without the native ZoneFactory.
+//!
+//! The T10 hardfork normally etches the ZonePortal implementation, the verifier, and the shared
+//! messenger at fixed protocol-managed addresses ([`ZONE_PORTAL_IMPL_ADDRESS`],
+//! [`ZONE_VERIFIER_ADDRESS`], [`ZONE_MESSENGER_ADDRESS`]). Those are vanity addresses reachable
+//! only by protocol-level state injection, so an EOA cannot reproduce them.
+//!
+//! This command deploys ordinary copies of the same runtime bytecode at CREATE-derived addresses
+//! using nothing but a private key and an RPC URL. That works on any network, whether or not T10
+//! is active, and is useful for inspecting or exercising the zone contracts directly.
+//!
+//! ## What this cannot do
+//!
+//! It cannot stand up a working *zone*. A live portal is an ERC-1167 proxy whose storage the
+//! factory initializes, and the implementation gates its one-time `initialize` on the caller being
+//! the factory: calling it from an EOA reverts `NotFactory()` immediately. Since the gate is the
+//! canonical [`ZONE_FACTORY_ADDRESS`], nothing an EOA can do satisfies it on a real network. Zone
+//! creation therefore still requires `createZone` on a chain where T10 is active.
+
+use alloy::{
+    network::{EthereumWallet, TransactionBuilder as _},
+    primitives::{Address, Bytes},
+    providers::{Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    signers::local::PrivateKeySigner,
+};
+use eyre::{Context as _, ensure, eyre};
+use tempo_contracts::{
+    precompiles::{
+        ZONE_FACTORY_ADDRESS, ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS,
+        ZONE_VERIFIER_ADDRESS,
+    },
+    zones::{ZONE_MESSENGER_RUNTIME, ZONE_PORTAL_RUNTIME, ZONE_VERIFIER_RUNTIME},
+};
+
+/// Deploy the ZonePortal implementation, verifier, and messenger runtimes without the factory.
+#[derive(Debug, clap::Args)]
+pub(crate) struct DeployZoneRuntimes {
+    /// RPC endpoint to deploy against.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: String,
+
+    /// Deployer private key, hex encoded. Pays for gas.
+    #[arg(long, env = "PRIVATE_KEY", hide_env_values = true)]
+    private_key: PrivateKeySigner,
+
+    /// Print the deployment plan and exit without sending transactions.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+/// Length of the [`runtime_initcode`] prefix, and therefore the offset of the runtime within it.
+const INITCODE_PREFIX_LEN: u8 = 10;
+
+/// Maximum deployed contract size (EIP-170).
+const MAX_CODE_SIZE: usize = 24_576;
+
+impl DeployZoneRuntimes {
+    pub(crate) async fn run(self) -> eyre::Result<()> {
+        // Ordered so the verifier and messenger, which a portal has to reference, come first.
+        let targets = [
+            (
+                "ZoneVerifier",
+                &ZONE_VERIFIER_RUNTIME,
+                ZONE_VERIFIER_ADDRESS,
+            ),
+            (
+                "ZoneMessenger",
+                &ZONE_MESSENGER_RUNTIME,
+                ZONE_MESSENGER_ADDRESS,
+            ),
+            (
+                "ZonePortal implementation",
+                &ZONE_PORTAL_RUNTIME,
+                ZONE_PORTAL_IMPL_ADDRESS,
+            ),
+        ];
+
+        for (label, runtime, _) in &targets {
+            ensure!(
+                runtime.len() <= MAX_CODE_SIZE,
+                "{label} runtime is {} bytes, over the {MAX_CODE_SIZE}-byte contract size limit",
+                runtime.len()
+            );
+        }
+
+        if self.dry_run {
+            println!("Would deploy (canonical protocol address in parentheses):");
+            for (label, runtime, canonical) in &targets {
+                println!("  {label} — {} bytes  ({canonical})", runtime.len());
+            }
+            return Ok(());
+        }
+
+        let deployer = self.private_key.address();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(self.private_key))
+            .connect(&self.rpc_url)
+            .await
+            .wrap_err("failed to connect to RPC")?;
+
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .wrap_err("failed to read chain id")?;
+        println!(
+            "Deployer {deployer} on chain {chain_id} via {}",
+            self.rpc_url
+        );
+
+        let mut deployed = Vec::with_capacity(targets.len());
+        for (label, runtime, canonical) in &targets {
+            let address = deploy_runtime(&provider, label, runtime).await?;
+            deployed.push((*label, address, *canonical));
+        }
+
+        println!("\nDeployed (canonical protocol address in parentheses):");
+        for (label, address, canonical) in &deployed {
+            println!("  {label:<25} {address}  ({canonical})");
+        }
+        println!(
+            "\nThese are CREATE-derived addresses, not the canonical ones the T10 boundary etches.\n\
+             Creating a usable zone still needs the native factory at {ZONE_FACTORY_ADDRESS}: the\n\
+             portal implementation rejects `initialize` from any other caller with NotFactory()."
+        );
+
+        Ok(())
+    }
+}
+
+/// Deploys `runtime` verbatim and returns the address it landed at.
+async fn deploy_runtime(
+    provider: &impl Provider,
+    label: &str,
+    runtime: &[u8],
+) -> eyre::Result<Address> {
+    let receipt = provider
+        .send_transaction(TransactionRequest::default().with_deploy_code(runtime_initcode(runtime)))
+        .await
+        .wrap_err_with(|| format!("failed to submit {label} deployment"))?
+        .get_receipt()
+        .await
+        .wrap_err_with(|| format!("failed to confirm {label} deployment"))?;
+
+    ensure!(
+        receipt.status(),
+        "{label} deployment reverted in {:?}",
+        receipt.transaction_hash
+    );
+    let deployed = receipt
+        .contract_address
+        .ok_or_else(|| eyre!("{label} receipt carried no contract address"))?;
+
+    // The initcode returns the runtime verbatim, so a mismatch means the chain rejected or
+    // truncated the code rather than that the transaction merely failed.
+    let onchain = provider
+        .get_code_at(deployed)
+        .await
+        .wrap_err_with(|| format!("failed to read back {label} code"))?;
+    ensure!(
+        onchain.as_ref() == runtime,
+        "{label} code at {deployed} does not match the expected runtime ({} vs {} bytes)",
+        onchain.len(),
+        runtime.len()
+    );
+
+    println!("  deployed {label} at {deployed} ({} bytes)", runtime.len());
+    Ok(deployed)
+}
+
+/// Wraps deployed runtime bytecode in minimal initcode that returns it verbatim.
+///
+/// `PUSH2 len; DUP1; PUSH1 10; PUSH0; CODECOPY; PUSH0; RETURN` — copies the trailing runtime out
+/// of the initcode and returns it as the deployed code.
+fn runtime_initcode(runtime: &[u8]) -> Bytes {
+    let len = u16::try_from(runtime.len()).expect("zone runtimes are far below 64 KiB");
+
+    let mut initcode = Vec::with_capacity(runtime.len() + usize::from(INITCODE_PREFIX_LEN));
+    initcode.push(0x61); // PUSH2 len
+    initcode.extend_from_slice(&len.to_be_bytes());
+    initcode.push(0x80); // DUP1
+    initcode.push(0x60); // PUSH1 <runtime offset>
+    initcode.push(INITCODE_PREFIX_LEN);
+    initcode.push(0x5f); // PUSH0 (memory destination)
+    initcode.push(0x39); // CODECOPY
+    initcode.push(0x5f); // PUSH0 (return offset)
+    initcode.push(0xf3); // RETURN
+    debug_assert_eq!(initcode.len(), usize::from(INITCODE_PREFIX_LEN));
+
+    initcode.extend_from_slice(runtime);
+    initcode.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initcode_returns_runtime_verbatim() {
+        let runtime = [0xefu8; 300];
+        let initcode = runtime_initcode(&runtime);
+
+        assert_eq!(
+            &initcode[..usize::from(INITCODE_PREFIX_LEN)],
+            &[0x61, 0x01, 0x2c, 0x80, 0x60, 0x0a, 0x5f, 0x39, 0x5f, 0xf3]
+        );
+        assert_eq!(&initcode[usize::from(INITCODE_PREFIX_LEN)..], &runtime);
+    }
+
+    #[test]
+    fn zone_runtimes_fit_the_contract_size_limit() {
+        for (label, runtime) in [
+            ("verifier", &ZONE_VERIFIER_RUNTIME),
+            ("messenger", &ZONE_MESSENGER_RUNTIME),
+            ("portal", &ZONE_PORTAL_RUNTIME),
+        ] {
+            assert!(
+                runtime.len() <= MAX_CODE_SIZE,
+                "{label} runtime is {} bytes, over the EIP-170 limit",
+                runtime.len()
+            );
+        }
+    }
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -3,10 +3,10 @@ use std::net::SocketAddr;
 
 use crate::{
     bootstrap_shadowfork::BootstrapShadowfork, check_abi::CheckAbi,
-    generate_devnet::GenerateDevnet, generate_genesis::GenerateGenesis,
-    generate_localnet::GenerateLocalnet, generate_shadowfork::GenerateShadowfork,
-    generate_state_bloat::GenerateStateBloat, get_dkg_outcome::GetDkgOutcome,
-    identity_transitions::GetIdentityTransitions,
+    deploy_zone_runtimes::DeployZoneRuntimes, generate_devnet::GenerateDevnet,
+    generate_genesis::GenerateGenesis, generate_localnet::GenerateLocalnet,
+    generate_shadowfork::GenerateShadowfork, generate_state_bloat::GenerateStateBloat,
+    get_dkg_outcome::GetDkgOutcome, identity_transitions::GetIdentityTransitions,
 };
 
 use alloy::signers::{local::MnemonicBuilder, utils::secret_key_to_address};
@@ -16,6 +16,7 @@ use eyre::Context;
 
 mod bootstrap_shadowfork;
 mod check_abi;
+mod deploy_zone_runtimes;
 mod generate_devnet;
 mod generate_genesis;
 mod generate_localnet;
@@ -57,6 +58,9 @@ async fn main() -> eyre::Result<()> {
             .run()
             .await
             .wrap_err("failed to generate state bloat file"),
+        Action::DeployZoneRuntimes(args) => {
+            args.run().await.wrap_err("failed to deploy zone runtimes")
+        }
     }
 }
 
@@ -82,6 +86,7 @@ enum Action {
     BootstrapShadowfork(BootstrapShadowfork),
     GenerateAddPeer(GenerateAddPeer),
     GenerateStateBloat(GenerateStateBloat),
+    DeployZoneRuntimes(DeployZoneRuntimes),
 }
 
 #[derive(Debug, clap::Args)]


### PR DESCRIPTION
`cargo xtask deploy-zone-runtimes` deploys the ZonePortal implementation, verifier, and shared messenger from just a private key and an RPC URL (`scripts/deploy-zone-runtimes.sh` wraps it). `--dry-run` prints the plan and sizes.

```bash
PRIVATE_KEY=0x... ETH_RPC_URL=https://rpc.moderato.tempo.xyz ./scripts/deploy-zone-runtimes.sh
```

T10 etches these at vanity addresses an EOA can't write to, so it deploys copies at CREATE-derived addresses: runtime wrapped in minimal initcode that returns it verbatim, then read back and compared against the expected bytes. Verified on a local `--chain dev` node — all three come out byte-identical to the canonical etched code.

**Scope, worth reading before using this.** No real portal can reference these copies. Portal proxies hardcode `ZONE_PORTAL_IMPL_ADDRESS` in their 45-byte runtime; the factory writes the canonical messenger and verifier into portal storage from constants, and `CreateZoneParams` has no fields for them; and the implementation gates `initialize` on the caller being the factory, reverting `NotFactory()` for an EOA. So this is for exercising the contracts standalone, not for standing up a zone — a usable zone needs the runtimes at their canonical addresses, which means genesis (`generate-genesis` already etches them when T10 is active at genesis) or the T10 boundary.