### PR TITLE
fix(ci): preserve scheduled OTLP default

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -170,6 +170,7 @@ jobs:
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '100' }}
       run-pairs: ${{ inputs['run-pairs'] || '3' }}
       clickhouse-run: feature-1
+      otlp: true
     secrets:
       BENCH_LOGS_PUSH_URL: ${{ secrets.BENCH_LOGS_PUSH_URL }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -63,6 +63,10 @@ on:
         type: string
         required: false
         default: "feature-1"
+      otlp:
+        type: boolean
+        required: false
+        default: true
     secrets:
       BENCH_LOGS_PUSH_URL:
         required: false


### PR DESCRIPTION
Passes the scheduled workflow’s OTLP default through the reusable benchmark workflow. The reusable workflow now declares `otlp` with a default of `true`, and the scheduled caller passes `true` explicitly, preserving direct manual `otlp=false` dispatches.

Prompted by: @shekhirin