### PR TITLE
ci: use GitHub STS for Cyclops audits

### DIFF
--- a/.github/sts/cyclops-audit.sts.yaml
+++ b/.github/sts/cyclops-audit.sts.yaml
@@ -1,0 +1,9 @@
+# Allow issue-comment workflows in Tempo to mint a short-lived token for the
+# GitHub API calls made by the Cyclops audit command.
+subject_pattern: repo:tempoxyz(@211589300)?/tempo(@994992847)?:ref:refs/heads/.+
+claim_pattern:
+  event_name: issue_comment
+permissions:
+  issues: write
+  members: read
+  pull_requests: write

--- a/.github/sts/pr-audit.sts.yaml
+++ b/.github/sts/pr-audit.sts.yaml
@@ -1,8 +1,8 @@
-# Allow issue-comment workflows in Tempo to mint a short-lived token for the
-# GitHub API calls made by the Cyclops audit command.
+# Allow issue-comment runs of Tempo's pr-audit workflow to mint a short-lived token for its GitHub API calls.
 subject_pattern: repo:tempoxyz(@211589300)?/tempo(@994992847)?:ref:refs/heads/.+
 claim_pattern:
   event_name: issue_comment
+  workflow_ref: tempoxyz/tempo/.github/workflows/pr-audit.yml@.*
 permissions:
   issues: write
   members: read

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -45,14 +45,18 @@ jobs:
         startsWith(github.event.comment.body, 'derek audit')
       )
     permissions:
-      contents: read
-      issues: write
-      pull-requests: write
+      id-token: write
     steps:
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        uses: tempoxyz/gh-actions/actions/github-sts@483bda4a2a4b5e04a51edff03768c1590d271f80
+        with:
+          policy: cyclops-audit
+
       - name: Check org membership
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const org = 'tempoxyz';
             const checkMembership = async (username) => {
@@ -84,7 +88,7 @@ jobs:
         id: args
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const usage = [
               '**Usage:** `cyclops audit [fast] [perf] [iterations=N] [hours=N] [config=pr-review.yaml] ',
@@ -230,7 +234,7 @@ jobs:
           ACTOR: ${{ steps.args.outputs.actor }}
           SUMMARY: ${{ steps.args.outputs.summary }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             try {
               await github.rest.reactions.createForIssueComment({
@@ -280,7 +284,7 @@ jobs:
           ACTOR: ${{ steps.args.outputs.actor }}
           SUMMARY: ${{ steps.args.outputs.summary }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             if (!process.env.COMMENT_ID) {
               core.setFailed('Missing acknowledgement comment id');

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -51,7 +51,7 @@ jobs:
         id: github-sts
         uses: tempoxyz/gh-actions/actions/github-sts@483bda4a2a4b5e04a51edff03768c1590d271f80
         with:
-          policy: cyclops-audit
+          policy: pr-audit
 
       - name: Check org membership
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
Migrates the comment-triggered Cyclops audit job from long-lived GitHub tokens to the repository GitHub STS action.

- Adds the dedicated `.github/sts/pr-audit.sts.yaml` policy.
- Restricts the token to `issue_comment` executions of `pr-audit.yml`.
- Grants only the GitHub API permissions required for membership checks and PR comments.
- Removes the Derek token dependencies from the audit job.

Prompted by: @sds