### PR TITLE
fix(ci): isolate gcloud state in benchmark workflow

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -455,6 +455,21 @@ jobs:
         run: |
           "$BENCH_REPO_DIR/scripts/configure_aws_s3_transfer.sh"
 
+      # gcloud persists credentials and command state in SQLite files below its
+      # config directory.  Keep that state out of the runner image's shared
+      # default directory: benchmark phases run many gcloud commands and IAP
+      # tunnels concurrently, and a stale/corrupt default database causes
+      # gcloud to abort before issuing the requested API call.
+      - name: Isolate Google Cloud CLI state
+        if: env.BENCH_INPUT_CLOUD == 'gcp'
+        run: |
+          gcloud_config_dir="$RUNNER_TEMP/gcloud-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$gcloud_config_dir"
+          {
+            echo "CLOUDSDK_CONFIG=$gcloud_config_dir"
+            echo "CLOUDSDK_CORE_PROJECT=$BENCH_GCP_PROJECT_ID"
+          } >> "$GITHUB_ENV"
+
       - name: Authenticate to Google Cloud
         if: env.BENCH_INPUT_CLOUD == 'gcp'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3


### PR DESCRIPTION
Adds the gcloud state-isolation step to the Tempo multi-region benchmark workflow. Each GCP run now uses a unique CLOUDSDK_CONFIG directory and project setting to avoid concurrent SQLite state corruption.

Prompted by: @sds