### PR TITLE
chore(tips): bump verification hardfork to T9

### DIFF
--- a/tips/verify/foundry.toml
+++ b/tips/verify/foundry.toml
@@ -1,5 +1,5 @@
 [profile.default]
-hardfork = "tempo:T8"
+hardfork = "tempo:T9"
 
 # layout and file system
 src = "src"

--- a/tips/verify/test/StablecoinDEX.t.sol
+++ b/tips/verify/test/StablecoinDEX.t.sol
@@ -2061,8 +2061,6 @@ contract StablecoinDEXTest is TempoTest {
     }
 
     /// @notice Test cancelStaleOrder with compound policy - maker blocked as sender
-    /// forge-config: default.hardfork = "tempo:T2"
-    /// forge-config: fuzz500.hardfork = "tempo:T2"
     function test_CancelStaleOrder_Succeeds_BlockedMaker_CompoundPolicy() public {
         // Create compound policy: sender blacklist, recipient always-allow, mint always-allow
         uint64 senderBlacklist = registry.createPolicy(admin, ITIP403Registry.PolicyType.BLACKLIST);
@@ -2092,8 +2090,6 @@ contract StablecoinDEXTest is TempoTest {
     }
 
     /// @notice Test cancelStaleOrder fails with compound policy when maker only blocked as recipient
-    /// forge-config: default.hardfork = "tempo:T2"
-    /// forge-config: fuzz500.hardfork = "tempo:T2"
     function test_CancelStaleOrder_Fails_MakerOnlyBlockedAsRecipient_CompoundPolicy() public {
         // Create compound policy: sender always-allow, recipient blacklist, mint always-allow
         uint64 recipientBlacklist =


### PR DESCRIPTION
Updates the TIP verification Foundry profile from Tempo T8 to T9.

Prompted by: @grandizzy