### PR TITLE
fix(ci): fetch ClickHouse allowlist from Tempo

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -318,9 +318,10 @@ jobs:
             const fs = require('fs');
             const path = 'contrib/bench/clickhouse-metrics.txt';
             const { data } = await github.rest.repos.getContent({
-              ...context.repo,
+              owner: 'tempoxyz',
+              repo: 'tempo',
               path,
-              ref: context.sha,
+              ref: context.repo.owner === 'tempoxyz' && context.repo.repo === 'tempo' ? context.sha : 'main',
             });
 
             if (Array.isArray(data) || data.type !== 'file' || !data.content) {


### PR DESCRIPTION
Fetch the ClickHouse metric allowlist explicitly from `tempoxyz/tempo`. This keeps the reusable benchmark workflow working when invoked from the multi-region benchmark repository.

Prompted by: @sds