### PR TITLE
refactor(follow): make forkchoice targets round-aware

### DIFF
--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -21,6 +21,7 @@ use commonware_cryptography::{
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
 use std::fmt::Display;
 use tempo_payload_types::EncodedBlock;
+use tempo_primitives::TempoConsensusContext;
 use tracing::warn;
 
 use crate::consensus::Digest;
@@ -386,7 +387,7 @@ impl commonware_consensus::CertifiableBlock for Block {
         match self.consensus_context {
             Some(ctx) => Context {
                 leader: ctx.proposer.to_inner(),
-                round: Round::new(Epoch::new(ctx.epoch), View::new(ctx.view)),
+                round: round_from_context(ctx),
                 parent: (View::new(ctx.parent_view), self.parent_digest()),
             },
             None => {
@@ -410,6 +411,10 @@ impl commonware_consensus::CertifiableBlock for Block {
             }
         }
     }
+}
+
+pub(crate) fn round_from_context(context: TempoConsensusContext) -> Round {
+    Round::new(Epoch::new(context.epoch), View::new(context.view))
 }
 
 fn validate_block_access_list_hash(

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -110,7 +110,7 @@ impl<TUpstream> Config<TUpstream> {
             actor: marshal_actor,
             mailbox: marshal_mailbox,
             finalized_floor: last_finalized_height,
-            finalized_tip: _,
+            ..
         } = alias::marshal::init(
             context.child("marshal"),
             page_cache_ref,

--- a/crates/consensus/src/follow/executor/actor.rs
+++ b/crates/consensus/src/follow/executor/actor.rs
@@ -24,21 +24,14 @@ use futures::{FutureExt as _, StreamExt as _, channel::mpsc, future::BoxFuture};
 use tempo_node::TempoExecutionData;
 use tracing::{Level, debug, error, instrument};
 
-use super::{Config, ExecutionEngine, FinalizedBlockProvider, Marshal};
-use crate::{
-    consensus::{Digest, block::Block},
-    utils::OptionFuture,
+use super::{
+    Config, ExecutionEngine, FinalizedBlockProvider, Marshal, ingress::Message, target::Target,
 };
-
-#[derive(Clone, Copy, Debug)]
-struct FinalizedTip {
-    height: Height,
-    digest: Digest,
-}
+use crate::{consensus::block::Block, utils::OptionFuture};
 
 pub(crate) struct Actor<TContext, P, E, M = crate::alias::marshal::Mailbox> {
     context: ContextCell<TContext>,
-    mailbox: mpsc::UnboundedReceiver<Update<Block>>,
+    mailbox: mpsc::UnboundedReceiver<Message>,
 
     execution_provider: P,
     execution_engine: E,
@@ -47,8 +40,8 @@ pub(crate) struct Actor<TContext, P, E, M = crate::alias::marshal::Mailbox> {
     epoch_strategy: FixedEpocher,
     floor: Height,
 
-    last_fcu: FinalizedTip,
-    latest_tip: FinalizedTip,
+    last_fcu: Target,
+    latest_tip: Target,
 
     block_queue: VecDeque<(Block, Exact)>,
     floor_candidate: Option<Height>,
@@ -69,7 +62,7 @@ where
     pub(super) fn new(
         context: TContext,
         config: Config<P, E, M>,
-        mailbox: mpsc::UnboundedReceiver<Update<Block>>,
+        mailbox: mpsc::UnboundedReceiver<Message>,
     ) -> Self {
         let Config {
             execution_provider,
@@ -80,13 +73,10 @@ where
             fcu_heartbeat_interval,
         } = config;
 
-        let tip = execution_provider
-            .finalized_block_num_hash()
-            .expect("failed reading finalized execution tip");
-        let tip = FinalizedTip {
-            height: Height::new(tip.number),
-            digest: Digest(tip.hash),
-        };
+        let finalized_header = execution_provider
+            .finalized_header()
+            .expect("failed reading finalized execution header");
+        let tip = Target::from_header(&finalized_header);
 
         Self {
             context: ContextCell::new(context),
@@ -129,6 +119,9 @@ where
                     match result {
                         ExecutionTaskResult::Completed(last_fcu) => {
                             self.last_fcu = last_fcu;
+                            if last_fcu.supersedes(&self.latest_tip) {
+                                self.latest_tip = last_fcu;
+                            }
 
                             // Emits an event on error.
                             let _: Result<_, _> = self.try_advance_floor().await;
@@ -140,20 +133,27 @@ where
                     }
                 }
 
-                Some(update) = self.mailbox.next() => {
-                    match update {
-                        Update::Block(block, ack) => {
+                Some(message) = self.mailbox.next() => {
+                    match message {
+                        Message::Update(Update::Block(block, ack)) => {
                             self.block_queue.push_back(((*block).clone(), ack));
                         }
 
-                        // Finalization certificates for Tip updates must be available
-                        // making them a good candidates for setting marshal's floor.
-                        Update::Tip(_, height, digest) => {
+                        // A Tip update has a persisted finalization, so it can
+                        // start a new floor cycle.
+                        Message::Update(Update::Tip(round, height, digest)) => {
                             if self.floor_candidate.is_none() {
                                 self.floor_candidate = Some(height);
                             }
-                            if height > self.latest_tip.height {
-                                self.latest_tip = FinalizedTip { height, digest };
+                            let candidate = Target::from_finalization(round, digest);
+                            if candidate.supersedes(&self.latest_tip) {
+                                self.latest_tip = candidate;
+                            }
+                        }
+                        Message::Finalization { round, digest } => {
+                            let candidate = Target::from_finalization(round, digest);
+                            if candidate.supersedes(&self.latest_tip) {
+                                self.latest_tip = candidate;
                             }
                         }
                     }
@@ -164,6 +164,10 @@ where
                 }
             }
         }
+    }
+
+    fn should_send_forkchoice(&self) -> bool {
+        self.latest_tip.digest != self.last_fcu.digest && self.latest_tip.supersedes(&self.last_fcu)
     }
 
     fn update_fcu_heartbeat_timer(&mut self) {
@@ -184,7 +188,7 @@ where
 
         let request = if let Some((block, ack)) = self.block_queue.pop_front() {
             ExecutionRequest::Block(block, ack)
-        } else if self.latest_tip.height > self.last_fcu.height || heartbeat {
+        } else if self.should_send_forkchoice() || heartbeat {
             ExecutionRequest::Forkchoice(self.latest_tip)
         } else {
             return;
@@ -199,9 +203,12 @@ where
 
     #[instrument(skip_all, err(level = Level::WARN))]
     async fn try_advance_floor(&mut self) -> eyre::Result<()> {
-        let finalized = self.execution_provider.finalized_block_num_hash()?;
-
-        let finalized_height = Height::new(finalized.number);
+        let finalized_height = Height::new(
+            self.execution_provider
+                .finalized_header()?
+                .num_hash()
+                .number,
+        );
         let epoch_length = self
             .epoch_strategy
             .containing(finalized_height)
@@ -244,19 +251,19 @@ where
 }
 
 enum ExecutionRequest {
-    Forkchoice(FinalizedTip),
+    Forkchoice(Target),
     Block(Block, Exact),
 }
 
 enum ExecutionTaskResult {
-    Completed(FinalizedTip),
+    Completed(Target),
     Fatal(Report),
 }
 
 async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
     context: TContext,
     execution_engine: E,
-    last_fcu: FinalizedTip,
+    last_fcu: Target,
     request: ExecutionRequest,
 ) -> ExecutionTaskResult {
     match request {
@@ -267,16 +274,13 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
             }
         }
         ExecutionRequest::Block(block, ack) => {
-            let tip = FinalizedTip {
-                height: block.height(),
-                digest: block.digest(),
-            };
+            let tip = Target::from_block(&block);
 
             if let Err(error) = submit_new_payload(&context, &execution_engine, block).await {
                 return ExecutionTaskResult::Fatal(error);
             }
 
-            let last_fcu = if tip.height > last_fcu.height {
+            let last_fcu = if tip.supersedes(&last_fcu) {
                 if let Err(error) =
                     submit_forkchoice_update(&context, &execution_engine, &tip).await
                 {
@@ -324,11 +328,11 @@ async fn submit_new_payload<TContext: Pacer, E: ExecutionEngine + ?Sized>(
     Ok(())
 }
 
-#[instrument(skip_all, fields(height = %tip.height, digest = %tip.digest))]
+#[instrument(skip_all, fields(round = ?tip.round, digest = %tip.digest))]
 async fn submit_forkchoice_update<TContext: Pacer, E: ExecutionEngine + ?Sized>(
     context: &TContext,
     execution_engine: &E,
-    tip: &FinalizedTip,
+    tip: &Target,
 ) -> eyre::Result<()> {
     let hash = tip.digest.0;
     let forkchoice = ForkchoiceState {

--- a/crates/consensus/src/follow/executor/ingress.rs
+++ b/crates/consensus/src/follow/executor/ingress.rs
@@ -1,17 +1,41 @@
 use commonware_actor::Feedback;
-use commonware_consensus::{Reporter, marshal::Update};
+use commonware_consensus::{Reporter, marshal::Update, types::Round};
 use futures::channel::mpsc;
 
-use crate::consensus::block::Block;
+use crate::consensus::{Digest, block::Block};
+
+#[derive(Debug)]
+pub(super) enum Message {
+    /// A finalized block or tip from marshal.
+    Update(Update<Block>),
+    /// A verified finalized tip whose block has not arrived yet.
+    Finalization { round: Round, digest: Digest },
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct Mailbox {
-    sender: mpsc::UnboundedSender<Update<Block>>,
+    sender: mpsc::UnboundedSender<Message>,
 }
 
 impl Mailbox {
-    pub(super) fn new(sender: mpsc::UnboundedSender<Update<Block>>) -> Self {
+    pub(super) fn new(sender: mpsc::UnboundedSender<Message>) -> Self {
         Self { sender }
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "used by the driver in a later stack commit")
+    )]
+    pub(crate) fn finalization(&self, round: Round, digest: Digest) {
+        let _ = self.send(Message::Finalization { round, digest });
+    }
+
+    fn send(&self, message: Message) -> Feedback {
+        if self.sender.unbounded_send(message).is_err() {
+            Feedback::Closed
+        } else {
+            Feedback::Ok
+        }
     }
 }
 
@@ -19,10 +43,6 @@ impl Reporter for Mailbox {
     type Activity = Update<Block>;
 
     fn report(&mut self, update: Self::Activity) -> Feedback {
-        if self.sender.unbounded_send(update).is_err() {
-            Feedback::Closed
-        } else {
-            Feedback::Ok
-        }
+        self.send(Message::Update(update))
     }
 }

--- a/crates/consensus/src/follow/executor/mod.rs
+++ b/crates/consensus/src/follow/executor/mod.rs
@@ -16,20 +16,25 @@ use commonware_consensus::{
 };
 use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_runtime::{Clock, Pacer, Spawner};
+use eyre::OptionExt as _;
 use futures::channel::mpsc;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
+use reth_ethereum::chainspec::EthChainSpec as _;
+use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_provider::{
-    BlockHashReader as _, BlockIdReader, ChainSpecProvider as _, DatabaseProviderFactory as _,
+    BlockHashReader, BlockIdReader, ChainSpecProvider as _, DatabaseProviderFactory as _,
+    HeaderProvider,
     providers::{BlockchainProvider, ProviderNodeTypes},
 };
 use tempo_node::{TempoExecutionData, TempoPayloadTypes};
 use tempo_payload_types::TempoPayloadAttributes;
+use tempo_primitives::TempoHeader;
 
 use crate::consensus::Digest;
 
 mod actor;
 mod ingress;
+mod target;
 
 #[cfg(test)]
 mod test;
@@ -62,9 +67,9 @@ where
 
 /// Finalized block state needed to initialize and advance the follower.
 pub(crate) trait FinalizedBlockProvider: Send + Sync {
-    /// Execution layer's effective finalized block. Returns genesis when no
+    /// Execution layer's effective finalized header. Returns genesis when no
     /// explicit finalized marker exists on a fresh chain.
-    fn finalized_block_num_hash(&self) -> eyre::Result<BlockNumHash>;
+    fn finalized_header(&self) -> eyre::Result<SealedHeader<TempoHeader>>;
 
     /// Persisted database block hash at `height`, excluding in-memory state.
     fn durable_block_hash(&self, height: u64) -> eyre::Result<Option<B256>>;
@@ -101,10 +106,15 @@ pub(crate) trait Marshal: Clone + Send + Sync {
 impl<N> FinalizedBlockProvider for BlockchainProvider<N>
 where
     N: ProviderNodeTypes,
+    N::Primitives: NodePrimitives<BlockHeader = TempoHeader>,
 {
-    fn finalized_block_num_hash(&self) -> eyre::Result<BlockNumHash> {
-        Ok(BlockIdReader::finalized_block_num_hash(self)?
-            .unwrap_or_else(|| BlockNumHash::new(0, self.chain_spec().genesis_hash())))
+    fn finalized_header(&self) -> eyre::Result<SealedHeader<TempoHeader>> {
+        let hash = BlockIdReader::finalized_block_num_hash(self)?
+            .map(|tip| tip.hash)
+            .unwrap_or_else(|| self.chain_spec().genesis_hash());
+        HeaderProvider::sealed_header_by_hash(self, hash)
+            .map_err(eyre::Report::new)?
+            .ok_or_eyre("finalized execution block is missing its header")
     }
 
     fn durable_block_hash(&self, height: u64) -> eyre::Result<Option<B256>> {

--- a/crates/consensus/src/follow/executor/target.rs
+++ b/crates/consensus/src/follow/executor/target.rs
@@ -1,0 +1,128 @@
+use commonware_consensus::types::Round;
+use reth_primitives_traits::SealedHeader;
+use tempo_primitives::TempoHeader;
+
+use crate::consensus::{
+    Digest,
+    block::{Block, round_from_context},
+};
+
+/// A possible finalized forkchoice target.
+///
+/// Execution headers before TIP-1031 do not contain a consensus round. After
+/// activation, every newly observed finalization has one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct Target {
+    pub(super) round: Option<Round>,
+    pub(super) digest: Digest,
+}
+
+impl Target {
+    pub(super) fn from_header(header: &SealedHeader<TempoHeader>) -> Self {
+        let tip = header.num_hash();
+        Self {
+            round: header.consensus_context.map(round_from_context),
+            digest: Digest(tip.hash),
+        }
+    }
+
+    pub(super) fn from_block(block: &Block) -> Self {
+        Self::from_header(block.block().sealed_header())
+    }
+
+    pub(super) const fn from_finalization(round: Round, digest: Digest) -> Self {
+        Self {
+            round: Some(round),
+            digest,
+        }
+    }
+
+    /// Newly observed finalizations are post-TIP-1031 and always have a round.
+    /// They therefore supersede a roundless genesis or pre-activation target.
+    pub(super) fn supersedes(&self, current: &Self) -> bool {
+        match (self.round, current.round) {
+            (Some(new), Some(old)) => new > old,
+            (Some(_), None) => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy_consensus::Header;
+    use commonware_consensus::types::{Epoch, View};
+    use reth_primitives_traits::SealedHeader;
+    use tempo_primitives::{TempoConsensusContext, TempoHeader, ed25519::PublicKey};
+
+    use super::*;
+
+    fn round(view: u64) -> Round {
+        Round::new(Epoch::zero(), View::new(view))
+    }
+
+    fn digest(byte: u8) -> Digest {
+        Digest(alloy_primitives::B256::with_last_byte(byte))
+    }
+
+    fn execution_header(
+        height: u64,
+        round: Option<Round>,
+        digest: Digest,
+    ) -> SealedHeader<TempoHeader> {
+        let consensus_context = round.map(|round| TempoConsensusContext {
+            epoch: round.epoch().get(),
+            view: round.view().get(),
+            parent_view: 0,
+            proposer: PublicKey::from_seed(0),
+        });
+        SealedHeader::new(
+            TempoHeader {
+                inner: Header {
+                    number: height,
+                    ..Default::default()
+                },
+                consensus_context,
+                ..Default::default()
+            },
+            digest.0,
+        )
+    }
+
+    #[test]
+    fn later_round_supersedes_earlier_round() {
+        let newer = Target::from_finalization(round(9), digest(1));
+        let older = Target::from_finalization(round(8), digest(2));
+        assert!(newer.supersedes(&older));
+        assert!(!older.supersedes(&newer));
+    }
+
+    #[test]
+    fn equal_round_does_not_supersede() {
+        let current = Target::from_finalization(round(8), digest(1));
+        let conflicting = Target::from_finalization(round(8), digest(2));
+        assert!(!conflicting.supersedes(&current));
+    }
+
+    #[test]
+    fn finalized_target_supersedes_roundless_execution_target() {
+        let header = execution_header(100, None, digest(1));
+        let prefork = Target::from_header(&header);
+        let finalized = Target::from_finalization(round(1), digest(2));
+        assert!(finalized.supersedes(&prefork));
+    }
+
+    #[test]
+    fn roundless_target_never_supersedes() {
+        let roundless = Target::from_header(&execution_header(100, None, digest(1)));
+        let finalized = Target::from_finalization(round(1), digest(2));
+        assert!(!roundless.supersedes(&finalized));
+        assert!(!roundless.supersedes(&roundless));
+    }
+
+    #[test]
+    fn execution_target_uses_header_round() {
+        let header = execution_header(100, Some(round(2)), digest(1));
+        assert_eq!(Target::from_header(&header).round, Some(round(2)));
+    }
+}

--- a/crates/consensus/src/follow/executor/target.rs
+++ b/crates/consensus/src/follow/executor/target.rs
@@ -42,6 +42,10 @@ impl Target {
     pub(super) fn supersedes(&self, current: &Self) -> bool {
         match (self.round, current.round) {
             (Some(new), Some(old)) => new > old,
+            // TIP-1031 is active. In supported startup states, a roundless
+            // execution target is genesis; restoring partially synchronized
+            // pre-TIP execution state is unsupported. Any newly verified
+            // finalization therefore supersedes it.
             (Some(_), None) => true,
             _ => false,
         }

--- a/crates/consensus/src/follow/executor/test/mod.rs
+++ b/crates/consensus/src/follow/executor/test/mod.rs
@@ -8,7 +8,7 @@ use alloy_primitives::B256;
 use commonware_consensus::{
     Reporter as _,
     marshal::Update,
-    types::{FixedEpocher, Height, Round},
+    types::{Epoch, FixedEpocher, Height, Round, View},
 };
 use commonware_macros::test_traced;
 use commonware_runtime::{Clock as _, Runner as _, Supervisor as _, deterministic};
@@ -16,7 +16,7 @@ use commonware_utils::{Acknowledgement as _, acknowledgement::Exact};
 
 use super::{Config, init};
 use crate::consensus::Digest;
-use utils::{StubExecutionProvider, StubMarshal, make_block};
+use utils::{StubExecutionProvider, StubMarshal, make_block, make_block_at_round};
 
 const EPOCH_LENGTH: NonZeroU64 = NonZeroU64::new(10).expect("epoch length is nonzero");
 const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(5);
@@ -34,6 +34,14 @@ async fn wait_until<T: commonware_runtime::Clock>(context: &T, mut cond: impl Fn
     assert!(cond(), "condition was not met before the test deadline");
 }
 
+fn round(view: u64) -> Round {
+    Round::new(Epoch::zero(), View::new(view))
+}
+
+fn digest(byte: u8) -> Digest {
+    Digest(B256::with_last_byte(byte))
+}
+
 #[test_traced]
 fn block_is_executed_canonicalized_acknowledged_and_advances_floor_to_deep_candidate() {
     deterministic::Runner::default().start(|context| async move {
@@ -41,7 +49,7 @@ fn block_is_executed_canonicalized_acknowledged_and_advances_floor_to_deep_candi
         let expected_floor = finalized_height - EPOCH_LENGTH.get() - 1;
         let block_height = finalized_height + 1;
         let provider = StubExecutionProvider::default();
-        provider.set_finalized(finalized_height, B256::with_last_byte(20));
+        provider.set_finalized(finalized_height, B256::with_last_byte(20), Round::zero());
         provider.set_durable(expected_floor, B256::with_last_byte(9));
 
         let marshal = StubMarshal::default();
@@ -72,7 +80,7 @@ fn block_is_executed_canonicalized_acknowledged_and_advances_floor_to_deep_candi
             );
         }
 
-        let block = make_block(block_height, B256::with_last_byte(20));
+        let block = make_block_at_round(block_height, B256::with_last_byte(20), round(1));
         let block_hash = block.block_hash();
         let (ack, waiter) = Exact::handle();
         assert!(mailbox.report(Update::Block(block.into(), ack)).accepted());
@@ -97,7 +105,7 @@ fn block_is_executed_canonicalized_acknowledged_and_advances_floor_to_deep_candi
 fn floor_candidate_uses_execution_depth_and_next_tip_starts_new_cycle() {
     deterministic::Runner::default().start(|context| async move {
         let provider = StubExecutionProvider::default();
-        provider.set_finalized(18, B256::with_last_byte(18));
+        provider.set_finalized(18, B256::with_last_byte(18), Round::zero());
         provider.set_durable(9, B256::with_last_byte(9));
 
         let marshal = StubMarshal::default();
@@ -131,7 +139,7 @@ fn floor_candidate_uses_execution_depth_and_next_tip_starts_new_cycle() {
         assert!(
             mailbox
                 .report(Update::Block(
-                    make_block(19, B256::with_last_byte(18)).into(),
+                    make_block_at_round(19, B256::with_last_byte(18), round(1)).into(),
                     ack,
                 ))
                 .accepted()
@@ -140,12 +148,12 @@ fn floor_candidate_uses_execution_depth_and_next_tip_starts_new_cycle() {
         context.sleep(Duration::from_millis(1)).await;
         assert_eq!(marshal.floor(), Height::zero());
 
-        provider.set_finalized(19, B256::with_last_byte(19));
+        provider.set_finalized(19, B256::with_last_byte(19), Round::zero());
         let (ack, waiter) = Exact::handle();
         assert!(
             mailbox
                 .report(Update::Block(
-                    make_block(20, B256::with_last_byte(19)).into(),
+                    make_block_at_round(20, B256::with_last_byte(19), round(2)).into(),
                     ack,
                 ))
                 .accepted()
@@ -153,12 +161,12 @@ fn floor_candidate_uses_execution_depth_and_next_tip_starts_new_cycle() {
         waiter.await.expect("valid payload should be acknowledged");
         wait_until(&context, || marshal.floor() == Height::new(9)).await;
 
-        provider.set_finalized(39, B256::with_last_byte(39));
+        provider.set_finalized(39, B256::with_last_byte(39), Round::zero());
         provider.set_durable(29, B256::with_last_byte(29));
         assert!(
             mailbox
                 .report(Update::Tip(
-                    Round::zero(),
+                    round(3),
                     Height::new(29),
                     Digest(B256::with_last_byte(29)),
                 ))
@@ -173,7 +181,7 @@ fn block_at_or_below_finalized_tip_does_not_regress_forkchoice() {
     deterministic::Runner::default().start(|context| async move {
         let finalized_height = EPOCH_LENGTH.get();
         let provider = StubExecutionProvider::default();
-        provider.set_finalized(finalized_height, B256::with_last_byte(20));
+        provider.set_finalized(finalized_height, B256::with_last_byte(20), Round::zero());
 
         let (actor, mut mailbox) = init(
             context.child("follower_executor"),
@@ -205,7 +213,7 @@ fn floor_does_not_advance_until_its_execution_block_is_durable() {
         let finalized_height = EPOCH_LENGTH.get() * 2;
         let block_height = finalized_height + 1;
         let provider = StubExecutionProvider::default();
-        provider.set_finalized(finalized_height, B256::with_last_byte(20));
+        provider.set_finalized(finalized_height, B256::with_last_byte(20), Round::zero());
 
         let marshal = StubMarshal::default();
         let (actor, mut mailbox) = init(
@@ -340,26 +348,18 @@ fn tips_are_monotonic_and_coalesced_while_forkchoice_is_in_flight() {
         actor.start();
 
         let first_digest = Digest(B256::with_last_byte(1));
-        let first_tip = Update::Tip(Round::zero(), Height::new(1), first_digest);
+        let first_tip = Update::Tip(round(1), Height::new(1), first_digest);
         assert!(mailbox.report(first_tip).accepted());
         wait_until(&context, || provider.forkchoices().len() == 1).await;
 
         let highest_digest = Digest(B256::with_last_byte(4));
-        let higher_tip = Update::Tip(
-            Round::zero(),
-            Height::new(3),
-            Digest(B256::with_last_byte(3)),
-        );
+        let higher_tip = Update::Tip(round(3), Height::new(3), Digest(B256::with_last_byte(3)));
         assert!(mailbox.report(higher_tip).accepted());
 
-        let lower_tip = Update::Tip(
-            Round::zero(),
-            Height::new(2),
-            Digest(B256::with_last_byte(2)),
-        );
+        let lower_tip = Update::Tip(round(2), Height::new(2), Digest(B256::with_last_byte(2)));
         assert!(mailbox.report(lower_tip).accepted());
 
-        let highest_tip = Update::Tip(Round::zero(), Height::new(4), highest_digest);
+        let highest_tip = Update::Tip(round(4), Height::new(4), highest_digest);
         assert!(mailbox.report(highest_tip).accepted());
 
         context.sleep(Duration::from_millis(1)).await;
@@ -376,6 +376,189 @@ fn tips_are_monotonic_and_coalesced_while_forkchoice_is_in_flight() {
         assert_eq!(forkchoices[1].head_block_hash, highest_digest.0);
         assert_eq!(forkchoices[1].safe_block_hash, highest_digest.0);
         assert_eq!(forkchoices[1].finalized_block_hash, highest_digest.0);
+    });
+}
+
+// A finalization can advance forkchoice before execution receives its block.
+#[test_traced]
+fn finalization_drives_forkchoice_by_round() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+
+        let (actor, mut mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        let first = Digest(B256::with_last_byte(1));
+        let _ = mailbox.report(Update::Tip(round(1), Height::new(1), first));
+        wait_until(&context, || provider.forkchoices().len() == 1).await;
+
+        let finalized = Digest(B256::with_last_byte(9));
+        mailbox.finalization(round(2), finalized);
+        wait_until(&context, || provider.forkchoices().len() == 2).await;
+
+        let _ = mailbox.report(Update::Tip(
+            round(1),
+            Height::new(2),
+            Digest(B256::with_last_byte(2)),
+        ));
+        context.sleep(Duration::from_millis(5)).await;
+
+        let forkchoices = provider.forkchoices();
+        assert_eq!(forkchoices.len(), 2);
+        assert_eq!(forkchoices[1].head_block_hash, finalized.0);
+        assert_eq!(forkchoices[1].safe_block_hash, finalized.0);
+        assert_eq!(forkchoices[1].finalized_block_hash, finalized.0);
+    });
+}
+
+/// An older finalization received while a block FCU is in flight must not
+/// become the next forkchoice target.
+#[test_traced]
+fn delayed_finalization_does_not_regress_newer_block_forkchoice() {
+    deterministic::Runner::default().start(|context| async move {
+        let current = Digest(B256::with_last_byte(10));
+        let provider = StubExecutionProvider::default();
+        provider.set_finalized(100, current.0, round(10));
+        let release_block_forkchoice = provider.pause_next_forkchoice();
+
+        let (actor, mut mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: HEARTBEAT_INTERVAL,
+            },
+        );
+        actor.start();
+
+        let block = make_block_at_round(101, current.0, round(13));
+        let newest = Digest(block.block_hash());
+        let (ack, waiter) = Exact::handle();
+        let _ = mailbox.report(Update::Block(block.into(), ack));
+        wait_until(&context, || {
+            provider.payload_count() == 1 && provider.forkchoices().len() == 1
+        })
+        .await;
+
+        let delayed = Digest(B256::with_last_byte(12));
+        mailbox.finalization(round(12), delayed);
+        context.sleep(Duration::from_millis(1)).await;
+
+        release_block_forkchoice
+            .send(())
+            .expect("the block FCU should still be waiting");
+        waiter.await.expect("valid payload should be acknowledged");
+        context.sleep(Duration::from_millis(1)).await;
+
+        let forkchoices = provider.forkchoices();
+        assert_eq!(forkchoices.len(), 1);
+        assert_eq!(forkchoices[0].head_block_hash, newest.0);
+
+        wait_until(&context, || provider.forkchoices().len() == 2).await;
+        assert_eq!(provider.forkchoices()[1].head_block_hash, newest.0);
+    });
+}
+
+#[test_traced]
+fn execution_tip_round_orders_finalizations_after_restart() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        provider.set_finalized(100, digest(100).0, round(7));
+
+        let (actor, mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        mailbox.finalization(round(6), digest(101));
+        context.sleep(Duration::from_millis(5)).await;
+        assert!(provider.forkchoices().is_empty());
+
+        let newer = digest(102);
+        mailbox.finalization(round(8), newer);
+        wait_until(&context, || !provider.forkchoices().is_empty()).await;
+        assert_eq!(provider.forkchoices()[0].head_block_hash, newer.0);
+    });
+}
+
+#[test_traced]
+fn finalization_supersedes_roundless_prefork_execution_tip() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        provider.set_prefork_finalized(100, digest(100).0);
+
+        let (actor, mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        context.sleep(Duration::from_millis(1)).await;
+        assert!(provider.forkchoices().is_empty());
+
+        let finalized = digest(101);
+        mailbox.finalization(round(1), finalized);
+        wait_until(&context, || !provider.forkchoices().is_empty()).await;
+        assert_eq!(provider.forkchoices()[0].head_block_hash, finalized.0);
+    });
+}
+
+#[test_traced]
+fn finalization_is_driven_to_from_genesis() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+
+        let (actor, mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        let finalized = Digest(B256::with_last_byte(9));
+        mailbox.finalization(round(5), finalized);
+
+        wait_until(&context, || !provider.forkchoices().is_empty()).await;
+        let forkchoices = provider.forkchoices();
+        assert_eq!(forkchoices.len(), 1);
+        assert_eq!(
+            forkchoices[0].head_block_hash, finalized.0,
+            "nothing is below genesis, so the certificate is driven directly",
+        );
     });
 }
 
@@ -457,7 +640,7 @@ fn durable_block_read_failure_does_not_exit_actor() {
     deterministic::Runner::default().start(|context| async move {
         let finalized_height = EPOCH_LENGTH.get() * 2;
         let provider = StubExecutionProvider::default();
-        provider.set_finalized(finalized_height, B256::with_last_byte(20));
+        provider.set_finalized(finalized_height, B256::with_last_byte(20), Round::zero());
         provider.fail_durable_reads();
         let marshal = StubMarshal::default();
 
@@ -475,8 +658,11 @@ fn durable_block_read_failure_does_not_exit_actor() {
 
         actor.start();
 
-        for block_height in [finalized_height + 1, finalized_height + 2] {
-            let block = make_block(block_height, B256::with_last_byte(20));
+        for (block_height, block_round) in [
+            (finalized_height + 1, round(1)),
+            (finalized_height + 2, round(2)),
+        ] {
+            let block = make_block_at_round(block_height, B256::with_last_byte(20), block_round);
             let (ack, waiter) = Exact::handle();
             assert!(mailbox.report(Update::Block(block.into(), ack)).accepted());
 
@@ -498,7 +684,7 @@ fn startup_uses_execution_finalized_tip_without_immediate_forkchoice() {
     deterministic::Runner::default().start(|context| async move {
         let provider = StubExecutionProvider::default();
         let finalized_hash = B256::with_last_byte(10);
-        provider.set_finalized(EPOCH_LENGTH.get(), finalized_hash);
+        provider.set_finalized(EPOCH_LENGTH.get(), finalized_hash, round(10));
 
         let (actor, _mailbox) = init(
             context.child("follower_executor"),

--- a/crates/consensus/src/follow/executor/test/utils.rs
+++ b/crates/consensus/src/follow/executor/test/utils.rs
@@ -14,25 +14,37 @@ use alloy_primitives::B256;
 use alloy_rpc_types_engine::{
     ForkchoiceState, ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum,
 };
-use commonware_consensus::types::Height;
+use commonware_consensus::types::{Height, Round};
 use futures::channel::oneshot;
 use parking_lot::Mutex;
 use reth_ethereum::rpc::eth::primitives::BlockNumHash;
-use reth_node_core::primitives::SealedBlock;
+use reth_node_core::primitives::{SealedBlock, SealedHeader};
 use tempo_node::TempoExecutionData;
 use tempo_payload_types::TempoPayloadAttributes;
-use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
+use tempo_primitives::{
+    Block as TempoBlock, BlockBody, TempoConsensusContext, TempoHeader, ed25519::PublicKey,
+};
 
 use super::super::{ExecutionEngine, FinalizedBlockProvider, Marshal};
 use crate::consensus::block::Block;
 
 pub(super) fn make_block(height: u64, parent_hash: B256) -> Block {
+    make_block_at_round(height, parent_hash, Round::zero())
+}
+
+pub(super) fn make_block_at_round(height: u64, parent_hash: B256, round: Round) -> Block {
     let header = TempoHeader {
         inner: Header {
             parent_hash,
             number: height,
             ..Default::default()
         },
+        consensus_context: Some(TempoConsensusContext {
+            epoch: round.epoch().get(),
+            view: round.view().get(),
+            parent_view: 0,
+            proposer: PublicKey::from_seed(0),
+        }),
         ..Default::default()
     };
     let inner = TempoBlock {
@@ -51,6 +63,7 @@ pub(super) struct StubExecutionProvider {
 #[derive(Default)]
 struct StubExecutionProviderInner {
     finalized: Mutex<BlockNumHash>,
+    finalized_round: Mutex<Option<Round>>,
     durable: Mutex<HashMap<u64, B256>>,
     fail_durable_reads: AtomicBool,
     payloads: AtomicUsize,
@@ -61,8 +74,16 @@ struct StubExecutionProviderInner {
 }
 
 impl StubExecutionProvider {
-    pub(super) fn set_finalized(&self, number: u64, hash: B256) {
+    pub(super) fn set_finalized(&self, number: u64, hash: B256, round: Round) {
         *self.inner.finalized.lock() = BlockNumHash::new(number, hash);
+        *self.inner.finalized_round.lock() = Some(round);
+    }
+
+    /// Models a finalized execution header from before TIP-1031, when headers
+    /// had no consensus context and therefore no round.
+    pub(super) fn set_prefork_finalized(&self, number: u64, hash: B256) {
+        *self.inner.finalized.lock() = BlockNumHash::new(number, hash);
+        *self.inner.finalized_round.lock() = None;
     }
 
     pub(super) fn set_durable(&self, height: u64, hash: B256) {
@@ -97,8 +118,29 @@ impl StubExecutionProvider {
 }
 
 impl FinalizedBlockProvider for StubExecutionProvider {
-    fn finalized_block_num_hash(&self) -> eyre::Result<BlockNumHash> {
-        Ok(*self.inner.finalized.lock())
+    fn finalized_header(&self) -> eyre::Result<SealedHeader<TempoHeader>> {
+        let tip = *self.inner.finalized.lock();
+        let consensus_context =
+            self.inner
+                .finalized_round
+                .lock()
+                .map(|round| TempoConsensusContext {
+                    epoch: round.epoch().get(),
+                    view: round.view().get(),
+                    parent_view: 0,
+                    proposer: PublicKey::from_seed(0),
+                });
+        Ok(SealedHeader::new(
+            TempoHeader {
+                inner: Header {
+                    number: tip.number,
+                    ..Default::default()
+                },
+                consensus_context,
+                ..Default::default()
+            },
+            tip.hash,
+        ))
     }
 
     fn durable_block_hash(&self, height: u64) -> eyre::Result<Option<B256>> {


### PR DESCRIPTION
Introduces a new message to the follower executor actor: certified tip. This will be used to signal to the execution layer that there is a new known finalized tip. That in turn will trigger the execution layer to sync to that tip.

To that end we also introduce a data structure called `Target` which is basically either: (height, digest) or (round, digest). The former comes from the execution layer and the latter is going to be received from the peers on the p2p network in the form of finalization certificates (and those do not carry the height, only round).

This builds on top of the previous refactor that introduced the StartupTip and allows comparing the incoming finalization certificates with whatever last branch saved locally.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>