### PR TITLE
fix(upstream): prevent retry storm due to subscription failure

### DIFF
--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -60,6 +60,7 @@ where
     pub(super) pending_stream: OptionFuture<BoxFuture<'static, eyre::Result<EventStream>>>,
     pub(super) event_stream: Option<EventStream>,
     pub(super) reconnect_jitter: fn() -> Duration,
+    pub(super) retry_attempt: u64,
     /// Requests waiting for the actor to establish a connection.
     pub(super) waiters: Vec<super::ingress::Message>,
 }
@@ -82,6 +83,7 @@ where
         pending_stream: OptionFuture::none(),
         event_stream: None,
         reconnect_jitter,
+        retry_attempt: 1,
         waiters: Vec::new(),
     };
 
@@ -109,12 +111,13 @@ where
                 biased;
 
                 (attempts, client) = &mut self.pending_connect => {
+                    self.retry_attempt = attempts;
                     match client {
                         Ok(client) => {
                             self.connection.replace(client);
                         }
                         Err(reason) => {
-                            let reconnect_in = reconnect_backoff(attempts) + (self.reconnect_jitter)();
+                            let reconnect_in = self.retry_connection();
                             warn_span!("reconnect").in_scope(|| warn!(
                                 %reason,
                                 attempts,
@@ -122,14 +125,6 @@ where
                                 url = %self.connector.endpoint(),
                                 "connecting to upstream node failed, attempting again",
                             ));
-                            self.pending_connect.replace({
-                                let sleep = self.context.sleep(reconnect_in);
-                                let connector = self.connector.clone();
-                                async move {
-                                    sleep.await;
-                                    connector.connect(attempts.saturating_add(1)).await
-                                }.boxed()
-                            });
                         }
                     }
                 }
@@ -142,12 +137,14 @@ where
                             self.event_stream = Some(stream);
                         }
                         Err(error) => {
-                            warn_span!("event_subscription").in_scope(|| warn!(
-                                reason = %error,
-                                "failed subscribing to events; reconnecting to upstream node"
-                            ));
                             self.connection.take();
                             self.event_stream = None;
+                            let reconnect_in = self.retry_connection();
+                            warn_span!("event_subscription").in_scope(|| warn!(
+                                reason = %error,
+                                reconnect_in = %display_duration(reconnect_in),
+                                "failed subscribing to events; reconnecting to upstream node",
+                            ));
                         }
                     }
                 }
@@ -155,24 +152,28 @@ where
                 event = next_event(&mut self.event_stream) => {
                     match event {
                         Some(Ok(event)) => {
+                            // A handshake and subscription response alone do not prove recovery.
+                            self.retry_attempt = 0;
                             debug_span!("consensus_event").in_scope(|| debug!(
                                 ?event, "received consensus event, forwarding to reporter"
                             ));
                             let _ = reporter.report(event);
                         }
                         Some(Err(error)) => {
+                            let reconnect_in = self.retry_event_stream();
                             warn_span!("event").in_scope(|| warn!(
                                 %error,
+                                reconnect_in = %display_duration(reconnect_in),
                                 "event stream encountered an error",
                             ));
-                            self.event_stream = None;
                         }
                         None => {
+                            let reconnect_in = self.retry_event_stream();
                             warn_span!("event_subscription").in_scope(|| warn!(
                                 url = %self.connector.endpoint(),
+                                reconnect_in = %display_duration(reconnect_in),
                                 "event stream terminated",
                             ));
-                            self.event_stream = None;
                         }
                     }
                 }
@@ -194,7 +195,9 @@ where
         }
 
         let Some(client) = self.connection.clone() else {
-            self.pending_connect.replace(self.connector.connect(1));
+            self.retry_attempt = self.retry_attempt.max(1);
+            self.pending_connect
+                .replace(self.connector.connect(self.retry_attempt));
             return;
         };
 
@@ -205,10 +208,67 @@ where
         if client.is_connected() {
             self.pending_stream.replace(client.subscribe_events());
         } else {
-            warn!(url = %self.connector.endpoint(), "upstream client disconnected, reconnecting");
             self.connection.take();
-            self.pending_connect.replace(self.connector.connect(1));
+            let reconnect_in = self.retry_connection();
+            warn!(
+                url = %self.connector.endpoint(),
+                reconnect_in = %display_duration(reconnect_in),
+                "upstream client disconnected, reconnecting",
+            );
         }
+    }
+
+    fn retry_event_stream(&mut self) -> Duration {
+        self.event_stream = None;
+        let Some(client) = self.connection.clone() else {
+            return self.retry_connection();
+        };
+
+        if client.is_connected() {
+            self.retry_subscription(client)
+        } else {
+            self.connection.take();
+            self.retry_connection()
+        }
+    }
+
+    fn retry_connection(&mut self) -> Duration {
+        let reconnect_in = self.begin_retry();
+        let sleep = self.context.sleep(reconnect_in);
+        let connector = self.connector.clone();
+        let attempts = self.retry_attempt;
+        self.pending_connect.replace(
+            async move {
+                sleep.await;
+                connector.connect(attempts).await
+            }
+            .boxed(),
+        );
+        reconnect_in
+    }
+
+    fn retry_subscription(&mut self, client: TConnector::Client) -> Duration {
+        let reconnect_in = self.begin_retry();
+        let sleep = self.context.sleep(reconnect_in);
+        self.pending_stream.replace(
+            async move {
+                sleep.await;
+                client.subscribe_events().await
+            }
+            .boxed(),
+        );
+        reconnect_in
+    }
+
+    fn begin_retry(&mut self) -> Duration {
+        let reconnect_in = reconnect_backoff(self.retry_attempt);
+        let reconnect_in = if reconnect_in.is_zero() {
+            reconnect_in
+        } else {
+            reconnect_in + (self.reconnect_jitter)()
+        };
+        self.retry_attempt = self.retry_attempt.saturating_add(1);
+        reconnect_in
     }
 
     /// Drains the waiters by fetching the data they are waiting for.

--- a/crates/consensus/src/follow/upstream/test/mod.rs
+++ b/crates/consensus/src/follow/upstream/test/mod.rs
@@ -120,9 +120,16 @@ fn subscription_failure_reconnects_and_subscribes_again() {
             actor::init(context.child("upstream"), connector.clone(), no_jitter);
         actor.start(StubReporter::default());
 
+        wait_until(&context, || client.subscriptions() == 1).await;
+        context.sleep(Duration::from_millis(1)).await;
+
+        assert_eq!(client.subscriptions(), 1);
+        assert_eq!(connector.attempts(), vec![1]);
+
+        context.sleep(actor::reconnect_backoff(1)).await;
         wait_until(&context, || client.subscriptions() == 2).await;
 
-        assert_eq!(connector.attempts(), vec![1, 1]);
+        assert_eq!(connector.attempts(), vec![1, 2]);
     });
 }
 
@@ -142,6 +149,12 @@ fn terminated_event_stream_is_resubscribed() {
             actor::init(context.child("upstream"), connector.clone(), no_jitter);
         actor.start(reporter.clone());
 
+        wait_until(&context, || client.subscriptions() == 1).await;
+        context.sleep(Duration::from_millis(1)).await;
+
+        assert_eq!(client.subscriptions(), 1);
+
+        context.sleep(actor::reconnect_backoff(1)).await;
         wait_until(&context, || client.subscriptions() == 2).await;
         wait_until(&context, || reporter.events().len() == 1).await;
 
@@ -160,6 +173,12 @@ fn event_stream_error_resubscribes_without_reconnecting() {
             actor::init(context.child("upstream"), connector.clone(), no_jitter);
         actor.start(StubReporter::default());
 
+        wait_until(&context, || client.subscriptions() == 1).await;
+        context.sleep(Duration::from_millis(1)).await;
+
+        assert_eq!(client.subscriptions(), 1);
+
+        context.sleep(actor::reconnect_backoff(1)).await;
         wait_until(&context, || client.subscriptions() == 2).await;
 
         assert_eq!(connector.attempts(), vec![1]);
@@ -185,8 +204,42 @@ fn disconnected_client_reconnects_before_resubscribing() {
         terminate_stream
             .send(())
             .expect("event stream should still be active");
+        context.sleep(Duration::from_millis(1)).await;
+
+        assert_eq!(replacement_client.subscriptions(), 0);
+        assert_eq!(connector.attempts(), vec![1]);
+
+        context.sleep(actor::reconnect_backoff(1)).await;
         wait_until(&context, || replacement_client.subscriptions() == 1).await;
 
-        assert_eq!(connector.attempts(), vec![1, 1]);
+        assert_eq!(connector.attempts(), vec![1, 2]);
+    });
+}
+
+#[test_traced]
+fn repeated_stream_terminations_escalate_backoff() {
+    deterministic::Runner::default().start(|context| async move {
+        let client = StubClient::connected();
+        client.queue_terminated_subscription();
+        client.queue_terminated_subscription();
+        client.queue_subscription();
+        let connector = StubConnector::new(client.clone());
+        let (actor, _mailbox) =
+            actor::init(context.child("upstream"), connector.clone(), no_jitter);
+        actor.start(StubReporter::default());
+
+        wait_until(&context, || client.subscriptions() == 1).await;
+        context.sleep(Duration::from_millis(1)).await;
+        assert_eq!(client.subscriptions(), 1);
+
+        context.sleep(actor::reconnect_backoff(1)).await;
+        wait_until(&context, || client.subscriptions() == 2).await;
+        context.sleep(Duration::from_millis(1)).await;
+        assert_eq!(client.subscriptions(), 2);
+
+        context.sleep(actor::reconnect_backoff(2)).await;
+        wait_until(&context, || client.subscriptions() == 3).await;
+
+        assert_eq!(connector.attempts(), vec![1]);
     });
 }


### PR DESCRIPTION
In case the subscription fails, we would be retrying without any delay.