### PR TITLE
fix(release): use pre-release preparation branch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -311,3 +311,49 @@ jobs:
             echo "| Expected image tag | \`${IMAGE_TAG}\` |"
             echo "| Existing branch reused | \`${REUSED}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mint scoped app token
+        id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: tempoxyz
+          repositories: tempo
+          permission-contents: read
+          permission-pull-requests: write
+          permission-metadata: read
+
+      - name: Open draft pull request
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_BRANCH: ${{ steps.release.outputs.release_branch }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          pr_url="$(
+            gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$RELEASE_BRANCH" \
+              --state open \
+              --json url \
+              --jq '.[0].url // empty'
+          )"
+
+          if [[ -z "$pr_url" ]]; then
+            pr_url="$(
+              gh pr create \
+                --repo "$GITHUB_REPOSITORY" \
+                --base main \
+                --head "$RELEASE_BRANCH" \
+                --draft \
+                --title "chore(release): prepare v${VERSION}" \
+                --body "Prepares Tempo v${VERSION} from ${SOURCE_SHA} by updating the workspace version and lockfile."
+            )"
+          fi
+
+          echo "Draft pull request: ${pr_url}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   prepare:
-    name: Prepare release/v${{ inputs.version }}
+    name: Prepare pre-release/v${{ inputs.version }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: release-pr
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
 
-          echo "release_branch=release/v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "release_branch=pre-release/v${VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Check out the requested source commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Publishes generated release commits to `pre-release/vX.Y.Z`, then opens or reuses a draft PR to `main` with the scoped release App token. The `release/*` ruleset requires checks at branch creation, so this uses unprotected preparation branches while preserving normal PR CI.

Validated with YAML parsing, embedded Bash syntax checks, and `git diff --check`.