### PR TITLE
fix(evm): classify protocol precompile errors

### DIFF
--- a/crates/evm/src/common.rs
+++ b/crates/evm/src/common.rs
@@ -1,4 +1,6 @@
-use crate::{TempoEvmTypes, TempoInvalidTransaction, TempoTxEnv};
+use crate::{
+    TempoEvmTypes, TempoInvalidTransaction, TempoTxEnv, error::map_tempo_precompile_error,
+};
 use alloy_consensus::transaction::Recovered;
 use alloy_primitives::{Address, B256, Bytes, LogData, TxKind, U256};
 use alloy_sol_types::SolCall;
@@ -165,7 +167,7 @@ pub trait TempoStateAccess<M = ()> {
 
             Ok(Ok(()))
         })
-        .map_err(|err: TempoPrecompileError| HandlerError::external(err))?
+        .map_err(map_tempo_precompile_error)?
     }
 
     /// Checks if the given token can be used as a fee token.

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -142,7 +142,7 @@ impl TempoInvalidTransaction {
 }
 
 pub(crate) enum TempoPrecompileErrorDisposition {
-    Recoverable(String),
+    Recoverable(TempoPrecompileError),
     Fatal(HandlerError),
 }
 
@@ -153,7 +153,6 @@ pub(crate) enum TempoPrecompileErrorDisposition {
 pub(crate) fn classify_tempo_precompile_error(
     error: TempoPrecompileError,
 ) -> TempoPrecompileErrorDisposition {
-    let message = error.to_string();
     match error {
         TempoPrecompileError::EvmError(code) => {
             TempoPrecompileErrorDisposition::Fatal(HandlerError::Fatal(code))
@@ -161,9 +160,9 @@ pub(crate) fn classify_tempo_precompile_error(
         error @ TempoPrecompileError::Fatal(_) => {
             TempoPrecompileErrorDisposition::Fatal(HandlerError::external(error))
         }
-        error => match error.into_precompile_result() {
+        error => match error.clone().into_precompile_result() {
             Err(PrecompileError::Revert(_)) | Err(PrecompileError::Halt(_)) => {
-                TempoPrecompileErrorDisposition::Recoverable(message)
+                TempoPrecompileErrorDisposition::Recoverable(error)
             }
             Err(PrecompileError::Fatal(error)) => {
                 TempoPrecompileErrorDisposition::Fatal(HandlerError::External(error))
@@ -175,8 +174,8 @@ pub(crate) fn classify_tempo_precompile_error(
 
 pub(crate) fn map_tempo_precompile_error(error: TempoPrecompileError) -> HandlerError {
     match classify_tempo_precompile_error(error) {
-        TempoPrecompileErrorDisposition::Recoverable(message) => {
-            HandlerError::external(TempoInvalidTransaction::PrecompileError(message))
+        TempoPrecompileErrorDisposition::Recoverable(error) => {
+            HandlerError::external(TempoInvalidTransaction::PrecompileError(error.to_string()))
         }
         TempoPrecompileErrorDisposition::Fatal(error) => error,
     }

--- a/crates/evm/src/error.rs
+++ b/crates/evm/src/error.rs
@@ -1,6 +1,8 @@
 //! Tempo EVM and transaction validation errors.
 
 use alloy_primitives::{Address, U256};
+use evm2::{ErrorCode, precompiles::PrecompileError, registry::HandlerError};
+use tempo_precompiles::error::TempoPrecompileError;
 use tempo_primitives::transaction::{KeyAuthorizationChainIdError, KeychainVersionError};
 
 /// Errors that can occur while configuring the Tempo EVM.
@@ -81,6 +83,8 @@ pub enum TempoInvalidTransaction {
     },
     #[error("keychain validation failed: {reason}")]
     KeychainValidationFailed { reason: String },
+    #[error("precompile error: {0}")]
+    PrecompileError(String),
     #[error("KeyAuthorization chain_id mismatch: expected {expected}, got {got}")]
     KeyAuthorizationChainIdMismatch { expected: u64, got: u64 },
     #[error("legacy V1 keychain signature is no longer accepted, use V2 (type 0x04)")]
@@ -129,10 +133,52 @@ impl TempoInvalidTransaction {
             | Self::AccessKeyExpiryInPast { .. }
             | Self::KeychainPrecompileError { .. }
             | Self::KeychainValidationFailed { .. }
+            | Self::PrecompileError(_)
             | Self::CollectFeePreTx(_)
             | Self::NonceManagerError(_)
             | Self::V2KeychainBeforeActivation => false,
         }
+    }
+}
+
+pub(crate) enum TempoPrecompileErrorDisposition {
+    Recoverable(String),
+    Fatal(HandlerError),
+}
+
+/// Classifies a protocol error using the same mapping as an EVM2 precompile call.
+///
+/// Ordinary protocol failures are reverts or non-fatal halts. They must not escape a completed
+/// transaction as raw handler errors. Only host/database failures are fatal at this boundary.
+pub(crate) fn classify_tempo_precompile_error(
+    error: TempoPrecompileError,
+) -> TempoPrecompileErrorDisposition {
+    let message = error.to_string();
+    match error {
+        TempoPrecompileError::EvmError(code) => {
+            TempoPrecompileErrorDisposition::Fatal(HandlerError::Fatal(code))
+        }
+        error @ TempoPrecompileError::Fatal(_) => {
+            TempoPrecompileErrorDisposition::Fatal(HandlerError::external(error))
+        }
+        error => match error.into_precompile_result() {
+            Err(PrecompileError::Revert(_)) | Err(PrecompileError::Halt(_)) => {
+                TempoPrecompileErrorDisposition::Recoverable(message)
+            }
+            Err(PrecompileError::Fatal(error)) => {
+                TempoPrecompileErrorDisposition::Fatal(HandlerError::External(error))
+            }
+            Ok(_) => unreachable!("Tempo precompile errors cannot produce success"),
+        },
+    }
+}
+
+pub(crate) fn map_tempo_precompile_error(error: TempoPrecompileError) -> HandlerError {
+    match classify_tempo_precompile_error(error) {
+        TempoPrecompileErrorDisposition::Recoverable(message) => {
+            HandlerError::external(TempoInvalidTransaction::PrecompileError(message))
+        }
+        TempoPrecompileErrorDisposition::Fatal(error) => error,
     }
 }
 
@@ -192,6 +238,7 @@ fn liquidity_pair_msg(user_token: &Option<Address>, validator_token: &Option<Add
 mod tests {
     use super::*;
     use evm2::registry::HandlerError;
+    use tempo_contracts::precompiles::StablecoinDEXError;
 
     #[test]
     fn test_error_display() {
@@ -233,6 +280,47 @@ mod tests {
         assert!(matches!(
             error.external_ref::<TempoInvalidTransaction>(),
             Some(TempoInvalidTransaction::InvalidFeePayerSignature)
+        ));
+    }
+
+    #[test]
+    fn classify_protocol_errors_like_evm2_precompile_calls() {
+        let recoverable = [
+            TempoPrecompileError::TIP20(TIP20Error::policy_forbids()),
+            TempoPrecompileError::StablecoinDEX(StablecoinDEXError::order_does_not_exist()),
+            TempoPrecompileError::UnknownFunctionSelector([0xde, 0xad, 0xbe, 0xef]),
+            TempoPrecompileError::OutOfGas,
+        ];
+
+        for error in recoverable {
+            assert!(matches!(
+                classify_tempo_precompile_error(error),
+                TempoPrecompileErrorDisposition::Recoverable(_)
+            ));
+        }
+    }
+
+    #[test]
+    fn classify_host_errors_as_fatal() {
+        assert!(matches!(
+            classify_tempo_precompile_error(TempoPrecompileError::EvmError(
+                ErrorCode::BAL_NOT_COVERED
+            )),
+            TempoPrecompileErrorDisposition::Fatal(HandlerError::Fatal(_))
+        ));
+        assert!(matches!(
+            classify_tempo_precompile_error(TempoPrecompileError::Fatal("database failure".into())),
+            TempoPrecompileErrorDisposition::Fatal(HandlerError::External(_))
+        ));
+    }
+
+    #[test]
+    fn maps_recoverable_errors_to_typed_transaction_errors() {
+        let error =
+            map_tempo_precompile_error(TempoPrecompileError::TIP20(TIP20Error::policy_forbids()));
+        assert!(matches!(
+            error.external_ref::<TempoInvalidTransaction>(),
+            Some(TempoInvalidTransaction::PrecompileError(_))
         ));
     }
 

--- a/crates/evm/src/handler/config.rs
+++ b/crates/evm/src/handler/config.rs
@@ -3,6 +3,10 @@
 use crate::{
     FeePaymentError, TempoEvmTx, TempoInvalidTransaction, TempoStateAccess, TempoTx, TempoTxEnv,
     common::is_tip20_fee_inference_call,
+    error::{
+        TempoPrecompileErrorDisposition, classify_tempo_precompile_error,
+        map_tempo_precompile_error,
+    },
 };
 use alloy_consensus::{Transaction, TxEip1559, TxEip2930, TxLegacy};
 use alloy_primitives::{Address, TxKind, U256};
@@ -412,8 +416,7 @@ pub(super) fn invalid(error: impl Into<TempoInvalidTransaction>) -> HandlerError
 fn map_protocol_result<R>(result: TempoResult<R>) -> HandlerResult<R> {
     match result {
         Ok(value) => Ok(value),
-        Err(TempoPrecompileError::EvmError(code)) => Err(HandlerError::Fatal(code)),
-        Err(error) => Err(HandlerError::external(error)),
+        Err(error) => Err(map_tempo_precompile_error(error)),
     }
 }
 
@@ -555,17 +558,17 @@ impl TxHandlerHooks<TempoEvmTypes> for TempoHandlerHooks {
                 beneficiary,
             ) {
                 Ok(validator_fee) => validator_fee,
-                Err(TempoPrecompileError::EvmError(code)) => {
-                    return Err(HandlerError::Fatal(code));
-                }
-                Err(error @ TempoPrecompileError::Fatal(_)) => {
-                    return Err(HandlerError::external(error));
-                }
                 Err(error) => {
-                    // A failed user execution already has the canonical receipt outcome. A
-                    // business error while refunding or settling its fee must not turn that
-                    // receipt into a block-fatal handler error. Roll back any partial post-tx
-                    // writes and retain the pre-tx fee reservation as the conservative charge.
+                    let message = match classify_tempo_precompile_error(error) {
+                        TempoPrecompileErrorDisposition::Recoverable(message) => message,
+                        TempoPrecompileErrorDisposition::Fatal(error) => return Err(error),
+                    };
+
+                    // A failed user execution already has the canonical receipt outcome. Any
+                    // recoverable precompile revert or halt while refunding or settling its fee
+                    // must not turn that receipt into a block-fatal handler error. Roll back any
+                    // partial post-tx writes and retain the pre-tx fee reservation as the
+                    // conservative charge.
                     let features = host.version().features;
                     host.state_mut().rollback(checkpoint, features);
                     if !result.status {
@@ -576,7 +579,7 @@ impl TxHandlerHooks<TempoEvmTypes> for TempoHandlerHooks {
                     // already committed its execution checkpoint. Keep the original execution
                     // result, with the reserved fee retained, rather than reporting a divergent
                     // block error for a protocol-level settlement failure.
-                    tracing::warn!(error = %error, "fee settlement failed after successful execution");
+                    tracing::warn!(error = %message, "fee settlement failed after successful execution");
                     U256::ZERO
                 }
             }
@@ -682,9 +685,12 @@ impl TempoHandlerHooks {
                         address: context.fee_token,
                     })
                 }
-                TempoPrecompileError::EvmError(code) => HandlerError::Fatal(code),
-                error @ TempoPrecompileError::Fatal(_) => HandlerError::external(error),
-                error => invalid(FeePaymentError::Other(error.to_string())),
+                error => match classify_tempo_precompile_error(error) {
+                    TempoPrecompileErrorDisposition::Recoverable(message) => {
+                        invalid(FeePaymentError::Other(message))
+                    }
+                    TempoPrecompileErrorDisposition::Fatal(error) => error,
+                },
             });
         }
 

--- a/crates/evm/src/handler/config.rs
+++ b/crates/evm/src/handler/config.rs
@@ -413,10 +413,46 @@ pub(super) fn invalid(error: impl Into<TempoInvalidTransaction>) -> HandlerError
     HandlerError::external(error.into())
 }
 
-fn map_protocol_result<R>(result: TempoResult<R>) -> HandlerResult<R> {
+fn map_protocol_result<R>(
+    result: TempoResult<R>,
+    map_recoverable: impl FnOnce(TempoPrecompileError) -> HandlerError,
+) -> HandlerResult<R> {
     match result {
         Ok(value) => Ok(value),
-        Err(error) => Err(map_tempo_precompile_error(error)),
+        Err(error) => match classify_tempo_precompile_error(error.clone()) {
+            TempoPrecompileErrorDisposition::Recoverable(_) => Err(map_recoverable(error)),
+            TempoPrecompileErrorDisposition::Fatal(error) => Err(error),
+        },
+    }
+}
+
+fn map_fee_protocol_error(
+    error: TempoPrecompileError,
+    host: &mut Evm<'_, TempoEvmTypes>,
+    fee_manager: &dyn ProtocolFeeManager,
+    fee_token: Address,
+    fee: U256,
+    beneficiary: Address,
+) -> HandlerError {
+    match error {
+        TempoPrecompileError::TIPFeeAMMError(TIPFeeAMMError::InsufficientLiquidity(_)) => {
+            let validator_token = fee_manager.get_validator_token(host, beneficiary).ok();
+            invalid(FeePaymentError::InsufficientAmmLiquidity {
+                user_token: validator_token.map(|_| fee_token),
+                validator_token,
+                fee,
+            })
+        }
+        TempoPrecompileError::TIP20(TIP20Error::InsufficientBalance(error)) => {
+            invalid(FeePaymentError::InsufficientFeeTokenBalance {
+                fee,
+                balance: error.available,
+            })
+        }
+        TempoPrecompileError::TIP20(TIP20Error::ContractPaused(_)) => {
+            invalid(TempoInvalidTransaction::FeeTokenPaused { address: fee_token })
+        }
+        error => invalid(FeePaymentError::Other(error.to_string())),
     }
 }
 
@@ -435,9 +471,8 @@ fn settle_storage_credit_refunds(
         return Ok(());
     }
 
-    let settled = map_protocol_result(StorageCtx::enter_evm_without_tip1060_accounting(
-        host,
-        || {
+    let settled = map_protocol_result(
+        StorageCtx::enter_evm_without_tip1060_accounting(host, || {
             let mut storage = StorageCtx;
             let mut settled = 0i64;
             for (key, word) in slots {
@@ -458,8 +493,9 @@ fn settle_storage_credit_refunds(
                 storage.sstore(STORAGE_CREDITS_ADDRESS, key, U256::from(balance))?;
             }
             Ok(settled)
-        },
-    ))?;
+        }),
+        map_tempo_precompile_error,
+    )?;
     result
         .gas
         .record_refund(settled.saturating_mul(STORAGE_CREDIT_VALUE as i64));
@@ -610,18 +646,20 @@ impl TempoHandlerHooks {
         };
         let spec = host.config_spec_id();
 
-        map_protocol_result(StorageCtx::enter_evm_without_tip1060_accounting(
-            host,
-            || {
+        map_protocol_result(
+            StorageCtx::enter_evm_without_tip1060_accounting(host, || {
                 AccountKeychain::new().set_tx_origin(envelope.evm_tx().signer())?;
                 TIP20ChannelReserve::new()
                     .set_channel_open_context_hash(envelope.channel_open_context_hash())
-            },
-        ))?;
+            }),
+            map_tempo_precompile_error,
+        )?;
 
         let fee_manager = host.ext().fee_manager.clone();
-        let fee_token =
-            map_protocol_result(fee_manager.get_fee_token(host, envelope, fee_payer, spec))?;
+        let fee_token = map_protocol_result(
+            fee_manager.get_fee_token(host, envelope, fee_payer, spec),
+            map_tempo_precompile_error,
+        )?;
         host.ext_mut().resolved_fee_token = Some(fee_token);
         if !fee_token.is_tip20() {
             return Err(invalid(TempoInvalidTransaction::FeeTokenNotTip20 {
@@ -665,32 +703,15 @@ impl TempoHandlerHooks {
             )
         {
             host.state_mut().rollback(checkpoint, features);
-            return Err(match error {
-                TempoPrecompileError::TIPFeeAMMError(TIPFeeAMMError::InsufficientLiquidity(_)) => {
-                    let validator_token = fee_manager.get_validator_token(host, beneficiary).ok();
-                    invalid(FeePaymentError::InsufficientAmmLiquidity {
-                        user_token: validator_token.map(|_| context.fee_token),
-                        validator_token,
-                        fee: context.collected,
-                    })
-                }
-                TempoPrecompileError::TIP20(TIP20Error::InsufficientBalance(error)) => {
-                    invalid(FeePaymentError::InsufficientFeeTokenBalance {
-                        fee: context.collected,
-                        balance: error.available,
-                    })
-                }
-                TempoPrecompileError::TIP20(TIP20Error::ContractPaused(_)) => {
-                    invalid(TempoInvalidTransaction::FeeTokenPaused {
-                        address: context.fee_token,
-                    })
-                }
-                error => match classify_tempo_precompile_error(error) {
-                    TempoPrecompileErrorDisposition::Recoverable(message) => {
-                        invalid(FeePaymentError::Other(message))
-                    }
-                    TempoPrecompileErrorDisposition::Fatal(error) => error,
-                },
+            return map_protocol_result(Err(error), |error| {
+                map_fee_protocol_error(
+                    error,
+                    host,
+                    fee_manager.as_ref(),
+                    context.fee_token,
+                    context.collected,
+                    beneficiary,
+                )
             });
         }
 

--- a/crates/evm/src/handler/config.rs
+++ b/crates/evm/src/handler/config.rs
@@ -545,14 +545,41 @@ impl TxHandlerHooks<TempoEvmTypes> for TempoHandlerHooks {
         let validator_fee = if actual_spending.is_zero() && refund.is_zero() {
             U256::ZERO
         } else {
-            map_protocol_result(fee_manager.collect_fee_post_tx(
+            let checkpoint = host.state().checkpoint();
+            match fee_manager.collect_fee_post_tx(
                 host,
                 fee_payer,
                 actual_spending,
                 refund,
                 fee_token,
                 beneficiary,
-            ))?
+            ) {
+                Ok(validator_fee) => validator_fee,
+                Err(TempoPrecompileError::EvmError(code)) => {
+                    return Err(HandlerError::Fatal(code));
+                }
+                Err(error @ TempoPrecompileError::Fatal(_)) => {
+                    return Err(HandlerError::external(error));
+                }
+                Err(error) => {
+                    // A failed user execution already has the canonical receipt outcome. A
+                    // business error while refunding or settling its fee must not turn that
+                    // receipt into a block-fatal handler error. Roll back any partial post-tx
+                    // writes and retain the pre-tx fee reservation as the conservative charge.
+                    let features = host.version().features;
+                    host.state_mut().rollback(checkpoint, features);
+                    if !result.status {
+                        return Ok(result);
+                    }
+
+                    // A successful user execution cannot be rewound from this hook: EVM2 has
+                    // already committed its execution checkpoint. Keep the original execution
+                    // result, with the reserved fee retained, rather than reporting a divergent
+                    // block error for a protocol-level settlement failure.
+                    tracing::warn!(error = %error, "fee settlement failed after successful execution");
+                    U256::ZERO
+                }
+            }
         };
         result.ext.validator_fee = validator_fee;
         Ok(result)

--- a/crates/evm/src/handler/config.rs
+++ b/crates/evm/src/handler/config.rs
@@ -413,16 +413,21 @@ pub(super) fn invalid(error: impl Into<TempoInvalidTransaction>) -> HandlerError
     HandlerError::external(error.into())
 }
 
-fn map_protocol_result<R>(
+fn map_protocol_result<R>(result: TempoResult<R>) -> Result<R, TempoPrecompileErrorDisposition> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) => Err(classify_tempo_precompile_error(error)),
+    }
+}
+
+fn map_protocol_handler_result<R>(
     result: TempoResult<R>,
     map_recoverable: impl FnOnce(TempoPrecompileError) -> HandlerError,
 ) -> HandlerResult<R> {
-    match result {
+    match map_protocol_result(result) {
         Ok(value) => Ok(value),
-        Err(error) => match classify_tempo_precompile_error(error.clone()) {
-            TempoPrecompileErrorDisposition::Recoverable(_) => Err(map_recoverable(error)),
-            TempoPrecompileErrorDisposition::Fatal(error) => Err(error),
-        },
+        Err(TempoPrecompileErrorDisposition::Recoverable(error)) => Err(map_recoverable(error)),
+        Err(TempoPrecompileErrorDisposition::Fatal(error)) => Err(error),
     }
 }
 
@@ -471,7 +476,7 @@ fn settle_storage_credit_refunds(
         return Ok(());
     }
 
-    let settled = map_protocol_result(
+    let settled = map_protocol_handler_result(
         StorageCtx::enter_evm_without_tip1060_accounting(host, || {
             let mut storage = StorageCtx;
             let mut settled = 0i64;
@@ -585,20 +590,17 @@ impl TxHandlerHooks<TempoEvmTypes> for TempoHandlerHooks {
             U256::ZERO
         } else {
             let checkpoint = host.state().checkpoint();
-            match fee_manager.collect_fee_post_tx(
+            match map_protocol_result(fee_manager.collect_fee_post_tx(
                 host,
                 fee_payer,
                 actual_spending,
                 refund,
                 fee_token,
                 beneficiary,
-            ) {
+            )) {
                 Ok(validator_fee) => validator_fee,
-                Err(error) => {
-                    let message = match classify_tempo_precompile_error(error) {
-                        TempoPrecompileErrorDisposition::Recoverable(message) => message,
-                        TempoPrecompileErrorDisposition::Fatal(error) => return Err(error),
-                    };
+                Err(TempoPrecompileErrorDisposition::Recoverable(error)) => {
+                    let message = error.to_string();
 
                     // A failed user execution already has the canonical receipt outcome. Any
                     // recoverable precompile revert or halt while refunding or settling its fee
@@ -618,6 +620,7 @@ impl TxHandlerHooks<TempoEvmTypes> for TempoHandlerHooks {
                     tracing::warn!(error = %message, "fee settlement failed after successful execution");
                     U256::ZERO
                 }
+                Err(TempoPrecompileErrorDisposition::Fatal(error)) => return Err(error),
             }
         };
         result.ext.validator_fee = validator_fee;
@@ -646,7 +649,7 @@ impl TempoHandlerHooks {
         };
         let spec = host.config_spec_id();
 
-        map_protocol_result(
+        map_protocol_handler_result(
             StorageCtx::enter_evm_without_tip1060_accounting(host, || {
                 AccountKeychain::new().set_tx_origin(envelope.evm_tx().signer())?;
                 TIP20ChannelReserve::new()
@@ -656,7 +659,7 @@ impl TempoHandlerHooks {
         )?;
 
         let fee_manager = host.ext().fee_manager.clone();
-        let fee_token = map_protocol_result(
+        let fee_token = map_protocol_handler_result(
             fee_manager.get_fee_token(host, envelope, fee_payer, spec),
             map_tempo_precompile_error,
         )?;
@@ -703,7 +706,7 @@ impl TempoHandlerHooks {
             )
         {
             host.state_mut().rollback(checkpoint, features);
-            return map_protocol_result(Err(error), |error| {
+            return map_protocol_handler_result(Err(error), |error| {
                 map_fee_protocol_error(
                     error,
                     host,

--- a/crates/evm/src/handler/tests.rs
+++ b/crates/evm/src/handler/tests.rs
@@ -3980,7 +3980,7 @@ use tempo_precompiles::{
     TIP_FEE_MANAGER_ADDRESS,
     storage::{ContractStorage, Handler, StorageActions},
     tip_fee_manager::TipFeeManager,
-    tip20::TIP20Token,
+    tip20::{TIP20Error, TIP20Token},
 };
 use tempo_primitives::{TempoAddressExt, TempoTxEnvelope, transaction::calc_gas_balance_spending};
 
@@ -4110,6 +4110,86 @@ impl ProtocolFeeManager for ValidatorTokenLookupFailsFeeManager {
     ) -> tempo_precompiles::error::Result<U256> {
         Ok(U256::ZERO)
     }
+}
+
+#[derive(Debug)]
+struct PolicyForbidsOnFeeSettlement;
+
+impl ProtocolFeeManager for PolicyForbidsOnFeeSettlement {
+    fn get_fee_token(
+        &self,
+        _host: &mut Evm<'_, TempoEvmTypes>,
+        _tx: &TempoTxEnv,
+        _fee_payer: Address,
+        _spec: TempoHardfork,
+    ) -> tempo_precompiles::error::Result<Address> {
+        Ok(DEFAULT_FEE_TOKEN)
+    }
+
+    fn collect_fee_pre_tx(
+        &self,
+        _host: &mut Evm<'_, TempoEvmTypes>,
+        _fee_payer: Address,
+        _user_token: Address,
+        _max_amount: U256,
+        _beneficiary: Address,
+        _skip_liquidity_check: bool,
+    ) -> tempo_precompiles::error::Result<Address> {
+        Ok(DEFAULT_FEE_TOKEN)
+    }
+
+    fn collect_fee_post_tx(
+        &self,
+        _host: &mut Evm<'_, TempoEvmTypes>,
+        _fee_payer: Address,
+        _actual_spending: U256,
+        _refund_amount: U256,
+        _fee_token: Address,
+        _beneficiary: Address,
+    ) -> tempo_precompiles::error::Result<U256> {
+        Err(TIP20Error::policy_forbids().into())
+    }
+}
+
+#[test]
+fn policy_forbids_during_fee_settlement_preserves_reverted_result() {
+    let spec = TempoHardfork::T8;
+    let ext = TempoEvmExt::default().with_fee_manager(PolicyForbidsOnFeeSettlement);
+    let precompiles = tempo_precompiles::TempoPrecompiles::new(
+        spec,
+        ext.actions.clone(),
+        ext.non_creditable_slots.clone(),
+    );
+    let mut evm = build_tempo_evm(
+        spec,
+        1,
+        TempoBlockEnv::default(),
+        InMemoryDB::default(),
+        precompiles,
+        ext,
+    );
+    let tx = Recovered::new_unchecked(
+        TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy {
+                chain_id: Some(1),
+                gas_limit: 50_000,
+                gas_price: 1,
+                to: TxKind::Call(PATH_USD_ADDRESS),
+                input: Bytes::new(),
+                ..Default::default()
+            },
+            Signature::test_signature(),
+        )),
+        SIGNER,
+    );
+
+    let result = evm
+        .transact(&tx)
+        .expect("business errors from fee settlement must not abort EVM execution")
+        .detach()
+        .result;
+    assert!(!result.status, "the user call should remain reverted");
+    assert_eq!(result.stop, InstrStop::Revert);
 }
 
 #[test]


### PR DESCRIPTION
Adds regression coverage for a protocol `PolicyForbids` during EVM2 fee settlement, then fixes the integration at the shared precompile-error boundary.

- Ordinary Tempo precompile errors are classified through EVM2's `Revert`/`Halt` mapping across protocol hook call sites.
- Recoverable post-execution errors roll back partial settlement writes and preserve the transaction receipt.
- Only EVM2/database-fatal errors escape as handler failures.

Validation:
- `cargo +nightly fmt --all -- --check`
- `git diff --check`
- Rust test execution is blocked in this sandbox because the pinned private `evm2` and Commonware git dependencies cannot be fetched.

Prompted by: @onbjerg