### PR TITLE
feat(node): add tempo/1 wire format

### DIFF
--- a/crates/consensus/src/follow/test_utils.rs
+++ b/crates/consensus/src/follow/test_utils.rs
@@ -3,7 +3,6 @@
 use std::{
     collections::HashMap,
     future::Future,
-    iter::repeat_with,
     num::NonZeroU64,
     sync::{
         Arc,
@@ -17,73 +16,28 @@ use commonware_codec::Encode as _;
 use commonware_consensus::{
     simplex::{
         scheme::bls12381_threshold::vrf::Scheme,
-        types::{Activity, Finalization, Finalize, Proposal},
+        types::{Activity, Finalization},
     },
-    types::{Epoch, Height, Round, View},
+    types::{Epoch, Height, Round},
 };
-use commonware_cryptography::{
-    Signer as _,
-    bls12381::{dkg::feldman_desmedt as dkg, primitives::variant::MinSig},
-    ed25519::{PrivateKey, PublicKey},
-};
-use commonware_math::algebra::Random as _;
-use commonware_parallel::Sequential;
-use commonware_utils::{N3f1, TryFromIterator as _, ordered};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use parking_lot::Mutex;
-use rand_core::CryptoRng;
 use reth_node_core::primitives::SealedBlock;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::rpc::consensus::CertifiedBlock;
 use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
 
 use super::driver::{ExecutionProvider, Marshal};
-use crate::consensus::{Block, Digest};
+use crate::{
+    consensus::{Block, Digest},
+    test_utils::make_certificate,
+};
+
+pub(crate) use crate::test_utils::dkg_fixture;
 
 type ConsensusActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 
 pub(crate) const EPOCH_LENGTH: NonZeroU64 = NonZeroU64::new(10).expect("epoch length is nonzero");
-
-pub(crate) struct DkgFixture {
-    pub(crate) outcome: OnchainDkgOutcome,
-    pub(crate) schemes: Vec<Scheme<PublicKey, MinSig>>,
-}
-
-pub(crate) fn dkg_fixture(rng: &mut impl CryptoRng, epoch: Epoch) -> DkgFixture {
-    let player_keys = repeat_with(|| PrivateKey::random(&mut *rng))
-        .take(4)
-        .collect::<Vec<_>>();
-    let players = ordered::Set::try_from_iter(
-        player_keys
-            .iter()
-            .map(|private_key| private_key.public_key()),
-    )
-    .expect("test players should be unique");
-
-    let (output, shares) =
-        dkg::deal::<_, _, N3f1>(&mut *rng, Default::default(), players).expect("test DKG");
-
-    let schemes = shares
-        .into_iter()
-        .map(|(_, share)| {
-            Scheme::signer(
-                crate::config::NAMESPACE,
-                output.players().clone(),
-                output.public().clone(),
-                share,
-            )
-            .expect("test share should match the public polynomial")
-        })
-        .collect();
-
-    let outcome = OnchainDkgOutcome {
-        epoch,
-        next_players: output.players().clone(),
-        output,
-        is_next_full_dkg: false,
-    };
-
-    DkgFixture { outcome, schemes }
-}
 
 pub(crate) fn make_block(height: u64, outcome: Option<&OnchainDkgOutcome>) -> Block {
     make_block_with_parent(height, Default::default(), outcome)
@@ -125,18 +79,7 @@ pub(crate) fn make_finalization(
     epoch: Epoch,
     schemes: &[Scheme<PublicKey, MinSig>],
 ) -> Finalization<Scheme<PublicKey, MinSig>, Digest> {
-    let proposal = Proposal::new(
-        Round::new(epoch, View::new(block.number())),
-        View::zero(),
-        block.digest(),
-    );
-    let votes = schemes
-        .iter()
-        .map(|scheme| Finalize::sign(scheme, proposal.clone()).expect("signer should sign"))
-        .collect::<Vec<_>>();
-
-    Finalization::from_finalizes(&schemes[0], &votes, &Sequential)
-        .expect("all test signers form a quorum")
+    make_certificate(block.digest(), epoch, block.number(), schemes)
 }
 
 pub(crate) fn make_certified_block(

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -20,6 +20,8 @@ pub(crate) mod network_identity;
 pub(crate) mod peer_manager;
 pub mod storage;
 pub(crate) mod subblocks;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub(crate) mod utils;
 pub(crate) mod validators;
 

--- a/crates/consensus/src/test_utils.rs
+++ b/crates/consensus/src/test_utils.rs
@@ -1,0 +1,87 @@
+//! Shared test fixtures.
+//!
+//! Threshold certificates need a dealt DKG output, which is expensive to
+//! reproduce and easy to get subtly wrong. Both the follower driver and the
+//! `tempo/1` actor need one, so it lives here rather than in either.
+
+use std::iter::repeat_with;
+
+use commonware_consensus::{
+    simplex::{
+        scheme::bls12381_threshold::vrf::Scheme,
+        types::{Finalization, Finalize, Proposal},
+    },
+    types::{Epoch, Round, View},
+};
+use commonware_cryptography::{
+    Signer as _,
+    bls12381::{dkg::feldman_desmedt as dkg, primitives::variant::MinSig},
+    ed25519::{PrivateKey, PublicKey},
+};
+use commonware_math::algebra::Random as _;
+use commonware_parallel::Sequential;
+use commonware_utils::{N3f1, TryFromIterator as _, ordered};
+use rand_core::CryptoRng;
+use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
+
+use crate::consensus::Digest;
+
+/// A dealt DKG output together with signers able to form a quorum over it.
+pub(crate) struct DkgFixture {
+    pub(crate) outcome: OnchainDkgOutcome,
+    pub(crate) schemes: Vec<Scheme<PublicKey, MinSig>>,
+}
+
+pub(crate) fn dkg_fixture(rng: &mut impl CryptoRng, epoch: Epoch) -> DkgFixture {
+    let player_keys = repeat_with(|| PrivateKey::random(&mut *rng))
+        .take(4)
+        .collect::<Vec<_>>();
+    let players = ordered::Set::try_from_iter(
+        player_keys
+            .iter()
+            .map(|private_key| private_key.public_key()),
+    )
+    .expect("test players should be unique");
+
+    let (output, shares) =
+        dkg::deal::<_, _, N3f1>(&mut *rng, Default::default(), players).expect("test DKG");
+
+    let schemes = shares
+        .into_iter()
+        .map(|(_, share)| {
+            Scheme::signer(
+                crate::config::NAMESPACE,
+                output.players().clone(),
+                output.public().clone(),
+                share,
+            )
+            .expect("test share should match the public polynomial")
+        })
+        .collect();
+
+    let outcome = OnchainDkgOutcome {
+        epoch,
+        next_players: output.players().clone(),
+        output,
+        is_next_full_dkg: false,
+    };
+
+    DkgFixture { outcome, schemes }
+}
+
+/// Builds a finalization certificate over an arbitrary payload.
+pub(crate) fn make_certificate(
+    payload: Digest,
+    epoch: Epoch,
+    view: u64,
+    schemes: &[Scheme<PublicKey, MinSig>],
+) -> Finalization<Scheme<PublicKey, MinSig>, Digest> {
+    let proposal = Proposal::new(Round::new(epoch, View::new(view)), View::zero(), payload);
+    let votes = schemes
+        .iter()
+        .map(|scheme| Finalize::sign(scheme, proposal.clone()).expect("signer should sign"))
+        .collect::<Vec<_>>();
+
+    Finalization::from_finalizes(&schemes[0], &votes, &Sequential)
+        .expect("all test signers form a quorum")
+}

--- a/crates/node/src/gossip/mod.rs
+++ b/crates/node/src/gossip/mod.rs
@@ -1,0 +1,17 @@
+//! The `tempo/1` RLPx subprotocol for gossiping consensus finalization
+//! certificates between Tempo nodes.
+//!
+//! A follower with gossip ingest enabled processes this protocol alongside
+//! upstream RPC. This provides a second finalization path, so an unavailable or
+//! unresponsive RPC server does not by itself stop follower progress. The
+//! follower can receive a certified tip from a `tempo/1` peer, verify it with the
+//! threshold key for that epoch, and update its execution layer.
+//!
+//! This module contains the code that must live next to reth. This includes the
+//! frame format and the per-connection stream polled by reth's session manager.
+//! The consensus crate decides how to process frames. It handles coalescing,
+//! fairness, rate limits, and certificate verification. The transport does not
+//! inspect certificate payloads because the consensus crate already depends on
+//! the node crate. The dependency cannot point in both directions.
+
+pub mod wire;

--- a/crates/node/src/gossip/wire.rs
+++ b/crates/node/src/gossip/wire.rs
@@ -1,0 +1,142 @@
+//! Frame format for the `tempo/1` subprotocol.
+//!
+//! The protocol has one message, `NewFinalization`. Its payload is an opaque
+//! consensus certificate. Certificate decoding needs the consensus codec, so
+//! it stays in the consensus crate. This keeps the node crate independent of
+//! the consensus crate.
+
+use alloy_primitives::bytes::{BufMut as _, BytesMut};
+use reth_ethereum::network::eth_wire::{Capability, protocol::Protocol};
+
+/// Name used during the `RLPx` handshake.
+const NAME: &str = "tempo";
+
+/// Protocol version.
+///
+/// Peers negotiate only the name and version. Change the version if the frame
+/// layout or certificate encoding changes.
+const VERSION: usize = 1;
+
+/// Number of message IDs reserved by the protocol.
+///
+/// Both peers must use the same count so later `RLPx` message IDs stay aligned.
+const MESSAGE_COUNT: u8 = 1;
+
+/// Message ID of `NewFinalization`.
+const NEW_FINALIZATION: u8 = 0x00;
+
+/// Largest frame accepted from a peer.
+///
+/// Certificates are much smaller. This limit reduces the work an
+/// unauthenticated peer can request before signature verification.
+pub const MAX_FRAME_BYTES: usize = 1024;
+
+/// Returns the capability announced during the handshake.
+pub const fn capability() -> Capability {
+    Capability::new_static(NAME, VERSION)
+}
+
+/// Returns the protocol announced during the handshake.
+pub const fn protocol() -> Protocol {
+    Protocol::new(capability(), MESSAGE_COUNT)
+}
+
+/// An error found before the certificate payload is decoded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum FrameError {
+    /// The frame has no message ID.
+    #[error("frame was empty")]
+    Empty,
+    /// The frame exceeds [`MAX_FRAME_BYTES`].
+    #[error("frame of {size} bytes exceeds the frame size limit")]
+    Oversized {
+        /// Size of the rejected frame.
+        size: usize,
+    },
+    /// The protocol does not define this message ID.
+    #[error("unknown message id `{0:#04x}`")]
+    UnknownMessage(u8),
+}
+
+/// Encodes a certificate as a `NewFinalization` frame.
+pub fn encode(certificate: &[u8]) -> BytesMut {
+    let mut frame = BytesMut::with_capacity(1 + certificate.len());
+    frame.put_u8(NEW_FINALIZATION);
+    frame.put_slice(certificate);
+    frame
+}
+
+/// Validates a frame and returns its certificate payload.
+///
+/// The returned payload borrows from the frame. A caller can inspect the
+/// certificate and relay the original frame without copying it.
+pub fn decode(frame: &[u8]) -> Result<&[u8], FrameError> {
+    if frame.len() > MAX_FRAME_BYTES {
+        return Err(FrameError::Oversized { size: frame.len() });
+    }
+
+    let (&id, payload) = frame.split_first().ok_or(FrameError::Empty)?;
+    if id != NEW_FINALIZATION {
+        return Err(FrameError::UnknownMessage(id));
+    }
+
+    Ok(payload)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Peers use the version to identify the frame layout. An incompatible
+    // layout must use a new version.
+    #[test]
+    fn frame_layout_is_frozen() {
+        assert_eq!(capability().name.as_ref(), "tempo");
+        assert_eq!(capability().version, 1);
+        assert_eq!(protocol(), Protocol::new(capability(), 1));
+
+        let frame = encode(&[0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(&frame[..], &[0x00, 0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn encode_decode_round_trips() {
+        let certificate = [0x01, 0x02, 0x03];
+        let frame = encode(&certificate);
+        assert_eq!(decode(&frame).unwrap(), &certificate);
+    }
+
+    #[test]
+    fn empty_payload_round_trips() {
+        let frame = encode(&[]);
+        assert_eq!(decode(&frame).unwrap(), &[] as &[u8]);
+    }
+
+    #[test]
+    fn oversized_frame_is_rejected() {
+        let frame = encode(&vec![0u8; MAX_FRAME_BYTES]);
+        assert_eq!(
+            decode(&frame),
+            Err(FrameError::Oversized {
+                size: MAX_FRAME_BYTES + 1
+            })
+        );
+    }
+
+    #[test]
+    fn frame_at_the_limit_is_accepted() {
+        let frame = encode(&vec![0u8; MAX_FRAME_BYTES - 1]);
+        assert_eq!(frame.len(), MAX_FRAME_BYTES);
+        assert!(decode(&frame).is_ok());
+    }
+
+    #[test]
+    fn empty_frame_is_rejected() {
+        assert_eq!(decode(&[]), Err(FrameError::Empty));
+    }
+
+    #[test]
+    fn unknown_message_id_is_rejected() {
+        assert_eq!(decode(&[0x01, 0xff]), Err(FrameError::UnknownMessage(1)));
+    }
+}

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -21,6 +21,7 @@ pub use tempo_transaction_pool::{
 };
 
 pub mod engine;
+pub mod gossip;
 pub mod node;
 pub mod rpc;
 pub mod telemetry;


### PR DESCRIPTION
Defines the versioned certificate frame and freezes its capability, message ID, and size limit with focused tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>