### PR TITLE
refactor: replace dead code allows with expects

### DIFF
--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -492,10 +492,10 @@ mod tests {
         // binary's CLI struct; we re-declare them here just so clap can
         // resolve the references during parse-time validation.
         #[arg(long = "follow")]
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         follow: Option<String>,
         #[arg(long = "dev")]
-        #[allow(dead_code)]
+        #[expect(dead_code)]
         dev: bool,
 
         #[command(flatten)]

--- a/crates/evm/benches/dex_execution.rs
+++ b/crates/evm/benches/dex_execution.rs
@@ -4,7 +4,7 @@
 //! fixed-cache execution path. This is intended as a small CodSpeed/flamegraph target for
 //! TIP-1062 order storage layout work.
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 mod common;
 
 use alloy_consensus::transaction::Recovered;

--- a/crates/node/tests/it/gas/helpers.rs
+++ b/crates/node/tests/it/gas/helpers.rs
@@ -231,25 +231,25 @@ impl TempoCalls {
         self
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn fee_token(mut self, fee_token: Option<Address>) -> Self {
         self.fee_token = fee_token;
         self
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn nonce_key(mut self, nonce_key: U256) -> Self {
         self.nonce_key = nonce_key;
         self
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = gas_limit;
         self
     }
 
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     pub(crate) fn expect_existing_nonce(mut self) -> Self {
         self.expect_existing_nonce = true;
         self

--- a/crates/node/tests/it/gas/helpers.rs
+++ b/crates/node/tests/it/gas/helpers.rs
@@ -243,7 +243,6 @@ impl TempoCalls {
         self
     }
 
-    #[expect(dead_code)]
     pub(crate) fn gas_limit(mut self, gas_limit: u64) -> Self {
         self.gas_limit = gas_limit;
         self

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -183,10 +183,10 @@ pub struct Orderbook {
     /// Quote token address
     pub quote: Address,
     /// Bid orders by tick
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     bids: Mapping<i16, TickLevel>,
     /// Ask orders by tick
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     asks: Mapping<i16, TickLevel>,
     /// Best bid tick for highest bid price.
     pub(crate) best_bid_tick: i16,
@@ -194,11 +194,11 @@ pub struct Orderbook {
     pub(crate) best_ask_tick: i16,
     /// (+T8) 1-based book ID; zero means unset.
     pub(crate) book_id: u32,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     /// Mapping of tick index to bid bitmap for price discovery
     bid_bitmap: Mapping<i16, U256>,
     /// Mapping of tick index to ask bitmap for price discovery
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     ask_bitmap: Mapping<i16, U256>,
 }
 

--- a/crates/precompiles/src/tip20_factory/mod.rs
+++ b/crates/precompiles/src/tip20_factory/mod.rs
@@ -41,7 +41,6 @@ pub struct TIP20Factory {}
 
 /// Computes the deterministic TIP20 address from sender and salt.
 /// Returns the address and the lower bytes used for derivation.
-#[cfg_attr(test, allow(dead_code))]
 pub(crate) fn compute_tip20_address(sender: Address, salt: B256) -> (Address, u64) {
     let hash = keccak256((sender, salt).abi_encode());
 

--- a/crates/precompiles/src/zone_factory/portal.rs
+++ b/crates/precompiles/src/zone_factory/portal.rs
@@ -40,7 +40,7 @@ pub struct PortalEncryptionKeyEntry {
 pub struct PortalWithdrawalQueue {
     head: U256,
     tail: U256,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     slots: Mapping<U256, B256>,
 }
 


### PR DESCRIPTION
Replaces all `allow(dead_code)` attributes with `expect(dead_code)` and removes a stale conditional suppressor. Intentional dead-code cases now remain checked by the compiler.

Validation:
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Package checks were blocked before compilation because Cargo could not fetch the pinned `commonware` revision (GitHub returned 401).

Prompted by: @pepyakin