### PR TITLE
fix(deps): keep Reqwest Rustls provider-neutral

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,7 +299,7 @@ proptest-arbitrary-interop = "0.1.0"
 rand = "0.9"
 rand_08 = { package = "rand", version = "0.8.5" }
 rand_core = "0.6.4"
-reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 semver = "1"
 serde = { version = "1.0.228", features = ["derive"], default-features = false }


### PR DESCRIPTION
## Summary

Tempo already selects `rustls/ring` explicitly, but its Reqwest dependency enables `reqwest/rustls`, which also selects AWS-LC. With Rustls 0.23 this compiles both providers and prevents automatic provider selection.

Use Reqwest's provider-neutral feature so the adjacent explicit `rustls/ring` selection is the sole Rustls backend.

## Validation

- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check -p tempo-alloy`
- `cargo tree -p tempo-alloy --edges normal,build -i aws-lc-rs` reports no matching package
