### PR TITLE
refactor(consensus): remove unused finalized marker lookup

### DIFF
--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -6,19 +6,17 @@
 
 use std::time::Instant;
 
-use alloy_consensus::Sealable as _;
 use commonware_consensus::simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization};
 use commonware_cryptography::{
     bls12381::primitives::variant::MinSig, certificate::Scheme as _, ed25519::PublicKey,
 };
 use commonware_runtime::{BufferPooler, Clock, Metrics, Spawner, Storage, buffer::paged::CacheRef};
 use commonware_storage::{
-    archive::{Archive as _, Identifier, immutable, prunable},
+    archive::{Archive as _, immutable, prunable},
     translator::TwoCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize};
 use eyre::{WrapErr as _, ensure};
-use reth_provider::{BlockIdReader, BlockReader};
 use tracing::{info, instrument};
 
 use crate::{
@@ -202,65 +200,4 @@ where
     );
 
     archive
-}
-
-/// Finds the latest finalization certificate backed by finalized execution storage.
-///
-/// Searches backwards from the execution provider's finalized tip. At
-/// most `max_depth` blocks behind that starting height are inspected.
-///
-/// Returns `None` if no persisted finalization certificate has a matching
-/// finalized execution block.
-pub async fn find_last_finalized_marker<TContext, P>(
-    context: &TContext,
-    execution_provider: &P,
-    max_depth: u64,
-) -> eyre::Result<Option<(u64, Finalization<Scheme<PublicKey, MinSig>, Digest>)>>
-where
-    TContext: Clock + Metrics + Spawner + Storage + BufferPooler + Clone + Send + 'static,
-    P: BlockIdReader + BlockReader<Block = tempo_primitives::Block> + Send + Sync + ?Sized,
-{
-    let page_cache = CacheRef::from_pooler(context, BUFFER_POOL_PAGE_SIZE, BUFFER_POOL_CAPACITY);
-    let archive = init_finalizations_archive(context, crate::PARTITION_PREFIX, page_cache)
-        .await
-        .wrap_err("failed to open finalizations-by-height archive")?;
-
-    if archive.last_index().is_none() {
-        return Ok(None);
-    }
-    let Some(finalized_tip) = execution_provider
-        .finalized_block_number()
-        .wrap_err("failed reading finalized block number from execution provider")?
-    else {
-        return Ok(None);
-    };
-
-    let search_end = finalized_tip.saturating_sub(max_depth);
-    for height in (search_end..=finalized_tip).rev() {
-        let Some(finalization) = archive
-            .get(Identifier::Index(height))
-            .await
-            .wrap_err_with(|| format!("failed reading finalization at height {height}"))?
-        else {
-            continue;
-        };
-
-        let Some(block) = execution_provider
-            .block_by_number(height)
-            .wrap_err_with(|| format!("failed reading block at height {height}"))?
-        else {
-            continue;
-        };
-
-        let finalization_digest = finalization.proposal.payload;
-        let block_digest = Digest(block.header.hash_slow());
-        ensure!(
-            finalization_digest == block_digest,
-            "digest mismatch at height `{height}`. finalization: {finalization_digest}, execution: {block_digest}",
-        );
-
-        return Ok(Some((height, finalization)));
-    }
-
-    Ok(None)
 }


### PR DESCRIPTION
Removes the unused `find_last_finalized_marker` helper and its now-unused imports.

Prompted by: @hamdiallam