### PR TITLE
fix(ci): use GitHub STS for e2e benchmarks

### DIFF
--- a/.github/sts/bench-e2e.sts.yaml
+++ b/.github/sts/bench-e2e.sts.yaml
@@ -1,0 +1,8 @@
+# Allow branch and pull-request e2e benchmark workflows in Tempo to mint a
+# short-lived token for the GitHub API calls and private ValScope checkout.
+subject_pattern: repo:tempoxyz(@211589300)?/tempo(@994992847)?:((ref:refs/heads/.+)|pull_request)
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull_requests: write

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -161,8 +161,7 @@ jobs:
       matrix: ${{ fromJSON(needs.resolve-refs.outputs.bench-matrix) }}
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
+      id-token: write
     with:
       actor: ${{ matrix.actor }}
       baseline: ${{ matrix.baseline_ref }}
@@ -178,7 +177,6 @@ jobs:
       clickhouse-run: feature-1
       samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply == false && 'false' || 'true' }}
     secrets:
-      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -327,8 +327,6 @@ on:
         required: false
         default: ""
     secrets:
-      DEREK_BENCH_TOKEN:
-        required: false
       TEMPO_TELEMETRY_URL:
         required: false
       GRAFANA_TEMPO:
@@ -356,8 +354,7 @@ env:
 
 permissions:
   contents: read
-  issues: write
-  pull-requests: write
+  id-token: write
 
 jobs:
   bench-e2e:
@@ -461,6 +458,12 @@ jobs:
       - name: Clean up previous results
         run: sudo rm -rf bench-results/ 2>/dev/null || true
 
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        uses: tempoxyz/gh-actions/actions/github-sts@483bda4a2a4b5e04a51edff03768c1590d271f80
+        with:
+          policy: bench-e2e
+
       - name: Resolve checkout ref
         id: checkout-ref
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -500,7 +503,7 @@ jobs:
           ref: main
           path: valscope
           persist-credentials: false
-          token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          token: ${{ steps.github-sts.outputs.token }}
 
       - name: Render txgen spec
         run: |
@@ -539,7 +542,7 @@ jobs:
           INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -603,14 +606,12 @@ jobs:
           node-version: 24
 
       - name: Install txgen
-        env:
-          TXGEN_GIT_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
         run: |
           CARGO_BIN_DIR="${CARGO_HOME:-$HOME/.cargo}/bin"
           echo "$CARGO_BIN_DIR" >> "$GITHUB_PATH"
           export PATH="$CARGO_BIN_DIR:$PATH"
 
-          TXGEN_GIT_URL="https://x-access-token:${TXGEN_GIT_TOKEN}@github.com/tempoxyz/txgen"
+          TXGEN_GIT_URL="https://github.com/tempoxyz/txgen"
           install_args=(--git "$TXGEN_GIT_URL" --locked)
           if [ -n "$BENCH_TXGEN_REF" ]; then
             TXGEN_REV="$(git ls-remote "$TXGEN_GIT_URL" "$BENCH_TXGEN_REF" "refs/heads/$BENCH_TXGEN_REF" "refs/tags/$BENCH_TXGEN_REF" | awk 'BEGIN { rev = "" } /\^\{\}$/ { rev = $1; exit } rev == "" { rev = $1 } END { if (rev != "") print rev }')"
@@ -781,7 +782,7 @@ jobs:
           INPUT_BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             if (process.env.BENCH_COMMENT_ID || !process.env.BENCH_PR) {
               return;
@@ -844,7 +845,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running benchmark...'});
@@ -856,7 +857,6 @@ jobs:
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
           BASELINE_NAME: ${{ steps.refs.outputs.baseline-name }}
           FEATURE_NAME: ${{ steps.refs.outputs.feature-name }}
-          BENCH_GH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
         run: |
           if [ "$BENCH_OTLP" != "true" ]; then
             unset TEMPO_TELEMETRY_URL
@@ -1051,7 +1051,7 @@ jobs:
           BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
           BENCH_VALSCOPE_PUBLISHED_URL: ${{ steps.publish-valscope-static.outputs.url }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const fs = require('fs');
             const resultsDir = process.env.BENCH_RESULTS_DIR;
@@ -1231,7 +1231,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -1245,7 +1245,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || github.token }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -624,6 +624,9 @@ jobs:
   bench-e2e:
     needs: tempo-bench-ack
     if: needs.tempo-bench-ack.outputs.mode == 'e2e'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/bench-e2e.yml
     with:
       pr: ${{ needs.tempo-bench-ack.outputs.pr }}
@@ -671,7 +674,6 @@ jobs:
       pr-head-sha: ${{ needs.tempo-bench-ack.outputs.pr-head-sha }}
       pr-head-ref: ${{ needs.tempo-bench-ack.outputs.pr-head-ref }}
     secrets:
-      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}


### PR DESCRIPTION
Replaces the long-lived benchmark token in the bench-e2e reusable workflow with a short-lived GitHub STS token, including the private ValScope checkout and GitHub API calls. Adds the repository trust policy and removes the token from the e2e caller path; txgen is fetched without credentials because it is public.

Prompted by: @shekhirin