### PR TITLE
fix(release): use release-pr environment for preparation workflow

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,7 +26,7 @@ jobs:
     name: Prepare release/v${{ inputs.version }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    environment: release
+    environment: release-pr
     permissions:
       contents: write
 


### PR DESCRIPTION
Updates the prepare-release workflow to use the `release-pr` environment, whose protection policy permits dispatches from `main`.

Prompted by: @kamsz