### PR TITLE
feat(tip-1093): extend expiring nonce window at T10

### DIFF
--- a/.changelog/tip-1093.md
+++ b/.changelog/tip-1093.md
@@ -1,0 +1,5 @@
+---
+tempo-primitives: minor
+---
+
+Implemented TIP-1093 by extending the expiring nonce validity window to five minutes and the replay-protection ring to 3,000,000 entries at T10 activation.

--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -97,7 +97,7 @@ impl Default for ExpiringNonceFiller {
 }
 
 impl ExpiringNonceFiller {
-    /// Default expiry window in seconds (25s, within the 30s max allowed by [TIP-1009]).
+    /// Default expiry window in seconds (25s, within the protocol maximum).
     ///
     /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
     pub const DEFAULT_EXPIRY_SECS: u64 = 25;

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -17,7 +17,7 @@ use reth_revm::{
 };
 use tempo_precompiles::{
     NONCE_PRECOMPILE_ADDRESS,
-    nonce::{NonceManager, expiring_nonce_max_expiry_secs, expiring_nonce_set_capacity},
+    nonce::NonceManager,
     storage::StorageAction,
     tip_fee_manager::amm::{Pool, compute_amount_out},
 };
@@ -227,8 +227,8 @@ where
         block_timestamp: u64,
     ) -> Result<(), BlockExecutionError> {
         let spec = self.inner.evm.ctx().cfg.spec;
-        let max_expiry_secs = expiring_nonce_max_expiry_secs(spec);
-        let capacity = expiring_nonce_set_capacity(spec);
+        let max_expiry_secs = spec.expiring_nonce_max_expiry_secs();
+        let capacity = spec.expiring_nonce_set_capacity();
         if expiring_nonce.valid_before <= block_timestamp
             || expiring_nonce.valid_before > block_timestamp.saturating_add(max_expiry_secs)
         {

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -17,7 +17,7 @@ use reth_revm::{
 };
 use tempo_precompiles::{
     NONCE_PRECOMPILE_ADDRESS,
-    nonce::{EXPIRING_NONCE_MAX_EXPIRY_SECS, EXPIRING_NONCE_SET_CAPACITY, NonceManager},
+    nonce::{NonceManager, expiring_nonce_max_expiry_secs, expiring_nonce_set_capacity},
     storage::StorageAction,
     tip_fee_manager::amm::{Pool, compute_amount_out},
 };
@@ -226,9 +226,11 @@ where
         expiring_nonce: ExpiringNonceReplay,
         block_timestamp: u64,
     ) -> Result<(), BlockExecutionError> {
+        let spec = self.inner.evm.ctx().cfg.spec;
+        let max_expiry_secs = expiring_nonce_max_expiry_secs(spec);
+        let capacity = expiring_nonce_set_capacity(spec);
         if expiring_nonce.valid_before <= block_timestamp
-            || expiring_nonce.valid_before
-                > block_timestamp.saturating_add(EXPIRING_NONCE_MAX_EXPIRY_SECS)
+            || expiring_nonce.valid_before > block_timestamp.saturating_add(max_expiry_secs)
         {
             return Err(StorageActionReplayError::ActionConflict.into());
         }
@@ -285,7 +287,7 @@ where
 
         let next = ptr
             .checked_add(U256::ONE)
-            .filter(|next| *next < EXPIRING_NONCE_SET_CAPACITY)
+            .filter(|next| *next < capacity)
             .unwrap_or(U256::ZERO);
         self.replay_state.record_sstore(
             NONCE_PRECOMPILE_ADDRESS,

--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -287,6 +287,30 @@ impl TempoHardfork {
         gas::TEMPO_T1_NEW_NONCE_KEY_GAS
     }
 
+    /// Returns the expiring nonce replay-protection capacity.
+    pub const fn expiring_nonce_set_capacity(&self) -> u32 {
+        const PRE_T10_CAPACITY: u32 = 300_000;
+        const POST_T10_CAPACITY: u32 = 3_000_000;
+
+        if self.is_t10() {
+            POST_T10_CAPACITY
+        } else {
+            PRE_T10_CAPACITY
+        }
+    }
+
+    /// Returns the maximum expiring nonce validity window in seconds.
+    pub const fn expiring_nonce_max_expiry_secs(&self) -> u64 {
+        const PRE_T10_MAX_EXPIRY_SECS: u64 = 30;
+        const POST_T10_MAX_EXPIRY_SECS: u64 = 300;
+
+        if self.is_t10() {
+            POST_T10_MAX_EXPIRY_SECS
+        } else {
+            PRE_T10_MAX_EXPIRY_SECS
+        }
+    }
+
     /// Returns the active hardfork at the given timestamp for the specified chain.
     ///
     /// Returns `None` if the chain ID is not a known Tempo chain.

--- a/crates/node/tests/it/tempo_transaction/helpers.rs
+++ b/crates/node/tests/it/tempo_transaction/helpers.rs
@@ -28,7 +28,7 @@ use tempo_primitives::{
     SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
         CallScope, KeyAuthorization, SelectorRule, SignedKeyAuthorization,
-        TEMPO_EXPIRING_NONCE_KEY, TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS, TokenLimit,
+        TEMPO_EXPIRING_NONCE_KEY, TokenLimit,
         tempo_transaction::Call,
         tt_signature::{
             KeychainSignature, P256SignatureWithPreHash, PrimitiveSignature, TempoSignature,
@@ -1214,6 +1214,7 @@ pub(crate) fn build_fill_request_context(
     signer_addr: Address,
     recipient: Address,
     current_timestamp: u64,
+    max_expiry_secs: u64,
 ) -> FillRequestContext {
     let valid_before_offset = test_case
         .valid_before_offset
@@ -1223,13 +1224,9 @@ pub(crate) fn build_fill_request_context(
         .map(|offset| resolve_timestamp_offset(current_timestamp, offset));
 
     let valid_before = valid_before_offset.or_else(|| match test_case.nonce_mode {
-        NonceMode::Expiring => Some(current_timestamp + TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS / 2),
-        NonceMode::ExpiringAtBoundary => {
-            Some(current_timestamp + TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS - 1)
-        }
-        NonceMode::ExpiringExceedsBoundary => {
-            Some(current_timestamp + TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS + 3600)
-        }
+        NonceMode::Expiring => Some(current_timestamp + max_expiry_secs / 2),
+        NonceMode::ExpiringAtBoundary => Some(current_timestamp + max_expiry_secs - 1),
+        NonceMode::ExpiringExceedsBoundary => Some(current_timestamp + max_expiry_secs + 3600),
         NonceMode::ExpiringInPast => Some(current_timestamp.saturating_sub(1)),
         _ => None,
     });
@@ -1297,10 +1294,16 @@ pub(crate) async fn fill_transaction_from_case(
     test_case: &FillTestCase,
     signer_addr: Address,
     current_timestamp: u64,
+    max_expiry_secs: u64,
 ) -> eyre::Result<(TempoTransaction, FillRequestContext)> {
     let recipient = Address::random();
-    let request_context =
-        build_fill_request_context(test_case, signer_addr, recipient, current_timestamp);
+    let request_context = build_fill_request_context(
+        test_case,
+        signer_addr,
+        recipient,
+        current_timestamp,
+        max_expiry_secs,
+    );
 
     let filled: serde_json::Value =
         legacy_compat::raw_request(provider, "eth_fillTransaction", &request_context.request)

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -34,6 +34,7 @@ use tempo_contracts::precompiles::{
 };
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
+    nonce::expiring_nonce_max_expiry_secs,
     tip20::ITIP20::{self},
 };
 use tempo_primitives::{
@@ -1967,7 +1968,7 @@ async fn test_aa_expiring_nonce_replay_protection() -> eyre::Result<()> {
     let current_timestamp = block.header.timestamp();
 
     // Create expiring nonce transaction
-    let valid_before = current_timestamp + 25;
+    let valid_before = current_timestamp + expiring_nonce_max_expiry_secs(setup.hardfork);
 
     let tx = create_expiring_nonce_tx(chain_id, valid_before, recipient);
 

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -34,7 +34,6 @@ use tempo_contracts::precompiles::{
 };
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
-    nonce::expiring_nonce_max_expiry_secs,
     tip20::ITIP20::{self},
 };
 use tempo_primitives::{
@@ -1968,7 +1967,7 @@ async fn test_aa_expiring_nonce_replay_protection() -> eyre::Result<()> {
     let current_timestamp = block.header.timestamp();
 
     // Create expiring nonce transaction
-    let valid_before = current_timestamp + expiring_nonce_max_expiry_secs(setup.hardfork);
+    let valid_before = current_timestamp + setup.hardfork.expiring_nonce_max_expiry_secs();
 
     let tx = create_expiring_nonce_tx(chain_id, valid_before, recipient);
 

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -15,7 +15,6 @@ use alloy_primitives::TxKind;
 use reth_primitives_traits::transaction::TxHashRef;
 use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
 use tempo_node::rpc::TempoTransactionRequest;
-use tempo_precompiles::nonce::expiring_nonce_max_expiry_secs;
 use tempo_primitives::{
     SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
@@ -693,7 +692,7 @@ pub(super) async fn run_estimate_gas_matrix<E: TestEnv>(
 /// deterministic by signing + recovering with a random signer.
 pub(super) async fn run_fill_transaction_matrix<E: TestEnv>(env: &mut E) -> eyre::Result<()> {
     let is_t3 = env.hardfork().is_t3();
-    let max_expiry_secs = expiring_nonce_max_expiry_secs(env.hardfork());
+    let max_expiry_secs = env.hardfork().expiring_nonce_max_expiry_secs();
     let supports_scoped_key_auth_rpc = env.supports_scoped_key_auth_rpc();
     let signer = PrivateKeySigner::random();
     let signer_addr = signer.address();
@@ -1742,7 +1741,7 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
 
     let uses_p256 = matches!(test_case.key_type, KeyType::P256 | KeyType::WebAuthn);
     let chain_id = env.chain_id();
-    let max_expiry_secs = expiring_nonce_max_expiry_secs(env.hardfork());
+    let max_expiry_secs = env.hardfork().expiring_nonce_max_expiry_secs();
 
     if uses_p256 && test_case.pre_bump_nonce.is_some() {
         return Err(eyre::eyre!(

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -15,6 +15,7 @@ use alloy_primitives::TxKind;
 use reth_primitives_traits::transaction::TxHashRef;
 use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
 use tempo_node::rpc::TempoTransactionRequest;
+use tempo_precompiles::nonce::expiring_nonce_max_expiry_secs;
 use tempo_primitives::{
     SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
@@ -692,6 +693,7 @@ pub(super) async fn run_estimate_gas_matrix<E: TestEnv>(
 /// deterministic by signing + recovering with a random signer.
 pub(super) async fn run_fill_transaction_matrix<E: TestEnv>(env: &mut E) -> eyre::Result<()> {
     let is_t3 = env.hardfork().is_t3();
+    let max_expiry_secs = expiring_nonce_max_expiry_secs(env.hardfork());
     let supports_scoped_key_auth_rpc = env.supports_scoped_key_auth_rpc();
     let signer = PrivateKeySigner::random();
     let signer_addr = signer.address();
@@ -757,9 +759,14 @@ pub(super) async fn run_fill_transaction_matrix<E: TestEnv>(env: &mut E) -> eyre
     for (index, test_case) in matrix.iter().enumerate() {
         println!("[{}/{}] {}", index + 1, matrix.len(), test_case.name);
 
-        let fill_result =
-            fill_transaction_from_case(env.provider(), test_case, signer_addr, current_timestamp)
-                .await;
+        let fill_result = fill_transaction_from_case(
+            env.provider(),
+            test_case,
+            signer_addr,
+            current_timestamp,
+            max_expiry_secs,
+        )
+        .await;
         let (filled_tx, request_context) = match fill_result {
             Ok(pair) => {
                 if matches!(test_case.expected, ExpectedOutcome::Rejection) {
@@ -1735,6 +1742,7 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
 
     let uses_p256 = matches!(test_case.key_type, KeyType::P256 | KeyType::WebAuthn);
     let chain_id = env.chain_id();
+    let max_expiry_secs = expiring_nonce_max_expiry_secs(env.hardfork());
 
     if uses_p256 && test_case.pre_bump_nonce.is_some() {
         return Err(eyre::eyre!(
@@ -1753,9 +1761,14 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
 
         let current_timestamp = env.current_block_timestamp().await?;
 
-        let fill_result =
-            fill_transaction_from_case(env.provider(), test_case, signer_addr, current_timestamp)
-                .await;
+        let fill_result = fill_transaction_from_case(
+            env.provider(),
+            test_case,
+            signer_addr,
+            current_timestamp,
+            max_expiry_secs,
+        )
+        .await;
 
         let (mut tx, _request_context) = match fill_result {
             Ok(pair) => pair,
@@ -1808,9 +1821,14 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
         let current_timestamp = env.current_block_timestamp().await?;
         let initial_protocol_nonce = env.provider().get_transaction_count(signer_addr).await?;
 
-        let fill_result =
-            fill_transaction_from_case(env.provider(), test_case, signer_addr, current_timestamp)
-                .await;
+        let fill_result = fill_transaction_from_case(
+            env.provider(),
+            test_case,
+            signer_addr,
+            current_timestamp,
+            max_expiry_secs,
+        )
+        .await;
 
         let (mut tx, request_context) = match fill_result {
             Ok(pair) => pair,

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -15,35 +15,6 @@ use crate::{
     storage::{Handler, Mapping},
 };
 use alloy::primitives::{Address, B256, U256};
-use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS;
-
-/// Capacity of the expiring nonce seen set from T10 (supports 10k TPS for 5 minutes).
-pub const POST_T10_EXPIRING_NONCE_SET_CAPACITY: u32 = 3_000_000;
-
-/// Maximum allowed skew for expiring nonce transactions from T10 (5 minutes).
-/// Transactions must have valid_before in (now, now + MAX_EXPIRY_SECS].
-pub const POST_T10_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 300;
-
-const PRE_T10_EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
-
-/// Returns the expiring nonce replay-protection capacity for `spec`.
-pub const fn expiring_nonce_set_capacity(spec: TempoHardfork) -> u32 {
-    if spec.is_t10() {
-        POST_T10_EXPIRING_NONCE_SET_CAPACITY
-    } else {
-        PRE_T10_EXPIRING_NONCE_SET_CAPACITY
-    }
-}
-
-/// Returns the maximum expiring nonce validity window for `spec`.
-pub const fn expiring_nonce_max_expiry_secs(spec: TempoHardfork) -> u64 {
-    if spec.is_t10() {
-        POST_T10_EXPIRING_NONCE_MAX_EXPIRY_SECS
-    } else {
-        TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS
-    }
-}
 
 /// NonceManager contract for managing 2D nonces as per the AA spec
 ///
@@ -156,8 +127,8 @@ impl NonceManager {
     ) -> Result<()> {
         let now: u64 = self.storage.timestamp().saturating_to();
         let spec = self.storage.spec();
-        let max_expiry_secs = expiring_nonce_max_expiry_secs(spec);
-        let capacity = expiring_nonce_set_capacity(spec);
+        let max_expiry_secs = spec.expiring_nonce_max_expiry_secs();
+        let capacity = spec.expiring_nonce_set_capacity();
 
         // 1. Validate expiry window for the active fork.
         if valid_before <= now || valid_before > now.saturating_add(max_expiry_secs) {
@@ -209,13 +180,14 @@ mod tests {
 
     use super::*;
     use alloy::primitives::address;
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]
     fn test_expiring_nonce_parameters_activate_at_t10() {
-        assert_eq!(expiring_nonce_max_expiry_secs(TempoHardfork::T9), 30);
-        assert_eq!(expiring_nonce_set_capacity(TempoHardfork::T9), 300_000);
-        assert_eq!(expiring_nonce_max_expiry_secs(TempoHardfork::T10), 300);
-        assert_eq!(expiring_nonce_set_capacity(TempoHardfork::T10), 3_000_000);
+        assert_eq!(TempoHardfork::T9.expiring_nonce_max_expiry_secs(), 30);
+        assert_eq!(TempoHardfork::T9.expiring_nonce_set_capacity(), 300_000);
+        assert_eq!(TempoHardfork::T10.expiring_nonce_max_expiry_secs(), 300);
+        assert_eq!(TempoHardfork::T10.expiring_nonce_set_capacity(), 3_000_000);
     }
 
     #[test]
@@ -445,7 +417,7 @@ mod tests {
     }
 
     fn assert_ring_buffer_pointer_wraps_at_capacity(spec: TempoHardfork) -> eyre::Result<()> {
-        let capacity = expiring_nonce_set_capacity(spec);
+        let capacity = spec.expiring_nonce_set_capacity();
         let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -15,13 +15,35 @@ use crate::{
     storage::{Handler, Mapping},
 };
 use alloy::primitives::{Address, B256, U256};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS;
 
-/// Capacity of the expiring nonce seen set (supports 10k TPS for 30 seconds).
-pub const EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
+/// Capacity of the expiring nonce seen set from T10 (supports 10k TPS for 5 minutes).
+pub const POST_T10_EXPIRING_NONCE_SET_CAPACITY: u32 = 3_000_000;
 
-/// Maximum allowed skew for expiring nonce transactions (30 seconds).
+/// Maximum allowed skew for expiring nonce transactions from T10 (5 minutes).
 /// Transactions must have valid_before in (now, now + MAX_EXPIRY_SECS].
-pub const EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
+pub const POST_T10_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 300;
+
+const PRE_T10_EXPIRING_NONCE_SET_CAPACITY: u32 = 300_000;
+
+/// Returns the expiring nonce replay-protection capacity for `spec`.
+pub const fn expiring_nonce_set_capacity(spec: TempoHardfork) -> u32 {
+    if spec.is_t10() {
+        POST_T10_EXPIRING_NONCE_SET_CAPACITY
+    } else {
+        PRE_T10_EXPIRING_NONCE_SET_CAPACITY
+    }
+}
+
+/// Returns the maximum expiring nonce validity window for `spec`.
+pub const fn expiring_nonce_max_expiry_secs(spec: TempoHardfork) -> u64 {
+    if spec.is_t10() {
+        POST_T10_EXPIRING_NONCE_MAX_EXPIRY_SECS
+    } else {
+        TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS
+    }
+}
 
 /// NonceManager contract for managing 2D nonces as per the AA spec
 ///
@@ -124,7 +146,7 @@ impl NonceManager {
     /// 4. Mark the hash as seen
     ///
     /// # Errors
-    /// - `InvalidExpiringNonceExpiry` — `valid_before` not in (now, now + EXPIRING_NONCE_MAX_EXPIRY_SECS]
+    /// - `InvalidExpiringNonceExpiry` — `valid_before` exceeds the active fork's expiry window
     /// - `ExpiringNonceReplay` — transaction hash is already recorded and has not yet expired
     /// - `ExpiringNonceSetFull` — the circular buffer slot holds an unexpired entry that can't be evicted
     pub fn check_and_mark_expiring_nonce(
@@ -133,10 +155,12 @@ impl NonceManager {
         valid_before: u64,
     ) -> Result<()> {
         let now: u64 = self.storage.timestamp().saturating_to();
+        let spec = self.storage.spec();
+        let max_expiry_secs = expiring_nonce_max_expiry_secs(spec);
+        let capacity = expiring_nonce_set_capacity(spec);
 
-        // 1. Validate expiry window: must be in (now, now + EXPIRING_NONCE_MAX_EXPIRY_SECS]
-        if valid_before <= now || valid_before > now.saturating_add(EXPIRING_NONCE_MAX_EXPIRY_SECS)
-        {
+        // 1. Validate expiry window for the active fork.
+        if valid_before <= now || valid_before > now.saturating_add(max_expiry_secs) {
             return Err(NonceError::invalid_expiring_nonce_expiry().into());
         }
 
@@ -169,11 +193,7 @@ impl NonceManager {
         self.expiring_nonce_seen[expiring_nonce_hash].write(valid_before)?;
 
         // 6. Advance pointer (wraps at CAPACITY, not u32::MAX)
-        let next = if ptr + 1 >= EXPIRING_NONCE_SET_CAPACITY {
-            0
-        } else {
-            ptr + 1
-        };
+        let next = if ptr + 1 >= capacity { 0 } else { ptr + 1 };
         self.expiring_nonce_ring_ptr.write(next)?;
 
         Ok(())
@@ -189,6 +209,14 @@ mod tests {
 
     use super::*;
     use alloy::primitives::address;
+
+    #[test]
+    fn test_expiring_nonce_parameters_activate_at_t10() {
+        assert_eq!(expiring_nonce_max_expiry_secs(TempoHardfork::T9), 30);
+        assert_eq!(expiring_nonce_set_capacity(TempoHardfork::T9), 300_000);
+        assert_eq!(expiring_nonce_max_expiry_secs(TempoHardfork::T10), 300);
+        assert_eq!(expiring_nonce_set_capacity(TempoHardfork::T10), 3_000_000);
+    }
 
     #[test]
     fn test_get_nonce_returns_zero_for_new_key() -> eyre::Result<()> {
@@ -320,7 +348,7 @@ mod tests {
 
     #[test]
     fn test_expiring_nonce_expiry_validation() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
@@ -342,15 +370,34 @@ mod tests {
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
-            // valid_before too far in future should fail (uses EXPIRING_NONCE_MAX_EXPIRY_SECS = 30)
+            // valid_before too far in future should fail before T10.
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, now + 31);
             assert_eq!(
                 result.unwrap_err(),
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
-            // valid_before at exactly EXPIRING_NONCE_MAX_EXPIRY_SECS should succeed
+            // valid_before at exactly the pre-T10 maximum should succeed
             mgr.check_and_mark_expiring_nonce(tx_hash, now + 30)?;
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t10_expiring_nonce_expiry_validation() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+        let now = 1000u64;
+        storage.set_timestamp(U256::from(now));
+        StorageCtx::enter(&mut storage, || {
+            let mut mgr = NonceManager::new();
+
+            mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0x22), now + 300)?;
+            assert_eq!(
+                mgr.check_and_mark_expiring_nonce(B256::repeat_byte(0x23), now + 301)
+                    .unwrap_err(),
+                TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
+            );
 
             Ok(())
         })
@@ -397,17 +444,16 @@ mod tests {
         })
     }
 
-    #[test]
-    fn test_ring_buffer_pointer_wraps_at_capacity() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new(1);
+    fn assert_ring_buffer_pointer_wraps_at_capacity(spec: TempoHardfork) -> eyre::Result<()> {
+        let capacity = expiring_nonce_set_capacity(spec);
+        let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
             let mut mgr = NonceManager::new();
 
             // Manually set pointer to just before capacity to test wrap
-            mgr.expiring_nonce_ring_ptr
-                .write(EXPIRING_NONCE_SET_CAPACITY - 1)?;
+            mgr.expiring_nonce_ring_ptr.write(capacity - 1)?;
 
             // Insert a tx - pointer should wrap to 0
             let tx_hash = B256::repeat_byte(0x77);
@@ -427,6 +473,16 @@ mod tests {
 
             Ok(())
         })
+    }
+
+    #[test]
+    fn test_ring_buffer_pointer_wraps_at_pre_t10_capacity() -> eyre::Result<()> {
+        assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T9)
+    }
+
+    #[test]
+    fn test_ring_buffer_pointer_wraps_at_t10_capacity() -> eyre::Result<()> {
+        assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T10)
     }
 
     #[test]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -22,8 +22,7 @@ pub use key_authorization::{
 pub use tempo_transaction::{
     Call, FEE_PAYER_SIGNATURE_MARKER, InvalidValidAfter, InvalidValidBefore,
     MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH,
-    SignatureType, TEMPO_EXPIRING_NONCE_KEY, TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS,
-    TEMPO_TX_TYPE_ID, TempoTransaction, validate_calls,
+    SignatureType, TEMPO_EXPIRING_NONCE_KEY, TEMPO_TX_TYPE_ID, TempoTransaction, validate_calls,
 };
 pub use tt_signed::AASigned;
 

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -31,9 +31,6 @@ pub const MAX_WEBAUTHN_SIGNATURE_LENGTH: usize = 2048; // 2KB max
 /// Nonce key marking an expiring nonce transaction (uses tx hash for replay protection).
 pub const TEMPO_EXPIRING_NONCE_KEY: U256 = U256::MAX;
 
-/// Maximum allowed expiry window for expiring nonce transactions before T10 (30 seconds).
-pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
-
 /// Signature type enumeration
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -31,7 +31,7 @@ pub const MAX_WEBAUTHN_SIGNATURE_LENGTH: usize = 2048; // 2KB max
 /// Nonce key marking an expiring nonce transaction (uses tx hash for replay protection).
 pub const TEMPO_EXPIRING_NONCE_KEY: U256 = U256::MAX;
 
-/// Maximum allowed expiry window for expiring nonce transactions (30 seconds).
+/// Maximum allowed expiry window for expiring nonce transactions before T10 (30 seconds).
 pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
 
 /// Signature type enumeration

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -47,10 +47,7 @@ use tempo_precompiles::{
         SelectorRule as PrecompileSelectorRule, TokenLimit,
     },
     error::TempoPrecompileError,
-    nonce::{
-        INonce::getNonceCall, NonceManager, expiring_nonce_max_expiry_secs,
-        expiring_nonce_set_capacity,
-    },
+    nonce::{INonce::getNonceCall, NonceManager},
     storage::{
         Handler as _, PrecompileStorageProvider, StorageActions, StorageCtx,
         evm::EvmPrecompileStorageProvider,
@@ -1121,8 +1118,8 @@ where
         }
 
         if is_expiring_nonce {
-            let max_expiry_secs = expiring_nonce_max_expiry_secs(*spec);
-            let capacity = expiring_nonce_set_capacity(*spec);
+            let max_expiry_secs = spec.expiring_nonce_max_expiry_secs();
+            let capacity = spec.expiring_nonce_set_capacity();
             // Expiring nonce transaction replay protection:
             // - Pre-T1B: use tx_hash for backwards-compatible behavior.
             // - T1B+: use the sender-scoped tx identifier (keccak256(encode_for_signing || sender))

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -48,8 +48,8 @@ use tempo_precompiles::{
     },
     error::TempoPrecompileError,
     nonce::{
-        EXPIRING_NONCE_MAX_EXPIRY_SECS, EXPIRING_NONCE_SET_CAPACITY, INonce::getNonceCall,
-        NonceManager,
+        INonce::getNonceCall, NonceManager, expiring_nonce_max_expiry_secs,
+        expiring_nonce_set_capacity,
     },
     storage::{
         Handler as _, PrecompileStorageProvider, StorageActions, StorageCtx,
@@ -1121,6 +1121,8 @@ where
         }
 
         if is_expiring_nonce {
+            let max_expiry_secs = expiring_nonce_max_expiry_secs(*spec);
+            let capacity = expiring_nonce_set_capacity(*spec);
             // Expiring nonce transaction replay protection:
             // - Pre-T1B: use tx_hash for backwards-compatible behavior.
             // - T1B+: use the sender-scoped tx identifier (keccak256(encode_for_signing || sender))
@@ -1162,7 +1164,7 @@ where
                             .read()
                             .map_err(|err| EVMError::Custom(err.to_string()))?;
 
-                        let next = (ptr + expiring_nonce_idx as u32) % EXPIRING_NONCE_SET_CAPACITY;
+                        let next = (ptr + expiring_nonce_idx as u32) % capacity;
 
                         nonce_manager
                             .expiring_nonce_ring_ptr
@@ -1181,8 +1183,7 @@ where
                         TempoPrecompileError::NonceError(
                             tempo_contracts::precompiles::NonceError::InvalidExpiringNonceExpiry(_),
                         ) => {
-                            let max_allowed =
-                                block_timestamp.saturating_add(EXPIRING_NONCE_MAX_EXPIRY_SECS);
+                            let max_allowed = block_timestamp.saturating_add(max_expiry_secs);
                             if valid_before <= block_timestamp {
                                 TempoInvalidTransaction::NonceManagerError(format!(
                                     "expiring nonce transaction expired: valid_before ({valid_before}) <= block timestamp ({block_timestamp})"
@@ -1190,7 +1191,7 @@ where
                                 .into()
                             } else {
                                 TempoInvalidTransaction::NonceManagerError(format!(
-                                    "expiring nonce valid_before ({valid_before}) too far in the future: must be within {EXPIRING_NONCE_MAX_EXPIRY_SECS}s of block timestamp ({block_timestamp}), max allowed is {max_allowed}"
+                                    "expiring nonce valid_before ({valid_before}) too far in the future: must be within {max_expiry_secs}s of block timestamp ({block_timestamp}), max allowed is {max_allowed}"
                                 ))
                                 .into()
                             }

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -5,7 +5,7 @@ description: Extends the expiring nonce validity window from 30 seconds to five 
 authors: @shekhirin
 status: Draft
 related: TIP-1009, TIP-0001
-protocolVersion: TBD
+protocolVersion: T10
 ---
 
 # TIP-1093: Extend Expiring Nonce Window to Five Minutes
@@ -84,9 +84,9 @@ clear the old `expiringNonceSeen` entry and insert the new hash and expiry.
 
 ## Activation and Compatibility
 
-The new constants MUST activate atomically at the protocol version selected for
-this TIP. Pool validation, transaction execution, action replay, transaction
-builders, and test helpers MUST use the same 300-second maximum.
+The new constants MUST activate atomically at T10. Pool validation, transaction
+execution, action replay, transaction builders, and test helpers MUST use the
+same 300-second maximum.
 
 At the activation boundary, transactions already recorded in the replay-
 protection state remain recorded and cannot be replayed. The capacity extension

--- a/tips/verify/test/TempoTransactionInvariant.t.sol
+++ b/tips/verify/test/TempoTransactionInvariant.t.sol
@@ -4027,8 +4027,16 @@ contract TempoTransactionInvariantTest is InvariantChecker {
 
     /// @dev Expiring nonce key constant (TIP-1009)
     uint256 private constant EXPIRING_NONCE_KEY = type(uint256).max;
-    /// @dev Maximum expiry window in seconds (TIP-1009)
-    uint64 private constant MAX_EXPIRY_SECS = 30;
+    /// @dev Maximum expiry windows in seconds before and after T10 (TIP-1009, TIP-1093)
+    uint64 private constant PRE_T10_MAX_EXPIRY_SECS = 30;
+    uint64 private constant T10_MAX_EXPIRY_SECS = 300;
+
+    function _maxExpirySecs() internal view returns (uint64) {
+        string memory profile = vm.envOr("FOUNDRY_PROFILE", string("default"));
+        return keccak256(bytes(profile)) == keccak256(bytes("next"))
+            ? T10_MAX_EXPIRY_SECS
+            : PRE_T10_MAX_EXPIRY_SECS;
+    }
 
     /// @notice Build an expiring nonce transaction
     /// @dev Sets nonceKey = uint256.max, nonce = 0, and validBefore within window
@@ -4180,7 +4188,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
             return;
         }
 
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs());
 
         (bytes memory signedTx, bytes32 txHash) =
             _buildExpiringNonceTx(senderIdx, recipient, amount, validBefore);
@@ -4221,7 +4229,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
             return;
         }
 
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs());
 
         (bytes memory signedTx, bytes32 txHash) =
             _buildExpiringNonceTx(senderIdx, recipient, amount, validBefore);
@@ -4290,7 +4298,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
     }
 
     /// @notice Handler E3: Attempt tx with validBefore too far in future
-    /// @dev Tx with validBefore > now + 30s should be rejected
+    /// @dev Tx with validBefore beyond the active hardfork's maximum should be rejected
     function handler_expiringNonceWindowTooFar(
         uint256 actorSeed,
         uint256 recipientSeed,
@@ -4316,7 +4324,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
 
         // Set validBefore beyond the max window
         extraOffset = bound(extraOffset, 1, 1 hours);
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS + extraOffset);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs() + extraOffset);
 
         (bytes memory signedTx,) = _buildExpiringNonceTx(senderIdx, recipient, amount, validBefore);
 
@@ -4356,7 +4364,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
             return;
         }
 
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs());
         uint64 wrongNonce = uint64(bound(nonceSeed, 1, 100));
 
         bytes memory signedTx =
@@ -4438,7 +4446,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
         uint256 protocolNonceBefore = vm.getNonce(sender);
         uint64 nonce2dBefore = nonce.getNonce(sender, 1); // Check a 2D nonce key
 
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs());
 
         (bytes memory signedTx, bytes32 txHash) =
             _buildExpiringNonceTx(senderIdx, recipient, amount, validBefore);
@@ -4497,7 +4505,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
             return;
         }
 
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs());
 
         // Build two different transactions (different amounts = different hashes)
         (bytes memory signedTx1, bytes32 txHash1) =
@@ -4974,7 +4982,7 @@ contract TempoTransactionInvariantTest is InvariantChecker {
             return;
         }
 
-        uint64 validBefore = uint64(block.timestamp + MAX_EXPIRY_SECS);
+        uint64 validBefore = uint64(block.timestamp + _maxExpirySecs());
 
         // Build expiring nonce TempoTransaction
         TempoCall[] memory calls = new TempoCall[](1);

--- a/tips/verify/test/TempoTransactionInvariant.t.sol
+++ b/tips/verify/test/TempoTransactionInvariant.t.sol
@@ -4032,8 +4032,8 @@ contract TempoTransactionInvariantTest is InvariantChecker {
     uint64 private constant T10_MAX_EXPIRY_SECS = 300;
 
     function _maxExpirySecs() internal view returns (uint64) {
-        string memory profile = vm.envOr("FOUNDRY_PROFILE", string("default"));
-        return keccak256(bytes(profile)) == keccak256(bytes("next"))
+        string memory hardfork = vm.getEvmVersion();
+        return keccak256(bytes(hardfork)) == keccak256(bytes("t10"))
             ? T10_MAX_EXPIRY_SECS
             : PRE_T10_MAX_EXPIRY_SECS;
     }


### PR DESCRIPTION
Activates TIP-1093 at T10 by extending the expiring nonce validity window from 30 seconds to five minutes and the replay-protection ring from 300,000 to 3,000,000 entries. Applies the hardfork-aware parameters consistently in execution, action replay, validation, and boundary coverage.