### PR TITLE
feat(follow): verify and apply gossiped certificates

### DIFF
--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -138,7 +138,7 @@ impl FinalizationVerifier {
 
         if !finalization.verify(rng, scheme.as_ref(), &Sequential) {
             return Err(if used_network_identity {
-                CertificateVerificationError::NetworkIdentityMismatch
+                CertificateVerificationError::FallbackVerificationFailed
             } else {
                 CertificateVerificationError::Invalid
             });
@@ -168,9 +168,10 @@ pub enum CertificateVerificationError {
     /// The signature failed against a scheme learned from a finalized boundary.
     #[error("finalization certificate verification failed")]
     Invalid,
-    /// The signature failed against the configured network identity.
-    #[error("finalization certificate did not verify against the network identity")]
-    NetworkIdentityMismatch,
+    /// The signature failed against the static fallback identity. The epoch-specific identity may
+    /// have rotated while the follower was offline.
+    #[error("finalization certificate did not verify against the network identity fallback")]
+    FallbackVerificationFailed,
 }
 
 /// An error returned while verifying a Tempo finalization certificate.
@@ -203,7 +204,7 @@ impl Error {
             self,
             Self::CertificateVerification(
                 CertificateVerificationError::Invalid
-                    | CertificateVerificationError::NetworkIdentityMismatch
+                    | CertificateVerificationError::FallbackVerificationFailed
             )
         )
     }

--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -111,13 +111,38 @@ impl FinalizationVerifier {
             });
         }
 
+        self.verify_certificate(rng, &finalization)
+            .map_err(|error| match error {
+                CertificateVerificationError::IdentityUnavailable {
+                    epoch,
+                    identity_from_epoch,
+                } => Error::IdentityUnavailable {
+                    epoch,
+                    identity_from_epoch,
+                },
+                CertificateVerificationError::Invalid => Error::VerificationFailed,
+                CertificateVerificationError::NetworkIdentityMismatch => {
+                    Error::NetworkIdentityMismatch
+                }
+            })?;
+
+        Ok(finalization)
+    }
+
+    /// Verify an already decoded certificate without requiring its block.
+    pub(crate) fn verify_certificate(
+        &self,
+        rng: &mut impl CryptoRng,
+        finalization: &Finalization<Scheme<PublicKey, MinSig>, Digest>,
+    ) -> Result<(), CertificateVerificationError> {
+        let epoch = finalization.epoch();
         let (scheme, used_network_identity) = match self.scheme_provider.scheme(epoch) {
             Some(scheme) => (scheme, false),
             None if epoch.get() >= self.network_identity.from_epoch => {
                 (self.network_scheme.clone(), true)
             }
             None => {
-                return Err(Error::IdentityUnavailable {
+                return Err(CertificateVerificationError::IdentityUnavailable {
                     epoch: epoch.get(),
                     identity_from_epoch: self.network_identity.from_epoch,
                 });
@@ -125,7 +150,11 @@ impl FinalizationVerifier {
         };
 
         if !finalization.verify(rng, scheme.as_ref(), &Sequential) {
-            return Err(Error::VerificationFailed);
+            return Err(if used_network_identity {
+                CertificateVerificationError::NetworkIdentityMismatch
+            } else {
+                CertificateVerificationError::Invalid
+            });
         }
 
         // Marshal verifies the certificate again while installing a floor, so retain a
@@ -134,8 +163,22 @@ impl FinalizationVerifier {
             self.scheme_provider.register(epoch, (*scheme).clone());
         }
 
-        Ok(finalization)
+        Ok(())
     }
+}
+
+/// Why an already decoded certificate could not be verified.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CertificateVerificationError {
+    /// No trusted identity is available for the certificate's epoch.
+    IdentityUnavailable {
+        epoch: u64,
+        identity_from_epoch: u64,
+    },
+    /// The signature failed against a scheme learned from a finalized boundary.
+    Invalid,
+    /// The signature failed against the configured network identity.
+    NetworkIdentityMismatch,
 }
 
 /// An error returned while verifying a Tempo finalization certificate.
@@ -167,6 +210,9 @@ pub enum Error {
     /// The threshold signature did not verify against the trusted identity.
     #[error("finalization certificate verification failed")]
     VerificationFailed,
+    /// The threshold signature did not verify against the configured network identity.
+    #[error("finalization certificate did not verify against the network identity")]
+    NetworkIdentityMismatch,
 }
 
 /// The concrete decoding error for a malformed finalization certificate.

--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -111,20 +111,7 @@ impl FinalizationVerifier {
             });
         }
 
-        self.verify_certificate(rng, &finalization)
-            .map_err(|error| match error {
-                CertificateVerificationError::IdentityUnavailable {
-                    epoch,
-                    identity_from_epoch,
-                } => Error::IdentityUnavailable {
-                    epoch,
-                    identity_from_epoch,
-                },
-                CertificateVerificationError::Invalid => Error::VerificationFailed,
-                CertificateVerificationError::NetworkIdentityMismatch => {
-                    Error::NetworkIdentityMismatch
-                }
-            })?;
+        self.verify_certificate(rng, &finalization)?;
 
         Ok(finalization)
     }
@@ -168,16 +155,21 @@ impl FinalizationVerifier {
 }
 
 /// Why an already decoded certificate could not be verified.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum CertificateVerificationError {
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum CertificateVerificationError {
     /// No trusted identity is available for the certificate's epoch.
+    #[error(
+        "finalization epoch `{epoch}` behind network identity starting epoch `{identity_from_epoch}`"
+    )]
     IdentityUnavailable {
         epoch: u64,
         identity_from_epoch: u64,
     },
     /// The signature failed against a scheme learned from a finalized boundary.
+    #[error("finalization certificate verification failed")]
     Invalid,
     /// The signature failed against the configured network identity.
+    #[error("finalization certificate did not verify against the network identity")]
     NetworkIdentityMismatch,
 }
 
@@ -199,20 +191,22 @@ pub enum Error {
         expected: u64,
         actual: u64,
     },
-    /// No trusted identity is available for the certificate's epoch.
-    #[error(
-        "finalization epoch `{epoch}` behind network identity starting epoch `{identity_from_epoch}`"
-    )]
-    IdentityUnavailable {
-        epoch: u64,
-        identity_from_epoch: u64,
-    },
-    /// The threshold signature did not verify against the trusted identity.
-    #[error("finalization certificate verification failed")]
-    VerificationFailed,
-    /// The threshold signature did not verify against the configured network identity.
-    #[error("finalization certificate did not verify against the network identity")]
-    NetworkIdentityMismatch,
+    /// The certificate could not be verified against an available identity.
+    #[error(transparent)]
+    CertificateVerification(#[from] CertificateVerificationError),
+}
+
+impl Error {
+    /// Whether the certificate's signature mismatched an available identity.
+    pub(crate) const fn is_signature_mismatch(&self) -> bool {
+        matches!(
+            self,
+            Self::CertificateVerification(
+                CertificateVerificationError::Invalid
+                    | CertificateVerificationError::NetworkIdentityMismatch
+            )
+        )
+    }
 }
 
 /// The concrete decoding error for a malformed finalization certificate.

--- a/crates/consensus/src/finalized_header_stream/mod.rs
+++ b/crates/consensus/src/finalized_header_stream/mod.rs
@@ -160,13 +160,7 @@ where
                     if latest_finalization.block.number() < start_after.number
                         || verifier
                             .decode_and_verify(&mut rng, &latest_finalization)
-                            .is_err_and(|error| {
-                                matches!(
-                                    error,
-                                    VerificationError::VerificationFailed
-                                        | VerificationError::NetworkIdentityMismatch
-                                )
-                            })
+                            .is_err_and(|error| error.is_signature_mismatch())
                     {
                         verifier = verifier_from_start(&rpc, &epoch_strategy, start_after).await?;
                     }
@@ -230,10 +224,7 @@ where
                     // If we can verify the latest finalization, trust it as the new chain tip.
                     self.plan = self.plan_to(certified.block.num_hash()).await?;
                 }
-                Err(
-                    VerificationError::VerificationFailed
-                    | VerificationError::NetworkIdentityMismatch,
-                ) => {
+                Err(error) if error.is_signature_mismatch() => {
                     // If we can't verify the finalization, attempt to sync to the first epoch transition we can verify.
                     let epoch = self
                         .epoch_strategy
@@ -376,10 +367,7 @@ where
                         .plan_to(BlockNumHash::new(boundary, certified.block.hash()))
                         .await;
                 }
-                Err(
-                    VerificationError::VerificationFailed
-                    | VerificationError::NetworkIdentityMismatch,
-                ) => {
+                Err(error) if error.is_signature_mismatch() => {
                     certificate_epoch = previous_epoch;
                 }
                 Err(error) => return Err(error.into()),

--- a/crates/consensus/src/finalized_header_stream/mod.rs
+++ b/crates/consensus/src/finalized_header_stream/mod.rs
@@ -161,7 +161,11 @@ where
                         || verifier
                             .decode_and_verify(&mut rng, &latest_finalization)
                             .is_err_and(|error| {
-                                matches!(error, VerificationError::VerificationFailed)
+                                matches!(
+                                    error,
+                                    VerificationError::VerificationFailed
+                                        | VerificationError::NetworkIdentityMismatch
+                                )
                             })
                     {
                         verifier = verifier_from_start(&rpc, &epoch_strategy, start_after).await?;
@@ -226,7 +230,10 @@ where
                     // If we can verify the latest finalization, trust it as the new chain tip.
                     self.plan = self.plan_to(certified.block.num_hash()).await?;
                 }
-                Err(VerificationError::VerificationFailed) => {
+                Err(
+                    VerificationError::VerificationFailed
+                    | VerificationError::NetworkIdentityMismatch,
+                ) => {
                     // If we can't verify the finalization, attempt to sync to the first epoch transition we can verify.
                     let epoch = self
                         .epoch_strategy
@@ -369,7 +376,10 @@ where
                         .plan_to(BlockNumHash::new(boundary, certified.block.hash()))
                         .await;
                 }
-                Err(VerificationError::VerificationFailed) => {
+                Err(
+                    VerificationError::VerificationFailed
+                    | VerificationError::NetworkIdentityMismatch,
+                ) => {
                     certificate_epoch = previous_epoch;
                 }
                 Err(error) => return Err(error.into()),

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -2,7 +2,7 @@ use alloy_consensus::BlockHeader as _;
 use commonware_consensus::{
     Epochable as _, Heightable as _, marshal,
     simplex::types::Activity,
-    types::{Epoch, Epocher as _, Height, Round},
+    types::{Epoch, Epocher as _, Height},
 };
 use commonware_runtime::{Clock, ContextCell, Spawner, spawn_cell};
 use commonware_utils::Acknowledgement as _;
@@ -16,22 +16,12 @@ use super::{
     Config, ExecutionProvider, Executor, FollowerProgress, Mailbox, Marshal, ingress::Message,
 };
 use crate::{
-    consensus::{Block, Digest},
+    consensus::Block,
     finalization_verifier::{
         CertificateVerificationError, Error as VerificationError, FinalizationVerifier,
     },
     gossip::{Certificate, Outcome},
 };
-
-/// Outcome of checking a certificate's signature.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum Verdict {
-    Verified,
-    /// Failed with an available scheme, so the sender is responsible.
-    Invalid,
-    /// No available scheme can verify it.
-    NeedsScheme,
-}
 
 pub(super) fn try_init<TContext, P, M, E>(
     context: TContext,
@@ -236,41 +226,28 @@ where
             .decode_and_verify(&mut self.context, &certified)
         {
             Ok(finalization) => finalization,
-            Err(error @ VerificationError::NetworkIdentityMismatch) => {
+            Err(
+                error @ VerificationError::CertificateVerification(
+                    CertificateVerificationError::NetworkIdentityMismatch,
+                ),
+            ) => {
                 debug!(%error, "failed to verify finalization certificate");
-
-                // This network may have rotated identity, so hint the boundary of
-                // the node's current epoch to unblock syncing through the next
-                // onchain scheme.
-                let boundary_height = self
-                    .config
-                    .epoch_strategy
-                    .last(self.current_epoch)
-                    .expect("strategy is valid for all heights and epochs");
-
-                debug!(
-                    current_epoch = %self.current_epoch,
-                    %boundary_height,
-                    "hinting current epoch boundary after finalization verification failed",
-                );
-
-                self.config.marshal.hint_finalized(boundary_height).await;
-
+                self.hint_current_epoch_boundary().await;
                 return Ok(());
             }
-            Err(VerificationError::VerificationFailed) => return Ok(()),
+            Err(VerificationError::CertificateVerification(
+                CertificateVerificationError::Invalid,
+            )) => return Ok(()),
             Err(error) => return Err(Report::new(error)),
         };
 
         let consensus_block = Block::from_execution_block_unchecked(certified.block, None);
 
         let round = finalization.round();
-        let digest = consensus_block.digest();
-
         // Always give the block to marshal, even if the round is stale. An RPC
         // event includes the block, and storing it may close a gap.
         let _ = self.config.marshal.certified(round, consensus_block).await;
-        self.report_verified(round, digest, finalization).await;
+        self.report_verified(finalization).await;
 
         Ok(())
     }
@@ -282,18 +259,35 @@ where
     /// points the execution layer at the same hash.
     #[instrument(skip_all, fields(round = %certificate.round(), digest = %certificate.proposal.payload))]
     async fn verify_and_apply(&mut self, certificate: Certificate) -> Outcome {
-        self.judge(certificate).await
-    }
-
-    async fn judge(&mut self, certificate: Certificate) -> Outcome {
         if certificate.round() <= self.progress.watermark() {
             return Outcome::Stale;
         }
 
-        match self.verify(&certificate).await {
-            Verdict::Verified => {}
-            Verdict::Invalid => return Outcome::Invalid,
-            Verdict::NeedsScheme => {
+        match self
+            .verifier
+            .verify_certificate(&mut self.context, &certificate)
+        {
+            Ok(()) => {}
+            Err(CertificateVerificationError::Invalid) => {
+                debug!(
+                    epoch = %certificate.epoch(),
+                    digest = %certificate.proposal.payload,
+                    "certificate failed verification against a registered scheme",
+                );
+                return Outcome::Invalid;
+            }
+            Err(CertificateVerificationError::IdentityUnavailable { .. }) => {
+                return Outcome::NeedsScheme {
+                    epoch: certificate.epoch(),
+                };
+            }
+            Err(CertificateVerificationError::NetworkIdentityMismatch) => {
+                debug!(
+                    epoch = %certificate.epoch(),
+                    digest = %certificate.proposal.payload,
+                    "certificate failed verification against the network identity",
+                );
+                self.hint_current_epoch_boundary().await;
                 return Outcome::NeedsScheme {
                     epoch: certificate.epoch(),
                 };
@@ -302,12 +296,13 @@ where
 
         let round = certificate.round();
         let digest = certificate.proposal.payload;
-        self.report_verified(round, digest, certificate).await;
+        self.report_verified(certificate).await;
+        self.config.executor.finalization(round, digest);
 
         Outcome::Admitted
     }
 
-    /// Hands a verified finalization to the rest of the follower.
+    /// Reports a verified finalization to marshal and publishes its progress.
     ///
     /// # Invariant
     ///
@@ -316,48 +311,16 @@ where
     /// an unchecked certificate would let an unauthenticated peer create
     /// unlimited state or stop the node by naming any epoch. Verification and
     /// reporting stay in one call chain so this rule is easy to check.
-    async fn report_verified(&mut self, round: Round, digest: Digest, finalization: Certificate) {
+    async fn report_verified(&mut self, finalization: Certificate) {
+        let round = finalization.round();
         self.progress.advance(round);
         self.config
             .marshal
             .report(Activity::Finalization(finalization))
             .await;
-        self.config.executor.finalization(round, digest);
     }
 
-    /// Selects the verifier for a certificate's epoch and checks the signature.
-    ///
-    /// A failure with a registered scheme is invalid and can be blamed on the
-    /// peer. A failure with the built-in network identity may mean the identity
-    /// has rotated. Do not blame the peer in that case. Doing so could disconnect
-    /// honest relayers while gossip is needed for recovery.
-    async fn verify(&mut self, finalization: &Certificate) -> Verdict {
-        match self
-            .verifier
-            .verify_certificate(&mut self.context, finalization)
-        {
-            Ok(()) => return Verdict::Verified,
-            Err(CertificateVerificationError::Invalid) => {
-                let epoch = finalization.epoch();
-                debug!(
-                    %epoch,
-                    digest = %finalization.proposal.payload,
-                    "certificate failed verification against a registered scheme",
-                );
-                return Verdict::Invalid;
-            }
-            Err(CertificateVerificationError::IdentityUnavailable { .. }) => {
-                return Verdict::NeedsScheme;
-            }
-            Err(CertificateVerificationError::NetworkIdentityMismatch) => {}
-        }
-
-        debug!(
-            epoch = %finalization.epoch(),
-            digest = %finalization.proposal.payload,
-            "certificate failed verification against the network identity",
-        );
-
+    async fn hint_current_epoch_boundary(&self) {
         // A failed built-in identity may mean it has rotated. Ask marshal for
         // the local epoch boundary, which contains the next scheme. Do not take
         // the height from the certificate because an unauthenticated peer could
@@ -374,8 +337,6 @@ where
             "hinting current epoch boundary after the network identity fallback failed",
         );
         self.config.marshal.hint_finalized(boundary_height).await;
-
-        Verdict::NeedsScheme
     }
 
     #[instrument(skip_all)]

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -1,8 +1,8 @@
 use alloy_consensus::BlockHeader as _;
 use commonware_consensus::{
-    Heightable as _, marshal,
+    Epochable as _, Heightable as _, marshal,
     simplex::types::Activity,
-    types::{Epoch, Epocher as _, Height},
+    types::{Epoch, Epocher as _, Height, Round},
 };
 use commonware_runtime::{Clock, ContextCell, Spawner, spawn_cell};
 use commonware_utils::Acknowledgement as _;
@@ -12,20 +12,36 @@ use tempo_node::rpc::consensus::{CertifiedBlock, Event};
 use tokio::{select, sync::mpsc};
 use tracing::{debug, instrument, warn};
 
-use super::{Config, ExecutionProvider, Mailbox, Marshal, ingress::Message};
+use super::{
+    Config, ExecutionProvider, Executor, FollowerProgress, Mailbox, Marshal, ingress::Message,
+};
 use crate::{
-    consensus::Block,
-    finalization_verifier::{Error as VerificationError, FinalizationVerifier},
+    consensus::{Block, Digest},
+    finalization_verifier::{
+        CertificateVerificationError, Error as VerificationError, FinalizationVerifier,
+    },
+    gossip::{Certificate, Outcome},
 };
 
-pub(super) fn try_init<TContext, P, M>(
+/// Outcome of checking a certificate's signature.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Verdict {
+    Verified,
+    /// Failed with an available scheme, so the sender is responsible.
+    Invalid,
+    /// No available scheme can verify it.
+    NeedsScheme,
+}
+
+pub(super) fn try_init<TContext, P, M, E>(
     context: TContext,
-    config: Config<P, M>,
-) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
+    config: Config<P, M, E>,
+) -> eyre::Result<super::Initialized<TContext, P, M, E>>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    E: Executor + 'static,
 {
     let (tx, rx) = mpsc::unbounded_channel();
     let mailbox = Mailbox(tx);
@@ -79,6 +95,7 @@ where
 
     let current_epoch = onchain_outcome.epoch;
 
+    let progress = FollowerProgress::new();
     let actor = Driver {
         context: ContextCell::new(context),
         config,
@@ -86,24 +103,27 @@ where
         startup_execution_boundary,
         current_epoch,
         verifier,
+        progress: progress.clone(),
     };
-    Ok((actor, mailbox))
+    Ok((actor, mailbox, progress))
 }
 
-pub(crate) struct Driver<TContext, P, M> {
+pub(crate) struct Driver<TContext, P, M, E = crate::follow::executor::Mailbox> {
     context: ContextCell<TContext>,
-    config: Config<P, M>,
+    config: Config<P, M, E>,
     mailbox: mpsc::UnboundedReceiver<Message>,
     startup_execution_boundary: Height,
     current_epoch: Epoch,
     verifier: FinalizationVerifier,
+    progress: FollowerProgress,
 }
 
-impl<C, P, M> Driver<C, P, M>
+impl<C, P, M, E> Driver<C, P, M, E>
 where
     C: Clock + Rng + CryptoRng + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    E: Executor + 'static,
 {
     pub(crate) fn start(mut self) -> commonware_runtime::Handle<()> {
         spawn_cell!(self.context, self.run())
@@ -133,6 +153,10 @@ where
                         }
                         Message::Finalized(update) => {
                             self.process_update(update).await;
+                        }
+                        Message::Certificate { certificate, response } => {
+                            let result = self.verify_and_apply(*certificate).await;
+                            let _ = response.send(result);
                         }
                     }
                 }
@@ -212,7 +236,7 @@ where
             .decode_and_verify(&mut self.context, &certified)
         {
             Ok(finalization) => finalization,
-            Err(error @ VerificationError::VerificationFailed) => {
+            Err(error @ VerificationError::NetworkIdentityMismatch) => {
                 debug!(%error, "failed to verify finalization certificate");
 
                 // This network may have rotated identity, so hint the boundary of
@@ -234,23 +258,136 @@ where
 
                 return Ok(());
             }
+            Err(VerificationError::VerificationFailed) => return Ok(()),
             Err(error) => return Err(Report::new(error)),
         };
 
         let consensus_block = Block::from_execution_block_unchecked(certified.block, None);
 
         let round = finalization.round();
-        let activity = Activity::Finalization(finalization);
+        let digest = consensus_block.digest();
 
+        // Always give the block to marshal, even if the round is stale. An RPC
+        // event includes the block, and storing it may close a gap.
         let _ = self.config.marshal.certified(round, consensus_block).await;
-        self.config.marshal.report(activity).await;
+        self.report_verified(round, digest, finalization).await;
+
         Ok(())
+    }
+
+    /// Verifies a gossiped certificate and applies it if valid.
+    ///
+    /// A certificate contains a block hash but no block. Applying it sends the
+    /// finalization to marshal so the resolver can fetch the block. It also
+    /// points the execution layer at the same hash.
+    #[instrument(skip_all, fields(round = %certificate.round(), digest = %certificate.proposal.payload))]
+    async fn verify_and_apply(&mut self, certificate: Certificate) -> Outcome {
+        self.judge(certificate).await
+    }
+
+    async fn judge(&mut self, certificate: Certificate) -> Outcome {
+        if certificate.round() <= self.progress.watermark() {
+            return Outcome::Stale;
+        }
+
+        match self.verify(&certificate).await {
+            Verdict::Verified => {}
+            Verdict::Invalid => return Outcome::Invalid,
+            Verdict::NeedsScheme => {
+                return Outcome::NeedsScheme {
+                    epoch: certificate.epoch(),
+                };
+            }
+        }
+
+        let round = certificate.round();
+        let digest = certificate.proposal.payload;
+        self.report_verified(round, digest, certificate).await;
+
+        Outcome::Admitted
+    }
+
+    /// Hands a verified finalization to the rest of the follower.
+    ///
+    /// # Invariant
+    ///
+    /// The caller must verify the signature first. Marshal creates an archive
+    /// for the certificate's epoch and stops the node if that fails. Reporting
+    /// an unchecked certificate would let an unauthenticated peer create
+    /// unlimited state or stop the node by naming any epoch. Verification and
+    /// reporting stay in one call chain so this rule is easy to check.
+    async fn report_verified(&mut self, round: Round, digest: Digest, finalization: Certificate) {
+        self.progress.advance(round);
+        self.config
+            .marshal
+            .report(Activity::Finalization(finalization))
+            .await;
+        self.config.executor.finalization(round, digest);
+    }
+
+    /// Selects the verifier for a certificate's epoch and checks the signature.
+    ///
+    /// A failure with a registered scheme is invalid and can be blamed on the
+    /// peer. A failure with the built-in network identity may mean the identity
+    /// has rotated. Do not blame the peer in that case. Doing so could disconnect
+    /// honest relayers while gossip is needed for recovery.
+    async fn verify(&mut self, finalization: &Certificate) -> Verdict {
+        match self
+            .verifier
+            .verify_certificate(&mut self.context, finalization)
+        {
+            Ok(()) => return Verdict::Verified,
+            Err(CertificateVerificationError::Invalid) => {
+                let epoch = finalization.epoch();
+                debug!(
+                    %epoch,
+                    digest = %finalization.proposal.payload,
+                    "certificate failed verification against a registered scheme",
+                );
+                return Verdict::Invalid;
+            }
+            Err(CertificateVerificationError::IdentityUnavailable { .. }) => {
+                return Verdict::NeedsScheme;
+            }
+            Err(CertificateVerificationError::NetworkIdentityMismatch) => {}
+        }
+
+        debug!(
+            epoch = %finalization.epoch(),
+            digest = %finalization.proposal.payload,
+            "certificate failed verification against the network identity",
+        );
+
+        // A failed built-in identity may mean it has rotated. Ask marshal for
+        // the local epoch boundary, which contains the next scheme. Do not take
+        // the height from the certificate because an unauthenticated peer could
+        // make the node fetch any height.
+        let boundary_height = self
+            .config
+            .epoch_strategy
+            .last(self.current_epoch)
+            .expect("strategy is valid for all heights and epochs");
+
+        debug!(
+            current_epoch = %self.current_epoch,
+            %boundary_height,
+            "hinting current epoch boundary after the network identity fallback failed",
+        );
+        self.config.marshal.hint_finalized(boundary_height).await;
+
+        Verdict::NeedsScheme
     }
 
     #[instrument(skip_all)]
     async fn process_update(&mut self, update: marshal::Update<Block>) {
-        let marshal::Update::Block(block, ack) = update else {
-            return;
+        // Marshal sends its startup tip and each finalization it stores. These
+        // durable tips provide the initial watermark and later progress.
+        let (block, ack) = match update {
+            marshal::Update::Tip(round, _, _) => {
+                self.progress.advance(round);
+                return;
+            }
+            marshal::Update::Block(block, ack) => (block, ack),
         };
 
         let epoch_info = self
@@ -279,8 +416,13 @@ where
             }
 
             self.current_epoch = self.current_epoch.max(onchain_outcome.epoch);
+
+            self.progress.scheme_installed(onchain_outcome.epoch);
         }
 
+        // Always acknowledge last. Marshal waits for every consumer before it
+        // sends the next update. Dropping the acknowledgement means shutdown,
+        // so an early return would stop block delivery.
         ack.acknowledge();
     }
 }

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -228,7 +228,7 @@ where
             Ok(finalization) => finalization,
             Err(
                 error @ VerificationError::CertificateVerification(
-                    CertificateVerificationError::NetworkIdentityMismatch,
+                    CertificateVerificationError::FallbackVerificationFailed,
                 ),
             ) => {
                 debug!(%error, "failed to verify finalization certificate");
@@ -281,11 +281,11 @@ where
                     epoch: certificate.epoch(),
                 };
             }
-            Err(CertificateVerificationError::NetworkIdentityMismatch) => {
+            Err(CertificateVerificationError::FallbackVerificationFailed) => {
                 debug!(
                     epoch = %certificate.epoch(),
                     digest = %certificate.proposal.payload,
-                    "certificate failed verification against the network identity",
+                    "certificate failed verification against the network identity fallback",
                 );
                 self.hint_current_epoch_boundary().await;
                 return Outcome::NeedsScheme {
@@ -378,7 +378,8 @@ where
 
             self.current_epoch = self.current_epoch.max(onchain_outcome.epoch);
 
-            self.progress.scheme_installed(onchain_outcome.epoch);
+            self.progress
+                .boundary_scheme_installed(onchain_outcome.epoch);
         }
 
         // Always acknowledge last. Marshal waits for every consumer before it

--- a/crates/consensus/src/follow/driver/ingress.rs
+++ b/crates/consensus/src/follow/driver/ingress.rs
@@ -1,14 +1,26 @@
 use commonware_actor::Feedback;
 use commonware_consensus::{Reporter, marshal};
 use tempo_node::rpc::consensus::Event;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
-use crate::consensus::Block;
+use crate::{
+    consensus::Block,
+    gossip::{CertSink, Certificate, Outcome},
+};
 
 #[derive(Debug)]
 pub(super) enum Message {
     Event(Box<Event>),
     Finalized(marshal::Update<Block>),
+    /// A `tempo/1` certificate waiting for verification.
+    #[allow(
+        dead_code,
+        reason = "constructed by the gossip actor in a following commit"
+    )]
+    Certificate {
+        certificate: Box<Certificate>,
+        response: oneshot::Sender<Outcome>,
+    },
 }
 
 impl From<Event> for Message {
@@ -20,6 +32,20 @@ impl From<Event> for Message {
 impl From<marshal::Update<Block>> for Message {
     fn from(value: marshal::Update<Block>) -> Self {
         Self::Finalized(value)
+    }
+}
+
+/// Routes certificates to the driver because it owns the epoch schemes.
+impl CertSink for Mailbox {
+    fn verify_and_apply(&self, certificate: Certificate) -> oneshot::Receiver<Outcome> {
+        let (response, receiver) = oneshot::channel();
+        // If the driver has stopped, the response sender is dropped and the
+        // caller receives an error.
+        let _ = self.0.send(Message::Certificate {
+            certificate: Box::new(certificate),
+            response,
+        });
+        receiver
     }
 }
 

--- a/crates/consensus/src/follow/driver/mod.rs
+++ b/crates/consensus/src/follow/driver/mod.rs
@@ -1,7 +1,8 @@
 //! Follower finalization driver.
 //!
-//! Validates finalized blocks received from upstream and reports them to marshal.
-//! Marshal's finalized tip updates independently drive the consensus feed.
+//! Validates finalized blocks received from upstream and certificates received
+//! through gossip, then reports verified finalizations to marshal. Marshal's
+//! finalized-tip updates independently drive the consensus feed.
 
 use std::future::Future;
 
@@ -32,16 +33,18 @@ use crate::{
 
 mod actor;
 mod ingress;
+mod progress;
 
 #[cfg(test)]
 mod test;
 
 pub(super) use actor::Driver;
 pub(super) use ingress::Mailbox;
+pub(crate) use progress::FollowerProgress;
 
 type ConsensusActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 
-pub(super) struct Config<P, M> {
+pub(super) struct Config<P, M, E = crate::follow::executor::Mailbox> {
     pub(super) execution_provider: P,
     pub(super) scheme_provider: SchemeProvider,
     pub(super) network_identity: NetworkIdentity,
@@ -49,18 +52,27 @@ pub(super) struct Config<P, M> {
     pub(super) last_finalized_height: Height,
 
     pub(super) marshal: M,
+    pub(super) executor: E,
 
     pub(super) epoch_strategy: FixedEpocher,
 }
 
-pub(super) fn try_init<TContext, P, M>(
+/// A driver, its mailbox, and a read-only progress handle.
+///
+/// The driver owns the progress because it is the only writer. Other components
+/// receive a clone that they can read.
+pub(super) type Initialized<TContext, P, M, E> =
+    (Driver<TContext, P, M, E>, Mailbox, FollowerProgress);
+
+pub(super) fn try_init<TContext, P, M, E>(
     context: TContext,
-    config: Config<P, M>,
-) -> eyre::Result<(Driver<TContext, P, M>, Mailbox)>
+    config: Config<P, M, E>,
+) -> eyre::Result<Initialized<TContext, P, M, E>>
 where
     TContext: Clock + Spawner,
     P: ExecutionProvider + 'static,
     M: Marshal + 'static,
+    E: Executor + 'static,
 {
     actor::try_init(context, config)
 }
@@ -69,6 +81,12 @@ where
 pub(super) trait ExecutionProvider: Send + Sync {
     fn finalized_block_number(&self) -> eyre::Result<u64>;
     fn finalized_header_by_number(&self, number: u64) -> eyre::Result<Option<TempoHeader>>;
+}
+
+/// Execution updates requested by the follower driver.
+pub(super) trait Executor: Send + Sync {
+    /// Uses a certificate's block as the forkchoice target.
+    fn finalization(&self, round: Round, digest: Digest);
 }
 
 /// Marshal operations used by the follower driver.
@@ -90,6 +108,12 @@ where
 
     fn finalized_header_by_number(&self, number: u64) -> eyre::Result<Option<TempoHeader>> {
         HeaderProvider::header_by_number(self, number).map_err(eyre::Report::new)
+    }
+}
+
+impl Executor for crate::follow::executor::Mailbox {
+    fn finalization(&self, round: Round, digest: Digest) {
+        Self::finalization(self, round, digest);
     }
 }
 

--- a/crates/consensus/src/follow/driver/progress.rs
+++ b/crates/consensus/src/follow/driver/progress.rs
@@ -1,0 +1,60 @@
+//! Progress the follower driver publishes.
+
+use commonware_consensus::types::{Epoch, Round};
+use parking_lot::RwLock;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Progress the follower driver publishes for anything that follows it.
+///
+/// The driver is the only writer because it is the only component that applies
+/// certificates. Other components receive clones that they can read.
+///
+/// The watermark is shared state because readers only need its latest value. A
+/// scheme installation is an event that must reach components holding
+/// certificates for that epoch, so it is broadcast.
+#[derive(Clone, Debug)]
+pub(crate) struct FollowerProgress {
+    watermark: Arc<RwLock<Round>>,
+    schemes: broadcast::Sender<Epoch>,
+}
+
+/// Schemes change only at epoch boundaries. This queue only needs to hold the
+/// schemes installed together during startup.
+const SCHEME_BACKLOG: usize = 8;
+
+impl FollowerProgress {
+    pub(crate) fn new() -> Self {
+        let (schemes, _) = broadcast::channel(SCHEME_BACKLOG);
+        Self {
+            watermark: Arc::new(RwLock::new(Round::zero())),
+            schemes,
+        }
+    }
+
+    /// Highest round the driver has applied.
+    pub(crate) fn watermark(&self) -> Round {
+        *self.watermark.read()
+    }
+
+    /// Records a round without allowing the watermark to move backward.
+    pub(crate) fn advance(&self, round: Round) {
+        let mut watermark = self.watermark.write();
+        *watermark = (*watermark).max(round);
+    }
+
+    /// Reports that a scheme is now available for its epoch.
+    pub(crate) fn scheme_installed(&self, epoch: Epoch) {
+        // The scheme is already installed; this notification only wakes gossip
+        // retries. Ignore the error because gossip may be disabled with no receivers.
+        let _ = self.schemes.send(epoch);
+    }
+
+    #[allow(
+        dead_code,
+        reason = "consumed by the gossip actor in a following commit"
+    )]
+    pub(crate) fn schemes(&self) -> broadcast::Receiver<Epoch> {
+        self.schemes.subscribe()
+    }
+}

--- a/crates/consensus/src/follow/driver/progress.rs
+++ b/crates/consensus/src/follow/driver/progress.rs
@@ -11,12 +11,12 @@ use tokio::sync::broadcast;
 /// certificates. Other components receive clones that they can read.
 ///
 /// The watermark is shared state because readers only need its latest value. A
-/// scheme installation is an event that must reach components holding
-/// certificates for that epoch, so it is broadcast.
+/// scheme learned from an authenticated boundary is an event that must reach
+/// components holding certificates for that epoch, so it is broadcast.
 #[derive(Clone, Debug)]
 pub(crate) struct FollowerProgress {
     watermark: Arc<RwLock<Round>>,
-    schemes: broadcast::Sender<Epoch>,
+    boundary_schemes: broadcast::Sender<Epoch>,
 }
 
 /// Schemes change only at epoch boundaries. This queue only needs to hold the
@@ -25,10 +25,10 @@ const SCHEME_BACKLOG: usize = 8;
 
 impl FollowerProgress {
     pub(crate) fn new() -> Self {
-        let (schemes, _) = broadcast::channel(SCHEME_BACKLOG);
+        let (boundary_schemes, _) = broadcast::channel(SCHEME_BACKLOG);
         Self {
             watermark: Arc::new(RwLock::new(Round::zero())),
-            schemes,
+            boundary_schemes,
         }
     }
 
@@ -43,18 +43,18 @@ impl FollowerProgress {
         *watermark = (*watermark).max(round);
     }
 
-    /// Reports that a scheme is now available for its epoch.
-    pub(crate) fn scheme_installed(&self, epoch: Epoch) {
+    /// Reports that an authenticated boundary installed a scheme for its epoch.
+    pub(crate) fn boundary_scheme_installed(&self, epoch: Epoch) {
         // The scheme is already installed; this notification only wakes gossip
         // retries. Ignore the error because gossip may be disabled with no receivers.
-        let _ = self.schemes.send(epoch);
+        let _ = self.boundary_schemes.send(epoch);
     }
 
     #[allow(
         dead_code,
         reason = "consumed by the gossip actor in a following commit"
     )]
-    pub(crate) fn schemes(&self) -> broadcast::Receiver<Epoch> {
-        self.schemes.subscribe()
+    pub(crate) fn boundary_schemes(&self) -> broadcast::Receiver<Epoch> {
+        self.boundary_schemes.subscribe()
     }
 }

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -277,6 +277,7 @@ fn gossiped_certificate_is_admitted_and_nudges_the_execution_layer() {
         )
         .expect("driver should initialize");
 
+        let mut boundary_schemes = progress.boundary_schemes();
         actor.start();
 
         let block = make_block(EPOCH_LENGTH.get() * 2 + 1, None);
@@ -301,6 +302,13 @@ fn gossiped_certificate_is_admitted_and_nudges_the_execution_layer() {
         assert!(
             schemes.scoped(network_fixture.outcome.epoch).is_some(),
             "marshal needs the successful fallback to re-verify the resolved block",
+        );
+        assert!(
+            matches!(
+                boundary_schemes.try_recv(),
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+            ),
+            "caching a successful fallback is not authenticated boundary progress",
         );
         assert_eq!(
             progress.watermark(),
@@ -474,10 +482,10 @@ fn gossiped_certificate_failing_registered_scheme_is_invalid() {
 /// need this scheme cannot be retried until the driver announces it. Polling
 /// cannot discover the new scheme.
 #[test_traced]
-fn installing_a_scheme_is_announced() {
+fn installing_a_boundary_scheme_is_announced() {
     deterministic::Runner::default().start(|mut context| async move {
         let rig = start_rig(&mut context);
-        let mut schemes = rig.progress.schemes();
+        let mut schemes = rig.progress.boundary_schemes();
         let next = dkg_fixture(&mut context, Epoch::new(1));
         let boundary = FixedEpocher::new(EPOCH_LENGTH)
             .last(Epoch::zero())
@@ -511,6 +519,10 @@ fn unverifiable_gossiped_certificate_is_not_blamed_on_the_sender() {
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
         let executor = StubExecutor::default();
+        let strategy = FixedEpocher::new(EPOCH_LENGTH);
+        let expected_boundary = strategy
+            .last(Epoch::zero())
+            .expect("epoch zero has a boundary");
 
         let (actor, mailbox, progress) = try_init(
             context.child("driver"),
@@ -524,7 +536,7 @@ fn unverifiable_gossiped_certificate_is_not_blamed_on_the_sender() {
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
                 executor: executor.clone(),
-                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                epoch_strategy: strategy,
             },
         )
         .expect("driver should initialize");
@@ -551,6 +563,7 @@ fn unverifiable_gossiped_certificate_is_not_blamed_on_the_sender() {
             "nothing was applied, so nothing advanced",
         );
         assert_eq!(marshal.report_count(), 0);
+        assert_eq!(marshal.hints(), vec![expected_boundary]);
         assert!(executor.finalizations().is_empty());
     });
 }
@@ -793,6 +806,60 @@ fn scheme_before_network_identity_epoch_is_required() {
         assert!(marshal.certified().is_empty());
         assert_eq!(marshal.report_count(), 0);
         assert!(marshal.hints().is_empty());
+    });
+}
+
+#[test_traced]
+fn gossiped_certificate_without_a_usable_identity_needs_scheme() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let missing_fixture = dkg_fixture(&mut context, Epoch::new(1));
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+
+        let marshal = StubMarshal::default();
+        let executor = StubExecutor::default();
+        let (actor, mailbox, progress) = try_init(
+            context.child("driver"),
+            Config {
+                execution_provider: provider,
+                scheme_provider: SchemeProvider::new(),
+                network_identity: NetworkIdentity {
+                    from_epoch: missing_fixture.outcome.epoch.get() + 1,
+                    identity: *missing_fixture.outcome.network_identity(),
+                },
+                last_finalized_height: Height::zero(),
+                marshal: marshal.clone(),
+                executor: executor.clone(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+            },
+        )
+        .expect("driver should initialize");
+
+        actor.start();
+
+        let block = make_block(EPOCH_LENGTH.get() + 1, None);
+        let certificate = make_finalization(
+            &block,
+            missing_fixture.outcome.epoch,
+            &missing_fixture.schemes,
+        );
+        let result = mailbox
+            .verify_and_apply(certificate)
+            .await
+            .expect("driver should answer");
+
+        assert_eq!(
+            result,
+            Outcome::NeedsScheme {
+                epoch: missing_fixture.outcome.epoch,
+            }
+        );
+        assert_eq!(progress.watermark(), Round::zero());
+        assert_eq!(marshal.report_count(), 0);
+        assert!(marshal.hints().is_empty());
+        assert!(executor.finalizations().is_empty());
     });
 }
 

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -5,23 +5,23 @@ use std::time::Duration;
 use commonware_consensus::{
     Reporter as _,
     marshal::Update,
-    types::{Epoch, Epocher as _, FixedEpocher, Height},
+    types::{Epoch, Epocher as _, FixedEpocher, Height, Round},
 };
 use commonware_cryptography::certificate::Provider as _;
 use commonware_macros::test_traced;
-use commonware_parallel::Sequential;
 use commonware_runtime::{Clock as _, Runner as _, Supervisor as _, deterministic};
 use commonware_utils::{Acknowledgement as _, acknowledgement::Exact};
 use tempo_chainspec::NetworkIdentity;
 use tempo_node::rpc::consensus::Event;
 
-use super::{Config, try_init};
+use super::{Config, FollowerProgress, try_init};
 use crate::{
     epoch::SchemeProvider,
     follow::test_utils::{
-        EPOCH_LENGTH, StubExecutionProvider, StubMarshal, dkg_fixture, make_block,
-        make_certified_block, make_finalization,
+        DkgFixture, EPOCH_LENGTH, StubExecutionProvider, StubExecutor, StubMarshal, dkg_fixture,
+        make_block, make_certified_block, make_finalization,
     },
+    gossip::{CertSink as _, Outcome},
 };
 
 const WAIT_ATTEMPTS: usize = 100;
@@ -63,6 +63,7 @@ fn startup_uses_previous_execution_boundary() {
                 },
                 last_finalized_height: finalized_height,
                 marshal: StubMarshal::default(),
+                executor: StubExecutor::default(),
                 epoch_strategy: strategy,
             },
         );
@@ -91,6 +92,7 @@ fn startup_propagates_finalized_block_read_failure() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                executor: StubExecutor::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -117,6 +119,7 @@ fn startup_requires_execution_boundary_header() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                executor: StubExecutor::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         );
@@ -135,7 +138,10 @@ fn valid_finalization_is_certified_and_reported() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
-        let (actor, mailbox) = try_init(
+
+        let executor = StubExecutor::default();
+
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -146,6 +152,7 @@ fn valid_finalization_is_certified_and_reported() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -174,7 +181,7 @@ fn valid_finalization_is_certified_and_reported() {
 }
 
 #[test_traced]
-fn network_identity_registers_verified_fallback_for_floor_installation() {
+fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
     deterministic::Runner::default().start(|mut context| async move {
         let fixture = dkg_fixture(&mut context, Epoch::zero());
         let network_fixture = dkg_fixture(&mut context, Epoch::new(2));
@@ -182,8 +189,9 @@ fn network_identity_registers_verified_fallback_for_floor_installation() {
         let provider = StubExecutionProvider::default();
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
+        let executor = StubExecutor::default();
         let schemes = SchemeProvider::new();
-        let (actor, mailbox) = try_init(
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -194,6 +202,7 @@ fn network_identity_registers_verified_fallback_for_floor_installation() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -222,32 +231,277 @@ fn network_identity_registers_verified_fallback_for_floor_installation() {
 
         assert_eq!(marshal.report_count(), 1);
         assert!(marshal.hints().is_empty());
-        let scheme = schemes
-            .scheme(network_fixture.outcome.epoch)
-            .expect("verified network identity fallback should be retained");
+    });
+}
+
+/// A gossiped certificate has no block. The driver sends the certificate to
+/// marshal and its round and digest to execution so both can pursue the same
+/// block.
+#[test_traced]
+fn gossiped_certificate_is_admitted_and_nudges_the_execution_layer() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let network_fixture = dkg_fixture(&mut context, Epoch::new(2));
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+        let marshal = StubMarshal::default();
+        let executor = StubExecutor::default();
+        let schemes = SchemeProvider::new();
+
+        let (actor, mailbox, progress) = try_init(
+            context.child("driver"),
+            Config {
+                execution_provider: provider,
+                scheme_provider: schemes.clone(),
+                network_identity: NetworkIdentity {
+                    from_epoch: network_fixture.outcome.epoch.get(),
+                    identity: *network_fixture.outcome.network_identity(),
+                },
+                last_finalized_height: Height::zero(),
+                marshal: marshal.clone(),
+                executor: executor.clone(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+            },
+        )
+        .expect("driver should initialize");
+
+        actor.start();
+
+        let block = make_block(EPOCH_LENGTH.get() * 2 + 1, None);
+        let finalization = make_finalization(
+            &block,
+            network_fixture.outcome.epoch,
+            &network_fixture.schemes,
+        );
+        let round = finalization.round();
+        let digest = block.digest();
+
         assert!(
-            finalization.verify(&mut context, scheme.as_ref(), &Sequential),
-            "registered fallback should verify the certificate during floor installation",
+            schemes.scoped(network_fixture.outcome.epoch).is_none(),
+            "the certificate must require the network identity fallback",
+        );
+
+        let result = mailbox
+            .verify_and_apply(finalization)
+            .await
+            .expect("driver should answer");
+        assert_eq!(result, Outcome::Admitted);
+        assert!(
+            schemes.scoped(network_fixture.outcome.epoch).is_some(),
+            "marshal needs the successful fallback to re-verify the resolved block",
+        );
+        assert_eq!(
+            progress.watermark(),
+            round,
+            "applying the certificate advanced the shared progress",
+        );
+
+        // The driver reports only the certificate to marshal.
+        assert_eq!(marshal.report_count(), 1);
+        assert!(marshal.certified().is_empty());
+        assert_eq!(executor.finalizations(), vec![(round, digest)]);
+
+        // The first offer advanced the watermark, so the same round is now stale.
+        let repeat = make_finalization(
+            &make_block(EPOCH_LENGTH.get() * 2 + 1, None),
+            network_fixture.outcome.epoch,
+            &network_fixture.schemes,
+        );
+        let result = mailbox
+            .verify_and_apply(repeat)
+            .await
+            .expect("driver should answer");
+        assert_eq!(result, Outcome::Stale);
+        assert_eq!(marshal.report_count(), 1);
+    });
+}
+
+/// A running driver and the state inspected by certificate tests.
+///
+/// This is a utility for a group of tests found below.
+struct Rig {
+    mailbox: super::Mailbox,
+    marshal: StubMarshal,
+    progress: FollowerProgress,
+    fixture: DkgFixture,
+}
+
+fn start_rig(context: &mut deterministic::Context) -> Rig {
+    let fixture = dkg_fixture(context, Epoch::zero());
+    let startup_block = make_block(0, Some(&fixture.outcome));
+    let provider = StubExecutionProvider::default();
+    provider.add_header(&startup_block);
+
+    let marshal = StubMarshal::default();
+
+    let (actor, mailbox, progress) = try_init(
+        context.child("driver"),
+        Config {
+            execution_provider: provider,
+            scheme_provider: SchemeProvider::new(),
+            network_identity: NetworkIdentity {
+                from_epoch: 0,
+                identity: *fixture.outcome.network_identity(),
+            },
+            last_finalized_height: Height::zero(),
+            marshal: marshal.clone(),
+            executor: StubExecutor::default(),
+            epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+        },
+    )
+    .expect("driver should initialize");
+    actor.start();
+
+    Rig {
+        mailbox,
+        marshal,
+        progress,
+        fixture,
+    }
+}
+
+/// An admitted certificate raises the watermark. The gossip actor uses it to
+/// discard offers that the driver would reject as stale.
+#[test_traced]
+fn newer_certificate_advances_watermark() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let rig = start_rig(&mut context);
+
+        let first = make_block(1, None);
+        let first_certificate = make_finalization(&first, Epoch::zero(), &rig.fixture.schemes);
+        let result = rig
+            .mailbox
+            .verify_and_apply(first_certificate)
+            .await
+            .expect("driver should answer");
+        assert_eq!(result, Outcome::Admitted);
+        let first_watermark = rig.progress.watermark();
+
+        let second = make_block(2, None);
+        let second_certificate = make_finalization(&second, Epoch::zero(), &rig.fixture.schemes);
+        let result = rig
+            .mailbox
+            .verify_and_apply(second_certificate)
+            .await
+            .expect("driver should answer");
+
+        assert_eq!(result, Outcome::Admitted);
+        assert!(
+            rig.progress.watermark() > first_watermark,
+            "a strictly newer certificate moves the watermark",
         );
     });
 }
 
+/// An upstream finalization can advance the driver without gossip. Its round
+/// must update the shared watermark so gossip can discard stale offers.
 #[test_traced]
-fn invalid_finalization_hints_current_epoch_boundary() {
+fn upstream_event_advances_watermark() {
     deterministic::Runner::default().start(|mut context| async move {
-        let fixture = dkg_fixture(&mut context, Epoch::zero());
-        let wrong_fixture = dkg_fixture(&mut context, Epoch::zero());
-        let startup_block = make_block(0, Some(&fixture.outcome));
-        let provider = StubExecutionProvider::default();
-        provider.add_header(&startup_block);
+        let rig = start_rig(&mut context);
 
-        let marshal = StubMarshal::default();
-        let strategy = FixedEpocher::new(EPOCH_LENGTH);
-        let expected_boundary = strategy
+        let block = make_block(1, None);
+        let certificate = make_finalization(&block, Epoch::zero(), &rig.fixture.schemes);
+        let round = certificate.round();
+
+        let _ = rig.mailbox.to_event_reporter().report(Event::Finalized {
+            block: make_certified_block(block, &certificate),
+            seen: 0,
+        });
+        wait_until(&context, || rig.progress.watermark() == round).await;
+
+        assert_eq!(rig.marshal.certified().len(), 1);
+        assert_eq!(rig.progress.watermark(), round);
+    });
+}
+
+/// Marshal reports a tip only after it stores the block. This report must also
+/// advance the shared watermark.
+#[test_traced]
+fn marshal_tip_advances_watermark() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let rig = start_rig(&mut context);
+
+        let block = make_block(1, None);
+        let digest = block.digest();
+        let certificate = make_finalization(&block, Epoch::zero(), &rig.fixture.schemes);
+        let round = certificate.proposal.round;
+
+        let _ =
+            rig.mailbox
+                .to_marshal_reporter()
+                .report(Update::Tip(round, Height::new(1), digest));
+        wait_until(&context, || rig.progress.watermark() == round).await;
+        assert_eq!(rig.progress.watermark(), round);
+    });
+}
+
+/// A gossiped certificate that fails an installed scheme is invalid. It must
+/// not advance progress or make marshal resolve its block.
+#[test_traced]
+fn gossiped_certificate_failing_registered_scheme_is_invalid() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let rig = start_rig(&mut context);
+        let wrong_fixture = dkg_fixture(&mut context, Epoch::zero());
+        let block = make_block(1, None);
+        let certificate = make_finalization(&block, Epoch::zero(), &wrong_fixture.schemes);
+
+        let result = rig
+            .mailbox
+            .verify_and_apply(certificate)
+            .await
+            .expect("driver should answer");
+
+        assert_eq!(result, Outcome::Invalid);
+        assert_eq!(rig.progress.watermark(), Round::zero());
+        assert_eq!(rig.marshal.report_count(), 0);
+    });
+}
+
+/// A boundary block provides the scheme for the next epoch. Certificates that
+/// need this scheme cannot be retried until the driver announces it. Polling
+/// cannot discover the new scheme.
+#[test_traced]
+fn installing_a_scheme_is_announced() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let rig = start_rig(&mut context);
+        let mut schemes = rig.progress.schemes();
+        let next = dkg_fixture(&mut context, Epoch::new(1));
+        let boundary = FixedEpocher::new(EPOCH_LENGTH)
             .last(Epoch::zero())
             .expect("epoch zero has a boundary");
 
-        let (actor, mailbox) = try_init(
+        let block = make_block(boundary.get(), Some(&next.outcome));
+        let (ack, waiter) = Exact::handle();
+        let _ = rig
+            .mailbox
+            .to_marshal_reporter()
+            .report(Update::Block(block.into(), ack));
+        waiter.await.expect("the update should be acknowledged");
+
+        assert_eq!(
+            schemes.try_recv().expect("a scheme was announced"),
+            Epoch::new(1),
+        );
+    });
+}
+
+/// A missing scheme may mean the network identity changed. Honest peers can send
+/// such certificates. Penalizing them could disconnect the node while gossip is
+/// its only way to catch up.
+#[test_traced]
+fn unverifiable_gossiped_certificate_is_not_blamed_on_the_sender() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let rotated = dkg_fixture(&mut context, Epoch::new(1));
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+        let marshal = StubMarshal::default();
+        let executor = StubExecutor::default();
+
+        let (actor, mailbox, progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -258,6 +512,65 @@ fn invalid_finalization_hints_current_epoch_boundary() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                executor: executor.clone(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+            },
+        )
+        .expect("driver should initialize");
+
+        actor.start();
+
+        // This certificate uses a key we do not have for an epoch with no scheme.
+        let block = make_block(EPOCH_LENGTH.get() + 1, None);
+        let finalization = make_finalization(&block, Epoch::new(1), &rotated.schemes);
+
+        let result = mailbox
+            .verify_and_apply(finalization)
+            .await
+            .expect("driver should answer");
+        assert_eq!(
+            result,
+            Outcome::NeedsScheme {
+                epoch: Epoch::new(1)
+            }
+        );
+        assert_eq!(
+            progress.watermark(),
+            Round::zero(),
+            "nothing was applied, so nothing advanced",
+        );
+        assert_eq!(marshal.report_count(), 0);
+        assert!(executor.finalizations().is_empty());
+    });
+}
+
+/// An upstream finalization that fails an installed scheme is dropped. It must
+/// not hint for another scheme or update marshal or execution.
+#[test_traced]
+fn upstream_finalization_failing_registered_scheme_is_dropped_without_hint() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let wrong_fixture = dkg_fixture(&mut context, Epoch::zero());
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+
+        let marshal = StubMarshal::default();
+        let executor = StubExecutor::default();
+        let strategy = FixedEpocher::new(EPOCH_LENGTH);
+
+        let (actor, mailbox, _progress) = try_init(
+            context.child("driver"),
+            Config {
+                execution_provider: provider,
+                scheme_provider: SchemeProvider::new(),
+                network_identity: NetworkIdentity {
+                    from_epoch: 0,
+                    identity: *fixture.outcome.network_identity(),
+                },
+                last_finalized_height: Height::zero(),
+                marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: strategy,
             },
         )
@@ -265,8 +578,77 @@ fn invalid_finalization_hints_current_epoch_boundary() {
 
         actor.start();
 
+        // Startup installed the epoch-zero scheme, so the driver does not use
+        // the network identity fallback.
         let block = make_block(1, None);
         let finalization = make_finalization(&block, Epoch::zero(), &wrong_fixture.schemes);
+        let certified = make_certified_block(block, &finalization);
+        let _ = mailbox.to_event_reporter().report(Event::Finalized {
+            block: certified,
+            seen: 0,
+        });
+
+        // This update is queued after the invalid event, so its acknowledgement
+        // proves that the event was handled.
+        let (ack, processed) = Exact::handle();
+        let _ = mailbox
+            .to_marshal_reporter()
+            .report(Update::Block(make_block(2, None).into(), ack));
+        processed
+            .await
+            .expect("the marker update should be acknowledged");
+
+        assert!(marshal.hints().is_empty());
+        assert!(marshal.certified().is_empty());
+        assert_eq!(marshal.report_count(), 0);
+        assert!(executor.finalizations().is_empty());
+    });
+}
+
+/// Failure against the built-in network identity may mean the identity changed.
+/// The driver requests the local epoch boundary so gap repair can fetch the
+/// block that contains the next scheme.
+#[test_traced]
+fn finalization_failing_the_identity_fallback_hints_current_epoch_boundary() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let wrong_fixture = dkg_fixture(&mut context, Epoch::new(1));
+        let startup_block = make_block(0, Some(&fixture.outcome));
+        let provider = StubExecutionProvider::default();
+        provider.add_header(&startup_block);
+
+        let marshal = StubMarshal::default();
+
+        let executor = StubExecutor::default();
+
+        let strategy = FixedEpocher::new(EPOCH_LENGTH);
+        let expected_boundary = strategy
+            .last(Epoch::zero())
+            .expect("epoch zero has a boundary");
+
+        let (actor, mailbox, _progress) = try_init(
+            context.child("driver"),
+            Config {
+                execution_provider: provider,
+                scheme_provider: SchemeProvider::new(),
+                network_identity: NetworkIdentity {
+                    from_epoch: 0,
+                    identity: *fixture.outcome.network_identity(),
+                },
+                last_finalized_height: Height::zero(),
+                marshal: marshal.clone(),
+                executor: executor.clone(),
+                epoch_strategy: strategy,
+            },
+        )
+        .expect("driver should initialize");
+
+        actor.start();
+
+        // Epoch one has no installed scheme, so verification uses the network
+        // identity. A different key models an identity change.
+        let block = make_block(EPOCH_LENGTH.get(), None);
+        let finalization = make_finalization(&block, Epoch::new(1), &wrong_fixture.schemes);
         let certified = make_certified_block(block, &finalization);
         let event = Event::Finalized {
             block: certified,
@@ -280,6 +662,7 @@ fn invalid_finalization_hints_current_epoch_boundary() {
         assert_eq!(marshal.hints(), vec![expected_boundary]);
         assert!(marshal.certified().is_empty());
         assert_eq!(marshal.report_count(), 0);
+        assert!(executor.finalizations().is_empty());
     });
 }
 
@@ -292,7 +675,8 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
 
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
-        let (actor, mailbox) = try_init(
+        let executor = StubExecutor::default();
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -303,6 +687,7 @@ fn mismatched_finalization_digest_is_dropped_without_stopping_driver() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -353,8 +738,11 @@ fn scheme_before_network_identity_epoch_is_required() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
+
+        let executor = StubExecutor::default();
+
         let schemes = SchemeProvider::new();
-        let (actor, mailbox) = try_init(
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -365,6 +753,7 @@ fn scheme_before_network_identity_epoch_is_required() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -411,7 +800,7 @@ fn boundary_update_registers_scheme_before_acknowledging() {
             .last(Epoch::zero())
             .expect("epoch zero has a boundary");
 
-        let (actor, mailbox) = try_init(
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -422,6 +811,7 @@ fn boundary_update_registers_scheme_before_acknowledging() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                executor: StubExecutor::default(),
                 epoch_strategy: strategy,
             },
         )
@@ -450,7 +840,7 @@ fn non_boundary_update_is_acknowledged_without_registering_a_scheme() {
         let provider = StubExecutionProvider::default();
         provider.add_header(&startup_block);
         let schemes = SchemeProvider::new();
-        let (actor, mailbox) = try_init(
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -461,6 +851,7 @@ fn non_boundary_update_is_acknowledged_without_registering_a_scheme() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: StubMarshal::default(),
+                executor: StubExecutor::default(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )
@@ -488,6 +879,9 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
         provider.add_header(&startup_block);
 
         let marshal = StubMarshal::default();
+
+        let executor = StubExecutor::default();
+
         let strategy = FixedEpocher::new(EPOCH_LENGTH);
         let last_finalized_height = Height::new(EPOCH_LENGTH.get() * 3);
         let current_epoch = strategy
@@ -503,7 +897,7 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
         marshal.add_block(make_block(boundary.get(), Some(&recovered_fixture.outcome)));
 
         let schemes = SchemeProvider::new();
-        let (actor, _mailbox) = try_init(
+        let (actor, _mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -514,6 +908,7 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
                 },
                 last_finalized_height,
                 marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: strategy,
             },
         )
@@ -537,7 +932,8 @@ fn non_finalized_events_are_ignored() {
         let provider = StubExecutionProvider::default();
         provider.add_header(&startup_block);
         let marshal = StubMarshal::default();
-        let (actor, mailbox) = try_init(
+        let executor = StubExecutor::default();
+        let (actor, mailbox, _progress) = try_init(
             context.child("driver"),
             Config {
                 execution_provider: provider,
@@ -548,6 +944,7 @@ fn non_finalized_events_are_ignored() {
                 },
                 last_finalized_height: Height::zero(),
                 marshal: marshal.clone(),
+                executor: executor.clone(),
                 epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
             },
         )

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -170,13 +170,24 @@ fn valid_finalization_is_certified_and_reported() {
 
         let mut reporter = mailbox.to_event_reporter();
         assert!(reporter.report(event).accepted());
-        wait_until(&context, || marshal.certified().len() == 1).await;
+
+        let (ack, processed) = Exact::handle();
+        let _ = mailbox
+            .to_marshal_reporter()
+            .report(Update::Block(make_block(2, None).into(), ack));
+        processed
+            .await
+            .expect("the marker update should be acknowledged");
 
         let certified = marshal.certified();
         assert_eq!(certified[0].0, finalization.proposal.round);
         assert_eq!(certified[0].1, block);
         assert_eq!(marshal.report_count(), 1);
         assert!(marshal.hints().is_empty());
+        assert!(
+            executor.finalizations().is_empty(),
+            "marshal's durable tip drives execution for upstream finalizations",
+        );
     });
 }
 

--- a/crates/consensus/src/follow/engine.rs
+++ b/crates/consensus/src/follow/engine.rs
@@ -170,7 +170,7 @@ impl<TUpstream> Config<TUpstream> {
         // No broadcast is needed in follow mode.
         let broadcast = stubs::null_broadcast(context.child("broadcast"), self.mailbox_size);
 
-        let (driver, driver_mailbox) = driver::try_init(
+        let (driver, driver_mailbox, _progress) = driver::try_init(
             context.child("driver"),
             driver::Config {
                 execution_provider: self.execution_node.provider.clone(),
@@ -178,6 +178,7 @@ impl<TUpstream> Config<TUpstream> {
                 network_identity: self.network_identity,
                 last_finalized_height,
                 marshal: marshal_mailbox,
+                executor: executor_mailbox.clone(),
                 epoch_strategy: epoch_strategy.clone(),
             },
         )

--- a/crates/consensus/src/follow/executor/ingress.rs
+++ b/crates/consensus/src/follow/executor/ingress.rs
@@ -22,10 +22,6 @@ impl Mailbox {
         Self { sender }
     }
 
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "used by the driver in a later stack commit")
-    )]
     pub(crate) fn finalization(&self, round: Round, digest: Digest) {
         let _ = self.send(Message::Finalization { round, digest });
     }

--- a/crates/consensus/src/follow/test_utils.rs
+++ b/crates/consensus/src/follow/test_utils.rs
@@ -27,13 +27,31 @@ use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_node::rpc::consensus::CertifiedBlock;
 use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
 
-use super::driver::{ExecutionProvider, Marshal};
+use super::driver::{ExecutionProvider, Executor, Marshal};
 use crate::{
     consensus::{Block, Digest},
     test_utils::make_certificate,
 };
 
-pub(crate) use crate::test_utils::dkg_fixture;
+pub(crate) use crate::test_utils::{DkgFixture, dkg_fixture};
+
+/// Records finalizations sent to execution.
+#[derive(Clone, Default)]
+pub(crate) struct StubExecutor {
+    finalizations: Arc<Mutex<Vec<(Round, Digest)>>>,
+}
+
+impl StubExecutor {
+    pub(crate) fn finalizations(&self) -> Vec<(Round, Digest)> {
+        self.finalizations.lock().clone()
+    }
+}
+
+impl Executor for StubExecutor {
+    fn finalization(&self, round: Round, digest: Digest) {
+        self.finalizations.lock().push((round, digest));
+    }
+}
 
 type ConsensusActivity = Activity<Scheme<PublicKey, MinSig>, Digest>;
 

--- a/crates/consensus/src/gossip/mod.rs
+++ b/crates/consensus/src/gossip/mod.rs
@@ -1,0 +1,57 @@
+//! Consensus-side half of the `tempo/1` subprotocol.
+//!
+//! The transport in `tempo-node` only moves bytes. Consensus decides what each
+//! frame means. This module defines the types shared by the transport-facing
+//! actor and follower driver. The driver owns the epoch schemes, so only the
+//! driver can verify a certificate.
+
+use commonware_consensus::{
+    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
+    types::Epoch,
+};
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use tokio::sync::oneshot;
+
+use crate::consensus::Digest;
+
+/// A finalization certificate as it travels over `tempo/1`.
+pub(crate) type Certificate = Finalization<Scheme<PublicKey, MinSig>, Digest>;
+
+/// Result of asking the driver to verify and apply a certificate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Outcome {
+    /// Verified and sent to marshal.
+    ///
+    /// Marshal still must fetch and store the block. `Admitted` does not mean
+    /// the finalization is stored.
+    Admitted,
+    /// At or below the highest round already applied.
+    Stale,
+    /// The signature failed with an available scheme, so the sender is responsible.
+    Invalid,
+    /// No usable scheme for the certificate's epoch.
+    ///
+    /// Do not blame the sender. After an identity rotation, an honest peer may
+    /// send a certificate before this node learns the new key. Penalizing peers
+    /// here could disconnect gossip while it is needed for recovery.
+    NeedsScheme {
+        /// Certificate epoch, used to retry after its scheme or a later one is installed.
+        epoch: Epoch,
+    },
+}
+
+/// Verifies certificates and applies them to the consensus layer.
+///
+/// This trait lets transport-facing actor tests use a stub instead of a driver,
+/// marshal, and scheme provider.
+#[cfg_attr(
+    not(test),
+    expect(dead_code, reason = "wired to the gossip actor in a following commit")
+)]
+pub(crate) trait CertSink: Clone + Send + 'static {
+    /// Submits a certificate for verification.
+    ///
+    /// The receiver returns the driver's result. It closes without a value if
+    /// the driver is shutting down.
+    fn verify_and_apply(&self, certificate: Certificate) -> oneshot::Receiver<Outcome>;
+}

--- a/crates/consensus/src/gossip/mod.rs
+++ b/crates/consensus/src/gossip/mod.rs
@@ -29,13 +29,13 @@ pub(crate) enum Outcome {
     Stale,
     /// The signature failed with an available scheme, so the sender is responsible.
     Invalid,
-    /// No usable scheme for the certificate's epoch.
+    /// No authenticated epoch scheme can currently verify the certificate.
     ///
-    /// Do not blame the sender. After an identity rotation, an honest peer may
-    /// send a certificate before this node learns the new key. Penalizing peers
-    /// here could disconnect gossip while it is needed for recovery.
+    /// Do not blame the sender. The network-identity fallback can reject an
+    /// honest certificate after an identity rotation but before this node learns
+    /// the new key from an authenticated boundary.
     NeedsScheme {
-        /// Certificate epoch, used to retry after its scheme or a later one is installed.
+        /// Certificate epoch, used to retry after a boundary installs its scheme or a later one.
         epoch: Epoch,
     },
 }

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -14,6 +14,7 @@ pub mod feed;
 pub mod finalization_verifier;
 pub mod finalized_header_stream;
 pub mod follow;
+pub(crate) mod gossip;
 pub mod metrics;
 mod network;
 pub(crate) mod network_identity;


### PR DESCRIPTION
Add a path for the driver that accepts the finalization certificate, and reports that certified tip to the follower executor (and thus reth).

This also introduces a FollowerProgress struct which allows tracking the progress.

All of this will be hooked up to the gossip actor.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>