### PR TITLE
fix(ci): fetch ClickHouse metric allowlist

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -311,6 +311,26 @@ jobs:
 
             core.setFailed(`@${username} is not a member of ${org}`);
 
+      - name: Fetch ClickHouse metric allowlist
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'contrib/bench/clickhouse-metrics.txt';
+            const { data } = await github.rest.repos.getContent({
+              ...context.repo,
+              path,
+              ref: context.sha,
+            });
+
+            if (Array.isArray(data) || data.type !== 'file' || !data.content) {
+              core.setFailed(`Expected ${path} to be a file at ${context.sha}`);
+              return;
+            }
+
+            fs.mkdirSync('contrib/bench', { recursive: true });
+            fs.writeFileSync(path, Buffer.from(data.content, 'base64'));
+
       - name: Checkout benchmark repo
         id: checkout_benchmark_repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Fetch the ClickHouse metric allowlist from the Tempo commit that triggered the workflow without checking out the full repository.

Prompted by: @sds