### PR TITLE
chore(commonware-p2p): size enforcing sender

### DIFF
--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -31,6 +31,7 @@ use crate::{
     consensus::application,
     dkg,
     epoch::{self, SchemeProvider},
+    network::limit_channel,
     peer_manager, storage, subblocks,
 };
 
@@ -61,6 +62,7 @@ pub struct Builder<TBlocker, TPeerManager> {
 
     pub mailbox_size: NonZeroUsize,
     pub deque_size: usize,
+    pub max_message_size: u32,
 
     /// Maximum time to wait for the leader's proposal before timing out a view.
     ///
@@ -295,6 +297,7 @@ where
 
         Ok(Engine {
             context: ContextCell::new(context),
+            max_message_size: self.max_message_size,
 
             broadcast,
             broadcast_mailbox,
@@ -340,6 +343,7 @@ where
     TPeerManager: AddressableManager<PublicKey = PublicKey>,
 {
     context: ContextCell<TContext>,
+    max_message_size: u32,
 
     /// broadcasts messages to and caches messages from untrusted peers.
     // XXX: alto calls this `buffered`. That's confusing. We call it `broadcast`.
@@ -477,6 +481,17 @@ where
             impl Receiver<PublicKey = PublicKey>,
         ),
     ) -> eyre::Result<()> {
+        let votes_channel = limit_channel(votes_channel, "votes", self.max_message_size);
+        let certificates_channel =
+            limit_channel(certificates_channel, "certificates", self.max_message_size);
+        let resolver_channel = limit_channel(resolver_channel, "resolver", self.max_message_size);
+        let broadcast_channel =
+            limit_channel(broadcast_channel, "broadcast", self.max_message_size);
+        let marshal_channel = limit_channel(marshal_channel, "marshal", self.max_message_size);
+        let dkg_channel = limit_channel(dkg_channel, "dkg", self.max_message_size);
+        let subblocks_channel =
+            limit_channel(subblocks_channel, "subblocks", self.max_message_size);
+
         let peer_manager = self.peer_manager.start();
 
         let broadcast = self.broadcast.start(broadcast_channel);

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -481,16 +481,31 @@ where
             impl Receiver<PublicKey = PublicKey>,
         ),
     ) -> eyre::Result<()> {
-        let votes_channel = limit_channel(votes_channel, "votes", self.max_message_size);
-        let certificates_channel =
-            limit_channel(certificates_channel, "certificates", self.max_message_size);
-        let resolver_channel = limit_channel(resolver_channel, "resolver", self.max_message_size);
-        let broadcast_channel =
-            limit_channel(broadcast_channel, "broadcast", self.max_message_size);
-        let marshal_channel = limit_channel(marshal_channel, "marshal", self.max_message_size);
-        let dkg_channel = limit_channel(dkg_channel, "dkg", self.max_message_size);
-        let subblocks_channel =
-            limit_channel(subblocks_channel, "subblocks", self.max_message_size);
+        let context = &*self.context;
+        let votes_channel = limit_channel(context, votes_channel, "votes", self.max_message_size);
+        let certificates_channel = limit_channel(
+            context,
+            certificates_channel,
+            "certificates",
+            self.max_message_size,
+        );
+        let resolver_channel =
+            limit_channel(context, resolver_channel, "resolver", self.max_message_size);
+        let broadcast_channel = limit_channel(
+            context,
+            broadcast_channel,
+            "broadcast",
+            self.max_message_size,
+        );
+        let marshal_channel =
+            limit_channel(context, marshal_channel, "marshal", self.max_message_size);
+        let dkg_channel = limit_channel(context, dkg_channel, "dkg", self.max_message_size);
+        let subblocks_channel = limit_channel(
+            context,
+            subblocks_channel,
+            "subblocks",
+            self.max_message_size,
+        );
 
         let peer_manager = self.peer_manager.start();
 

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -27,7 +27,7 @@ use tempo_node::TempoFullNode;
 use tracing::info;
 
 use crate::{
-    alias,
+    alias, config,
     consensus::application,
     dkg,
     epoch::{self, SchemeProvider},
@@ -482,28 +482,46 @@ where
         ),
     ) -> eyre::Result<()> {
         let context = &*self.context;
-        let votes_channel = limit_channel(context, votes_channel, "votes", self.max_message_size);
+        let votes_channel = limit_channel(
+            context,
+            votes_channel,
+            config::VOTES_CHANNEL_IDENT,
+            self.max_message_size,
+        );
         let certificates_channel = limit_channel(
             context,
             certificates_channel,
-            "certificates",
+            config::CERTIFICATES_CHANNEL_IDENT,
             self.max_message_size,
         );
-        let resolver_channel =
-            limit_channel(context, resolver_channel, "resolver", self.max_message_size);
+        let resolver_channel = limit_channel(
+            context,
+            resolver_channel,
+            config::RESOLVER_CHANNEL_IDENT,
+            self.max_message_size,
+        );
         let broadcast_channel = limit_channel(
             context,
             broadcast_channel,
-            "broadcast",
+            config::BROADCASTER_CHANNEL_IDENT,
             self.max_message_size,
         );
-        let marshal_channel =
-            limit_channel(context, marshal_channel, "marshal", self.max_message_size);
-        let dkg_channel = limit_channel(context, dkg_channel, "dkg", self.max_message_size);
+        let marshal_channel = limit_channel(
+            context,
+            marshal_channel,
+            config::MARSHAL_CHANNEL_IDENT,
+            self.max_message_size,
+        );
+        let dkg_channel = limit_channel(
+            context,
+            dkg_channel,
+            config::DKG_CHANNEL_IDENT,
+            self.max_message_size,
+        );
         let subblocks_channel = limit_channel(
             context,
             subblocks_channel,
-            "subblocks",
+            config::SUBBLOCKS_CHANNEL_IDENT,
             self.max_message_size,
         );
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -13,6 +13,7 @@ pub(crate) mod executor;
 pub mod feed;
 pub mod follow;
 pub mod metrics;
+mod network;
 pub(crate) mod network_identity;
 pub(crate) mod peer_manager;
 pub mod storage;
@@ -115,6 +116,7 @@ pub async fn run_consensus_stack(
 
         mailbox_size: config.mailbox_size,
         deque_size: config.deque_size,
+        max_message_size: config.max_message_size_bytes,
 
         time_to_propose: config.wait_for_proposal.into_duration(),
         time_to_collect_notarizations: config.wait_for_notarizations.into_duration(),

--- a/crates/consensus/src/network.rs
+++ b/crates/consensus/src/network.rs
@@ -1,7 +1,7 @@
 use std::time::SystemTime;
 
 use commonware_actor::{Feedback, Unreliable};
-use commonware_p2p::{CheckedSender, LimitedSender, Recipients, UnlimitedSender};
+use commonware_p2p::{CheckedSender, LimitedSender, Recipients};
 use commonware_runtime::{
     IoBufs, Metrics,
     telemetry::metrics::{Counter, MetricsExt as _},
@@ -42,7 +42,10 @@ pub(crate) fn limit_channel<S, R>(
             "dropped_oversized_messages",
             "outbound p2p messages dropped for exceeding the maximum message size",
         );
-    (SizeLimited::new(sender, channel, max_size, dropped), receiver)
+    (
+        SizeLimited::new(sender, channel, max_size, dropped),
+        receiver,
+    )
 }
 
 fn within_limit(
@@ -64,24 +67,6 @@ fn within_limit(
     }
 
     Some(message)
-}
-
-impl<S: UnlimitedSender> UnlimitedSender for SizeLimited<S> {
-    type PublicKey = S::PublicKey;
-
-    fn send(
-        &mut self,
-        recipients: Recipients<Self::PublicKey>,
-        message: impl Into<IoBufs> + Send,
-        priority: bool,
-    ) -> Unreliable<Feedback> {
-        let Some(message) = within_limit(message, self.channel, self.max_size, &self.dropped)
-        else {
-            return Unreliable::rejected();
-        };
-
-        self.inner.send(recipients, message, priority)
-    }
 }
 
 pub(crate) struct SizeLimitedChecked<S> {

--- a/crates/consensus/src/network.rs
+++ b/crates/consensus/src/network.rs
@@ -1,9 +1,9 @@
 //! A channel wrapper that drops messages that exceed a pre-defined size.
 //!
-//! This layer defends against the `assert!` in
-//! [`commonware_p2p::authenticated::lookup::channels::UnlimitedSender::send`]
-//! that would lead to the node panicking if we ever exceeds the pre-configured
-//! message size.
+//! This layer defends against the `assert!` in commonware's internal channels
+//! (`commonware_p2p::authenticated::lookup::channels::UnlimitedSender::send` at
+//! the time of writing) that would lead to the node panicking if we ever
+//! exceeds the pre-configured message size.
 //!
 //! Note the interaction between size-limits and rate-limits: commonware
 //! performs rate-limits via the [`LimitedSender::check`] API prior to sending a
@@ -17,7 +17,7 @@
 use std::time::SystemTime;
 
 use commonware_actor::{Feedback, Unreliable};
-use commonware_p2p::{CheckedSender, LimitedSender, Recipients};
+use commonware_p2p::{Channel, CheckedSender, LimitedSender, Recipients};
 use commonware_runtime::{
     IoBufs, Metrics,
     telemetry::metrics::{Counter, MetricsExt as _},
@@ -28,13 +28,13 @@ use tracing::warn;
 #[derive(Clone)]
 pub(crate) struct SizeLimited<S> {
     inner: S,
-    channel: &'static str,
+    channel: Channel,
     max_size: usize,
     dropped: Counter,
 }
 
 impl<S> SizeLimited<S> {
-    fn new(inner: S, channel: &'static str, max_size: u32, dropped: Counter) -> Self {
+    fn new(inner: S, channel: Channel, max_size: u32, dropped: Counter) -> Self {
         Self {
             inner,
             channel,
@@ -48,7 +48,7 @@ impl<S> SizeLimited<S> {
 pub(crate) fn limit_channel<S, R>(
     context: &impl Metrics,
     (sender, receiver): (S, R),
-    channel: &'static str,
+    channel: Channel,
     max_size: u32,
 ) -> (SizeLimited<S>, R) {
     let dropped = context
@@ -66,7 +66,7 @@ pub(crate) fn limit_channel<S, R>(
 
 fn within_limit(
     message: impl Into<IoBufs>,
-    channel: &'static str,
+    channel: Channel,
     max_size: usize,
     dropped: &Counter,
 ) -> Option<IoBufs> {
@@ -87,7 +87,7 @@ fn within_limit(
 
 pub(crate) struct SizeLimitedChecked<S> {
     inner: S,
-    channel: &'static str,
+    channel: Channel,
     max_size: usize,
     dropped: Counter,
 }
@@ -192,7 +192,7 @@ mod tests {
     fn rejects_oversized_messages() {
         let peer = PrivateKey::random(test_rng()).public_key();
         let dropped = inert_counter();
-        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4, dropped.clone());
+        let mut sender = SizeLimited::new(InertSender(peer.clone()), 0, 4, dropped.clone());
 
         let sent = sender.send(Recipients::One(peer), b"large".to_vec(), false);
 
@@ -204,7 +204,7 @@ mod tests {
     fn forwards_messages_within_limit() {
         let peer = PrivateKey::random(test_rng()).public_key();
         let dropped = inert_counter();
-        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4, dropped.clone());
+        let mut sender = SizeLimited::new(InertSender(peer.clone()), 0, 4, dropped.clone());
 
         let sent = sender.send(Recipients::One(peer.clone()), b"four".to_vec(), false);
 

--- a/crates/consensus/src/network.rs
+++ b/crates/consensus/src/network.rs
@@ -2,7 +2,10 @@ use std::time::SystemTime;
 
 use commonware_actor::{Feedback, Unreliable};
 use commonware_p2p::{CheckedSender, LimitedSender, Recipients, UnlimitedSender};
-use commonware_runtime::IoBufs;
+use commonware_runtime::{
+    IoBufs, Metrics,
+    telemetry::metrics::{Counter, MetricsExt as _},
+};
 use tracing::warn;
 
 /// A p2p sender that rejects messages larger than the configured network limit.
@@ -11,34 +14,46 @@ pub(crate) struct SizeLimited<S> {
     inner: S,
     channel: &'static str,
     max_size: usize,
+    dropped: Counter,
 }
 
 impl<S> SizeLimited<S> {
-    const fn new(inner: S, channel: &'static str, max_size: u32) -> Self {
+    fn new(inner: S, channel: &'static str, max_size: u32, dropped: Counter) -> Self {
         Self {
             inner,
             channel,
             max_size: max_size as usize,
+            dropped,
         }
     }
 }
 
 /// Apply the outbound size limit to a registered p2p channel.
 pub(crate) fn limit_channel<S, R>(
+    context: &impl Metrics,
     (sender, receiver): (S, R),
     channel: &'static str,
     max_size: u32,
 ) -> (SizeLimited<S>, R) {
-    (SizeLimited::new(sender, channel, max_size), receiver)
+    let dropped = context
+        .child("network")
+        .with_attribute("channel", channel)
+        .counter(
+            "dropped_oversized_messages",
+            "outbound p2p messages dropped for exceeding the maximum message size",
+        );
+    (SizeLimited::new(sender, channel, max_size, dropped), receiver)
 }
 
 fn within_limit(
     message: impl Into<IoBufs>,
     channel: &'static str,
     max_size: usize,
+    dropped: &Counter,
 ) -> Option<IoBufs> {
     let message = message.into();
     if message.len() > max_size {
+        dropped.inc();
         warn!(
             channel,
             message_size = message.len(),
@@ -60,7 +75,8 @@ impl<S: UnlimitedSender> UnlimitedSender for SizeLimited<S> {
         message: impl Into<IoBufs> + Send,
         priority: bool,
     ) -> Unreliable<Feedback> {
-        let Some(message) = within_limit(message, self.channel, self.max_size) else {
+        let Some(message) = within_limit(message, self.channel, self.max_size, &self.dropped)
+        else {
             return Unreliable::rejected();
         };
 
@@ -72,6 +88,7 @@ pub(crate) struct SizeLimitedChecked<S> {
     inner: S,
     channel: &'static str,
     max_size: usize,
+    dropped: Counter,
 }
 
 impl<S: CheckedSender> CheckedSender for SizeLimitedChecked<S> {
@@ -82,7 +99,8 @@ impl<S: CheckedSender> CheckedSender for SizeLimitedChecked<S> {
     }
 
     fn send(self, message: impl Into<IoBufs> + Send, priority: bool) -> Unreliable<Feedback> {
-        let Some(message) = within_limit(message, self.channel, self.max_size) else {
+        let Some(message) = within_limit(message, self.channel, self.max_size, &self.dropped)
+        else {
             return Unreliable::rejected();
         };
 
@@ -107,6 +125,7 @@ impl<S: LimitedSender> LimitedSender for SizeLimited<S> {
                 inner,
                 channel: self.channel,
                 max_size: self.max_size,
+                dropped: self.dropped.clone(),
             })
     }
 }
@@ -119,10 +138,18 @@ mod tests {
     use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
     use commonware_math::algebra::Random as _;
     use commonware_p2p::{CheckedSender, LimitedSender, Recipients, Sender as _};
-    use commonware_runtime::IoBufs;
+    use commonware_runtime::{
+        IoBufs,
+        telemetry::metrics::{Counter, Registered, Registration, raw},
+    };
     use commonware_utils::test_rng;
 
     use super::SizeLimited;
+
+    /// A counter that is not exposed by any metrics registry.
+    fn inert_counter() -> Counter {
+        Registered::with_registration(raw::Counter::default(), Registration::from(()))
+    }
 
     #[derive(Clone)]
     struct InertSender<P>(P);
@@ -163,20 +190,24 @@ mod tests {
     #[test]
     fn rejects_oversized_messages() {
         let peer = PrivateKey::random(test_rng()).public_key();
-        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4);
+        let dropped = inert_counter();
+        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4, dropped.clone());
 
         let sent = sender.send(Recipients::One(peer), b"large".to_vec(), false);
 
         assert!(sent.is_empty());
+        assert_eq!(dropped.get(), 1);
     }
 
     #[test]
     fn forwards_messages_within_limit() {
         let peer = PrivateKey::random(test_rng()).public_key();
-        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4);
+        let dropped = inert_counter();
+        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4, dropped.clone());
 
         let sent = sender.send(Recipients::One(peer.clone()), b"four".to_vec(), false);
 
         assert_eq!(sent, vec![peer]);
+        assert_eq!(dropped.get(), 0);
     }
 }

--- a/crates/consensus/src/network.rs
+++ b/crates/consensus/src/network.rs
@@ -1,0 +1,182 @@
+use std::time::SystemTime;
+
+use commonware_actor::{Feedback, Unreliable};
+use commonware_p2p::{CheckedSender, LimitedSender, Recipients, UnlimitedSender};
+use commonware_runtime::IoBufs;
+use tracing::warn;
+
+/// A p2p sender that rejects messages larger than the configured network limit.
+#[derive(Clone)]
+pub(crate) struct SizeLimited<S> {
+    inner: S,
+    channel: &'static str,
+    max_size: usize,
+}
+
+impl<S> SizeLimited<S> {
+    const fn new(inner: S, channel: &'static str, max_size: u32) -> Self {
+        Self {
+            inner,
+            channel,
+            max_size: max_size as usize,
+        }
+    }
+}
+
+/// Apply the outbound size limit to a registered p2p channel.
+pub(crate) fn limit_channel<S, R>(
+    (sender, receiver): (S, R),
+    channel: &'static str,
+    max_size: u32,
+) -> (SizeLimited<S>, R) {
+    (SizeLimited::new(sender, channel, max_size), receiver)
+}
+
+fn within_limit(
+    message: impl Into<IoBufs>,
+    channel: &'static str,
+    max_size: usize,
+) -> Option<IoBufs> {
+    let message = message.into();
+    if message.len() > max_size {
+        warn!(
+            channel,
+            message_size = message.len(),
+            max_size,
+            "dropping oversized outbound p2p message"
+        );
+        return None;
+    }
+
+    Some(message)
+}
+
+impl<S: UnlimitedSender> UnlimitedSender for SizeLimited<S> {
+    type PublicKey = S::PublicKey;
+
+    fn send(
+        &mut self,
+        recipients: Recipients<Self::PublicKey>,
+        message: impl Into<IoBufs> + Send,
+        priority: bool,
+    ) -> Unreliable<Feedback> {
+        let Some(message) = within_limit(message, self.channel, self.max_size) else {
+            return Unreliable::rejected();
+        };
+
+        self.inner.send(recipients, message, priority)
+    }
+}
+
+pub(crate) struct SizeLimitedChecked<S> {
+    inner: S,
+    channel: &'static str,
+    max_size: usize,
+}
+
+impl<S: CheckedSender> CheckedSender for SizeLimitedChecked<S> {
+    type PublicKey = S::PublicKey;
+
+    fn recipients(&self) -> Vec<Self::PublicKey> {
+        self.inner.recipients()
+    }
+
+    fn send(self, message: impl Into<IoBufs> + Send, priority: bool) -> Unreliable<Feedback> {
+        let Some(message) = within_limit(message, self.channel, self.max_size) else {
+            return Unreliable::rejected();
+        };
+
+        self.inner.send(message, priority)
+    }
+}
+
+impl<S: LimitedSender> LimitedSender for SizeLimited<S> {
+    type PublicKey = S::PublicKey;
+    type Checked<'a>
+        = SizeLimitedChecked<S::Checked<'a>>
+    where
+        Self: 'a;
+
+    fn check(
+        &mut self,
+        recipients: Recipients<Self::PublicKey>,
+    ) -> Result<Self::Checked<'_>, SystemTime> {
+        self.inner
+            .check(recipients)
+            .map(|inner| SizeLimitedChecked {
+                inner,
+                channel: self.channel,
+                max_size: self.max_size,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::SystemTime;
+
+    use commonware_actor::{Feedback, Unreliable};
+    use commonware_cryptography::{Signer as _, ed25519::PrivateKey};
+    use commonware_math::algebra::Random as _;
+    use commonware_p2p::{CheckedSender, LimitedSender, Recipients, Sender as _};
+    use commonware_runtime::IoBufs;
+    use commonware_utils::test_rng;
+
+    use super::SizeLimited;
+
+    #[derive(Clone)]
+    struct InertSender<P>(P);
+
+    struct InertCheckedSender<P>(P);
+
+    impl<P: commonware_cryptography::PublicKey> LimitedSender for InertSender<P> {
+        type PublicKey = P;
+        type Checked<'a>
+            = InertCheckedSender<P>
+        where
+            Self: 'a;
+
+        fn check(
+            &mut self,
+            recipients: Recipients<Self::PublicKey>,
+        ) -> Result<Self::Checked<'_>, SystemTime> {
+            let recipient = match recipients {
+                Recipients::One(recipient) => recipient,
+                _ => self.0.clone(),
+            };
+            Ok(InertCheckedSender(recipient))
+        }
+    }
+
+    impl<P: commonware_cryptography::PublicKey> CheckedSender for InertCheckedSender<P> {
+        type PublicKey = P;
+
+        fn recipients(&self) -> Vec<Self::PublicKey> {
+            vec![self.0.clone()]
+        }
+
+        fn send(self, _message: impl Into<IoBufs> + Send, _priority: bool) -> Unreliable<Feedback> {
+            Unreliable::new(Feedback::Ok)
+        }
+    }
+
+    #[test]
+    fn rejects_oversized_messages() {
+        let peer = PrivateKey::random(test_rng()).public_key();
+        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4);
+
+        let sent = sender.send(Recipients::One(peer), b"large".to_vec(), false);
+
+        assert!(sent.is_empty());
+    }
+
+    #[test]
+    fn forwards_messages_within_limit() {
+        let peer = PrivateKey::random(test_rng()).public_key();
+        let mut sender = SizeLimited::new(InertSender(peer.clone()), "test", 4);
+
+        let sent = sender.send(Recipients::One(peer.clone()), b"four".to_vec(), false);
+
+        assert_eq!(sent, vec![peer]);
+    }
+}

--- a/crates/consensus/src/network.rs
+++ b/crates/consensus/src/network.rs
@@ -1,3 +1,19 @@
+//! A channel wrapper that drops messages that exceed a pre-defined size.
+//!
+//! This layer defends against the `assert!` in
+//! [`commonware_p2p::authenticated::lookup::channels::UnlimitedSender::send`]
+//! that would lead to the node panicking if we ever exceeds the pre-configured
+//! message size.
+//!
+//! Note the interaction between size-limits and rate-limits: commonware
+//! performs rate-limits via the [`LimitedSender::check`] API prior to sending a
+//! a message. This means that if a rate-limiter is in place (which is always
+//! the case), then a rate-limiting token will be consumed before the message is
+//! sent and potentially dropped because it exceeds limits.
+//!
+//! To avoid this waste, commonware either needs to change the assert! into a
+//! graceful rejection (so that the token can be reclaimed), or allow performing
+//! the size check before.
 use std::time::SystemTime;
 
 use commonware_actor::{Feedback, Unreliable};

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -296,6 +296,7 @@ pub async fn setup_validators(
             signer: private_key.clone(),
             mailbox_size: commonware_utils::NZUsize!(1024),
             deque_size: 10,
+            max_message_size: 1024 * 1024,
             time_to_propose: Duration::from_secs(2),
             time_to_collect_notarizations: Duration::from_secs(3),
             time_to_retry_nullify_broadcast: Duration::from_secs(10),

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -52,6 +52,8 @@ mod tests;
 pub const CONSENSUS_NODE_PREFIX: &str = "consensus";
 pub const EXECUTION_NODE_PREFIX: &str = "execution";
 
+const MAX_MESSAGE_SIZE: u32 = 1024 * 1024;
+
 fn generate_consensus_node_config(
     rng: &mut impl CryptoRng,
     signers: u32,
@@ -243,7 +245,7 @@ pub async fn setup_validators(
     let (network, mut oracle) = Network::new(
         context.child("network"),
         simulated::Config {
-            max_size: 1024 * 1024,
+            max_size: MAX_MESSAGE_SIZE,
             disconnect_on_block: true,
             tracked_peer_sets: commonware_utils::NZUsize!(3),
         },
@@ -296,7 +298,7 @@ pub async fn setup_validators(
             signer: private_key.clone(),
             mailbox_size: commonware_utils::NZUsize!(1024),
             deque_size: 10,
-            max_message_size: 1024 * 1024,
+            max_message_size: MAX_MESSAGE_SIZE,
             time_to_propose: Duration::from_secs(2),
             time_to_collect_notarizations: Duration::from_secs(3),
             time_to_retry_nullify_broadcast: Duration::from_secs(10),


### PR DESCRIPTION
commonware-p2p will panic if the message send is beyond the max message size. Create a wrapper that will prematurely reject these messages