### PR TITLE
fix(ci): use separate STS token for ValScope

### DIFF
--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -464,6 +464,14 @@ jobs:
         with:
           policy: bench-e2e
 
+      - name: Fetch ValScope token via STS
+        id: valscope-sts
+        if: env.BENCH_VALSCOPE == 'true'
+        uses: tempoxyz/gh-actions/actions/github-sts@483bda4a2a4b5e04a51edff03768c1590d271f80
+        with:
+          scope: tempoxyz/valscope
+          policy: tempo-bench-e2e
+
       - name: Resolve checkout ref
         id: checkout-ref
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -503,7 +511,7 @@ jobs:
           ref: main
           path: valscope
           persist-credentials: false
-          token: ${{ steps.github-sts.outputs.token }}
+          token: ${{ steps.valscope-sts.outputs.token }}
 
       - name: Render txgen spec
         run: |


### PR DESCRIPTION
Fixes the ValScope checkout in `bench-e2e` by minting a separate STS token scoped to `tempoxyz/valscope` using the merged `tempo-bench-e2e` policy.

The existing `bench-e2e` STS token remains dedicated to Tempo API operations. The ValScope token is requested only when ValScope reporting is enabled and is passed only to the private repository checkout.

Validated the workflow YAML and confirmed the failed run was caused by the Tempo-scoped token returning `Repository not found` for `tempoxyz/valscope`.

Prompted by: @sds