### PR TITLE
fix(ci): remove benchmark hardfork allowlist

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -188,7 +188,6 @@ jobs:
             const stringArgs = new Set(['mode', 'preset', 'baseline-args', 'feature-args', 'baseline-features', 'feature-features', 'bench-args', 'bench-env', 'baseline-env', 'feature-env', 'chain', 'baseline-hardfork', 'feature-hardfork', 'run-side']);
             const boolArgs = new Set(['samply', 'tracy', 'force-bloat', 'no-cache', 'no-slack', 'otlp', 'valscope', 'metrics', 'skip-state-root']);
             const bloatValues = new Set(['1', '10', '100']);
-            const hardforkValues = new Set(['T0', 'T1', 'T1A', 'T1B', 'T1C', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8', 'T9', 'T10']);
             const defaults = { mode: 'e2e', preset: 'default', duration: '300', bloat: '100', 'token-count': '4', tps: '50000', accounts: '1000', 'max-concurrent-requests': '5000', baseline: '', feature: '', 'baseline-hardfork': '', 'feature-hardfork': '', 'baseline-features': '', 'feature-features': '', 'txgen-ref': '', samply: 'false', tracy: 'off', 'tracy-seconds': '10', 'tracy-offset': '', otlp: 'true', valscope: 'false', metrics: 'false', 'skip-state-root': 'false', 'baseline-args': '', 'feature-args': '', 'gas-limit': '1000000000000', 'general-gas-limit': '1000000000000', 'force-bloat': 'false', 'no-cache': 'false', 'no-slack': 'false', 'bench-args': '', 'bench-env': '', 'baseline-env': '', 'feature-env': '', blocks: '5000', warmup: '', chain: 'mainnet', 'run-pairs': '2', 'run-side': 'comparison' };
             const unknown = [];
             const invalid = [];
@@ -272,7 +271,7 @@ jobs:
             if (unknown.length) errors.push(`Unknown argument(s): \`${unknown.join('`, `')}\``);
             if (invalid.length) errors.push(`Invalid value(s): ${invalid.join(', ')}`);
             if (errors.length) {
-              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [general-gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [skip-state-root] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
+              const msg = `❌ **Invalid bench command**\n\n${errors.join('\n')}\n\n**Usage:** \`@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [general-gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=HARDFORK] [feature-hardfork=HARDFORK] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [skip-state-root] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]\``;
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -333,7 +332,7 @@ jobs:
               tracyOffset = String(Math.floor(Number(duration) / 2));
             }
 
-            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [general-gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [feature-hardfork=T0|T1|T1A|T1B|T1C|T2|T3|T4|T5|T6|T7|T8] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [skip-state-root] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
+            const usageStr = '**Usage:** `@decofe bench [mode=MODE] [chain=mainnet|testnet] [blocks=N] [warmup=N] [run-pairs=N] [run-side=comparison|feature] [preset=NAME] [duration=N] [bloat=1|10|100] [token-count=N] [tps=N] [accounts=N] [max-concurrent-requests=N] [gas-limit=N|NM|NG|NT] [general-gas-limit=N|NM|NG|NT] [baseline=REF] [feature=REF] [baseline-hardfork=HARDFORK] [feature-hardfork=HARDFORK] [baseline-features="FEATURES"] [feature-features="FEATURES"] [txgen-ref=REF] [samply] [tracy] [otlp] [metrics[=true|false]] [valscope] [skip-state-root] [force-bloat] [no-cache] [no-slack] [tracy-seconds=N] [tracy-offset=N] [baseline-args="ARGS"] [feature-args="ARGS"] [bench-args="ARGS"] [bench-env="VARS"] [baseline-env="VARS"] [feature-env="VARS"]`';
 
             // Validate chain value
             if (!['mainnet', 'testnet'].includes(chain)) {
@@ -406,20 +405,9 @@ jobs:
               return;
             }
             if (baselineHardfork || featureHardfork) {
+              // Downstream benchmark scripts validate names against Tempo metadata.
               baselineHardfork = baselineHardfork.toUpperCase();
               featureHardfork = featureHardfork.toUpperCase();
-              const badHardforks = [baselineHardfork, featureHardfork].filter(value => !hardforkValues.has(value));
-              if (badHardforks.length) {
-                const msg = `❌ **Invalid bench command**\n\nUnknown hardfork(s): \`${badHardforks.join('`, `')}\`. Must be one of: \`${Array.from(hardforkValues).join('`, `')}\`.\n\n${usageStr}`;
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body: msg,
-                });
-                core.setFailed(msg);
-                return;
-              }
             }
 
             // Validate tracy value

--- a/xtask/src/generate_hardfork.rs
+++ b/xtask/src/generate_hardfork.rs
@@ -342,6 +342,9 @@ fn append_bench_hardfork(
     let marker = format!("'{previous}'");
     let replacement = format!("'{previous}', '{hardfork}'");
     let count = source.matches(&marker).count();
+    if count == 0 {
+        return Ok(source.to_owned());
+    }
     ensure!(
         count == 1,
         "expected one benchmark hardfork allowlist entry"
@@ -503,5 +506,23 @@ mod tests {
         let updated = append_bench_hardfork(source, &variants, "T10", "T11").unwrap();
         assert!(updated.contains("['T9', 'T10', 'T11']"));
         assert_eq!(updated.matches("T9|T10|T11").count(), 4);
+    }
+
+    #[test]
+    fn current_benchmark_workflow_without_allowlist_does_not_break_add_hardfork() {
+        let variants = [
+            "Genesis", "T0", "T1", "T1A", "T1B", "T1C", "T2", "T3", "T4", "T5", "T6", "T7", "T8",
+            "T9", "T10",
+        ]
+        .into_iter()
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+        let source = include_str!("../../.github/workflows/bench.yml");
+
+        let updated = append_bench_hardfork(source, &variants, "T10", "T11")
+            .expect("add-hardfork should tolerate the current benchmark workflow shape without an in-workflow hardfork allowlist");
+
+        assert!(updated.contains("baseline-hardfork=HARDFORK"));
+        assert!(updated.contains("feature-hardfork=HARDFORK"));
     }
 }


### PR DESCRIPTION
Removes the hardcoded hardfork allowlist from the benchmark PR-comment parser. The benchmark scripts already validate hardfork names from tracked Tempo genesis metadata, so the workflow now forwards normalized values and only enforces paired arguments; usage text uses `HARDFORK` instead of requiring a workflow edit for each new fork.

Prompted by: @grandizzy