### PR TITLE
docs(tip-1093): extend expiring nonce window to five minutes

### DIFF
--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -70,13 +70,11 @@ The capacity is calculated as:
 ```
 
 The `expiringNonceRing` mapping continues to store one 32-byte transaction hash
-per entry. For capacity planning, implementations MUST budget approximately 107
-bytes per live expiring-nonce entry, including MPT node overhead, MDBX metadata,
-and RLP encoding. At full capacity, 3,000,000 entries therefore require
-approximately 321 MB of effective storage. This estimate is based on the
-controlled 100,000-transaction benchmark at 5,000 TPS in
+per entry. Including MPT node overhead, MDBX metadata, and RLP encoding, each
+live expiring-nonce entry uses approximately 107 bytes, or 321 MB at full
+capacity. This estimate is based on the controlled 100,000-transaction benchmark
+at 5,000 TPS in
 [TIP-1009](https://tips.sh/1009?h=8965-8968#controlled-benchmark-100k-transactions-at-5k-tps)
-and supersedes raw 32-byte slot accounting.
 
 The ring pointer remains bounded to `[0, EXPIRING_NONCE_SET_CAPACITY)` and wraps
 to zero after entry `2,999,999`. Before overwriting an occupied ring entry, the

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -87,6 +87,13 @@ The new constants MUST activate atomically at the protocol version selected for
 this TIP. Pool validation, transaction execution, action replay, transaction
 builders, and test helpers MUST use the same 300-second maximum.
 
+At the activation boundary, transactions already recorded in the replay-
+protection state remain recorded and cannot be replayed. The capacity extension
+adds previously unallocated ring slots, so new post-activation transactions are
+inserted into those slots rather than overwriting pre-activation entries. The
+activation therefore does not create a replay window for transactions that were
+accepted before the boundary.
+
 Before activation, nodes continue enforcing the TIP-1009 30-second limit. After
 activation, nodes enforcing different limits or capacities MUST be treated as
 incompatible and MUST NOT participate in the same canonical chain.

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -1,0 +1,192 @@
+---
+id: TIP-1093
+title: Extend Expiring Nonce Window to Five Minutes
+description: Extends the expiring nonce validity window from 30 seconds to five minutes and resizes replay-protection storage accordingly.
+authors: @shekhirin
+status: Draft
+related: TIP-1009, Transactions
+protocolVersion: TBD
+---
+
+# TIP-1093: Extend Expiring Nonce Window to Five Minutes
+
+## Abstract
+
+This TIP extends the maximum validity window for expiring nonce transactions from
+30 seconds to five minutes. It increases the circular replay-protection buffer
+from 300,000 to 3,000,000 entries, preserving the TIP-1009 sizing target of
+10,000 expiring-nonce transactions per second.
+
+The storage layout and replay-protection algorithm remain unchanged. The larger
+window gives applications more time between signing a transaction and submitting
+it while retaining bounded replay-protection state.
+
+## Motivation
+
+Some use cases require more than 30 seconds between signing a transaction and
+sending it. This can happen when a transaction is signed on a separate device,
+passes through an approval workflow, or is queued by a relayer before it reaches
+the network. A five-minute window supports these workflows without requiring
+applications to re-sign transactions that are still intended to be valid.
+
+TIP-1009 currently allows a maximum `validBefore` of 30 seconds and sizes its
+replay-protection ring for 10,000 TPS over that interval. Keeping the existing
+capacity while increasing the window would cause the ring to overwrite entries
+that are still valid at the target throughput. This TIP therefore changes the
+window and capacity together.
+
+Alternatives considered:
+
+- Keep the 30-second window and require applications to re-sign delayed
+  transactions. This does not support workflows where the original signature
+  must remain valid during approval or relay.
+- Keep 300,000 entries. At 10,000 TPS, the ring would wrap in 30 seconds and
+  valid transactions would be rejected with `ExpiringNonceSetFull`.
+- Make the capacity configurable per chain. This would make the protocol
+  behavior and safety margin dependent on deployment configuration; this TIP
+  keeps a fixed capacity and leaves future retuning to a subsequent protocol
+  change.
+
+## Assumptions
+
+- TIP-1009 expiring nonce semantics and the existing nonce storage layout remain
+  active.
+- The sizing target remains 10,000 expiring-nonce transactions per second.
+- The ring capacity is sized for sustained peak throughput, with operators able
+  to add implementation-level headroom if required.
+- Nodes activate the new window and capacity at the same protocol version. A
+  node that retains the old constants is not compatible after activation.
+
+If sustained throughput exceeds the sizing target, the safety check MUST reject
+an insertion rather than overwrite an unexpired entry. Increasing capacity or
+the window requires another protocol change.
+
+## Threat Model
+
+- An attacker may submit a captured signed transaction repeatedly. The
+  `expiringNonceSeen` mapping and ring MUST continue to reject the same
+  transaction hash while its `validBefore` has not elapsed.
+- An attacker may submit transactions at or above the sizing target to exhaust
+  the ring. The existing unexpired-entry check MUST prevent replay-protection
+  state from being overwritten and MUST return `ExpiringNonceSetFull`.
+- A compromised signing or relaying environment has up to five minutes, rather
+  than 30 seconds, to submit a valid captured transaction. This increased replay
+  window is an accepted consequence of the feature and must be disclosed to
+  integrators.
+- No actor gains permission to alter, clear, or extend another transaction's
+  expiry. `validBefore` remains part of the signed transaction semantics.
+
+---
+
+# Specification
+
+## Expiry Window
+
+For an expiring nonce transaction, `validBefore` MUST satisfy:
+
+```text
+now < validBefore <= now + 300
+```
+
+where `now` is the current block timestamp. Transactions with
+`validBefore <= now` or `validBefore > now + 300` MUST be rejected during pool
+validation and execution.
+
+The transaction MUST continue to use `nonceKey = uint256.max`, `nonce = 0`, and
+the TIP-1009 expiring nonce hash. No other nonce mode is changed by this TIP.
+
+## Replay-Protection Capacity
+
+The implementation constants become:
+
+```text
+EXPIRING_NONCE_MAX_EXPIRY_SECS = 300
+EXPIRING_NONCE_SET_CAPACITY = 3_000_000
+```
+
+The capacity is calculated as:
+
+```text
+10,000 transactions/second × 300 seconds = 3,000,000 entries
+```
+
+The `expiringNonceRing` mapping continues to store one 32-byte transaction hash
+per entry. At full capacity, the ring contains approximately 96 MB of raw hash
+values. The corresponding live `expiringNonceSeen` entries add approximately
+96 MB of raw 32-byte storage slots, excluding trie, database, and metadata
+overhead.
+
+The ring pointer remains bounded to `[0, EXPIRING_NONCE_SET_CAPACITY)` and wraps
+to zero after entry `2,999,999`. Before overwriting an occupied ring entry, the
+implementation MUST read the old hash's expiry and reject with
+`ExpiringNonceSetFull` if that expiry is still in the future. Otherwise it MUST
+clear the old `expiringNonceSeen` entry and insert the new hash and expiry.
+
+## State and Gas Behavior
+
+The storage layout remains:
+
+```text
+expiringNonceSeen: mapping(bytes32 => uint64)
+expiringNonceRing: mapping(uint32 => bytes32)
+expiringNonceRingPtr: uint32
+```
+
+No storage migration is required because the mappings are already keyed by the
+ring index and transaction hash. The larger capacity increases the maximum live
+state and the number of ring slots that can be initialized over time.
+
+The intrinsic gas schedule is unchanged by this TIP. Implementations MUST
+re-benchmark the expiring nonce path, including first use of new ring slots,
+steady-state overwrites, and the full-buffer safety check, before activation.
+
+## Activation and Compatibility
+
+The new constants MUST activate atomically at the protocol version selected for
+this TIP. Pool validation, transaction execution, action replay, transaction
+builders, and test helpers MUST use the same 300-second maximum.
+
+Before activation, nodes continue enforcing the TIP-1009 30-second limit. After
+activation, nodes enforcing different limits or capacities MUST be treated as
+incompatible and MUST NOT participate in the same canonical chain.
+
+# Tooling
+
+SDKs and transaction builders that expose the expiring nonce validity limit
+MUST update their helper constants and validation messages from 30 seconds to
+300 seconds. Pool, RPC, and test fixtures MUST accept valid expiries throughout
+the five-minute window and reject expiries beyond it.
+
+Relayer and wallet documentation SHOULD warn that a signed transaction can
+remain valid for up to five minutes and SHOULD expose the selected
+`validBefore` timestamp to users.
+
+# Observability
+
+Existing transaction rejection metrics MUST distinguish expiry-window failures
+from `ExpiringNonceSetFull` failures. Operators SHOULD monitor:
+
+- the count and rate of `ExpiringNonceSetFull` errors;
+- the rate of expiring nonce transactions and the estimated ring wrap interval;
+- live expiring nonce ring and seen-set state size; and
+- the age of entries when they are evicted.
+
+These signals answer whether the 3,000,000-entry capacity is sufficient and
+whether a traffic spike is causing valid transactions to be rejected.
+
+# Invariants
+
+- A transaction hash MUST NOT execute twice while its recorded expiry is in the
+  future.
+- `validBefore <= now` MUST always be rejected.
+- `validBefore > now + 300` MUST always be rejected after activation.
+- An expiring nonce transaction MUST have `nonceKey = uint256.max`, `nonce = 0`,
+  and a set `validBefore`.
+- The ring MUST never overwrite an entry whose recorded expiry is in the future.
+- Expiring nonce transactions MUST NOT mutate the protocol nonce or any normal
+  2D nonce.
+- The ring pointer MUST always remain below `3,000,000`.
+
+The test suite MUST cover boundary timestamps at `now`, `now + 300`, and
+`now + 301`; replay during and after expiry; pointer wraparound at the new
+capacity; full-buffer rejection; and concurrent expiring nonce transactions.

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -70,10 +70,13 @@ The capacity is calculated as:
 ```
 
 The `expiringNonceRing` mapping continues to store one 32-byte transaction hash
-per entry. At full capacity, the ring contains approximately 96 MB of raw hash
-values. The corresponding live `expiringNonceSeen` entries add approximately
-96 MB of raw 32-byte storage slots, excluding trie, database, and metadata
-overhead.
+per entry. For capacity planning, implementations MUST budget approximately 107
+bytes per live expiring-nonce entry, including MPT node overhead, MDBX metadata,
+and RLP encoding. At full capacity, 3,000,000 entries therefore require
+approximately 321 MB of effective storage. This estimate is based on the
+controlled 100,000-transaction benchmark at 5,000 TPS in
+[TIP-1009](https://tips.sh/1009?h=8965-8968#controlled-benchmark-100k-transactions-at-5k-tps)
+and supersedes raw 32-byte slot accounting.
 
 The ring pointer remains bounded to `[0, EXPIRING_NONCE_SET_CAPACITY)` and wraps
 to zero after entry `2,999,999`. Before overwriting an occupied ring entry, the

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -4,7 +4,7 @@ title: Extend Expiring Nonce Window to Five Minutes
 description: Extends the expiring nonce validity window from 30 seconds to five minutes and resizes replay-protection storage accordingly.
 authors: @shekhirin
 status: Draft
-related: TIP-1009, Transactions
+related: TIP-1009, TIP-0001
 protocolVersion: TBD
 ---
 

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -35,47 +35,6 @@ capacity while increasing the window would cause the ring to overwrite entries
 that are still valid at the target throughput. This TIP therefore changes the
 window and capacity together.
 
-Alternatives considered:
-
-- Keep the 30-second window and require applications to re-sign delayed
-  transactions. This does not support workflows where the original signature
-  must remain valid during approval or relay.
-- Keep 300,000 entries. At 10,000 TPS, the ring would wrap in 30 seconds and
-  valid transactions would be rejected with `ExpiringNonceSetFull`.
-- Make the capacity configurable per chain. This would make the protocol
-  behavior and safety margin dependent on deployment configuration; this TIP
-  keeps a fixed capacity and leaves future retuning to a subsequent protocol
-  change.
-
-## Assumptions
-
-- TIP-1009 expiring nonce semantics and the existing nonce storage layout remain
-  active.
-- The sizing target remains 10,000 expiring-nonce transactions per second.
-- The ring capacity is sized for sustained peak throughput, with operators able
-  to add implementation-level headroom if required.
-- Nodes activate the new window and capacity at the same protocol version. A
-  node that retains the old constants is not compatible after activation.
-
-If sustained throughput exceeds the sizing target, the safety check MUST reject
-an insertion rather than overwrite an unexpired entry. Increasing capacity or
-the window requires another protocol change.
-
-## Threat Model
-
-- An attacker may submit a captured signed transaction repeatedly. The
-  `expiringNonceSeen` mapping and ring MUST continue to reject the same
-  transaction hash while its `validBefore` has not elapsed.
-- An attacker may submit transactions at or above the sizing target to exhaust
-  the ring. The existing unexpired-entry check MUST prevent replay-protection
-  state from being overwritten and MUST return `ExpiringNonceSetFull`.
-- A compromised signing or relaying environment has up to five minutes, rather
-  than 30 seconds, to submit a valid captured transaction. This increased replay
-  window is an accepted consequence of the feature and must be disclosed to
-  integrators.
-- No actor gains permission to alter, clear, or extend another transaction's
-  expiry. `validBefore` remains part of the signed transaction semantics.
-
 ---
 
 # Specification
@@ -122,24 +81,6 @@ implementation MUST read the old hash's expiry and reject with
 `ExpiringNonceSetFull` if that expiry is still in the future. Otherwise it MUST
 clear the old `expiringNonceSeen` entry and insert the new hash and expiry.
 
-## State and Gas Behavior
-
-The storage layout remains:
-
-```text
-expiringNonceSeen: mapping(bytes32 => uint64)
-expiringNonceRing: mapping(uint32 => bytes32)
-expiringNonceRingPtr: uint32
-```
-
-No storage migration is required because the mappings are already keyed by the
-ring index and transaction hash. The larger capacity increases the maximum live
-state and the number of ring slots that can be initialized over time.
-
-The intrinsic gas schedule is unchanged by this TIP. Implementations MUST
-re-benchmark the expiring nonce path, including first use of new ring slots,
-steady-state overwrites, and the full-buffer safety check, before activation.
-
 ## Activation and Compatibility
 
 The new constants MUST activate atomically at the protocol version selected for
@@ -149,44 +90,3 @@ builders, and test helpers MUST use the same 300-second maximum.
 Before activation, nodes continue enforcing the TIP-1009 30-second limit. After
 activation, nodes enforcing different limits or capacities MUST be treated as
 incompatible and MUST NOT participate in the same canonical chain.
-
-# Tooling
-
-SDKs and transaction builders that expose the expiring nonce validity limit
-MUST update their helper constants and validation messages from 30 seconds to
-300 seconds. Pool, RPC, and test fixtures MUST accept valid expiries throughout
-the five-minute window and reject expiries beyond it.
-
-Relayer and wallet documentation SHOULD warn that a signed transaction can
-remain valid for up to five minutes and SHOULD expose the selected
-`validBefore` timestamp to users.
-
-# Observability
-
-Existing transaction rejection metrics MUST distinguish expiry-window failures
-from `ExpiringNonceSetFull` failures. Operators SHOULD monitor:
-
-- the count and rate of `ExpiringNonceSetFull` errors;
-- the rate of expiring nonce transactions and the estimated ring wrap interval;
-- live expiring nonce ring and seen-set state size; and
-- the age of entries when they are evicted.
-
-These signals answer whether the 3,000,000-entry capacity is sufficient and
-whether a traffic spike is causing valid transactions to be rejected.
-
-# Invariants
-
-- A transaction hash MUST NOT execute twice while its recorded expiry is in the
-  future.
-- `validBefore <= now` MUST always be rejected.
-- `validBefore > now + 300` MUST always be rejected after activation.
-- An expiring nonce transaction MUST have `nonceKey = uint256.max`, `nonce = 0`,
-  and a set `validBefore`.
-- The ring MUST never overwrite an entry whose recorded expiry is in the future.
-- Expiring nonce transactions MUST NOT mutate the protocol nonce or any normal
-  2D nonce.
-- The ring pointer MUST always remain below `3,000,000`.
-
-The test suite MUST cover boundary timestamps at `now`, `now + 300`, and
-`now + 301`; replay during and after expiry; pointer wraparound at the new
-capacity; full-buffer rejection; and concurrent expiring nonce transactions.


### PR DESCRIPTION
Adds TIP-1093, extending the expiring nonce validity window from 30 seconds to five minutes. The proposal resizes the replay-protection ring from 300,000 to 3,000,000 entries at the existing 10,000 TPS sizing target and documents compatibility, security, tooling, observability, and invariant requirements.

Prompted by: @shekhirin