### PR TITLE
refactor(tip-1095): simplify channel policy plumbing

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -927,37 +927,31 @@ impl TIP20Token {
     pub(crate) fn channel_reserve_transfer(
         &mut self,
         from: Address,
-        to: Address,
+        to: Recipient,
         amount: U256,
         receive_policy_sender: Address,
-    ) -> Result<bool> {
-        if from != TIP20_CHANNEL_RESERVE_ADDRESS && to != TIP20_CHANNEL_RESERVE_ADDRESS {
+    ) -> Result<()> {
+        if from != TIP20_CHANNEL_RESERVE_ADDRESS
+            && to.original_address() != TIP20_CHANNEL_RESERVE_ADDRESS
+        {
             return Err(TIP20Error::unauthorized().into());
         }
 
-        let to = Recipient::resolve(to)?;
         self.check_not_paused()?;
         to.validate()?;
         self.check_and_update_spending_limit(from, amount)?;
 
-        if self.storage.spec().is_t6() {
-            if to.target == RECEIVE_POLICY_GUARD_ADDRESS {
-                return Err(ReceivePolicyGuardError::address_reserved().into());
-            }
-            if TIP403Registry::new()
-                .validate_receive_policy(self.address, receive_policy_sender, to.target)?
-                .is_some()
-            {
-                return Err(TIP20Error::policy_forbids().into());
-            }
+        if self.storage.spec().is_t6() && to.target == RECEIVE_POLICY_GUARD_ADDRESS {
+            return Err(ReceivePolicyGuardError::address_reserved().into());
         }
+        self.ensure_receive_policy_authorized(receive_policy_sender, to.target)?;
 
         self._transfer(from, &to, amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(amount) {
             self.emit_event(hop)?;
         }
 
-        Ok(true)
+        Ok(())
     }
 
     /// Debits `spender`'s allowance on `owner`. No-op when unlimited.
@@ -1501,6 +1495,11 @@ impl Recipient {
         })
     }
 
+    /// Returns the original recipient address used by the transfer.
+    fn original_address(&self) -> Address {
+        self.virtual_addr.unwrap_or(self.target)
+    }
+
     /// Validates that the recipient is not:
     /// - the zero address (preventing accidental burns)
     /// - an address with the TIP-20 prefix (preventing transfers to token contracts)
@@ -1516,7 +1515,7 @@ impl Recipient {
     /// For virtual recipients `to` is the virtual address (first hop); for regular
     /// recipients this is the only `Transfer` event needed.
     pub(crate) fn build_transfer_event(&self, from: Address, amount: U256) -> TIP20Event {
-        TIP20Event::transfer(from, self.virtual_addr.unwrap_or(self.target), amount)
+        TIP20Event::transfer(from, self.original_address(), amount)
     }
 
     /// Builds the forwarding `Transfer(virtual, master, amount)` event for virtual recipients.

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -167,7 +167,7 @@ impl TIP20ChannelReserve {
             token.ensure_receive_policy_authorized(msg_sender, payee)?;
             token.channel_reserve_transfer(
                 msg_sender,
-                self.address,
+                Recipient::direct(self.address),
                 U256::from(call.deposit),
                 msg_sender,
             )?;
@@ -243,13 +243,11 @@ impl TIP20ChannelReserve {
         let mut token = TIP20Token::from_address(call.descriptor.token)?;
 
         if self.storage.spec().is_t11() {
-            token.ensure_transfer_authorized(
-                call.descriptor.payer,
-                Recipient::resolve(call.descriptor.payee)?.target,
-            )?;
+            let payee = Recipient::resolve(call.descriptor.payee)?;
+            token.ensure_transfer_authorized(call.descriptor.payer, payee.target)?;
             token.channel_reserve_transfer(
                 self.address,
-                call.descriptor.payee,
+                payee,
                 U256::from(delta),
                 call.descriptor.payer,
             )?;
@@ -323,7 +321,7 @@ impl TIP20ChannelReserve {
                 token.ensure_receive_policy_authorized(msg_sender, payee)?;
                 token.channel_reserve_transfer(
                     msg_sender,
-                    self.address,
+                    Recipient::direct(self.address),
                     U256::from(call.additionalDeposit),
                     msg_sender,
                 )?;
@@ -446,13 +444,11 @@ impl TIP20ChannelReserve {
         if self.storage.spec().is_t11() {
             let mut token = TIP20Token::from_address(call.descriptor.token)?;
             if !delta.is_zero() {
-                token.ensure_transfer_authorized(
-                    call.descriptor.payer,
-                    Recipient::resolve(call.descriptor.payee)?.target,
-                )?;
+                let payee = Recipient::resolve(call.descriptor.payee)?;
+                token.ensure_transfer_authorized(call.descriptor.payer, payee.target)?;
                 token.channel_reserve_transfer(
                     self.address,
-                    call.descriptor.payee,
+                    payee,
                     U256::from(delta),
                     call.descriptor.payer,
                 )?;
@@ -460,7 +456,7 @@ impl TIP20ChannelReserve {
             if !refund.is_zero() {
                 token.channel_reserve_transfer(
                     self.address,
-                    call.descriptor.payer,
+                    Recipient::resolve(call.descriptor.payer)?,
                     U256::from(refund),
                     self.address,
                 )?;
@@ -538,7 +534,7 @@ impl TIP20ChannelReserve {
                 let mut token = TIP20Token::from_address(call.descriptor.token)?;
                 token.channel_reserve_transfer(
                     self.address,
-                    call.descriptor.payer,
+                    Recipient::resolve(call.descriptor.payer)?,
                     U256::from(refund),
                     self.address,
                 )?;
@@ -981,29 +977,20 @@ mod tests {
     ) -> Result<()> {
         let mut registry = TIP403Registry::new();
         registry.initialize()?;
-        let recipient_policy = registry.create_policy(
+        let recipient_policy = registry.create_policy_with_accounts(
             admin,
-            ITIP403Registry::createPolicyCall {
+            ITIP403Registry::createPolicyWithAccountsCall {
                 admin,
                 policyType: ITIP403Registry::PolicyType::WHITELIST,
+                accounts: recipients.to_vec(),
             },
         )?;
-        for &recipient in recipients {
-            registry.modify_policy_whitelist(
-                admin,
-                ITIP403Registry::modifyPolicyWhitelistCall {
-                    policyId: recipient_policy,
-                    account: recipient,
-                    allowed: true,
-                },
-            )?;
-        }
         let compound_policy = registry.create_compound_policy(
             admin,
             ITIP403Registry::createCompoundPolicyCall {
-                senderPolicyId: 1,
+                senderPolicyId: ALLOW_ALL_POLICY_ID,
                 recipientPolicyId: recipient_policy,
-                mintRecipientPolicyId: 1,
+                mintRecipientPolicyId: ALLOW_ALL_POLICY_ID,
             },
         )?;
         token.change_transfer_policy_id(
@@ -1012,6 +999,31 @@ mod tests {
                 newPolicyId: compound_policy,
             },
         )
+    }
+
+    fn install_receive_sender_blacklist(
+        receiver: Address,
+        blocked_sender: Address,
+    ) -> Result<(TIP403Registry, u64)> {
+        let mut registry = TIP403Registry::new();
+        registry.initialize()?;
+        let sender_policy = registry.create_policy_with_accounts(
+            receiver,
+            ITIP403Registry::createPolicyWithAccountsCall {
+                admin: receiver,
+                policyType: ITIP403Registry::PolicyType::BLACKLIST,
+                accounts: vec![blocked_sender],
+            },
+        )?;
+        registry.set_receive_policy(
+            receiver,
+            ITIP403Registry::setReceivePolicyCall {
+                senderPolicyId: sender_policy,
+                tokenFilterId: ALLOW_ALL_POLICY_ID,
+                recoveryAuthority: Address::ZERO,
+            },
+        )?;
+        Ok((registry, sender_policy))
     }
 
     #[test]
@@ -1443,24 +1455,7 @@ mod tests {
             let mut reserve = TIP20ChannelReserve::new();
             reserve.initialize()?;
 
-            let mut registry = TIP403Registry::new();
-            registry.initialize()?;
-            let sender_policy = registry.create_policy(
-                payee,
-                ITIP403Registry::createPolicyCall {
-                    admin: payee,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
-            registry.set_receive_policy(
-                payee,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: sender_policy,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
-                },
-            )?;
+            let (mut registry, sender_policy) = install_receive_sender_blacklist(payee, payer)?;
 
             let salt = B256::random();
             seed_expiring_nonce_hash(&mut reserve)?;
@@ -1566,24 +1561,7 @@ mod tests {
 
             // Receive policies remain mutable after funding. The payee now rejects only the
             // logical payer, while the physical reserve sender remains authorized.
-            let mut registry = TIP403Registry::new();
-            registry.initialize()?;
-            let sender_policy = registry.create_policy(
-                payee,
-                ITIP403Registry::createPolicyCall {
-                    admin: payee,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-            set_blacklisted(&mut registry, payee, sender_policy, payer, true)?;
-            registry.set_receive_policy(
-                payee,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: sender_policy,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
-                },
-            )?;
+            let (mut registry, sender_policy) = install_receive_sender_blacklist(payee, payer)?;
 
             let cumulative = U96::from(40);
             let digest =
@@ -1791,30 +1769,8 @@ mod tests {
 
             // Originator recovery would make a guarded reserve-originated refund unclaimable.
             // Channel refunds reject the policy instead and leave channel state intact.
-            let mut registry = TIP403Registry::new();
-            registry.initialize()?;
-            let sender_policy = registry.create_policy(
-                payer,
-                ITIP403Registry::createPolicyCall {
-                    admin: payer,
-                    policyType: ITIP403Registry::PolicyType::BLACKLIST,
-                },
-            )?;
-            set_blacklisted(
-                &mut registry,
-                payer,
-                sender_policy,
-                TIP20_CHANNEL_RESERVE_ADDRESS,
-                true,
-            )?;
-            registry.set_receive_policy(
-                payer,
-                ITIP403Registry::setReceivePolicyCall {
-                    senderPolicyId: sender_policy,
-                    tokenFilterId: ALLOW_ALL_POLICY_ID,
-                    recoveryAuthority: Address::ZERO,
-                },
-            )?;
+            let (mut registry, sender_policy) =
+                install_receive_sender_blacklist(payer, TIP20_CHANNEL_RESERVE_ADDRESS)?;
 
             let close_result = reserve.close(
                 payee,


### PR DESCRIPTION
Stacks on #6957.

Reuses the TIP-1028 authorization helper, resolves virtual payees once, and removes meaningless internal return values. It also consolidates policy setup in channel-reserve tests without changing protocol behavior.

Validated with `rustup run nightly cargo test -p tempo-precompiles tip20_channel_reserve`.