### PR TITLE
fix(evm): preserve EVM2 protocol error stages

### DIFF
--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -1,6 +1,7 @@
 //! Tempo EVM and transaction validation errors.
 
 use alloy_primitives::{Address, U256};
+use tempo_precompiles::error::TempoPrecompileError;
 use tempo_primitives::transaction::{KeyAuthorizationChainIdError, KeychainVersionError};
 
 /// Errors that can occur while configuring the Tempo EVM.
@@ -13,6 +14,24 @@ pub enum TempoEvmError {
     /// Invalid EVM configuration.
     #[error("invalid EVM configuration: {0}")]
     InvalidEvmConfig(String),
+}
+
+/// A protocol error raised while executing one of the EVM handler stages.
+#[derive(Debug, thiserror::Error)]
+#[error("{stage}: {source}")]
+pub struct TempoProtocolError {
+    /// Handler stage that surfaced the protocol error.
+    pub stage: &'static str,
+    /// Original protocol error.
+    #[source]
+    pub source: TempoPrecompileError,
+}
+
+impl TempoProtocolError {
+    /// Attach a handler stage without erasing the original protocol error.
+    pub const fn new(stage: &'static str, source: TempoPrecompileError) -> Self {
+        Self { stage, source }
+    }
 }
 
 /// Tempo-specific transaction validation errors.
@@ -234,6 +253,17 @@ mod tests {
             error.external_ref::<TempoInvalidTransaction>(),
             Some(TempoInvalidTransaction::InvalidFeePayerSignature)
         ));
+    }
+
+    #[test]
+    fn protocol_errors_preserve_the_handler_stage() {
+        let error = TempoProtocolError::new(
+            "collect_fee_post_tx",
+            TempoPrecompileError::Fatal("test failure".into()),
+        );
+
+        assert_eq!(error.to_string(), "collect_fee_post_tx: test failure");
+        assert_eq!(error.stage, "collect_fee_post_tx");
     }
 
     #[test]

--- a/crates/evm/src/handler/config.rs
+++ b/crates/evm/src/handler/config.rs
@@ -1,8 +1,8 @@
 //! EVM2 transaction handler plumbing.
 
 use crate::{
-    FeePaymentError, TempoEvmTx, TempoInvalidTransaction, TempoStateAccess, TempoTx, TempoTxEnv,
-    common::is_tip20_fee_inference_call,
+    FeePaymentError, TempoEvmTx, TempoInvalidTransaction, TempoProtocolError, TempoStateAccess,
+    TempoTx, TempoTxEnv, common::is_tip20_fee_inference_call,
 };
 use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxLegacy};
 use alloy_primitives::{Address, TxKind, U256};
@@ -409,11 +409,13 @@ pub(super) fn invalid(error: impl Into<TempoInvalidTransaction>) -> HandlerError
     HandlerError::external(error.into())
 }
 
-fn map_protocol_result<R>(result: TempoResult<R>) -> HandlerResult<R> {
+fn map_protocol_result<R>(stage: &'static str, result: TempoResult<R>) -> HandlerResult<R> {
     match result {
         Ok(value) => Ok(value),
         Err(TempoPrecompileError::EvmError(code)) => Err(HandlerError::Fatal(code)),
-        Err(error) => Err(HandlerError::external(error)),
+        Err(error) => Err(HandlerError::external(TempoProtocolError::new(
+            stage, error,
+        ))),
     }
 }
 
@@ -432,9 +434,9 @@ fn settle_storage_credit_refunds(
         return Ok(());
     }
 
-    let settled = map_protocol_result(StorageCtx::enter_evm_without_tip1060_accounting(
-        host,
-        || {
+    let settled = map_protocol_result(
+        "settle_storage_credit_refunds",
+        StorageCtx::enter_evm_without_tip1060_accounting(host, || {
             let mut storage = StorageCtx;
             let mut settled = 0i64;
             for (key, word) in slots {
@@ -455,8 +457,8 @@ fn settle_storage_credit_refunds(
                 storage.sstore(STORAGE_CREDITS_ADDRESS, key, U256::from(balance))?;
             }
             Ok(settled)
-        },
-    ))?;
+        }),
+    )?;
     result
         .gas
         .record_refund(settled.saturating_mul(STORAGE_CREDIT_VALUE as i64));
@@ -545,14 +547,17 @@ impl TxHandlerHooks<TempoEvmTypes> for TempoHandlerHooks {
         let validator_fee = if actual_spending.is_zero() && refund.is_zero() {
             U256::ZERO
         } else {
-            map_protocol_result(fee_manager.collect_fee_post_tx(
-                host,
-                fee_payer,
-                actual_spending,
-                refund,
-                fee_token,
-                beneficiary,
-            ))?
+            map_protocol_result(
+                "collect_fee_post_tx",
+                fee_manager.collect_fee_post_tx(
+                    host,
+                    fee_payer,
+                    actual_spending,
+                    refund,
+                    fee_token,
+                    beneficiary,
+                ),
+            )?
         };
         result.ext.validator_fee = validator_fee;
         Ok(result)
@@ -580,18 +585,20 @@ impl TempoHandlerHooks {
         };
         let spec = host.config_spec_id();
 
-        map_protocol_result(StorageCtx::enter_evm_without_tip1060_accounting(
-            host,
-            || {
+        map_protocol_result(
+            "resolve_fee_context_storage",
+            StorageCtx::enter_evm_without_tip1060_accounting(host, || {
                 AccountKeychain::new().set_tx_origin(envelope.evm_tx().signer())?;
                 TIP20ChannelReserve::new()
                     .set_channel_open_context_hash(envelope.channel_open_context_hash())
-            },
-        ))?;
+            }),
+        )?;
 
         let fee_manager = host.ext().fee_manager.clone();
-        let fee_token =
-            map_protocol_result(fee_manager.get_fee_token(host, envelope, fee_payer, spec))?;
+        let fee_token = map_protocol_result(
+            "resolve_fee_token",
+            fee_manager.get_fee_token(host, envelope, fee_payer, spec),
+        )?;
         host.ext_mut().resolved_fee_token = Some(fee_token);
         if !fee_token.is_tip20() {
             return Err(invalid(TempoInvalidTransaction::FeeTokenNotTip20 {
@@ -657,7 +664,9 @@ impl TempoHandlerHooks {
                 }
                 TempoPrecompileError::EvmError(code) => HandlerError::Fatal(code),
                 error @ TempoPrecompileError::Fatal(_) => HandlerError::external(error),
-                error => invalid(FeePaymentError::Other(error.to_string())),
+                error => invalid(FeePaymentError::Other(format!(
+                    "collect_fee_pre_tx: {error}"
+                ))),
             });
         }
 

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -28,7 +28,7 @@ pub use assemble::TempoBlockAssembler;
 pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 pub use common::{TempoStateAccess, TempoTx};
 pub use context::{TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
-pub use error::{FeePaymentError, TempoEvmError, TempoInvalidTransaction};
+pub use error::{FeePaymentError, TempoEvmError, TempoInvalidTransaction, TempoProtocolError};
 pub use evm::{TempoEvm, TempoEvmFactory};
 pub use handler::{
     FeeTokenResolver, ProtocolFeeManager, TempoBlockEnv, TempoBlockExt, TempoConfig,


### PR DESCRIPTION
## Summary

- Preserve the handler stage when a `TempoPrecompileError` escapes EVM2 protocol/fee handling.
- Tag storage-credit settlement, fee-token resolution, pre-fee collection, and post-fee settlement errors.
- Keep fatal/database errors fatal and avoid swallowing `HandlerError` while narrowing the next replay investigation.

This is a draft follow-up to the Moderato EVM2 incident. The affected transaction was `0x15b04d20e9353f098c2be8c6c5970d16d9c3fd1cfacf1b40483a7e7f6386de3c`; the stage context is needed before choosing a semantic conversion that could alter fee state.

## Validation

- `cargo +nightly fmt --all -- --check`
- Focused Rust tests are blocked before compilation because the sandbox cannot authenticate to fetch the pinned private `evm2` and `commonware` git dependencies.

Prompted by: @onbjerg