### PR TITLE
fix(consensus): accept certified side branches above finality

### DIFF
--- a/crates/consensus/src/follow/executor/actor.rs
+++ b/crates/consensus/src/follow/executor/actor.rs
@@ -221,18 +221,8 @@ where
             .wrap_err("failed locating certified block in execution")?
         {
             BlockLocation::Canonical(height) => {
-                let height = Height::new(height);
-                let block_epoch = self
-                    .epoch_strategy
-                    .containing(height)
-                    .expect("strategy is valid for all heights and epochs")
-                    .epoch();
-                ensure!(
-                    block_epoch == candidate_round.epoch(),
-                    "certified block `{digest}` is canonical at height `{height}` in epoch \
-                     `{block_epoch}`, but its certificate is from epoch `{}`",
-                    candidate_round.epoch(),
-                );
+                let height =
+                    self.validate_certified_height(candidate_round, candidate.digest, height)?;
                 ensure!(
                     height != current_height,
                     "certified block `{digest}` and execution tip `{}` are different canonical \
@@ -242,10 +232,20 @@ where
                 self.observe(Target::finalized(candidate_round, height, candidate.digest));
             }
             BlockLocation::NonCanonical(height) => {
-                return Err(eyre!(
+                let height =
+                    self.validate_certified_height(candidate_round, candidate.digest, height)?;
+
+                // Under consensus safety, a verified block above the finalized tip must extend
+                // the finalized chain. Its certificate can select a side branch above that tip.
+                // A block at or below the tip conflicts with finality.
+                ensure!(
+                    height > current_height,
                     "verified certificate names noncanonical execution block `{digest}` at height \
-                     `{height}`"
-                ));
+                     `{height}`, which is not above finalized execution tip `{}` at height \
+                     `{current_height}`",
+                    current.digest,
+                );
+                self.observe(Target::finalized(candidate_round, height, candidate.digest));
             }
             BlockLocation::Unknown => {
                 // A stale block must already be in the canonical chain. Therefore, a verified
@@ -255,6 +255,27 @@ where
         }
 
         Ok(())
+    }
+
+    fn validate_certified_height(
+        &self,
+        round: Round,
+        digest: Digest,
+        height: u64,
+    ) -> eyre::Result<Height> {
+        let height = Height::new(height);
+        let block_epoch = self
+            .epoch_strategy
+            .containing(height)
+            .expect("strategy is valid for all heights and epochs")
+            .epoch();
+        ensure!(
+            block_epoch == round.epoch(),
+            "certified block `{digest}` is at height `{height}` in epoch `{block_epoch}`, but its \
+             certificate is from epoch `{}`",
+            round.epoch(),
+        );
+        Ok(height)
     }
 
     fn should_send_forkchoice(&self) -> bool {

--- a/crates/consensus/src/follow/executor/test/mod.rs
+++ b/crates/consensus/src/follow/executor/test/mod.rs
@@ -655,7 +655,41 @@ fn same_epoch_known_descendant_drives_forkchoice_after_restart() {
 }
 
 #[test_traced]
-fn same_epoch_noncanonical_certified_tip_stops_executor() {
+fn same_epoch_known_noncanonical_descendant_drives_forkchoice_after_restart() {
+    deterministic::Runner::default().start(|context| async move {
+        let execution_digest = Digest(B256::with_last_byte(12));
+        let certified = Digest(B256::with_last_byte(15));
+        let provider = StubExecutionProvider::default();
+        provider.set_finalized(12, execution_digest.0);
+        provider.set_block_location(certified.0, BlockLocation::NonCanonical(15));
+
+        let (actor, mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                startup_tip: crate::alias::marshal::StartupTip {
+                    round: Some(epoch_round(1, 1)),
+                    height: Height::new(11),
+                    digest: Digest(B256::with_last_byte(11)),
+                },
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        mailbox.certified_tip(epoch_round(1, 9), certified);
+
+        wait_until(&context, || !provider.forkchoices().is_empty()).await;
+        assert_eq!(provider.forkchoices()[0].head_block_hash, certified.0);
+    });
+}
+
+#[test_traced]
+fn same_epoch_noncanonical_ancestor_stops_executor() {
     deterministic::Runner::default().start(|context| async move {
         let execution_digest = Digest(B256::with_last_byte(12));
         let certified = Digest(B256::with_last_byte(19));
@@ -689,13 +723,81 @@ fn same_epoch_noncanonical_certified_tip_stops_executor() {
 }
 
 #[test_traced]
-fn certified_round_must_match_known_block_epoch() {
+fn same_epoch_noncanonical_block_at_execution_tip_stops_executor() {
+    deterministic::Runner::default().start(|context| async move {
+        let execution_digest = Digest(B256::with_last_byte(12));
+        let certified = Digest(B256::with_last_byte(19));
+        let provider = StubExecutionProvider::default();
+        provider.set_finalized(12, execution_digest.0);
+        provider.set_block_location(certified.0, BlockLocation::NonCanonical(12));
+
+        let (actor, mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                startup_tip: crate::alias::marshal::StartupTip {
+                    round: Some(epoch_round(1, 1)),
+                    height: Height::new(11),
+                    digest: Digest(B256::with_last_byte(11)),
+                },
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        let handle = actor.start();
+
+        mailbox.certified_tip(epoch_round(1, 9), certified);
+        handle.await.expect("executor should stop cleanly");
+
+        assert!(provider.forkchoices().is_empty());
+    });
+}
+
+#[test_traced]
+fn canonical_block_epoch_must_match_certified_round() {
     deterministic::Runner::default().start(|context| async move {
         let execution_digest = Digest(B256::with_last_byte(12));
         let certified = Digest(B256::with_last_byte(22));
         let provider = StubExecutionProvider::default();
         provider.set_finalized(12, execution_digest.0);
         provider.set_block_location(certified.0, BlockLocation::Canonical(22));
+
+        let (actor, mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                startup_tip: crate::alias::marshal::StartupTip {
+                    round: Some(epoch_round(1, 1)),
+                    height: Height::new(11),
+                    digest: Digest(B256::with_last_byte(11)),
+                },
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        let handle = actor.start();
+
+        mailbox.certified_tip(epoch_round(1, 9), certified);
+        handle.await.expect("executor should stop cleanly");
+
+        assert!(provider.forkchoices().is_empty());
+    });
+}
+
+#[test_traced]
+fn noncanonical_block_epoch_must_match_certified_round() {
+    deterministic::Runner::default().start(|context| async move {
+        let execution_digest = Digest(B256::with_last_byte(12));
+        let certified = Digest(B256::with_last_byte(22));
+        let provider = StubExecutionProvider::default();
+        provider.set_finalized(12, execution_digest.0);
+        provider.set_block_location(certified.0, BlockLocation::NonCanonical(22));
 
         let (actor, mailbox) = init(
             context.child("follower_executor"),


### PR DESCRIPTION
Treat a verified same-epoch certificate for a known noncanonical block above the execution finalized tip as a forward fork-choice target. Blocks at or below the finalized height and blocks whose height does not match the certificate epoch remain fatal.