### PR TITLE
fix(ci): build Docker images on release branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - "rc/*"
+      - "release/*"
     tags:
       - "v*.*.*"
   merge_group:


### PR DESCRIPTION
Add `release/*` to the Docker workflow push branch filters so creating or pushing a release branch triggers the image build.\n\nPrompted by: @kamsz