### PR TITLE
deps: pin Reth to Tempo v1.11 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2255,6 +2255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -4210,7 +4219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4713,7 +4722,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -5692,6 +5701,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -5800,7 +5810,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6970,7 +6980,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8606,8 +8616,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8633,8 +8643,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8646,6 +8656,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "rand 0.9.4",
+ "rayon",
  "reth-chainspec",
  "reth-errors",
  "reth-ethereum-primitives",
@@ -8653,6 +8664,7 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
+ "reth-tasks",
  "reth-trie",
  "reth-trie-sparse",
  "revm",
@@ -8664,8 +8676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8684,8 +8696,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8697,8 +8709,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8769,7 +8781,6 @@ dependencies = [
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
- "socket2",
  "tar",
  "tokio",
  "tokio-stream",
@@ -8781,8 +8792,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8791,8 +8802,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8844,8 +8855,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8860,8 +8871,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8874,8 +8885,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8887,8 +8898,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8912,8 +8923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -8941,8 +8952,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8967,8 +8978,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -8997,8 +9008,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9012,8 +9023,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9037,8 +9048,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9061,8 +9072,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9085,8 +9096,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9120,8 +9131,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9177,12 +9188,13 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "aes",
  "alloy-primitives",
  "alloy-rlp",
+ "block-padding",
  "byteorder",
  "cipher",
  "concat-kdf",
@@ -9204,8 +9216,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9227,8 +9239,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9240,12 +9252,10 @@ dependencies = [
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-evm",
- "reth-execution-errors",
  "reth-execution-types",
  "reth-payload-builder-primitives",
  "reth-payload-primitives",
  "reth-primitives-traits",
- "reth-storage-api",
  "reth-trie-common",
  "serde",
  "thiserror 2.0.18",
@@ -9254,8 +9264,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9270,7 +9280,6 @@ dependencies = [
  "indexmap 2.14.0",
  "metrics",
  "moka",
- "parking_lot",
  "rayon",
  "reth-chain-state",
  "reth-chainspec",
@@ -9294,11 +9303,11 @@ dependencies = [
  "reth-stages",
  "reth-stages-api",
  "reth-static-file",
- "reth-storage-overlay",
  "reth-tasks",
  "reth-tracing",
  "reth-trie",
  "reth-trie-common",
+ "reth-trie-db",
  "reth-trie-parallel",
  "reth-trie-sparse",
  "revm",
@@ -9311,8 +9320,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9341,8 +9350,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9359,8 +9368,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9375,8 +9384,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9398,8 +9407,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9409,8 +9418,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9437,8 +9446,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9459,8 +9468,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9500,8 +9509,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "clap",
  "eyre",
@@ -9523,8 +9532,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9539,8 +9548,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9555,8 +9564,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9568,8 +9577,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9598,8 +9607,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9612,8 +9621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9622,8 +9631,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9632,7 +9641,6 @@ dependencies = [
  "alloy-primitives",
  "auto_impl",
  "derive_more",
- "fixed-cache",
  "futures-util",
  "metrics",
  "rayon",
@@ -9648,8 +9656,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9668,8 +9676,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9686,8 +9694,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9699,8 +9707,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9718,8 +9726,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9756,8 +9764,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9770,8 +9778,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "serde",
  "serde_json",
@@ -9780,8 +9788,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9806,8 +9814,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "bytes",
  "futures",
@@ -9826,8 +9834,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9843,8 +9851,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "bindgen",
  "cc",
@@ -9852,11 +9860,10 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "futures",
- "libc",
  "metrics",
  "metrics-derive",
  "reth-primitives-traits",
@@ -9866,8 +9873,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9875,8 +9882,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -9889,8 +9896,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9919,7 +9926,6 @@ dependencies = [
  "reth-eth-wire-types",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
- "reth-evm",
  "reth-evm-ethereum",
  "reth-fs-util",
  "reth-metrics",
@@ -9948,8 +9954,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9973,8 +9979,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9997,8 +10003,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10012,8 +10018,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10026,8 +10032,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10043,8 +10049,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10067,8 +10073,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10121,11 +10127,11 @@ dependencies = [
  "reth-rpc-layer",
  "reth-stages",
  "reth-static-file",
- "reth-storage-overlay",
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-db",
  "secp256k1 0.30.0",
  "serde_json",
  "tokio",
@@ -10135,8 +10141,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10190,8 +10196,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10200,7 +10206,6 @@ dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "ethereum_ssz",
- "ethereum_ssz_derive",
  "eyre",
  "http-body-util",
  "jsonrpsee",
@@ -10224,7 +10229,6 @@ dependencies = [
  "reth-rpc",
  "reth-rpc-api",
  "reth-rpc-builder",
- "reth-rpc-engine-api",
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
@@ -10239,8 +10243,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10263,8 +10267,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10287,8 +10291,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "bytes",
  "eyre",
@@ -10316,8 +10320,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10328,8 +10332,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10352,8 +10356,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10364,8 +10368,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10387,8 +10391,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10430,8 +10434,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10464,7 +10468,6 @@ dependencies = [
  "reth-static-file-types",
  "reth-storage-api",
  "reth-storage-errors",
- "reth-storage-overlay",
  "reth-tasks",
  "reth-tokio-util",
  "reth-trie",
@@ -10479,13 +10482,14 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "itertools 0.14.0",
  "metrics",
+ "rayon",
  "reth-config",
  "reth-db-api",
  "reth-errors",
@@ -10506,8 +10510,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10522,8 +10526,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10537,8 +10541,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10614,8 +10618,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10644,8 +10648,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10687,8 +10691,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10707,8 +10711,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10738,8 +10742,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10785,8 +10789,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10836,8 +10840,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10850,8 +10854,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10881,8 +10885,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10932,8 +10936,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10960,8 +10964,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10974,8 +10978,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -10994,8 +10998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11009,8 +11013,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11035,8 +11039,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11051,35 +11055,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-storage-overlay"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
-dependencies = [
- "alloy-eips",
- "alloy-primitives",
- "metrics",
- "parking_lot",
- "rayon",
- "reth-chain-state",
- "reth-errors",
- "reth-ethereum-primitives",
- "reth-metrics",
- "reth-primitives-traits",
- "reth-prune-types",
- "reth-stages-types",
- "reth-storage-api",
- "reth-storage-errors",
- "reth-tasks",
- "reth-trie",
- "reth-trie-common",
- "reth-trie-db",
- "tracing",
-]
-
-[[package]]
 name = "reth-tasks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11099,8 +11077,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11115,8 +11093,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11125,8 +11103,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "clap",
  "eyre",
@@ -11145,8 +11123,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11164,8 +11142,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11207,8 +11185,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11232,8 +11210,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11259,12 +11237,15 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
+ "metrics",
+ "parking_lot",
  "reth-db-api",
  "reth-execution-errors",
+ "reth-metrics",
  "reth-primitives-traits",
  "reth-storage-api",
  "reth-storage-errors",
@@ -11275,16 +11256,19 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
  "alloy-rlp",
  "crossbeam-channel",
  "crossbeam-utils",
+ "derive_more",
+ "itertools 0.14.0",
  "metrics",
  "rand 0.9.4",
+ "rayon",
  "reth-execution-errors",
  "reth-metrics",
  "reth-primitives-traits",
@@ -11300,8 +11284,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=fc3f7da#fc3f7da91b345cd011767a3e71cde541ebfa02e0"
+version = "2.3.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=70d1149#70d11499e53286a38bb1f2d8061fbb9af060fdff"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11316,7 +11300,6 @@ dependencies = [
  "serde_json",
  "slotmap",
  "smallvec",
- "strum",
  "tracing",
 ]
 
@@ -11835,7 +11818,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11915,7 +11898,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12563,7 +12546,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12839,7 +12822,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14972,7 +14955,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fc3f7da", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "70d1149", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/p2p_proxy.rs
+++ b/bin/tempo/src/p2p_proxy.rs
@@ -473,9 +473,6 @@ async fn run_p2p_network(
             IncomingEthRequest::GetCells { response, .. } => {
                 let _ = response.send(Ok(Default::default()));
             }
-            // Snap sync is not supported by the proxy; drop the response sender to signal
-            // that the request could not be served.
-            IncomingEthRequest::GetSnap { .. } => {}
         }
     }
 

--- a/crates/evm/src/engine.rs
+++ b/crates/evm/src/engine.rs
@@ -3,7 +3,7 @@ use alloy_consensus::crypto::RecoveryError;
 use alloy_primitives::Address;
 use reth_evm::{
     ConfigureEngineEvm, ConfigureEvm, EvmEnvFor, ExecutableTxIterator, ExecutionCtxFor,
-    FromRecoveredTx, RecoveredTx, SenderRecoveryCache, ToTxEnv, block::ExecutableTxParts,
+    FromRecoveredTx, RecoveredTx, ToTxEnv, block::ExecutableTxParts,
 };
 use reth_primitives_traits::{SealedOrRecoveredBlock, SignedTransaction};
 use tempo_payload_types::TempoExecutionData;
@@ -39,7 +39,6 @@ impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
         payload: &TempoExecutionData,
     ) -> Result<impl ExecutableTxIterator<Self>, Self::Error> {
         let block = payload.block.clone();
-        let sender_recovery_cache = self.inner.sender_recovery_cache.clone();
         let mut transactions = Vec::with_capacity(block.body().transactions.len());
         let mut expiring_nonce_idx = 0;
 
@@ -53,12 +52,7 @@ impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
         }
 
         Ok((transactions, move |(index, expiring_nonce_idx)| {
-            RecoveredInBlock::new(
-                block.clone(),
-                index,
-                expiring_nonce_idx,
-                sender_recovery_cache.as_ref(),
-            )
+            RecoveredInBlock::new(block.clone(), index, expiring_nonce_idx)
         }))
     }
 }
@@ -79,21 +73,12 @@ impl RecoveredInBlock {
         block: SealedOrRecoveredBlock<Block>,
         index: usize,
         expiring_nonce_idx: Option<usize>,
-        sender_recovery_cache: Option<&SenderRecoveryCache>,
     ) -> Result<Self, RecoveryError> {
-        let recovered_sender = block
+        let sender = block
             .recovered_block()
-            .and_then(|block| block.senders().get(index).copied());
-        let tx = &block.body().transactions[index];
-        let sender = if let Some(sender) = recovered_sender {
-            sender
-        } else if tx.is_system_tx() {
-            tx.try_recover()?
-        } else if let Some(cache) = sender_recovery_cache {
-            cache.recover(tx)?
-        } else {
-            tx.try_recover()?
-        };
+            .and_then(|block| block.senders().get(index).copied())
+            .map(Ok)
+            .unwrap_or_else(|| block.body().transactions[index].try_recover())?;
         Ok(Self {
             block,
             index,
@@ -135,7 +120,7 @@ impl ExecutableTxParts<TempoTxEnv, TempoTxEnvelope> for RecoveredInBlock {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use alloy_consensus::{BlockHeader, Signed, TxLegacy, transaction::TxHashRef};
+    use alloy_consensus::{BlockHeader, Signed, TxLegacy};
     use alloy_primitives::{B256, Bytes, Signature, TxKind, U256};
     use alloy_rlp::{Encodable, bytes::BytesMut};
     use rayon::iter::{IntoParallelIterator, ParallelIterator};
@@ -209,15 +194,11 @@ mod tests {
     #[test]
     fn test_tx_iterator_for_payload() {
         let chainspec = Arc::new(TempoChainSpec::from_genesis(MODERATO.genesis().clone()));
-        let sender_recovery_cache = SenderRecoveryCache::new(4);
-        let evm_config = TempoEvmConfig::new(chainspec.clone())
-            .with_sender_recovery_cache(sender_recovery_cache.clone());
+        let evm_config = TempoEvmConfig::new(chainspec.clone());
 
         let tx1 = create_legacy_tx();
         let tx2 = create_legacy_tx();
         let system_tx = create_subblock_metadata_tx(chainspec.chain().id(), 1);
-        let tx_hash = *tx1.tx_hash();
-        let system_tx_hash = *system_tx.tx_hash();
 
         let block = create_test_block(vec![tx1, tx2, system_tx]);
 
@@ -242,9 +223,6 @@ mod tests {
             let recovered = recover_fn.convert(item);
             assert!(recovered.is_ok());
         }
-
-        assert!(sender_recovery_cache.get(&tx_hash).is_some());
-        assert_eq!(sender_recovery_cache.get(&system_tx_hash), None);
     }
 
     #[test]

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -38,7 +38,7 @@ use alloy_evm::{
 use alloy_primitives::Address;
 pub use evm::TempoEvmFactory;
 use reth_chainspec::EthChainSpec;
-use reth_evm::{self, ConfigureEvm, EvmEnvFor, SenderRecoveryCache, block::StateDB};
+use reth_evm::{self, ConfigureEvm, EvmEnvFor, block::StateDB};
 use reth_primitives_traits::{SealedBlock, SealedHeader};
 use tempo_primitives::{
     Block, SubBlockMetadata, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
@@ -97,12 +97,6 @@ impl TempoEvmConfig {
             inner,
             block_assembler: TempoBlockAssembler::new(chain_spec),
         }
-    }
-
-    /// Uses the provided sender recovery cache.
-    pub fn with_sender_recovery_cache(mut self, cache: SenderRecoveryCache) -> Self {
-        self.inner = self.inner.with_sender_recovery_cache(cache);
-        self
     }
 
     /// Returns the chain spec

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -439,10 +439,7 @@ where
     type EVM = TempoEvmConfig;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let mut evm_config = TempoEvmConfig::new(ctx.chain_spec());
-        if let Some(cache) = ctx.sender_recovery_cache() {
-            evm_config = evm_config.with_sender_recovery_cache(cache.clone());
-        }
+        let evm_config = TempoEvmConfig::new(ctx.chain_spec());
         Ok(evm_config)
     }
 }

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -47,9 +47,8 @@ use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
     EthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
-        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthSubscriptions, EthTransactions,
-        LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction,
-        SpawnBlocking, Trace,
+        Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthTransactions, LoadBlock,
+        LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction, SpawnBlocking, Trace,
         bal::GetBlockAccessList,
         estimate::EstimateCall,
         pending_block::{BuildPendingEnv, PendingEnvBuilder},
@@ -472,7 +471,6 @@ where
 }
 
 impl<N> EstimateCall for TempoEthApi<N> where N: TempoEthApiBounds {}
-impl<N> EthSubscriptions for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> LoadBlock for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> LoadReceipt for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> EthBlocks for TempoEthApi<N> where N: TempoEthApiBounds {}

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -370,7 +370,7 @@ where
         let BuildArguments {
             cached_reads,
             execution_cache,
-            mut state_root_handle,
+            mut trie_handle,
             config,
             cancel,
             best_payload,
@@ -539,22 +539,19 @@ where
         maybe_override_fee_recipient(&mut executor, &attributes);
 
         let bal_task_handle = if self.enable_bal {
-            let bal_task_handle = self.spawn_bal_task(
-                state_root_handle
-                    .as_mut()
-                    .map(|handle| handle.take_state_hook()),
-            );
+            let bal_task_handle =
+                self.spawn_bal_task(trie_handle.as_mut().map(|handle| handle.state_hook()));
             executor
                 .evm_mut()
                 .db_mut()
                 .set_state_hook(Some(Box::new(bal_task_handle.state_hook())));
             Some(bal_task_handle)
         } else {
-            if let Some(handle) = state_root_handle.as_mut() {
+            if let Some(handle) = trie_handle.as_mut() {
                 executor
                     .evm_mut()
                     .db_mut()
-                    .set_state_hook(Some(Box::new(handle.take_state_hook())));
+                    .set_state_hook(Some(Box::new(handle.state_hook())));
             }
             None
         };
@@ -1022,14 +1019,13 @@ where
         // Drop the BAL task sender to trigger finalization.
         let bal_rx = bal_task_handle.map(|handle| handle.into_bal_rx());
 
-        let hashed_state = if let Some(Ok(hashed_state)) = state_root_handle
+        let hashed_state = if let Some(Ok(hashed_state)) = trie_handle
             .as_mut()
-            .and_then(|handle| handle.try_take_hashed_state_rx())
-            .map(|rx| rx.recv())
+            .map(|handle| handle.take_hashed_state_rx().recv())
         {
             hashed_state
         } else {
-            Arc::new(finish_provider.hashed_post_state(&db.bundle_state))
+            finish_provider.hashed_post_state(&db.bundle_state)
         };
 
         let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =
@@ -1041,7 +1037,7 @@ where
                     "skipping payload state-root computation"
                 );
                 None
-            } else if let Some(mut handle) = state_root_handle {
+            } else if let Some(mut handle) = trie_handle {
                 let state_root_wait_start = Instant::now();
                 let _span = debug_span!(target: "payload_builder", "await_state_root").entered();
                 match handle.state_root() {
@@ -1080,16 +1076,24 @@ where
             (None, None)
         };
 
-        let (state_root, trie_updates) = if self.config.skip_state_root {
-            (parent_header.state_root(), Arc::new(Default::default()))
+        let (state_root, trie_updates, changed_paths) = if self.config.skip_state_root {
+            (
+                parent_header.state_root(),
+                Arc::new(Default::default()),
+                None,
+            )
         } else if let Some(outcome) = state_root_outcome {
-            (outcome.state_root, outcome.trie_updates)
+            (
+                outcome.state_root,
+                outcome.trie_updates,
+                outcome.changed_paths,
+            )
         } else {
             let (state_root, trie_updates) = finish_provider
-                .state_root_with_updates((*hashed_state).clone())
+                .state_root_with_updates(hashed_state.clone())
                 .map_err(BlockExecutionError::other)?;
 
-            (state_root, Arc::new(trie_updates))
+            (state_root, Arc::new(trie_updates), None)
         };
 
         let RootsTaskResult {
@@ -1291,8 +1295,9 @@ where
         let executed_block = BuiltPayloadExecutedBlock {
             recovered_block: block,
             execution_output: Arc::new(execution_output),
-            hashed_state,
+            hashed_state: Arc::new(hashed_state),
             trie_updates,
+            changed_paths,
         };
 
         let payload = TempoBuiltPayload::new(


### PR DESCRIPTION
1. Revert Reth dependencies to Tempo v1.11 Reth pin + https://github.com/paradigmxyz/reth/pull/26480 ([diff](https://github.com/paradigmxyz/reth/compare/tempo/v1.11...alexey/tempo-reth-patched))
2. Revert changes made after Reth bumps, so that Tempo is compatible with older Reth version