### PR TITLE
fix(ci): use GitHub STS for replay benchmarks

### DIFF
--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -121,7 +121,7 @@ cleanup_reth_ipc() {
 # ============================================================================
 
 echo "Installing txgen-tempo and bench-cli..."
-cargo install --git "https://x-access-token:${DEREK_BENCH_TOKEN}@github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
+cargo install --git "https://github.com/tempoxyz/txgen" --locked txgen-tempo bench-cli
 command -v "$TXGEN_TEMPO_BIN"
 command -v "$TXGEN_BENCH_BIN"
 
@@ -462,10 +462,10 @@ run_single() {
 
 update_bench_status() {
   local status="$1"
-  if [ -z "${BENCH_COMMENT_ID:-}" ] || [ -z "${BENCH_GH_TOKEN:-${DEREK_BENCH_TOKEN:-}}" ]; then
+  if [ -z "${BENCH_COMMENT_ID:-}" ] || [ -z "${BENCH_GH_TOKEN:-}" ]; then
     return 0
   fi
-  local token="${BENCH_GH_TOKEN:-${DEREK_BENCH_TOKEN}}"
+  local token="$BENCH_GH_TOKEN"
   local body
   body=$(printf 'cc @%s\n\n🚀 Benchmark started! [View job](%s)\n\n⏳ **Status:** %s\n\n%s' \
     "${BENCH_ACTOR:-}" "${BENCH_JOB_URL:-}" "$status" "${BENCH_CONFIG:-}")

--- a/.github/sts/bench-replay.sts.yaml
+++ b/.github/sts/bench-replay.sts.yaml
@@ -1,0 +1,8 @@
+# Allow branch and pull-request replay benchmark workflows in Tempo to mint a
+# short-lived token for GitHub API calls.
+subject_pattern: repo:tempoxyz(@211589300)?/tempo(@994992847)?:((ref:refs/heads/.+)|pull_request)
+permissions:
+  contents: read
+  actions: read
+  issues: write
+  pull_requests: write

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -222,7 +222,7 @@ jobs:
     permissions:
       actions: read
       contents: read
-      pull-requests: write
+      id-token: write
     with:
       chain: ${{ needs.resolve-refs.outputs.chain }}
       pr: ""
@@ -240,7 +240,6 @@ jobs:
       slack: ${{ github.event_name == 'workflow_dispatch' && inputs.slack || 'always' }}
       run-label: ${{ github.event_name == 'schedule' && 'Replay Nightly' || 'Replay Bench' }}
     secrets:
-      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -150,8 +150,6 @@ on:
         required: false
         default: "Replay Bench"
     secrets:
-      DEREK_BENCH_TOKEN:
-        required: false
       DEREK_TOKEN:
         required: false
       TEMPO_TELEMETRY_URL:
@@ -181,7 +179,7 @@ env:
 
 permissions:
   contents: read
-  pull-requests: write
+  id-token: write
 
 jobs:
   bench-replay:
@@ -254,6 +252,12 @@ jobs:
             printf 'GRAFANA_TEMPO=%s\n' "$GRAFANA_TEMPO_SECRET" >> "$GITHUB_ENV"
           fi
 
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        uses: tempoxyz/gh-actions/actions/github-sts@483bda4a2a4b5e04a51edff03768c1590d271f80
+        with:
+          policy: bench-replay
+
       - name: Resolve checkout ref
         id: checkout-ref
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -267,7 +271,7 @@ jobs:
           INPUT_FEATURE_FEATURES: ${{ inputs.feature-features }}
           INPUT_REF: ${{ github.ref }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             if (context.eventName === 'workflow_dispatch') {
               // Auto-discover PR for the current branch
@@ -331,7 +335,7 @@ jobs:
         if: env.BENCH_COMMENT_ID
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
@@ -462,7 +466,7 @@ jobs:
         if: success() && env.BENCH_COMMENT_ID
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const s = require('./.github/scripts/bench-update-status.js');
             await s({github, context, status: 'Running replay benchmark...'});
@@ -472,7 +476,7 @@ jobs:
         env:
           BASELINE_REF: ${{ steps.refs.outputs.baseline-ref }}
           FEATURE_REF: ${{ steps.refs.outputs.feature-ref }}
-          DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
+          BENCH_GH_TOKEN: ${{ steps.github-sts.outputs.token }}
           CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
           CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
           CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
@@ -602,7 +606,7 @@ jobs:
           PUSH_CHARTS_SHA: ${{ steps.push-charts.outputs.sha }}
           PUSH_CHARTS_PATH: ${{ steps.push-charts.outputs.path }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const fs = require('fs');
 
@@ -705,7 +709,7 @@ jobs:
         if: failure() && env.BENCH_COMMENT_ID
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({
@@ -750,7 +754,7 @@ jobs:
         if: cancelled() && env.BENCH_COMMENT_ID
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.issues.updateComment({

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -688,6 +688,9 @@ jobs:
   bench-replay:
     needs: tempo-bench-ack
     if: needs.tempo-bench-ack.outputs.mode == 'replay'
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/bench-replay.yml
     with:
       chain: ${{ needs.tempo-bench-ack.outputs.chain }}
@@ -711,7 +714,6 @@ jobs:
       pr-head-sha: ${{ needs.tempo-bench-ack.outputs.pr-head-sha }}
       pr-head-ref: ${{ needs.tempo-bench-ack.outputs.pr-head-ref }}
     secrets:
-      DEREK_BENCH_TOKEN: ${{ secrets.DEREK_BENCH_TOKEN }}
       DEREK_TOKEN: ${{ secrets.DEREK_TOKEN }}
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}


### PR DESCRIPTION
Moves replay benchmarks from the legacy long-lived benchmark token to GitHub STS, matching the e2e benchmark workflow. The short-lived token now handles GitHub API/comment updates and private dependency access, while callers grant only the permissions needed to mint it.

Prompted by: @sds