### PR TITLE
fix(precompiles): ensure new portal is not initialized

### DIFF
--- a/crates/contracts/src/precompiles/zone_factory.rs
+++ b/crates/contracts/src/precompiles/zone_factory.rs
@@ -114,6 +114,8 @@ crate::sol! {
         error NotOwner();
         error InvalidAdmin();
         error InvalidSequencerSet();
+        error AlreadyInitialized();
+
         function owner() external view returns (address);
         function transferOwnership(address newOwner) external;
         function createZone(CreateZoneParams calldata params)

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -381,7 +381,7 @@ mod tests {
                     sequencers: vec![SEQUENCER_A, SEQUENCER_B],
                     threshold: 2,
                     verifier: ZONE_VERIFIER_ADDRESS,
-                    rpcUrl: params.rpcUrl,
+                    rpcUrl: params.rpcUrl.clone(),
                 }
             );
 
@@ -393,7 +393,7 @@ mod tests {
                 ZONE_PORTAL_PROXY_RUNTIME.as_slice()
             );
 
-            let portal = ZonePortalStorage::new(created.portal);
+            let mut portal = ZonePortalStorage::new(created.portal);
             assert_eq!(portal.admin.read()?, ADMIN);
             assert_eq!(portal.block_hash.read()?, B256::ZERO);
             assert_eq!(
@@ -465,6 +465,12 @@ mod tests {
             assert_eq!(
                 StorageCtx.sload(created.portal, U256::from(24))?,
                 U256::from(CREATION_BLOCK)
+            );
+
+            // Ensure portal can't be re-initialized
+            assert_eq!(
+                portal.initialize(1, &params),
+                Err(ZoneFactoryError::already_initialized().into())
             );
             Ok(())
         })

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -101,6 +101,10 @@ impl ZonePortalStorage {
         zone_id: u32,
         params: &IZoneFactory::CreateZoneParams,
     ) -> Result<()> {
+        if self.initialized.read()? {
+            return Err(ZoneFactoryError::already_initialized().into());
+        }
+
         self.storage.set_code(
             self.address,
             Bytecode::new_legacy(Bytes::from_static(&ZONE_PORTAL_PROXY_RUNTIME)),


### PR DESCRIPTION
ref: `ZONES-225`

defense in depth to avoid re-initializing a portal by mistake