### PR TITLE
feat(alloy): add authorization request builders

### DIFF
--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -471,26 +471,6 @@ mod tests {
     }
 
     #[test]
-    fn eip7702_builder_helpers_forward_to_inner_request() {
-        let authorization = SignedAuthorization::new_unchecked(
-            Authorization {
-                chain_id: U256::from(1337),
-                address: Address::ZERO,
-                nonce: 0,
-            },
-            0,
-            U256::ZERO,
-            U256::ZERO,
-        );
-        let expected = vec![authorization];
-
-        let request = TempoTransactionRequest::default().with_authorization_list(expected.clone());
-
-        assert_eq!(request.inner.authorization_list, Some(expected.clone()));
-        assert_eq!(request.authorization_list(), Some(&expected));
-    }
-
-    #[test]
     fn output_tx_type_empty_request_is_not_aa() {
         let req = TempoTransactionRequest::default();
         assert_ne!(req.output_tx_type(), TempoTxType::AA);

--- a/crates/alloy/src/network.rs
+++ b/crates/alloy/src/network.rs
@@ -3,9 +3,11 @@ use std::fmt::Debug;
 use crate::rpc::{TempoHeaderResponse, TempoTransactionReceipt, TempoTransactionRequest};
 use alloy_consensus::{ReceiptWithBloom, TxType, error::UnsupportedTransactionType};
 
+use alloy_eips::eip7702::SignedAuthorization;
 use alloy_network::{
     BuildResult, Ethereum, EthereumWallet, IntoWallet, Network, NetworkTransactionBuilder,
-    NetworkWallet, TransactionBuilder, TransactionBuilderError, UnbuiltTransactionError,
+    NetworkWallet, TransactionBuilder, TransactionBuilder7702, TransactionBuilderError,
+    UnbuiltTransactionError,
 };
 use alloy_primitives::{Address, Bytes, ChainId, TxKind, U256};
 use alloy_provider::fillers::{ChainIdFiller, JoinFill, NonceFiller, RecommendedFillers};
@@ -135,6 +137,16 @@ impl TransactionBuilder for TempoTransactionRequest {
 
     fn set_access_list(&mut self, access_list: AccessList) {
         TransactionBuilder::set_access_list(&mut self.inner, access_list)
+    }
+}
+
+impl TransactionBuilder7702 for TempoTransactionRequest {
+    fn authorization_list(&self) -> Option<&Vec<SignedAuthorization>> {
+        TransactionBuilder7702::authorization_list(&self.inner)
+    }
+
+    fn set_authorization_list(&mut self, authorization_list: Vec<SignedAuthorization>) {
+        TransactionBuilder7702::set_authorization_list(&mut self.inner, authorization_list)
     }
 }
 
@@ -299,7 +311,6 @@ impl IntoWallet<TempoNetwork> for PrivateKeySigner {
 mod tests {
     use super::*;
     use alloy_consensus::{TxEip1559, TxEip2930, TxEip7702, TxLegacy};
-    use alloy_eips::eip7702::SignedAuthorization;
     use alloy_primitives::{B256, Signature};
     use alloy_rpc_types_eth::{AccessListItem, Authorization, TransactionRequest};
     use tempo_primitives::{
@@ -457,6 +468,26 @@ mod tests {
             .to_string();
 
         assert_eq!(actual_error, expected_error);
+    }
+
+    #[test]
+    fn eip7702_builder_helpers_forward_to_inner_request() {
+        let authorization = SignedAuthorization::new_unchecked(
+            Authorization {
+                chain_id: U256::from(1337),
+                address: Address::ZERO,
+                nonce: 0,
+            },
+            0,
+            U256::ZERO,
+            U256::ZERO,
+        );
+        let expected = vec![authorization];
+
+        let request = TempoTransactionRequest::default().with_authorization_list(expected.clone());
+
+        assert_eq!(request.inner.authorization_list, Some(expected.clone()));
+        assert_eq!(request.authorization_list(), Some(&expected));
     }
 
     #[test]

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -168,6 +168,34 @@ impl TempoTransactionRequest {
         self.calls.push(call);
     }
 
+    /// Replace the Tempo authorization list for this transaction.
+    pub fn set_tempo_authorization_list(
+        &mut self,
+        authorization_list: Vec<TempoSignedAuthorization>,
+    ) {
+        self.tempo_authorization_list = authorization_list;
+    }
+
+    /// Builder-pattern method for replacing the Tempo authorization list.
+    pub fn with_tempo_authorization_list(
+        mut self,
+        authorization_list: Vec<TempoSignedAuthorization>,
+    ) -> Self {
+        self.tempo_authorization_list = authorization_list;
+        self
+    }
+
+    /// Builder-pattern method for appending one Tempo authorization.
+    pub fn tempo_authorization(mut self, authorization: TempoSignedAuthorization) -> Self {
+        self.tempo_authorization_list.push(authorization);
+        self
+    }
+
+    /// Append one authorization to the Tempo authorization list.
+    pub fn push_tempo_authorization(&mut self, authorization: TempoSignedAuthorization) {
+        self.tempo_authorization_list.push(authorization);
+    }
+
     /// Set the access-key signature type used for gas estimation.
     pub fn set_key_type(&mut self, key_type: SignatureType) {
         self.key_type = Some(key_type);
@@ -541,8 +569,13 @@ impl<P: Provider<TempoNetwork>, D: CallDecoder> TempoCallBuilderExt
 mod tests {
     use super::*;
     use alloy_primitives::{Bytes, Signature, address};
-    use tempo_primitives::transaction::{
-        Call, KeyAuthorization, PrimitiveSignature, TEMPO_EXPIRING_NONCE_KEY,
+    use alloy_rpc_types_eth::Authorization;
+    use tempo_primitives::{
+        TempoSignature,
+        transaction::{
+            Call, KeyAuthorization, PrimitiveSignature, TEMPO_EXPIRING_NONCE_KEY,
+            TempoSignedAuthorization,
+        },
     };
 
     fn nz(value: u64) -> NonZeroU64 {
@@ -773,6 +806,34 @@ mod tests {
             .call(call.clone());
 
         assert_eq!(request.calls, vec![call.clone(), call]);
+    }
+
+    #[test]
+    fn test_tempo_authorization_helpers() {
+        let authorization = |address| {
+            TempoSignedAuthorization::new_unchecked(
+                Authorization {
+                    chain_id: U256::from(4217),
+                    address,
+                    nonce: 0,
+                },
+                TempoSignature::Primitive(PrimitiveSignature::default()),
+            )
+        };
+        let first = authorization(address!("0x1111111111111111111111111111111111111111"));
+        let second = authorization(address!("0x2222222222222222222222222222222222222222"));
+
+        let mut request = TempoTransactionRequest::default()
+            .with_tempo_authorization_list(vec![first.clone()])
+            .tempo_authorization(second.clone());
+        assert_eq!(
+            request.tempo_authorization_list,
+            vec![first.clone(), second.clone()]
+        );
+
+        request.set_tempo_authorization_list(vec![second.clone()]);
+        request.push_tempo_authorization(first.clone());
+        assert_eq!(request.tempo_authorization_list, vec![second, first]);
     }
 
     #[test]

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -569,13 +569,8 @@ impl<P: Provider<TempoNetwork>, D: CallDecoder> TempoCallBuilderExt
 mod tests {
     use super::*;
     use alloy_primitives::{Bytes, Signature, address};
-    use alloy_rpc_types_eth::Authorization;
-    use tempo_primitives::{
-        TempoSignature,
-        transaction::{
-            Call, KeyAuthorization, PrimitiveSignature, TEMPO_EXPIRING_NONCE_KEY,
-            TempoSignedAuthorization,
-        },
+    use tempo_primitives::transaction::{
+        Call, KeyAuthorization, PrimitiveSignature, TEMPO_EXPIRING_NONCE_KEY,
     };
 
     fn nz(value: u64) -> NonZeroU64 {
@@ -806,34 +801,6 @@ mod tests {
             .call(call.clone());
 
         assert_eq!(request.calls, vec![call.clone(), call]);
-    }
-
-    #[test]
-    fn test_tempo_authorization_helpers() {
-        let authorization = |address| {
-            TempoSignedAuthorization::new_unchecked(
-                Authorization {
-                    chain_id: U256::from(4217),
-                    address,
-                    nonce: 0,
-                },
-                TempoSignature::Primitive(PrimitiveSignature::default()),
-            )
-        };
-        let first = authorization(address!("0x1111111111111111111111111111111111111111"));
-        let second = authorization(address!("0x2222222222222222222222222222222222222222"));
-
-        let mut request = TempoTransactionRequest::default()
-            .with_tempo_authorization_list(vec![first.clone()])
-            .tempo_authorization(second.clone());
-        assert_eq!(
-            request.tempo_authorization_list,
-            vec![first.clone(), second.clone()]
-        );
-
-        request.set_tempo_authorization_list(vec![second.clone()]);
-        request.push_tempo_authorization(first.clone());
-        assert_eq!(request.tempo_authorization_list, vec![second, first]);
     }
 
     #[test]


### PR DESCRIPTION
Adds Tempo authorization-list setters and builder helpers, including single-item append APIs. Implements Alloy's `TransactionBuilder7702` for `TempoTransactionRequest` so standard EIP-7702 builders and `CallBuilder::authorization_list` work with `TempoNetwork`.