### PR TITLE
Fix ClickHouse allowlist source in benchmark workflow

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -318,9 +318,10 @@ jobs:
             const fs = require('fs');
             const path = 'contrib/bench/clickhouse-metrics.txt';
             const { data } = await github.rest.repos.getContent({
-              ...context.repo,
+              owner: 'tempoxyz',
+              repo: 'tempo',
               path,
-              ref: context.sha,
+              ref: context.repo.owner === 'tempoxyz' && context.repo.repo === 'tempo' ? context.sha : 'main',
             });
 
             if (Array.isArray(data) || data.type !== 'file' || !data.content) {


### PR DESCRIPTION
Fetch the ClickHouse metric allowlist explicitly from `tempoxyz/tempo`. This keeps the benchmark workflow working when run from the multi-region benchmark repository while retaining the same workflow content in both repositories.

Validation:
- `git diff --check`
- Benchmark-repo smoke run: https://github.com/tempoxyz/tempo-multi-region-benchmark/actions/runs/30567021304
  - The corrected run passed the allowlist-fetch step and proceeded into benchmark setup. GitHub API rate limiting prevented final-status retrieval during this update.