### PR TITLE
docs(tip-1095): simplify specification

### DIFF
--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -12,263 +12,134 @@ protocolVersion: T11
 
 ## Abstract
 
-This TIP makes TIP-1034 channels compatible with TIP-20 tokens whose TIP-403 recipient policy
-allows a payee but does not allow the channel reserve or payer. Channel funding and captures enforce
-policy against the logical `payer -> payee` payment, rather than the intermediate custody movement.
-Descriptor-bound refunds bypass TIP-403 recipient authorization so the payer retains unilateral
-recovery, while pause state and address-level receive policies continue to apply.
+This TIP lets recipient-restricted TIP-20 tokens use TIP-1034 channels without authorizing the
+channel reserve or every payer as a recipient. Funding and capture apply TIP-403 to the logical
+`payer -> payee` payment. Refunds return funds to the payer without TIP-403 authorization.
+
+Token pause state and TIP-1028 receive policies still apply to every movement.
 
 ## Motivation
 
-TIP-1015 supports closed-loop credits by allowing any holder to send while restricting transfer
-recipients to one or more vendors. TIP-1034 currently cannot use such a token without broadening its
-recipient policy:
+A channel moves tokens through reserve custody:
 
 ```text
-funding:    payer   -> channel reserve
-capture:    reserve -> payee
-refund:     reserve -> payer
+funding: payer   -> reserve
+capture: reserve -> payee
+refund:  reserve -> payer
 ```
 
-The token sees these physical custody movements. A vendor-only recipient policy rejects funding
-because the reserve is not a vendor and rejects refunds because the payer is not a vendor.
-Whitelisting the reserve and every payer would permit peer-to-peer transfers among those recipients,
-which defeats the closed-loop policy.
+A recipient policy that allows only the payee rejects funding because the reserve is not allowed,
+and rejects refunds because the payer is not allowed. Allowing the reserve and every payer would
+weaken the policy by making those addresses valid recipients for ordinary transfers.
 
-The channel descriptor and reserve state already identify the logical payer, payee, captured amount,
-and refund amount. The reserve can therefore enforce policy on the underlying payment while treating
-its own custody movements as an implementation detail. This preserves the issuer's intended
-`payer -> payee` restriction without requiring a new TIP-403 policy type.
+The channel already authenticates its payer, payee, and balances. TIP-403 can therefore apply to
+the payment the channel represents instead of its intermediate custody movements. A blanket
+exemption for reserve transfers would be unsafe because it could send captured funds to a forbidden
+payee.
 
 ## Assumptions
 
-1. `TIP20_CHANNEL_RESERVE` is the canonical TIP-1034 precompile and its implementation is part of
-   the trusted protocol.
-2. A channel's payer and payee are immutable because both are bound into `channelId` and every
-   post-open operation supplies the same authenticated descriptor.
-3. The reserve can invoke a native TIP-20 movement path that is not exposed through the TIP-20 ABI.
-4. TIP-1028 address-level receive policies remain independent from token-level TIP-403 policy.
-   Channel movements respect those policies by reverting rejected delivery instead of creating a
-   guarded receipt that channel accounting cannot represent.
-5. Token pause state remains authoritative for all channel movements, including refunds. A paused
-   token can therefore delay channel exits until it is unpaused.
+- The TIP-1034 reserve is trusted protocol code. Its descriptor binds an immutable payer and payee
+  to each channel.
+- The reserve can use an internal TIP-20 transfer function that is unavailable through the
+  public TIP-20 ABI.
+- TIP-1028 receive policies and token pause state remain independent of TIP-403 authorization.
 
 ## Threat Model
 
-- **Payer:** May choose arbitrary channel fields and attempt to use reserve custody to pay a
-  recipient forbidden by the token policy. The reserve MUST validate the logical payer/payee path
-  before funding or capture.
-- **Payee or operator:** May submit valid vouchers and choose a permitted capture amount, but MUST
-  NOT redirect captures or refunds away from descriptor-bound recipients.
-- **Token issuer:** Controls the token's transfer policy and pause roles. Policy changes may prevent
-  new captures, but MUST NOT redirect reserve custody or prevent a TIP-403-only payer refund.
-- **TIP-1034 reserve:** Is trusted to derive refund recipients and amounts exclusively from channel
-  state. No public or internal caller-controlled entrypoint may request an arbitrary policy-bypassed
-  transfer.
-- **TIP-1028 receive-policy administrator:** May reject an inbound channel movement according to
-  TIP-1028. This TIP does not bypass that authority, but does not create guarded channel receipts.
+- Channel participants may choose channel fields and submit valid vouchers, but cannot redirect a
+  capture or refund away from the descriptor-bound address.
+- The token issuer may change TIP-403 policy or pause the token. This may delay a channel operation,
+  but cannot redirect reserve custody.
+- A TIP-1028 policy may reject a capture or refund. The operation must remain retryable.
 
 ---
 
 # Specification
 
-## Logical And Physical Transfers
+After T11, TIP-403 authorization for channel operations is:
 
-For TIP-1034 operations, implementations MUST distinguish:
-
-- the **physical transfer**, which moves a TIP-20 balance into or out of reserve custody; and
-- the **logical transfer**, which represents the channel payment from `payer` to `payee`.
-
-TIP-403 authorization MUST follow this table after activation:
-
-| Operation | Physical transfer | TIP-403 authorization |
+| Operation | Physical movement | TIP-403 authorization |
 |---|---|---|
-| `open` | `payer -> reserve` | `payer -> payee` |
-| Nonzero `topUp` | `payer -> reserve` | `payer -> payee` |
-| `settle` capture | `reserve -> payee` | `payer -> payee` |
-| `close` capture | `reserve -> payee` | `payer -> payee` |
-| `close` refund | `reserve -> payer` | Bypassed |
-| `withdraw` refund | `reserve -> payer` | Bypassed |
+| `open`, nonzero `topUp` | `payer -> reserve` | `payer -> payee` |
+| `settle`, capture in `close` | `reserve -> payee` | `payer -> payee` |
+| refund in `close`, `withdraw` | `reserve -> payer` | bypassed |
 
-For virtual payees, recipient authorization MUST use the resolved master address, matching ordinary
-TIP-20 recipient-policy behavior.
+For a virtual payee, authorization uses its resolved master address, as in an ordinary TIP-20
+transfer.
 
-This TIP does not change TIP-403 policy evaluation for ordinary TIP-20 transfers, minting, the
-stablecoin DEX, fee collection, or any precompile other than the TIP-1034 reserve.
+## Funding and Capture
 
-## Funding
+Before funding or capture, the reserve must check the descriptor payer as the TIP-403 sender and
+the resolved descriptor payee as the TIP-403 recipient under the token's current policy. It then
+moves the physical balance without separately applying TIP-403 to the reserve address.
 
-Before `open` or a nonzero `topUp` moves funds, the reserve MUST:
+All existing channel checks still apply. Token pause state, balances, access-key limits, recipient
+validity, and TIP-1028 policy must be enforced as they are for native TIP-20 transfers.
 
-1. resolve the descriptor payee as a TIP-20 recipient;
-2. require the payer to be authorized as a sender under the token's active policy;
-3. require the resolved payee to be authorized as a recipient under that policy;
-4. enforce token pause state, payer balance, payer access-key spending limits, recipient validity,
-   and the reserve's applicable TIP-1028 policy, reverting if delivery is rejected; and
-5. move the physical amount from payer to reserve without separately requiring the reserve to be an
-   authorized TIP-403 recipient.
-
-A forbidden payee MUST cause funding to revert even though the reserve itself receives the physical
-balance. A forbidden payer MUST likewise be unable to fund or top up a channel.
-
-## Captures
-
-Before `settle` or the capture leg of `close` moves a nonzero amount, the reserve MUST:
-
-1. perform all existing channel, caller, bound, and voucher checks;
-2. require the descriptor payer to be currently authorized as a sender;
-3. require the resolved descriptor payee to be currently authorized as a recipient;
-4. enforce token pause state, recipient validity, and the actual payee's applicable TIP-1028
-   policy using the descriptor payer as the policy sender, reverting if delivery is rejected; and
-5. move the physical amount from reserve to the descriptor payee without separately evaluating the
-   reserve as the policy sender.
-
-The reserve MUST NOT treat every reserve-originated transfer as authorized. Captures remain bound to
-the descriptor payee and the logical policy path. Consequently, a payer cannot open a channel with
-an unauthorized payee and use settlement as a transfer-policy bypass.
+A failed capture must not advance cumulative settlement or close the channel.
 
 ## Refunds
 
-The refund leg of `close` and the payer-only `withdraw` path MUST bypass TIP-403 sender and recipient
-authorization. This bypass is valid only when all of the following are true:
+The refund in `close` and the payer-only `withdraw` path bypass TIP-403 only when:
 
-1. the physical sender is `TIP20_CHANNEL_RESERVE`;
-2. the recipient is the descriptor payer;
-3. the amount equals the refund derived from authenticated channel state; and
-4. the operation deletes or terminally closes that channel according to TIP-1034.
+- the physical sender is the channel reserve;
+- the recipient is the descriptor payer; and
+- the amount is the refund derived from authenticated channel state.
 
-Refunds MUST continue to enforce token pause state, physical recipient validity, balance
-conservation, and TIP-1028 address-level receive policy using `TIP20_CHANNEL_RESERVE` as the policy
-sender. If TIP-1028 rejects an inbound refund, the operation MUST revert without deleting the
-channel or creating a guarded receipt. The payer can update its receive policy and retry the close
-or withdrawal.
+Pause state, recipient validity, and TIP-1028 policy still apply. If a refund is rejected, the
+operation must revert without deleting the channel or moving funds, so the payer can update its
+receive policy and retry.
 
-The payer's `requestClose` followed by `withdraw` MUST remain unilateral. No token-policy
-administrator, payee, or operator action may be required solely because the payer is not an
-authorized TIP-403 recipient.
+`requestClose` followed by `withdraw` remains unilateral. The payer does not need the issuer,
+payee, or operator to authorize the refund under TIP-403.
 
-## Native TIP-20 Integration
+## TIP-20 Integration
 
-The channel reserve MUST perform the logical payer and payee TIP-403 checks directly in the funding
-and capture operations before moving custody. Descriptor-bound refund operations MUST omit those
-checks only after deriving the payer and refund amount from authenticated channel state.
+The transfer function used by the reserve must be internal-only and must reject transfers where
+neither endpoint is the channel reserve. Funding and capture use the descriptor payer as the sender
+for TIP-1028 evaluation; refunds use the reserve.
 
-The TIP-20 implementation MUST provide an internal-only custody-movement primitive for the channel
-reserve. It accepts the physical endpoints and the sender identity used for TIP-1028 receive-policy
-evaluation, but does not select or evaluate a TIP-403 policy mode. Funding and capture MUST supply
-the descriptor payer as the TIP-1028 policy sender. Refunds MUST supply
-`TIP20_CHANNEL_RESERVE`, preserving the ordinary physical sender identity for receive-policy
-evaluation.
+TIP-1028 rejection must revert instead of creating a `ReceivePolicyGuard` receipt, because channel
+accounting cannot represent guarded funds. Successful movements update balances and rewards and
+emit the same physical `Transfer` events as ordinary TIP-20 movements.
 
-Before moving custody, the primitive MUST evaluate the destination's TIP-1028 policy. A rejected
-channel movement MUST revert with `PolicyForbids()` and MUST NOT transfer funds to
-`ReceivePolicyGuard` or create a claim receipt. `settle` MUST update cumulative settlement only
-after a successful capture. At T11, `close` and `withdraw` MUST delete terminal channel state only
-after every nonzero capture and refund succeeds.
+## Activation and Compatibility
 
-The primitive MUST NOT be exposed in the TIP-20 ABI. It MUST reject physical movements for which
-neither endpoint is `TIP20_CHANNEL_RESERVE`. The trusted reserve implementation MUST invoke it only
-after applying the operation-specific rules above.
+This behavior activates at T11 and applies to both new and existing channels. Before T11, TIP-1034
+keeps its original physical transfer-policy checks.
 
-All validation other than the TIP-403 checks applied by the reserve MUST match native TIP-20
-transfer behavior. Successful movements MUST update rewards and balances and emit the same physical
-`Transfer` events as the corresponding custody movement. Virtual-recipient forwarding events MUST
-remain unchanged.
-
-## Activation And Existing Channels
-
-The behavior activates at T11. Before T11, channel reserve operations retain TIP-1034's original
-physical transfer-policy checks.
-
-After activation, the new rules apply to both newly opened and already active channels. No channel
-state migration is required because payer, payee, token, and accounting state are already available
-from the descriptor and packed channel state.
-
-## Interface And Storage Compatibility
-
-This TIP introduces no public ABI, event, channel identity, voucher, or storage-layout changes.
-Existing TIP-1034 clients and indexers remain compatible.
+No channel migration is required. This TIP changes no public ABI, channel ID, voucher, event, or
+storage layout. It does not change TIP-403 behavior outside the channel reserve.
 
 # Tooling
 
-Wallets and MPP clients require no protocol-interface or session-format changes. Token-issuance
-tooling SHOULD explain that a TIP-1015 recipient whitelist containing a service payee can support
-TIP-1034 after T11 without also whitelisting the reserve or every payer. An MPP server whose
-settlement is rejected by the payee's current TIP-1028 policy SHOULD stop accepting new spend for
-that channel and retry only after the policy allows delivery; the channel remains recoverable.
-
-Integration tests for restricted credits SHOULD exercise direct transfer rejection, channel
-funding and top-up, settlement, payee close with a positive capture and refund, unilateral payer
-withdrawal, blocked capture retry, and blocked refund retry.
+N/A. Existing TIP-1034 clients and session formats are unchanged.
 
 # Observability
 
-No new events are required. Existing TIP-20 `Transfer` events expose physical custody movement, and
-TIP-1034 `ChannelOpened`, `Settled`, and `ChannelClosed` events expose the logical payer, payee,
-capture, and refund amounts.
-
-Operators diagnosing a failed channel operation SHOULD inspect both the channel event history and
-the token's current TIP-403 and TIP-1028 policies. A rejected channel movement emits no
-`TransferBlocked` event because the operation reverts before guard custody is created.
+N/A. TIP-20 `Transfer` events continue to show physical custody movements. TIP-1034 channel events
+continue to show the logical payer, payee, capture, and refund.
 
 # Invariants
 
-1. Ordinary holder-to-holder transfers remain forbidden when the active recipient policy forbids
-   the recipient.
-2. Funding succeeds only when the logical `payer -> payee` path is authorized.
-3. Captures succeed only when the logical `payer -> payee` path is authorized at capture time.
-4. Neither reserve custody nor a channel voucher can route captured value to a payee forbidden by
-   TIP-403.
-5. A refund can go only to the descriptor payer and cannot exceed `deposit - captureAmount` for
-   `close` or `deposit - settled` for `withdraw`.
-6. A payer can recover the refundable balance through `requestClose` and `withdraw` without being
-   an authorized TIP-403 recipient.
-7. TIP-403-free custody movement is unreachable through the public TIP-20 ABI and is used without
-   logical payer-payee checks only for descriptor-bound, reserve-originated refunds.
-8. Token pause state and TIP-1028 receive policy continue to apply to every physical channel
-   movement; a TIP-1028 rejection leaves channel accounting and reserve custody unchanged.
-9. Channel and token fund-conservation invariants remain unchanged.
-10. Pre-T11 execution retains the original physical transfer-policy behavior.
-11. No channel movement creates a `ReceivePolicyGuard` receipt or marks guarded funds as captured,
-    settled, or refunded.
+- Ordinary TIP-20 transfers remain subject to the token's TIP-403 policy.
+- Funding and capture succeed only while the logical `payer -> payee` transfer is authorized.
+- Captured funds can go only to the descriptor payee.
+- A refund can go only to the descriptor payer and cannot exceed the refundable channel balance.
+- The payer can recover refundable funds without being an authorized TIP-403 recipient.
+- The TIP-403 bypass is unavailable through the public TIP-20 ABI and is used only for
+  reserve refunds whose recipient and amount come from channel state.
+- Pause state and TIP-1028 apply to every physical movement. Rejection leaves balances and channel
+  accounting unchanged and creates no guarded receipt.
+- Token and channel balance conservation is unchanged.
+- Pre-T11 execution is unchanged.
 
 ## Success Criteria
 
-This TIP is successful when a recipient-restricted TIP-20 can fund, top up, settle, close, and
-refund a channel without authorizing the reserve or payer as TIP-403 recipients; ordinary forbidden
-transfers remain rejected; TIP-1028-rejected captures and refunds remain retryable; and pre-T11
-execution ordering and public interfaces remain unchanged.
-
-## Alternatives Considered
-
-### Whitelist The Reserve And Payers
-
-Adding the reserve and every payer to a recipient whitelist permits funding and refunds, but it also
-permits ordinary transfers to those payer addresses. This weakens closed-loop credit semantics and
-requires unbounded policy administration.
-
-### Exempt Every Reserve-Originated Transfer
-
-A sender-based reserve exemption would allow a payer to name an arbitrary payee and route funds
-through settlement, bypassing the token's recipient policy. This TIP instead distinguishes captures
-from refunds using authenticated channel state.
-
-### Extend TIP-1015 With Pair-Aware Policies
-
-A pair-aware policy could express sender-dependent recipient rules, but it would add policy types,
-registry state, issuer configuration, and evaluation overhead for a custody issue that TIP-1034 can
-resolve from state it already authenticates.
-
-### Administrator-Assisted Refunds
-
-An issuer could atomically whitelist a payer, close the channel, and remove the payer. That makes
-refund liveness depend on the issuer and does not preserve the payer-only unilateral withdrawal.
-
-### Charge-Only Credits
-
-Applications can omit TIP-1034 and use direct charges. This remains valid, but it unnecessarily
-prevents restricted credits from using efficient streaming sessions when the reserve can safely
-separate logical payments from physical custody.
+A recipient-restricted token can fund, top up, settle, close, and refund a channel without
+authorizing the reserve or payer as recipients, while forbidden ordinary transfers and forbidden
+channel payees remain rejected.
 
 ## References
 


### PR DESCRIPTION
Stacks on #6957.

Rewrites TIP-1095 around the logical transfer rules and core invariants. Removes repeated implementation detail while preserving T11 activation, refund safety, TIP-1028 behavior, and compatibility.