### PR TITLE
ci: consolidate workflow validation

### DIFF
--- a/.github/workflows/amp-review.yml
+++ b/.github/workflows/amp-review.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
     steps:
       - name: Run Amp Code Review
-        uses: docker://ghcr.io/sourcegraph/cra-github:latest
+        uses: docker://ghcr.io/sourcegraph/cra-github@sha256:e0cddc552fe89730913c277ed3a21d061a49c5decbeb0e5e42b3fd844c364c69 # latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AMP_SERVER_URL: ${{ vars.AMP_SERVER_URL }}

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -483,14 +483,14 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: env.BENCH_INPUT_CLOUD == 'gcp'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ env.BENCH_GCP_WIF_PROVIDER }}
           service_account: ${{ env.BENCH_GCP_SERVICE_ACCOUNT }}
 
       - name: Setup Google Cloud CLI
         if: env.BENCH_INPUT_CLOUD == 'gcp'
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
           project_id: ${{ env.BENCH_GCP_PROJECT_ID }}
 

--- a/.github/workflows/bench-replay-scheduled.yml
+++ b/.github/workflows/bench-replay-scheduled.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Alert on stale nightly
         if: steps.refs.outputs.is-stale == 'true' && !(github.event_name == 'workflow_dispatch' && inputs.slack == 'never')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
           SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Resolve checkout ref
         id: checkout-ref
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_BASELINE_NAME: ${{ inputs.baseline-name }}
           INPUT_FEATURE_NAME: ${{ inputs.feature-name }}
@@ -333,7 +333,7 @@ jobs:
 
       - name: Resolve job URL and update status
         if: env.BENCH_COMMENT_ID
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ steps.github-sts.outputs.token }}
           script: |
@@ -378,7 +378,7 @@ jobs:
 
       - name: Resolve PR head branch
         id: pr-info
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_REF_NAME: ${{ github.ref_name }}
           INPUT_SHA: ${{ github.sha }}
@@ -403,7 +403,7 @@ jobs:
 
       - name: Resolve baseline and feature refs
         id: refs
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           INPUT_BASELINE: ${{ inputs.baseline }}
           INPUT_FEATURE: ${{ inputs.feature }}
@@ -464,7 +464,7 @@ jobs:
 
       - name: Update status (running benchmark)
         if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ steps.github-sts.outputs.token }}
           script: |
@@ -545,7 +545,7 @@ jobs:
       - name: Upload results
         id: upload-results
         if: "!cancelled()"
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: tempo-bench-replay-${{ inputs.chain || 'mainnet' }}-results
           path: ${{ env.BENCH_WORK_DIR }}/
@@ -601,7 +601,7 @@ jobs:
 
       - name: Compare & comment
         if: success() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PUSH_CHARTS_SHA: ${{ steps.push-charts.outputs.sha }}
           PUSH_CHARTS_PATH: ${{ steps.push-charts.outputs.path }}
@@ -696,7 +696,7 @@ jobs:
 
       - name: Send Slack notification (success)
         if: success() && (env.BENCH_SLACK == 'always' || env.BENCH_SLACK == 'on-win')
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
           SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
@@ -707,7 +707,7 @@ jobs:
 
       - name: Update status (failed)
         if: failure() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ steps.github-sts.outputs.token }}
           script: |
@@ -721,7 +721,7 @@ jobs:
 
       - name: Send Slack notification (failure)
         if: failure() && env.BENCH_SLACK != 'never' && env.BENCH_SLACK != 'on-win'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
           SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
@@ -752,7 +752,7 @@ jobs:
 
       - name: Update status (cancelled)
         if: cancelled() && env.BENCH_COMMENT_ID
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ steps.github-sts.outputs.token }}
           script: |

--- a/.github/workflows/workflow-validation.yml
+++ b/.github/workflows/workflow-validation.yml
@@ -1,14 +1,16 @@
-name: Scan GitHub Actions
+name: Workflow Validation
 
 on:
   pull_request:
     paths:
       - ".github/**"
+      - ".pinact.yaml"
   push:
     branches:
       - main
     paths:
       - ".github/**"
+      - ".pinact.yaml"
   schedule:
     - cron: "17 9 * * 1"
   workflow_dispatch:
@@ -16,9 +18,13 @@ on:
 permissions: {}
 
 jobs:
-  scan:
+  workflow-validation:
+    name: Workflow Validation
     if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@183a02178c660ce295e9a262edc5857cb7135f06 # main
     permissions:
       actions: read
       contents: read
+    with:
+      config: .github/zizmor.yml
+      pinact: true

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,21 @@
+version: 3
+
+rules:
+  # These Tempo-owned actions are SHA-pinned but do not publish releases that
+  # pinact can use for version-comment or minimum-age verification.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionRepoFullName in ["tempoxyz/changelogs", "tempoxyz/ci", "tempoxyz/gh-actions"]
+      - expr: ActionVersion matches "^[0-9a-f]{40}$"
+  # rust-toolchain uses moving toolchain branches rather than release tags; the
+  # workflow scanner still enforces immutable commit pins.
+  - ignore: true
+    conditions:
+      - expr: ActionName == "dtolnay/rust-toolchain"
+      - expr: ActionVersion matches "^[0-9a-f]{40}$"
+  # OCI images use digest pins rather than Git commit SHAs.
+  - ignore: true
+    conditions:
+      - expr: |
+          ActionName matches "^docker://.+" && ActionVersion matches "^sha256:[0-9a-f]{64}$"


### PR DESCRIPTION
Consolidates zizmor, actionlint, and action pin policy into the shared Tempo workflow-validation job while preserving the repository's existing security baselines. It also pins the Amp review image exposed by the consolidated scan and records narrow immutable-pin exceptions locally.

Part of [OSS-545](https://linear.app/tempoxyz/issue/OSS-545).
