### PR TITLE
fix(ci): restrict add-hardfork workflow to main

### DIFF
--- a/.github/workflows/add-hardfork.yml
+++ b/.github/workflows/add-hardfork.yml
@@ -21,9 +21,9 @@ concurrency:
 jobs:
   add-hardfork:
     name: Add ${{ inputs.hardfork }} hardfork
-    if: ${{ github.repository == 'tempoxyz/tempo' }}
+    if: ${{ github.repository == 'tempoxyz/tempo' && github.ref == 'refs/heads/main' }}
     runs-on: depot-ubuntu-latest-4
-    environment: release-pr
+    environment: add-hardfork
     permissions: {}
     steps:
       - name: Mint scoped app token


### PR DESCRIPTION
Restricts the manually dispatched Add hardfork workflow to runs from main and moves it to the new add-hardfork environment.

Prompted by: @grandizzy