### PR TITLE
fix(ci): allow release bump to fetch Git dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -360,7 +360,7 @@ jobs:
           path.write_text("".join(lines), encoding="utf-8")
           PY
 
-          cargo update -p tempo --offline
+          cargo update -p tempo
 
           if git diff --quiet -- Cargo.toml Cargo.lock; then
             echo "No Cargo version changes needed"


### PR DESCRIPTION
Removes offline mode from the release version-bump step so fresh runners can fetch pinned Commonware Git dependencies before updating Cargo.lock.

Prompted by: @shekhirin