### PR TITLE
chore(ci): use master for Foundry checkouts

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: e51ac519c591dbd581481198ea22cece27c4fa7a
+          ref: master
           path: foundry
           persist-credentials: false
 
@@ -261,7 +261,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: e51ac519c591dbd581481198ea22cece27c4fa7a
+          ref: master
           path: foundry
           persist-credentials: false
 


### PR DESCRIPTION
Updates both Foundry checkouts in the specs workflow to track `master` instead of a pinned commit.

Prompted by: @grandizzy