### PR TITLE
feat(revm): add explicit execution context

### DIFF
--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -263,7 +263,7 @@ mod tests {
 
         assert_eq!(
             tx_env.execution_context(),
-            Some(tempo_revm::ExecutionContext::Simulation)
+            tempo_revm::ExecutionContext::Simulation
         );
         assert_eq!(
             tx_env.channel_open_context_hash(),

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -262,6 +262,10 @@ mod tests {
         let tx_env = req.try_into_tx_env(&evm_env).expect("try_into_tx_env");
 
         assert_eq!(
+            tx_env.execution_context(),
+            Some(tempo_revm::ExecutionContext::Simulation)
+        );
+        assert_eq!(
             tx_env.channel_open_context_hash(),
             Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER)
         );

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -6,7 +6,7 @@ use tempo_primitives::{
     SignatureType, TempoSignature,
     transaction::{Call, RecoveredTempoAuthorization},
 };
-use tempo_revm::{TempoBatchCallEnv, TempoTxEnv};
+use tempo_revm::{ExecutionContext, TempoBatchCallEnv, TempoTxEnv};
 
 /// Non-zero transaction identifier used only for RPC simulations.
 ///
@@ -64,6 +64,7 @@ impl TempoTransactionRequest {
 
         tx_env.fee_token = fee_token;
         tx_env.is_system_tx = false;
+        tx_env.execution_context = Some(ExecutionContext::Simulation);
         tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
         tx_env.fee_payer = fee_payer;
         tx_env.tempo_tx_env = if is_aa {
@@ -219,12 +220,13 @@ mod tests {
         let env = request
             .try_into_tempo_tx_env(TempoTxEnv::default(), true)
             .expect("valid simulation request");
-        let aa = env.tempo_tx_env.expect("AA simulation env");
+        let aa = env.tempo_tx_env.as_ref().expect("AA simulation env");
 
         assert_eq!(aa.override_key_id, Some(key_id));
         assert_eq!(aa.aa_calls.len(), 1);
         assert_eq!(aa.aa_calls[0].to, TxKind::Call(target));
         assert!(matches!(aa.signature, TempoSignature::Keychain(_)));
+        assert_eq!(env.execution_context(), Some(ExecutionContext::Simulation));
         assert_eq!(
             env.unique_tx_identifier,
             Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER)

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -64,7 +64,7 @@ impl TempoTransactionRequest {
 
         tx_env.fee_token = fee_token;
         tx_env.is_system_tx = false;
-        tx_env.execution_context = Some(ExecutionContext::Simulation);
+        tx_env.execution_context = ExecutionContext::Simulation;
         tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
         tx_env.fee_payer = fee_payer;
         tx_env.tempo_tx_env = if is_aa {
@@ -226,7 +226,7 @@ mod tests {
         assert_eq!(aa.aa_calls.len(), 1);
         assert_eq!(aa.aa_calls[0].to, TxKind::Call(target));
         assert!(matches!(aa.signature, TempoSignature::Keychain(_)));
-        assert_eq!(env.execution_context(), Some(ExecutionContext::Simulation));
+        assert_eq!(env.execution_context(), ExecutionContext::Simulation);
         assert_eq!(
             env.unique_tx_identifier,
             Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER)

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -25,4 +25,4 @@ pub use fee_manager::{FeeTokenResolver, ProtocolFeeContext, ProtocolFeeManager, 
 pub use handler::{ValidationContext, calculate_aa_batch_intrinsic_gas};
 pub use revm::interpreter::instructions::utility::IntoAddress;
 pub use tempo_primitives::TempoBlockEnv;
-pub use tx::{TempoBatchCallEnv, TempoTxEnv};
+pub use tx::{ExecutionContext, TempoBatchCallEnv, TempoTxEnv};

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -1,5 +1,5 @@
 use crate::TempoInvalidTransaction;
-use alloy_consensus::{Typed2718, crypto::secp256k1};
+use alloy_consensus::{Typed2718, crypto::secp256k1, transaction::TxHashRef};
 use alloy_evm::{FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, TransactionEnvMut};
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use core::num::NonZeroU64;
@@ -64,6 +64,22 @@ pub struct TempoBatchCallEnv {
     /// Stores how many other expiring nonce transactions are there in the block before this one.
     pub expiring_nonce_idx: Option<usize>,
 }
+
+/// Identifies the kind of execution represented by a transaction environment.
+///
+/// Signed transactions carry their canonical transaction hash. RPC simulations have no canonical
+/// transaction hash because request normalization and signing can change the eventual transaction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionContext {
+    /// Execution or validation of a signed transaction.
+    Transaction {
+        /// Canonical hash of the signed transaction.
+        tx_hash: B256,
+    },
+    /// Non-committing execution of an RPC transaction request.
+    Simulation,
+}
+
 /// Tempo transaction environment.
 #[derive(Debug, Clone, Default, derive_more::Deref, derive_more::DerefMut)]
 pub struct TempoTxEnv {
@@ -77,6 +93,11 @@ pub struct TempoTxEnv {
 
     /// Whether the transaction is a system transaction.
     pub is_system_tx: bool,
+
+    /// Whether this environment represents a signed transaction or an RPC simulation.
+    ///
+    /// Synthetic environments created directly by tests or other callers may leave this unset.
+    pub execution_context: Option<ExecutionContext>,
 
     /// Sender-scoped transaction identifier used for replay-sensitive features.
     ///
@@ -114,6 +135,11 @@ impl TempoTxEnv {
         self.tempo_tx_env
             .as_ref()
             .is_some_and(|aa| aa.subblock_transaction)
+    }
+
+    /// Returns the semantic execution context, when supplied by the environment builder.
+    pub fn execution_context(&self) -> Option<ExecutionContext> {
+        self.execution_context
     }
 
     /// Returns the sender-scoped transaction identifier.
@@ -343,6 +369,9 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
             },
             fee_token: *fee_token,
             is_system_tx: false,
+            execution_context: Some(ExecutionContext::Transaction {
+                tx_hash: *aa_signed.hash(),
+            }),
             unique_tx_identifier: Some(aa_signed.expiring_nonce_hash(caller)),
             fee_payer: fee_payer_signature.map(|sig| {
                 secp256k1::recover_signer(&sig, tx.fee_payer_signature_hash(caller)).ok()
@@ -379,22 +408,34 @@ impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 fee_token: None,
                 is_system_tx: tx.is_system_tx(),
+                execution_context: Some(ExecutionContext::Transaction {
+                    tx_hash: *tx.tx_hash(),
+                }),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 fee_payer: None,
                 tempo_tx_env: None, // Non-AA transaction
             },
             TempoTxEnvelope::Eip2930(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
+                execution_context: Some(ExecutionContext::Transaction {
+                    tx_hash: *tx.tx_hash(),
+                }),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::Eip1559(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
+                execution_context: Some(ExecutionContext::Transaction {
+                    tx_hash: *tx.tx_hash(),
+                }),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::Eip7702(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
+                execution_context: Some(ExecutionContext::Transaction {
+                    tx_hash: *tx.tx_hash(),
+                }),
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
@@ -434,7 +475,7 @@ mod tests {
         },
     };
 
-    use crate::{TempoInvalidTransaction, TempoTxEnv};
+    use crate::{ExecutionContext, TempoInvalidTransaction, TempoTxEnv};
 
     fn create_call(to: TxKind) -> Call {
         Call {
@@ -543,6 +584,12 @@ mod tests {
         let expiring_env = TempoTxEnv::from_recovered_tx(&expiring_signed, caller);
         let expected_identifier = expiring_signed.expiring_nonce_hash(caller);
         assert_eq!(
+            expiring_env.execution_context(),
+            Some(ExecutionContext::Transaction {
+                tx_hash: *expiring_signed.hash(),
+            })
+        );
+        assert_eq!(
             expiring_env.channel_open_context_hash(),
             Some(expected_identifier),
             "expiring nonce channel opens must use the sender-scoped transaction identifier"
@@ -578,6 +625,10 @@ mod tests {
         };
 
         let tx_env = super::TempoTxEnv::from_recovered_tx(&envelope, caller);
+        assert_eq!(
+            tx_env.execution_context(),
+            Some(ExecutionContext::Transaction { tx_hash })
+        );
         let signature_hash = signed.signature_hash();
         assert_ne!(
             signature_hash, tx_hash,
@@ -608,6 +659,7 @@ mod tests {
         assert!(tx_env.inner.access_list.is_empty());
         assert!(tx_env.fee_token.is_none());
         assert!(!tx_env.is_system_tx);
+        assert_eq!(tx_env.execution_context(), None);
         assert!(tx_env.fee_payer.is_none());
         assert!(tx_env.tempo_tx_env.is_none());
     }

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -69,7 +69,7 @@ pub struct TempoBatchCallEnv {
 ///
 /// Signed transactions carry their canonical transaction hash. RPC simulations have no canonical
 /// transaction hash because request normalization and signing can change the eventual transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum ExecutionContext {
     /// Execution or validation of a signed transaction.
     Transaction {
@@ -77,6 +77,7 @@ pub enum ExecutionContext {
         tx_hash: B256,
     },
     /// Non-committing execution of an RPC transaction request.
+    #[default]
     Simulation,
 }
 
@@ -95,9 +96,7 @@ pub struct TempoTxEnv {
     pub is_system_tx: bool,
 
     /// Whether this environment represents a signed transaction or an RPC simulation.
-    ///
-    /// Synthetic environments created directly by tests or other callers may leave this unset.
-    pub execution_context: Option<ExecutionContext>,
+    pub execution_context: ExecutionContext,
 
     /// Sender-scoped transaction identifier used for replay-sensitive features.
     ///
@@ -137,8 +136,8 @@ impl TempoTxEnv {
             .is_some_and(|aa| aa.subblock_transaction)
     }
 
-    /// Returns the semantic execution context, when supplied by the environment builder.
-    pub fn execution_context(&self) -> Option<ExecutionContext> {
+    /// Returns the semantic execution context.
+    pub fn execution_context(&self) -> ExecutionContext {
         self.execution_context
     }
 
@@ -369,9 +368,9 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
             },
             fee_token: *fee_token,
             is_system_tx: false,
-            execution_context: Some(ExecutionContext::Transaction {
+            execution_context: ExecutionContext::Transaction {
                 tx_hash: *aa_signed.hash(),
-            }),
+            },
             unique_tx_identifier: Some(aa_signed.expiring_nonce_hash(caller)),
             fee_payer: fee_payer_signature.map(|sig| {
                 secp256k1::recover_signer(&sig, tx.fee_payer_signature_hash(caller)).ok()
@@ -408,34 +407,34 @@ impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
                 fee_token: None,
                 is_system_tx: tx.is_system_tx(),
-                execution_context: Some(ExecutionContext::Transaction {
+                execution_context: ExecutionContext::Transaction {
                     tx_hash: *tx.tx_hash(),
-                }),
+                },
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 fee_payer: None,
                 tempo_tx_env: None, // Non-AA transaction
             },
             TempoTxEnvelope::Eip2930(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
-                execution_context: Some(ExecutionContext::Transaction {
+                execution_context: ExecutionContext::Transaction {
                     tx_hash: *tx.tx_hash(),
-                }),
+                },
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::Eip1559(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
-                execution_context: Some(ExecutionContext::Transaction {
+                execution_context: ExecutionContext::Transaction {
                     tx_hash: *tx.tx_hash(),
-                }),
+                },
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
             TempoTxEnvelope::Eip7702(inner) => Self {
                 inner: TxEnv::from_recovered_tx(inner.tx(), sender),
-                execution_context: Some(ExecutionContext::Transaction {
+                execution_context: ExecutionContext::Transaction {
                     tx_hash: *tx.tx_hash(),
-                }),
+                },
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
                 ..Default::default()
             },
@@ -585,9 +584,9 @@ mod tests {
         let expected_identifier = expiring_signed.expiring_nonce_hash(caller);
         assert_eq!(
             expiring_env.execution_context(),
-            Some(ExecutionContext::Transaction {
+            ExecutionContext::Transaction {
                 tx_hash: *expiring_signed.hash(),
-            })
+            }
         );
         assert_eq!(
             expiring_env.channel_open_context_hash(),
@@ -627,7 +626,7 @@ mod tests {
         let tx_env = super::TempoTxEnv::from_recovered_tx(&envelope, caller);
         assert_eq!(
             tx_env.execution_context(),
-            Some(ExecutionContext::Transaction { tx_hash })
+            ExecutionContext::Transaction { tx_hash }
         );
         let signature_hash = signed.signature_hash();
         assert_ne!(
@@ -659,7 +658,7 @@ mod tests {
         assert!(tx_env.inner.access_list.is_empty());
         assert!(tx_env.fee_token.is_none());
         assert!(!tx_env.is_system_tx);
-        assert_eq!(tx_env.execution_context(), None);
+        assert_eq!(tx_env.execution_context(), ExecutionContext::Simulation);
         assert!(tx_env.fee_payer.is_none());
         assert!(tx_env.tempo_tx_env.is_none());
     }


### PR DESCRIPTION
Adds an explicit `ExecutionContext` to `TempoTxEnv` so consumers can distinguish signed transactions from RPC simulations without inspecting sentinel values. Signed transaction environments carry their canonical transaction hash; RPC conversion marks `Simulation` while the existing unique identifier remains internal to its channel-reserve behavior.

This provides a semantic integration point for [ZONE-144](https://linear.app/tempoxyz/issue/ZONE-144/t1-025-private-rpc-simulations-omit-transaction-context-needed-for).

Verification:
- `cargo +nightly fmt --all -- --check`
- `cargo +nightly clippy -p tempo-revm -p tempo-alloy --all-targets --all-features -- -D warnings`