### PR TITLE
fix(ci): require immutable STS subject IDs

### DIFF
--- a/.github/sts/bench-e2e.sts.yaml
+++ b/.github/sts/bench-e2e.sts.yaml
@@ -1,6 +1,6 @@
 # Allow branch and pull-request e2e benchmark workflows in Tempo to mint a
 # short-lived token for the GitHub API calls and private ValScope checkout.
-subject_pattern: repo:tempoxyz(@211589300)?/tempo(@994992847)?:((ref:refs/heads/.+)|pull_request)
+subject_pattern: repo:tempoxyz@211589300/tempo@994992847:((ref:refs/heads/.+)|pull_request)
 permissions:
   contents: read
   actions: read

--- a/.github/sts/bench-replay.sts.yaml
+++ b/.github/sts/bench-replay.sts.yaml
@@ -1,6 +1,6 @@
 # Allow branch and pull-request replay benchmark workflows in Tempo to mint a
 # short-lived token for GitHub API calls.
-subject_pattern: repo:tempoxyz(@211589300)?/tempo(@994992847)?:((ref:refs/heads/.+)|pull_request)
+subject_pattern: repo:tempoxyz@211589300/tempo@994992847:((ref:refs/heads/.+)|pull_request)
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
Requires immutable organization and repository IDs in both Tempo STS policies, matching tempoxyz/tempo-multi-region-benchmark#339. This rejects legacy name-only subjects while preserving the existing branch and pull-request tails and permissions.

Prompted by: @sds