### PR TITLE
deps: update reth from main (2026-08-11)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
         with:
+          toolchain: nightly-2026-08-06
           components: clippy
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -284,7 +284,27 @@ jobs:
       - name: Build foundry forge with coverage instrumentation
         if: needs.check-precompiles.outputs.coverage == 'true'
         working-directory: foundry
-        run: RUSTFLAGS="-C instrument-coverage" cargo build --bin forge --profile release --no-default-features
+        run: |
+          # Instrument only the binary (to link the profiling runtime) and the
+          # Tempo crates covered by this job. Instrumenting revm's opcode loop
+          # makes the Solidity invariant suite several times slower.
+          cat > "$RUNNER_TEMP/rustc-coverage-wrapper" <<'EOF'
+          #!/usr/bin/env bash
+          case " $* " in
+            *" --crate-name forge "*|*" --crate-name tempo_precompiles "*|*" --crate-name tempo_contracts "*)
+              exec sccache "$@" -C instrument-coverage
+              ;;
+            *)
+              exec sccache "$@"
+              ;;
+          esac
+          EOF
+          chmod +x "$RUNNER_TEMP/rustc-coverage-wrapper"
+          # Wrapper-added flags are invisible to Cargo's freshness checks, so
+          # do not reuse an uninstrumented target directory restored by cache.
+          cargo clean --profile release
+          RUSTC_WRAPPER="$RUNNER_TEMP/rustc-coverage-wrapper" \
+            cargo build --bin forge --profile release --no-default-features
 
       # Build WITHOUT coverage on main/merge-group runs.
       - name: Build foundry forge

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "clap",
  "eyre",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "serde",
  "serde_json",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "bytes",
  "futures",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "bindgen",
  "cc",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "futures",
  "libc",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10395,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "bytes",
  "eyre",
@@ -10685,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10697,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10848,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11153,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11377,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11403,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11447,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11484,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "clap",
  "eyre",
@@ -11514,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11533,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11645,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11670,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
+source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13391,6 +13391,7 @@ dependencies = [
  "reth-primitives-traits",
  "reth-rpc-convert",
  "reth-rpc-eth-types",
+ "rustls",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "clap",
  "eyre",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "serde",
  "serde_json",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "bytes",
  "futures",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "bindgen",
  "cc",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "futures",
  "libc",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10395,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "bytes",
  "eyre",
@@ -10685,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10697,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10848,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11153,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11377,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11403,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11447,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11484,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "clap",
  "eyre",
@@ -11514,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11533,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11645,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11670,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
+source = "git+https://github.com/paradigmxyz/reth?rev=9253c0f#9253c0f8bc62469e17abb9b5b122f6fc4ae27ad2"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8865,7 +8865,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8892,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8923,7 +8923,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8943,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8956,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9040,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9103,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9119,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9171,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9200,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9271,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9320,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9436,7 +9436,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9463,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9600,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9618,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9634,7 +9634,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9657,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9668,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9696,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9718,7 +9718,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "clap",
  "eyre",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9798,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9814,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9827,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9857,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9871,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9881,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9907,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9945,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9958,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9977,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "serde",
  "serde_json",
@@ -10039,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10065,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "bytes",
  "futures",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10102,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "bindgen",
  "cc",
@@ -10111,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "futures",
  "libc",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10134,7 +10134,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10148,7 +10148,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10232,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10256,7 +10256,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10271,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10285,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10302,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10326,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10394,7 +10394,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10449,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10498,7 +10498,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10522,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10546,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "bytes",
  "eyre",
@@ -10575,7 +10575,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10587,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10611,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10623,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10646,7 +10646,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10689,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10765,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10796,7 +10796,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10903,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10946,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10966,7 +10966,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10997,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11044,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11095,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11140,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11191,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11219,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11253,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11294,7 +11294,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11311,7 +11311,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11337,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11358,7 +11358,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11374,7 +11374,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11384,7 +11384,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "clap",
  "eyre",
@@ -11404,7 +11404,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11466,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11492,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11519,7 +11519,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11535,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11560,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
+source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdf7932042b511ad4ad67f7eeac896df62439ac91a8c516d678b79cbe3f9c27"
+checksum = "6c8d8a7d7e896331d13d94cd50779a843d3fb3d8b0389826e43638f6276bc4b3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
+checksum = "51b9eb70841f76b69b1205bb57b551b7d7afd8407ad57cbda02e833877507c16"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
+checksum = "f89486e1bd2c5c56522cf18e73460c3fe7b54d50f5e80131466e62b7632edfcb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
+checksum = "b4c0dadb2468adc8aaaaad4c9a6cfa6bd055fe6596c40017067b37671f2c45f5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
+checksum = "fddc9c1868d6331b56926de8ab4c4a80d8dcb7bc4f8f7bebc6a89d0548f79af2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
+checksum = "3fe3f812d024acd2a612aea20629130cd59595064f1420953e6e20c84165def9"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
+checksum = "921b3dccecc4e9dd571c9f9a728d913c2fc7a8ecdfce6005ed99751817523d0d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
+checksum = "989d701ece9bccec3294991ce4b4a39dd1cecd0979ea58e86b9878679591b4f5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
+checksum = "acfca49fbbe3b30de8114b9cfd89029f87cb33ca7e8a5f5f48a809caaf085126"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
+checksum = "2af7b76520abc91b9e0f1aa987d42df55a66494f94a1881cdadd9b8f67e0b924"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
+checksum = "3a3fb53b31526b0f97cdbfaf9d8bb72b3e4a9ac7965148d79ecec4c733c8558e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71044e076a7c243454619e36279fc4654bc1ff846fbf666663ef574388859c84"
+checksum = "197325ef17fcdf5dfa21999a2a33877b82bb5009d5cc9b5c7f5ddb840fa3b6bb"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
+checksum = "f5274f9ada7f558d2feaba16fadcb96022512566cf424147f9cfa2000bc2e458"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
+checksum = "12a456d697d4f639d20ac242981de13b94f911c99199e4175e85eaf52b8f785c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980671fae7bff5ab0ae2d0bfe5c97e42cda103fece106f8d0e584a41c789fc7c"
+checksum = "7f36ee47a0f4e901b95180fbe86c92fec3ea73f12c88c5ec70d1cb41abb8d911"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
+checksum = "7d7e911c628067c406effef5137d0e253d98e117cdb81d47aacfe2816199297e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
+checksum = "5493c88bfdd02271de47f28d69481191a2af6b2907901a3a8c7aff79a6b574eb"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22759d1d0e79082a5a06f75dc45bf55dfedbb4ac9890da1f179d85a5d2f32f7"
+checksum = "b8573342cde98a4d40120b7bc0063fbda42cfd87fb305ab834704177b60d8691"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b918cbaadbdcffa4ed64840a5ecbde80a6476ab23adc8c5c8ae6feec081058c"
+checksum = "bddf06191e2b12eaaeb3a50ef29a8f3416fb74c61421b80f9d7554c4c1d59a56"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
+checksum = "866fa880cfd95681c979bf3f8385964c2317ef7423c31c0de53159f01112fedf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
+checksum = "9d3b805bb9cafaf1362c28b377e2035e49fc5ae0a5ee3ea61bafd9a5d33959e1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04a8f30a439c995d71ab999d56a828dcbe4d90b4f012419832779e60acf86af"
+checksum = "2b973745b97a364c0215f681b2fb3cb6f0bbeda4dcdba5f56c50f999719ec96f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12cafc0ee2290122ec4e069bb0f2389a356f4b5414f2e82de8288049c2bc98a"
+checksum = "2a6fae28f1bda2586b117a5754b49366160770e63e09ac93fc3d872015a5a993"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157eec8f8661e6e70e3749c0a4d918a8831f0b0fc152aed60c0de457faca420b"
+checksum = "4962825b8819e54028cbdaadeba128a613afa55c91b9a88e0b0dc257772a14d7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
+checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
+checksum = "afa150cd076471ef21aa7b181d8186cb86c3239518859a2e5d80fbec74f0ec38"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1a457df25c6f8cec9cf3fd15db7864780c19c24e372cd4fff66e2bf1cff1c8"
+checksum = "c621822c9971a3d895bbd5620dca425ca78ce3345b60ae8268a89f1faa35cd8a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d9d231dc021653db081a6ec8f2c84f06d7b61c9585a437ab3febe9b7f33f35"
+checksum = "e774bb2e422fb7a1d07618273fe62ea3665c6cba800979cffa7a5a162f2cd69e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32c516c9f3153b83cb6b006b5ff26a651dc2868fef970b62b70f61b63c6701c"
+checksum = "61301531ee6aacbb242b9f7daca4bc6cf6529f21498e9f6aeecae7ea15afca4b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
+checksum = "f125bb730d4772538835d4a31e8e5ed5068e2a991619ba32711fd53ad8c93032"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f109f645c0ee244e76e4470c1eeedbca39dc082d17b4950d9c4b1735dee44142"
+checksum = "b4c5f7e7e14e6d22ba836739c0dd2573d1aea1512275e0caf597ba03e8d62e43"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
+checksum = "3cd5dbd32cae5d1bc3afaf455064ebd9bcce70b57de220468908717c225225dd"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
+checksum = "f0b7b1f0e528ae788d05937f5b351afae3b4c1e08f17a061d868bd28e56aa9e3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b51470da19d0ed256bb3cf31042cceca3ce01714a9ca76624fc71a999f6a27"
+checksum = "b964b4c048eea647a701a6af07307c64995c4abd42d46ba0b3be9593ae3c333c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67177a75a6e8a44f39ccbbc64a3e3a70186ef401d7313285b56735d4285aa34"
+checksum = "efecf9efc5d56276e115b13b36ff27311b8cd6f72affc9788a10ff46b55b2616"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
+checksum = "b3e2386593cef5b12c7d439dbcf62d7d51c3a50dc943909b42ae34b48f1b69dc"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1178,7 +1178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3844,7 +3844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4277,7 +4277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4780,7 +4780,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.1.3",
+ "windows-link 0.2.1",
  "windows-result 0.4.1",
 ]
 
@@ -5867,7 +5867,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7037,7 +7037,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8716,7 +8716,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8743,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8774,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8794,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8807,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8891,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8901,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8954,10 +8954,11 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "eyre",
  "humantime-serde",
+ "reth-network-peers",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
@@ -8970,7 +8971,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8984,7 +8985,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8997,7 +8998,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9022,7 +9023,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9051,7 +9052,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9077,7 +9078,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9107,7 +9108,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9122,7 +9123,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9147,7 +9148,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9171,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9195,7 +9196,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9230,7 +9231,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9287,7 +9288,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9314,7 +9315,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9337,7 +9338,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9364,7 +9365,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9421,7 +9422,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9451,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9469,7 +9470,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9485,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9509,7 +9510,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9520,7 +9521,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9548,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9570,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9611,7 +9612,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "clap",
  "eyre",
@@ -9634,7 +9635,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9650,7 +9651,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9666,7 +9667,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9679,7 +9680,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9709,7 +9710,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9723,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9733,7 +9734,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9759,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9779,7 +9780,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9797,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9810,7 +9811,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9829,7 +9830,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9867,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9881,7 +9882,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "serde",
  "serde_json",
@@ -9891,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9917,7 +9918,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "bytes",
  "futures",
@@ -9937,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9954,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "bindgen",
  "cc",
@@ -9963,7 +9964,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "futures",
  "libc",
@@ -9977,7 +9978,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9986,7 +9987,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10000,7 +10001,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10059,7 +10060,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10084,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10108,7 +10109,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10123,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10137,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10154,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10178,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10246,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10301,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10350,7 +10351,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10374,7 +10375,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10398,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "bytes",
  "eyre",
@@ -10427,7 +10428,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10439,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10463,7 +10464,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10475,7 +10476,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10498,7 +10499,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10541,7 +10542,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10590,7 +10591,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10617,7 +10618,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10633,7 +10634,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10648,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10688,7 +10689,6 @@ dependencies = [
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -10725,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10798,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10818,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10849,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10896,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10947,7 +10947,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10961,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10992,7 +10992,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11043,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11071,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11085,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11105,7 +11105,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11120,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11146,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11163,7 +11163,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11189,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11210,7 +11210,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11236,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "clap",
  "eyre",
@@ -11256,7 +11256,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11275,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11318,7 +11318,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11344,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11371,7 +11371,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11387,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11412,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
+source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11956,7 +11956,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12036,7 +12036,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12695,7 +12695,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12971,7 +12971,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14042,9 +14042,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -14527,9 +14527,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -14541,7 +14541,6 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -14722,12 +14721,6 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -15100,7 +15093,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8d8a7d7e896331d13d94cd50779a843d3fb3d8b0389826e43638f6276bc4b3"
+checksum = "7bdf7932042b511ad4ad67f7eeac896df62439ac91a8c516d678b79cbe3f9c27"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9eb70841f76b69b1205bb57b551b7d7afd8407ad57cbda02e833877507c16"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89486e1bd2c5c56522cf18e73460c3fe7b54d50f5e80131466e62b7632edfcb"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c0dadb2468adc8aaaaad4c9a6cfa6bd055fe6596c40017067b37671f2c45f5"
+checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -353,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddc9c1868d6331b56926de8ab4c4a80d8dcb7bc4f8f7bebc6a89d0548f79af2"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -379,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe3f812d024acd2a612aea20629130cd59595064f1420953e6e20c84165def9"
+checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
+checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -413,9 +413,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921b3dccecc4e9dd571c9f9a728d913c2fc7a8ecdfce6005ed99751817523d0d"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d701ece9bccec3294991ce4b4a39dd1cecd0979ea58e86b9878679591b4f5"
+checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -469,9 +469,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfca49fbbe3b30de8114b9cfd89029f87cb33ca7e8a5f5f48a809caaf085126"
+checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af7b76520abc91b9e0f1aa987d42df55a66494f94a1881cdadd9b8f67e0b924"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -519,7 +519,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash 0.2.0",
+ "foldhash",
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3fb53b31526b0f97cdbfaf9d8bb72b3e4a9ac7965148d79ecec4c733c8558e"
+checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197325ef17fcdf5dfa21999a2a33877b82bb5009d5cc9b5c7f5ddb840fa3b6bb"
+checksum = "71044e076a7c243454619e36279fc4654bc1ff846fbf666663ef574388859c84"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -630,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5274f9ada7f558d2feaba16fadcb96022512566cf424147f9cfa2000bc2e458"
+checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -656,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a456d697d4f639d20ac242981de13b94f911c99199e4175e85eaf52b8f785c"
+checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -673,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36ee47a0f4e901b95180fbe86c92fec3ea73f12c88c5ec70d1cb41abb8d911"
+checksum = "980671fae7bff5ab0ae2d0bfe5c97e42cda103fece106f8d0e584a41c789fc7c"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -685,9 +685,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7e911c628067c406effef5137d0e253d98e117cdb81d47aacfe2816199297e"
+checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c88bfdd02271de47f28d69481191a2af6b2907901a3a8c7aff79a6b574eb"
+checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573342cde98a4d40120b7bc0063fbda42cfd87fb305ab834704177b60d8691"
+checksum = "d22759d1d0e79082a5a06f75dc45bf55dfedbb4ac9890da1f179d85a5d2f32f7"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddf06191e2b12eaaeb3a50ef29a8f3416fb74c61421b80f9d7554c4c1d59a56"
+checksum = "7b918cbaadbdcffa4ed64840a5ecbde80a6476ab23adc8c5c8ae6feec081058c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -745,9 +745,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866fa880cfd95681c979bf3f8385964c2317ef7423c31c0de53159f01112fedf"
+checksum = "d30ff2e8f7d05433c1d36cf0f1ba045bf071a3d139f63923742fbdfb171dfe44"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -765,9 +765,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3b805bb9cafaf1362c28b377e2035e49fc5ae0a5ee3ea61bafd9a5d33959e1"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -787,9 +787,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b973745b97a364c0215f681b2fb3cb6f0bbeda4dcdba5f56c50f999719ec96f"
+checksum = "b04a8f30a439c995d71ab999d56a828dcbe4d90b4f012419832779e60acf86af"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -802,9 +802,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6fae28f1bda2586b117a5754b49366160770e63e09ac93fc3d872015a5a993"
+checksum = "a12cafc0ee2290122ec4e069bb0f2389a356f4b5414f2e82de8288049c2bc98a"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4962825b8819e54028cbdaadeba128a613afa55c91b9a88e0b0dc257772a14d7"
+checksum = "157eec8f8661e6e70e3749c0a4d918a8831f0b0fc152aed60c0de457faca420b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -828,9 +828,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa150cd076471ef21aa7b181d8186cb86c3239518859a2e5d80fbec74f0ec38"
+checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -855,9 +855,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c621822c9971a3d895bbd5620dca425ca78ce3345b60ae8268a89f1faa35cd8a"
+checksum = "dc1a457df25c6f8cec9cf3fd15db7864780c19c24e372cd4fff66e2bf1cff1c8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e774bb2e422fb7a1d07618273fe62ea3665c6cba800979cffa7a5a162f2cd69e"
+checksum = "46d9d231dc021653db081a6ec8f2c84f06d7b61c9585a437ab3febe9b7f33f35"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -892,9 +892,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61301531ee6aacbb242b9f7daca4bc6cf6529f21498e9f6aeecae7ea15afca4b"
+checksum = "c32c516c9f3153b83cb6b006b5ff26a651dc2868fef970b62b70f61b63c6701c"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -910,9 +910,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f125bb730d4772538835d4a31e8e5ed5068e2a991619ba32711fd53ad8c93032"
+checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -929,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5f7e7e14e6d22ba836739c0dd2573d1aea1512275e0caf597ba03e8d62e43"
+checksum = "f109f645c0ee244e76e4470c1eeedbca39dc082d17b4950d9c4b1735dee44142"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd5dbd32cae5d1bc3afaf455064ebd9bcce70b57de220468908717c225225dd"
+checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1042,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7b1f0e528ae788d05937f5b351afae3b4c1e08f17a061d868bd28e56aa9e3"
+checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b964b4c048eea647a701a6af07307c64995c4abd42d46ba0b3be9593ae3c333c"
+checksum = "e7b51470da19d0ed256bb3cf31042cceca3ce01714a9ca76624fc71a999f6a27"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1078,9 +1078,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efecf9efc5d56276e115b13b36ff27311b8cd6f72affc9788a10ff46b55b2616"
+checksum = "e67177a75a6e8a44f39ccbbc64a3e3a70186ef401d7313285b56735d4285aa34"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.3.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e2386593cef5b12c7d439dbcf62d7d51c3a50dc943909b42ae34b48f1b69dc"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1247,43 +1247,43 @@ checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
 dependencies = [
  "ark-ec",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
 name = "ark-bn254"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
  "ark-ec",
- "ark-ff 0.6.0",
+ "ark-ff 0.5.0",
  "ark-r1cs-std",
- "ark-std 0.6.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
 name = "ark-ec"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
- "ark-ff 0.6.0",
+ "ark-ff 0.5.0",
  "ark-poly",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.17.1",
- "itertools 0.14.0",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1349,23 +1349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ff"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
-dependencies = [
- "ark-ff-asm 0.6.0",
- "ark-ff-macros 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
- "digest 0.10.7",
- "educe",
- "num-bigint",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,16 +1373,6 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "ark-ff-asm"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1444,45 +1417,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-ff-macros"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
-dependencies = [
- "num-bigint",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "ark-poly"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
 dependencies = [
  "ahash",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.17.1",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
+checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
 dependencies = [
  "ark-ec",
- "ark-ff 0.6.0",
+ "ark-ff 0.5.0",
  "ark-relations",
- "ark-std 0.6.0",
+ "ark-std 0.5.0",
  "educe",
- "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1491,18 +1450,14 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
+checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
 dependencies = [
- "ark-ff 0.6.0",
- "ark-poly",
- "ark-serialize 0.6.0",
- "ark-std 0.6.0",
- "foldhash 0.1.5",
- "indexmap 2.14.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -1532,6 +1487,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1539,23 +1495,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-serialize"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
-dependencies = [
- "ark-serialize-derive",
- "ark-std 0.6.0",
- "digest 0.10.7",
- "num-bigint",
- "serde_with",
-]
-
-[[package]]
 name = "ark-serialize-derive"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1587,16 +1530,6 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "ark-std"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -2423,7 +2356,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "once_cell",
- "phf 0.13.1",
+ "phf",
  "rustc-hash 2.1.2",
  "static_assertions",
 ]
@@ -2632,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.8"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2961,7 +2894,7 @@ dependencies = [
  "const-hex",
  "digest 0.10.7",
  "generic-array",
- "ripemd 0.1.3",
+ "ripemd",
  "serde",
  "sha2 0.10.9",
  "sha3 0.10.9",
@@ -3370,7 +3303,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -4792,12 +4725,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -5244,13 +5171,22 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -5259,8 +5195,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "allocator-api2",
- "foldhash 0.2.0",
+ "foldhash",
  "serde",
  "serde_core",
 ]
@@ -6773,7 +6708,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -7498,7 +7433,7 @@ dependencies = [
  "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -7787,18 +7722,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
-dependencies = [
- "phf_macros 0.14.0",
- "phf_shared 0.14.0",
+ "phf_macros",
+ "phf_shared",
  "serde",
 ]
 
@@ -7809,17 +7734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
-dependencies = [
- "fastrand",
- "phf_shared 0.14.0",
+ "phf_shared",
 ]
 
 [[package]]
@@ -7828,21 +7743,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
-dependencies = [
- "phf_generator 0.14.0",
- "phf_shared 0.14.0",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7853,15 +7755,6 @@ name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -8972,7 +8865,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8892,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +8923,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +8943,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +8956,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9040,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9177,9 +9070,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
+checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9198,9 +9091,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
+checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9210,7 +9103,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9226,7 +9119,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9240,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9253,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9278,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9307,7 +9200,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9333,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9363,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9378,7 +9271,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9403,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9427,7 +9320,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9451,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9486,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9543,7 +9436,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9570,7 +9463,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9677,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9707,7 +9600,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9618,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9741,14 +9634,13 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
  "futures-util",
- "reth-codecs",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
@@ -9765,7 +9657,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9776,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9804,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9826,7 +9718,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9867,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "clap",
  "eyre",
@@ -9890,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9906,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9922,7 +9814,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9935,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9965,7 +9857,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9979,7 +9871,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9989,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10015,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10035,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10053,7 +9945,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10066,7 +9958,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10085,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10137,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "serde",
  "serde_json",
@@ -10147,7 +10039,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10173,7 +10065,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "bytes",
  "futures",
@@ -10193,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10210,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "bindgen",
  "cc",
@@ -10219,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "futures",
  "libc",
@@ -10233,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10242,7 +10134,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10256,7 +10148,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10315,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10340,7 +10232,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10364,7 +10256,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10379,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10393,7 +10285,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10410,7 +10302,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10434,7 +10326,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10502,7 +10394,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10557,7 +10449,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10606,7 +10498,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10630,7 +10522,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10654,7 +10546,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "bytes",
  "eyre",
@@ -10683,7 +10575,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10695,7 +10587,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10719,7 +10611,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10731,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10754,7 +10646,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10763,9 +10655,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
+checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10797,7 +10689,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10846,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10873,7 +10765,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10889,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10904,7 +10796,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10981,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11011,7 +10903,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11054,7 +10946,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11074,7 +10966,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11105,7 +10997,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11152,7 +11044,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11203,7 +11095,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11217,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11232,9 +11124,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
+checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11248,7 +11140,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11299,7 +11191,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11327,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11341,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11361,7 +11253,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11376,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11402,7 +11294,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11419,7 +11311,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11337,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11466,7 +11358,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11482,7 +11374,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11492,7 +11384,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "clap",
  "eyre",
@@ -11504,7 +11396,7 @@ dependencies = [
  "tracing-journald",
  "tracing-logfmt",
  "tracing-samply",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "tracing-tracy",
  "tracy-client",
 ]
@@ -11512,7 +11404,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11524,14 +11416,14 @@ dependencies = [
  "opentelemetry_sdk 0.32.1",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11574,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11600,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11627,7 +11519,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11643,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11668,7 +11560,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=c505ed2#c505ed2e097b142040da1bb36d60472ee56c66c0"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11689,18 +11581,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
+checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
+checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11717,21 +11609,21 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
 dependencies = [
  "bitvec",
- "phf 0.14.0",
+ "phf",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
+checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11746,9 +11638,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
+checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11762,9 +11654,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
+checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11778,9 +11670,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
+checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
 dependencies = [
  "auto_impl",
  "either",
@@ -11792,9 +11684,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
+checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11811,9 +11703,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
+checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
 dependencies = [
  "auto_impl",
  "either",
@@ -11829,9 +11721,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.42.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3958b5de5c2c08c6a49b8d94f6ead3e9cd7980c43d6ed240aa3d6485d53269b5"
+checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11849,9 +11741,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
+checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11862,15 +11754,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
+checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.6.0",
- "ark-serialize 0.6.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
  "arrayref",
  "aurora-engine-modexp",
  "aws-lc-rs",
@@ -11881,16 +11773,16 @@ dependencies = [
  "p256 0.13.2",
  "revm-context-interface",
  "revm-primitives",
- "ripemd 0.2.0",
+ "ripemd",
  "secp256k1 0.31.1",
- "sha2 0.11.0",
+ "sha2 0.10.9",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
+checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11899,9 +11791,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
+version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -11967,15 +11859,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "ripemd"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
-dependencies = [
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -12080,16 +11963,15 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.20.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
- "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -13434,12 +13316,10 @@ dependencies = [
  "age",
  "alloy-consensus",
  "alloy-primitives",
- "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
- "alloy-transport",
  "axum",
  "bytes",
  "clap",
@@ -13478,7 +13358,6 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "tempfile",
- "tempo-alloy",
  "tempo-chainspec",
  "tempo-consensus-config",
  "tempo-dkg-onchain-artifacts",
@@ -13491,7 +13370,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "url",
 ]
 
@@ -13588,7 +13467,7 @@ dependencies = [
  "tempo-primitives",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13905,7 +13784,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempo-contracts",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -13963,7 +13842,7 @@ dependencies = [
  "tempo-telemetry-util",
  "tokio",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14340,9 +14219,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.29.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -14577,7 +14456,7 @@ dependencies = [
  "symlink",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14599,7 +14478,7 @@ checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
 dependencies = [
  "serde_json",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14630,7 +14509,7 @@ checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14653,7 +14532,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14668,7 +14547,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "web-time",
 ]
 
@@ -14685,7 +14564,7 @@ dependencies = [
  "memmap2",
  "smallvec",
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
 ]
 
 [[package]]
@@ -14695,6 +14574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
  "tracing-core",
 ]
 
@@ -14726,7 +14614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
 dependencies = [
  "tracing-core",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.23",
  "tracy-client",
 ]
 
@@ -14809,9 +14697,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.29.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -14823,6 +14711,7 @@ dependencies = [
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -15003,6 +14892,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9814,6 +9814,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "bytes",
  "derive_more",
  "reth-chainspec",
@@ -9827,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9868,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "clap",
  "eyre",
@@ -9891,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9907,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9923,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9936,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9966,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9980,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9990,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10016,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10036,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10054,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10067,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10086,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10124,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10138,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "serde",
  "serde_json",
@@ -10148,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10174,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "bytes",
  "futures",
@@ -10194,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10211,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "bindgen",
  "cc",
@@ -10220,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "futures",
  "libc",
@@ -10234,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10243,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10257,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10316,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10341,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10365,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10380,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10394,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10411,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10435,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10503,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10558,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10607,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10631,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10655,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "bytes",
  "eyre",
@@ -10684,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10696,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10720,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10732,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10755,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10798,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10847,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10874,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10890,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10905,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10981,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11011,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11054,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11074,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11105,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11152,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11203,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11217,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11248,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11299,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11327,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11341,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11361,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11376,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11402,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11419,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11446,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11466,7 +11467,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11482,7 +11483,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11492,7 +11493,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "clap",
  "eyre",
@@ -11512,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11531,7 +11532,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11574,7 +11575,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11600,7 +11601,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11627,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11643,7 +11644,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11668,7 +11669,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
+source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1349,6 +1349,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1390,16 @@ name = "ark-ff-asm"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
  "syn 2.0.117",
@@ -1408,6 +1435,19 @@ name = "ark-ff-macros"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -1487,7 +1527,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1495,10 +1535,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint",
+ "serde_with",
+]
+
+[[package]]
 name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1530,6 +1594,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -4415,7 +4489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4928,7 +5002,7 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
+ "windows-link 0.1.3",
  "windows-result 0.4.1",
 ]
 
@@ -6030,7 +6104,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7194,7 +7268,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11963,15 +12037,16 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
@@ -12104,7 +12179,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12184,7 +12259,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12864,7 +12939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12885,9 +12960,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"
@@ -13144,7 +13219,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15227,7 +15302,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "bech32",
  "chacha20poly1305",
  "cookie-factory",
- "hmac 0.12.1",
+ "hmac",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
@@ -80,7 +80,7 @@ dependencies = [
  "scrypt",
  "sha2 0.10.9",
  "subtle",
- "x25519-dalek 2.0.1",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -393,9 +393,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.37.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acde665074b478c97047dc2a461b4916cac77922d690e5b7415d1941ae7ff7bf"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -519,8 +519,8 @@ dependencies = [
  "const-hex",
  "derive_more",
  "fixed-cache",
- "foldhash",
- "getrandom 0.4.3",
+ "foldhash 0.2.0",
+ "getrandom 0.4.2",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
@@ -848,7 +848,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve 0.13.8",
+ "elliptic-curve",
  "k256",
  "thiserror 2.0.18",
 ]
@@ -867,7 +867,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "k256",
- "spki 0.7.3",
+ "spki",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -885,7 +885,7 @@ dependencies = [
  "async-trait",
  "gcloud-sdk",
  "k256",
- "spki 0.7.3",
+ "spki",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1247,43 +1247,43 @@ checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
 
 [[package]]
 name = "ark-bls12-381"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+checksum = "be2ede2c0c96fa37d5d3484e8a59fec566c4a52b8c84bf993eaa6c67d7225a4c"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-bn254"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-r1cs-std",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
 name = "ark-ec"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-poly",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
- "itertools 0.13.0",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1458,30 +1458,31 @@ dependencies = [
 
 [[package]]
 name = "ark-poly"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
 dependencies = [
  "ahash",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
  "educe",
  "fnv",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "ark-r1cs-std"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941551ef1df4c7a401de7068758db6503598e6f01850bdb2cfdb614a1f9dbea1"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
 dependencies = [
  "ark-ec",
- "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "ark-relations",
- "ark-std 0.5.0",
+ "ark-std 0.6.0",
  "educe",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -1490,14 +1491,18 @@ dependencies = [
 
 [[package]]
 name = "ark-relations"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec46ddc93e7af44bcab5230937635b06fb5744464dd6a7e7b083e80ebd274384"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
 dependencies = [
- "ark-ff 0.5.0",
- "ark-std 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-poly",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.14.0",
  "tracing",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1527,7 +1532,6 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
@@ -1540,22 +1544,11 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
 dependencies = [
- "ark-serialize-derive 0.6.0",
+ "ark-serialize-derive",
  "ark-std 0.6.0",
  "digest 0.10.7",
  "num-bigint",
  "serde_with",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1867,7 +1860,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
@@ -2139,12 +2132,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base16ct"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
-
-[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2312,6 +2299,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -2430,7 +2426,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indexmap 2.14.0",
  "once_cell",
- "phf",
+ "phf 0.13.1",
  "rustc-hash 2.1.2",
  "static_assertions",
 ]
@@ -2639,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "arbitrary",
  "blst",
@@ -2856,15 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.4.6"
+version = "0.5.0-pre.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
-
-[[package]]
-name = "cmov"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
 
 [[package]]
 name = "codspeed"
@@ -2933,7 +2923,7 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
  "k256",
  "serde",
  "sha2 0.10.9",
@@ -2948,7 +2938,7 @@ checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
 dependencies = [
  "bitvec",
  "coins-bip32",
- "hmac 0.12.1",
+ "hmac",
  "once_cell",
  "pbkdf2",
  "rand 0.8.6",
@@ -2968,7 +2958,7 @@ dependencies = [
  "const-hex",
  "digest 0.10.7",
  "generic-array",
- "ripemd",
+ "ripemd 0.1.3",
  "serde",
  "sha2 0.10.9",
  "sha3 0.10.9",
@@ -3035,71 +3025,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "commonware-actor"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beac6262223b45c6843ab70b245b526b28836a8257b1759a509ba5fab24fa4a6"
-dependencies = [
- "cfg-if",
- "commonware-macros",
- "commonware-runtime",
- "crossbeam-queue",
- "futures-util",
- "parking_lot",
-]
-
-[[package]]
 name = "commonware-broadcast"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2d7e56dc894ad3f55dbe5726468915492ae8e4650ad2a45c1bcfd138c2037f"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",
  "commonware-runtime",
  "commonware-utils",
+ "prometheus-client",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-codec"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eb7efe071cea13e8b23a0a7f584398870c401d2b2aabfb6b9ab3634ebcba3a"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "arbitrary",
  "bytes",
  "cfg-if",
- "commonware-codec-macros",
- "commonware-conformance",
  "commonware-macros",
  "paste",
- "rand_chacha 0.10.0",
- "rand_core 0.10.1",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "commonware-codec-macros"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a876bec347344381948901d0f5ec2e9443ebc8dbab99a63bc2db78c2fc2efbdd"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "commonware-coding"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409e9997c1bb3273b9570c26ddef4f252327c9bf18968d4439a83cfd1d3e5661"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3110,50 +3068,24 @@ dependencies = [
  "commonware-storage",
  "commonware-utils",
  "num-rational",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "rayon",
+ "reed-solomon-simd",
  "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "commonware-conformance"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0840a6116d784b84ec0c64244f310a2f325af79fbe7b093fc812e8ac8efd12"
-dependencies = [
- "commonware-conformance-macros",
- "commonware-formatting",
- "commonware-macros",
- "futures",
- "serde",
- "sha2 0.11.0",
- "toml 0.9.12+spec-1.1.0",
-]
-
-[[package]]
-name = "commonware-conformance-macros"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c8b6096c3820f9e3f01be1954e49509c75a53598a465b8adb6c87ad3f4d308"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "commonware-consensus"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf15e3402e26f062695d4dd5e4b5967f601dc7303d06b9fafdb20a6485a3a0a"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
  "cfg-if",
- "commonware-actor",
  "commonware-broadcast",
  "commonware-codec",
  "commonware-coding",
  "commonware-cryptography",
- "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-p2p",
@@ -3164,8 +3096,10 @@ dependencies = [
  "commonware-utils",
  "futures",
  "pin-project",
- "rand 0.10.2",
- "rand_core 0.10.1",
+ "prometheus-client",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_distr 0.4.3",
  "rayon",
  "thiserror 2.0.18",
  "tracing",
@@ -3173,13 +3107,10 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b842f31e1aaa1af284a1f9dc4f1234761f72d07e70d53cf3f1521b0870ade094"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "ahash",
  "anyhow",
- "arbitrary",
  "aws-lc-rs",
  "blake3",
  "blst",
@@ -3187,62 +3118,31 @@ dependencies = [
  "cfg-if",
  "chacha20poly1305",
  "commonware-codec",
- "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
- "cpufeatures 0.2.17",
  "crc-fast",
- "ctutils 0.3.1",
- "curve25519-dalek 5.0.0",
- "ecdsa 0.17.0",
- "fixedbitset",
+ "ctutils",
+ "ecdsa",
+ "ed25519-consensus",
  "getrandom 0.2.17",
- "getrandom 0.4.3",
- "hashbrown 0.16.1",
  "num-rational",
  "num-traits",
- "once_cell",
- "p256 0.14.0",
- "rand 0.10.2",
- "rand_chacha 0.10.0",
- "rand_core 0.10.1",
- "sha2 0.11.0",
+ "p256",
+ "rand 0.8.6",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
- "x25519-dalek 3.0.0",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
-name = "commonware-formatting"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab01b7f2798e29b0a4f7b47da5b7f3c106881578af3e69e8d2ee9d89d7c1d4fd"
-dependencies = [
- "commonware-macros",
- "const-hex",
-]
-
-[[package]]
-name = "commonware-invariants"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7626b0950e91aad9e954163daa74cbab108825ac6fe5f9967c4ab9e1cedd87a5"
-dependencies = [
- "arbitrary",
- "commonware-formatting",
- "commonware-macros",
- "rand 0.10.2",
- "rand_chacha 0.10.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "commonware-macros"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e37a17d5c99ec6711098c6614af1023fd32926aa0414ec0f0613f6bb940278"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3250,9 +3150,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d44bceee874226efca172f0e9ec9ec4eb486788ba6be1d98710f3f159b807af"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3263,27 +3162,22 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593fa0c5aa8bd8d350724b9b1ad4e85072845aa85a06b39ca4598998bbec1e00"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "arbitrary",
  "bytes",
  "commonware-codec",
- "commonware-invariants",
  "commonware-macros",
  "commonware-parallel",
  "commonware-utils",
- "rand_core 0.10.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "commonware-p2p"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f974fcd27c0dad7ae73caeaf00c8330fd29c60f5ff1f679ccc1a51c8ed95bc"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -3297,34 +3191,30 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits",
- "rand 0.10.2",
- "rand_core 0.10.1",
- "rand_distr 0.6.0",
+ "prometheus-client",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "rand_distr 0.4.3",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7109817274c671f1fb0ba17cf8aecfbb70672d29379284feeac43fa1b1dc0201"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "cfg-if",
  "commonware-macros",
- "dashmap",
- "futures",
  "rayon",
 ]
 
 [[package]]
 name = "commonware-resolver"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a497cc9e9a2cd205d96474d0d40c7731f29085cd467adbe9ff0f94719659582"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "bytes",
- "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -3333,70 +3223,52 @@ dependencies = [
  "commonware-stream",
  "commonware-utils",
  "futures",
- "rand 0.10.2",
- "rand_core 0.10.1",
+ "prometheus-client",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a84bc6cefb099b1ffce3e04705a1e61e91d895b9f09b9e1be14c8ec5823c181"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "ahash",
  "axum",
  "bytes",
  "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
- "commonware-formatting",
  "commonware-macros",
  "commonware-parallel",
- "commonware-runtime-macros",
  "commonware-utils",
  "criterion",
- "crossbeam-utils",
+ "crossbeam-queue",
  "futures",
  "getrandom 0.2.17",
- "getrandom 0.4.3",
  "governor",
  "libc",
- "opentelemetry 0.32.0",
- "opentelemetry-otlp 0.32.0",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry 0.31.0",
+ "opentelemetry-otlp 0.31.1",
+ "opentelemetry_sdk 0.31.0",
  "pin-project",
  "prometheus-client",
- "rand 0.10.2",
- "rand_core 0.10.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "rayon",
- "sha2 0.11.0",
+ "sha2 0.10.9",
  "sysinfo 0.37.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber 0.3.23",
-]
-
-[[package]]
-name = "commonware-runtime-macros"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f7b39ef9fd9f1df4fe4445c9a5ec5ba012d90d1602b12a8b8626a8563ab02c"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "tracing-opentelemetry 0.32.1",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "commonware-storage"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac18e2b696ab7bbecf1059bc3b8d39fc0af002180906d65c7df3112fd9385de"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3404,14 +3276,14 @@ dependencies = [
  "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
- "commonware-formatting",
  "commonware-macros",
  "commonware-parallel",
  "commonware-runtime",
  "commonware-utils",
  "futures",
  "futures-util",
- "hashbrown 0.16.1",
+ "prometheus-client",
+ "rayon",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -3419,41 +3291,34 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8890b69e3fa209bc9e87d199ff60ca5a21c88322d32914847511887e6dc5364b"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
  "commonware-cryptography",
- "commonware-formatting",
  "commonware-macros",
  "commonware-runtime",
  "commonware-utils",
  "futures",
- "rand_core 0.10.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "thiserror 2.0.18",
- "x25519-dalek 3.0.0",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "commonware-utils"
-version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a484dd46b738d9b5ba892312425e71e6afaf4320e388d74449bd9ca0ea14cd76"
+version = "2026.4.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
 dependencies = [
- "ahash",
- "arbitrary",
  "bytes",
  "cfg-if",
  "commonware-codec",
- "commonware-formatting",
  "commonware-macros",
  "futures",
  "getrandom 0.2.17",
- "getrandom 0.3.4",
- "getrandom 0.4.3",
  "hashbrown 0.16.1",
  "num-bigint",
  "num-integer",
@@ -3461,10 +3326,9 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "pin-project",
- "rand 0.10.2",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "tokio",
- "tracing",
  "zeroize",
 ]
 
@@ -3540,12 +3404,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -3638,12 +3496,6 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "cpubits"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -3835,22 +3687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
-dependencies = [
- "cpubits",
- "ctutils 0.4.2",
- "getrandom 0.4.3",
- "hybrid-array",
- "num-traits",
- "rand_core 0.10.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3867,9 +3703,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.3",
  "hybrid-array",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3889,21 +3723,11 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
+checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
 dependencies = [
- "cmov 0.4.6",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov 0.5.4",
- "subtle",
+ "cmov",
 ]
 
 [[package]]
@@ -3916,23 +3740,7 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version 0.4.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "curve25519-dalek-derive",
- "digest 0.11.3",
- "fiat-crypto 0.3.0",
+ "fiat-crypto",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -3947,6 +3755,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core 0.6.4",
+ "subtle-ng",
+ "zeroize",
 ]
 
 [[package]]
@@ -4023,7 +3844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4058,18 +3879,8 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
-name = "der"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
-dependencies = [
- "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -4160,7 +3971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
+ "const-oid",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -4172,9 +3983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
  "crypto-common 0.2.2",
- "ctutils 0.4.2",
 ]
 
 [[package]]
@@ -4299,28 +4108,13 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der 0.7.10",
+ "der",
  "digest 0.10.7",
- "elliptic-curve 0.13.8",
- "rfc6979 0.4.0",
- "serdect 0.2.0",
- "signature 2.2.0",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
-dependencies = [
- "der 0.8.1",
- "digest 0.11.3",
- "elliptic-curve 0.14.1",
- "rfc6979 0.6.0",
- "signature 3.0.0",
- "spki 0.8.0",
- "zeroize",
+ "elliptic-curve",
+ "rfc6979",
+ "serdect",
+ "signature",
+ "spki",
 ]
 
 [[package]]
@@ -4329,8 +4123,22 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
- "signature 2.2.0",
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core 0.6.4",
+ "sha2 0.9.9",
+ "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -4339,7 +4147,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -4375,37 +4183,17 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct 0.2.0",
- "crypto-bigint 0.5.5",
+ "base16ct",
+ "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.1",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
- "pkcs8 0.10.2",
+ "pkcs8",
  "rand_core 0.6.4",
- "sec1 0.7.3",
- "serdect 0.2.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "elliptic-curve"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
-dependencies = [
- "base16ct 1.0.0",
- "crypto-bigint 0.7.5",
- "crypto-common 0.2.2",
- "digest 0.11.3",
- "ff 0.14.0",
- "group 0.14.0",
- "hybrid-array",
- "pkcs8 0.11.0",
- "rand_core 0.10.1",
- "sec1 0.8.1",
+ "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -4619,26 +4407,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ff"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
-dependencies = [
- "rand_core 0.10.1",
- "subtle",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -4796,6 +4568,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -5046,16 +4824,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -5167,19 +4945,8 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.1",
+ "ff",
  "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "group"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
-dependencies = [
- "ff 0.14.0",
- "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -5249,7 +5016,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -5260,7 +5027,7 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -5269,7 +5036,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash",
+ "allocator-api2",
+ "foldhash 0.2.0",
  "serde",
  "serde_core",
 ]
@@ -5360,7 +5128,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand 0.10.2",
+ "rand 0.10.1",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -5380,7 +5148,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie",
- "rand 0.10.2",
+ "rand 0.10.1",
  "ring",
  "serde",
  "thiserror 2.0.18",
@@ -5406,7 +5174,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.2",
+ "rand 0.10.1",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -5434,7 +5202,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
 ]
 
 [[package]]
@@ -5444,15 +5212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.3",
 ]
 
 [[package]]
@@ -5552,13 +5311,11 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
- "subtle",
  "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -5815,6 +5572,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -6468,7 +6231,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature 2.2.0",
+ "signature",
  "simple_asn1",
  "zeroize",
 ]
@@ -6480,12 +6243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
+ "ecdsa",
+ "elliptic-curve",
  "once_cell",
- "serdect 0.2.0",
+ "serdect",
  "sha2 0.10.9",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -6568,6 +6331,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "left-right"
@@ -6782,7 +6551,7 @@ dependencies = [
  "generator",
  "scoped-tls",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7291,7 +7060,6 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "arbitrary",
  "num-integer",
  "num-traits",
  "serde",
@@ -7482,6 +7250,7 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -7507,7 +7276,7 @@ dependencies = [
  "opentelemetry 0.32.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7542,12 +7311,15 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
+ "http 1.4.0",
  "opentelemetry 0.31.0",
  "opentelemetry-http 0.31.0",
  "opentelemetry-proto 0.31.0",
  "opentelemetry_sdk 0.31.0",
+ "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -7577,6 +7349,9 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry_sdk 0.31.0",
+ "prost 0.14.3",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -7608,7 +7383,11 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "opentelemetry 0.31.0",
+ "percent-encoding",
+ "rand 0.9.4",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -7625,8 +7404,6 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -7641,24 +7418,11 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa 0.16.9",
- "elliptic-curve 0.13.8",
- "primeorder 0.13.6",
- "serdect 0.2.0",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "serdect",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "p256"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
-dependencies = [
- "ecdsa 0.17.0",
- "elliptic-curve 0.14.1",
- "primefield",
- "primeorder 0.14.0",
- "sha2 0.11.0",
 ]
 
 [[package]]
@@ -7742,7 +7506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac 0.12.1",
+ "hmac",
 ]
 
 [[package]]
@@ -7796,8 +7560,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
- "phf_shared",
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
  "serde",
 ]
 
@@ -7808,7 +7582,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -7817,8 +7601,21 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7829,6 +7626,15 @@ name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -7871,18 +7677,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
-dependencies = [
- "der 0.8.1",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -8101,40 +7897,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "primefield"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
-dependencies = [
- "crypto-bigint 0.7.5",
- "crypto-common 0.2.2",
- "ff 0.14.0",
- "rand_core 0.10.1",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve 0.13.8",
- "serdect 0.2.0",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
-dependencies = [
- "elliptic-curve 0.14.1",
- "once_cell",
- "primefield",
- "serdect 0.4.3",
- "wnaf",
+ "elliptic-curve",
+ "serdect",
 ]
 
 [[package]]
@@ -8550,12 +8319,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
 
@@ -8577,16 +8346,6 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -8616,22 +8375,22 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
-dependencies = [
- "num-traits",
- "rand 0.10.2",
 ]
 
 [[package]]
@@ -8755,6 +8514,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "readme-rustdocifier"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
+
+[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8778,6 +8543,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "reed-solomon-simd"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "fixedbitset",
+ "once_cell",
+ "readme-rustdocifier",
 ]
 
 [[package]]
@@ -8939,7 +8716,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8966,7 +8743,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8997,7 +8774,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9017,7 +8794,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9030,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9114,7 +8891,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9124,7 +8901,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9144,9 +8921,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb43f4858fef4e3b42b80954d2edf1ff67c8ad7498347083cdc7d0f6eff2f081"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9165,9 +8942,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798ae4d6b264764bc0d742468bd32c7fb515e774645d4930f95ff6311f3ae14"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9177,7 +8954,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9193,7 +8970,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9207,7 +8984,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9220,7 +8997,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9245,7 +9022,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9274,7 +9051,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9300,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9330,7 +9107,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9345,7 +9122,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9370,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9394,7 +9171,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9418,7 +9195,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9453,7 +9230,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9510,7 +9287,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9521,7 +9298,7 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "hmac 0.12.1",
+ "hmac",
  "pin-project",
  "rand 0.8.6",
  "reth-network-peers",
@@ -9537,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9560,7 +9337,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9587,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9644,7 +9421,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9674,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9692,7 +9469,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9708,13 +9485,14 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
  "futures-util",
+ "reth-codecs",
  "reth-db-api",
  "reth-era",
  "reth-era-downloader",
@@ -9731,7 +9509,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9742,7 +9520,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9770,7 +9548,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9792,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9833,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "clap",
  "eyre",
@@ -9856,7 +9634,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9872,7 +9650,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9888,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9901,7 +9679,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9931,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9945,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9955,7 +9733,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9981,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10001,7 +9779,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10019,7 +9797,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10032,7 +9810,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10051,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10089,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10103,7 +9881,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "serde",
  "serde_json",
@@ -10113,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10139,7 +9917,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "bytes",
  "futures",
@@ -10159,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10176,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "bindgen",
  "cc",
@@ -10185,7 +9963,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "futures",
  "libc",
@@ -10199,7 +9977,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10208,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10222,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10281,7 +10059,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10306,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10330,7 +10108,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10345,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10359,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10376,7 +10154,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10400,7 +10178,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10468,7 +10246,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10523,7 +10301,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10572,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10596,7 +10374,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10620,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "bytes",
  "eyre",
@@ -10649,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10661,7 +10439,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10685,7 +10463,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10697,7 +10475,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10720,7 +10498,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10729,9 +10507,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59c928b2865af5bcdbce94800270b7f7798f27a22ca0aabdd2b7d3e6587c9ce"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10763,7 +10541,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10812,7 +10590,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10839,7 +10617,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10855,7 +10633,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10870,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10947,7 +10725,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10977,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11020,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11040,7 +10818,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11071,7 +10849,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11118,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11169,7 +10947,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11183,7 +10961,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11198,9 +10976,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936ba1aa863f2bbb2a0b5f28ea8a114058154e74969385ab27355421d56f9a03"
+checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11214,7 +10992,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11265,7 +11043,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11293,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11307,7 +11085,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11327,7 +11105,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11342,7 +11120,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11368,7 +11146,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11385,7 +11163,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11411,7 +11189,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11432,7 +11210,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11448,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11458,7 +11236,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "clap",
  "eyre",
@@ -11470,7 +11248,7 @@ dependencies = [
  "tracing-journald",
  "tracing-logfmt",
  "tracing-samply",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracing-tracy",
  "tracy-client",
 ]
@@ -11478,7 +11256,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11489,15 +11267,15 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.32.1",
  "tracing",
- "tracing-opentelemetry",
- "tracing-subscriber 0.3.23",
+ "tracing-opentelemetry 0.33.0",
+ "tracing-subscriber",
  "url",
 ]
 
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11540,7 +11318,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11566,7 +11344,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11593,7 +11371,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11609,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11634,7 +11412,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9d25749#9d25749e3182bcefabb9920179bc91e64c4291d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=8bfea20#8bfea20a911f3724000c5e927a3763ef84cf8cac"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11655,18 +11433,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1bd4ae4f54a2ba813eef082910bc646bd31cab8ed134308fa71f1068331fb84"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "41.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d51c254839fb36357d0b02d02e46ba57e683d7b017e2da33b47ae74685a9e59"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11683,21 +11461,21 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33493cf6d996e9242db4f2002caef48ec9aa8c4f3fff3b18aed10ef3942eec7"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
- "phf",
+ "phf 0.14.0",
  "revm-primitives",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e48fc736d9542c082ea5305be44b6a14b53a615f0147ad57f62189fd813068"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11712,9 +11490,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac68282a454318246817486835a446519291dd0a8167d09de14c7e96f2147696"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11728,9 +11506,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d761681a43e48408ea23f7f66ff56ff7b6128cadb8f9135d1b94787d0c0fc6b4"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11744,9 +11522,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e37d62fa60b45987b408486c84ebef4af4e7ddf1b3b96b4955a7263fd4e92"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -11758,9 +11536,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "41.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5e043ebfc0899c435e44475796285898e4f822e637bd67856da79cc170bd9df"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11777,9 +11555,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "41.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e470b2a5e177918944d8cd26174455b61b8fbfbbe7fe411d28b4097e410d11e"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -11795,9 +11573,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df57773f1122efc6d02e4126a2482e26936b759692d3b7a0fc649a21e4c893d9"
+checksum = "3958b5de5c2c08c6a49b8d94f6ead3e9cd7980c43d6ed240aa3d6485d53269b5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11815,9 +11593,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5547f653f9e4c47b4f9a9075a0b7c0faea5fa29b7873f392733a943837825d"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11828,15 +11606,15 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "41.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d785931e4b8750cf9d79c808c22f05979c8d191baafc8badd4651db82584c1c"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
  "ark-ec",
- "ark-ff 0.5.0",
- "ark-serialize 0.5.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayref",
  "aurora-engine-modexp",
  "aws-lc-rs",
@@ -11844,19 +11622,19 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "p256 0.13.2",
+ "p256",
  "revm-context-interface",
  "revm-primitives",
- "ripemd",
+ "ripemd 0.2.0",
  "secp256k1 0.31.1",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
 name = "revm-primitives"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66f39151a31afe93d97f7ac894dd9dcc989368d5ccba19ce079bfc1d73b77452"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11865,9 +11643,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "41.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ef2fffc28acc41e8ef7525f2b1d16288a10f80579a1b33e7e62abc9892314a"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -11883,18 +11661,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
-]
-
-[[package]]
-name = "rfc6979"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
-dependencies = [
- "crypto-bigint 0.7.5",
- "hmac 0.13.0",
 ]
 
 [[package]]
@@ -11933,6 +11701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -12410,25 +12187,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct 0.2.0",
- "der 0.7.10",
+ "base16ct",
+ "der",
  "generic-array",
- "pkcs8 0.10.2",
- "serdect 0.2.0",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "sec1"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
-dependencies = [
- "base16ct 1.0.0",
- "ctutils 0.4.2",
- "der 0.8.1",
- "hybrid-array",
+ "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -12697,17 +12460,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct 0.2.0",
- "serde",
-]
-
-[[package]]
-name = "serdect"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
-dependencies = [
- "base16ct 1.0.0",
+ "base16ct",
  "serde",
 ]
 
@@ -12720,6 +12473,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -12828,16 +12594,6 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "digest 0.11.3",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -12980,17 +12736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
-name = "spki"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
-dependencies = [
- "base64ct",
- "der 0.8.1",
+ "der",
 ]
 
 [[package]]
@@ -13047,6 +12793,12 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "symbolic-common"
@@ -13216,7 +12968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.52.0",
@@ -13255,7 +13007,7 @@ dependencies = [
  "opentelemetry-otlp 0.31.1",
  "pyroscope",
  "pyroscope_pprofrs",
- "rand 0.10.2",
+ "rand 0.8.6",
  "reqwest 0.13.3",
  "reth-chainspec",
  "reth-cli",
@@ -13340,7 +13092,7 @@ dependencies = [
  "eyre",
  "futures",
  "http 1.4.0",
- "p256 0.13.2",
+ "p256",
  "reqwest 0.13.3",
  "reth-evm",
  "reth-primitives-traits",
@@ -13398,7 +13150,6 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
- "commonware-actor",
  "commonware-broadcast",
  "commonware-codec",
  "commonware-consensus",
@@ -13420,9 +13171,8 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prometheus-client",
- "rand 0.10.2",
  "rand 0.8.6",
- "rand_core 0.10.1",
+ "rand_core 0.6.4",
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-ethereum",
@@ -13445,7 +13195,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "url",
 ]
 
@@ -13459,8 +13209,8 @@ dependencies = [
  "commonware-math",
  "commonware-utils",
  "const-hex",
- "rand 0.10.2",
- "rand_core 0.10.1",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
  "secrecy",
  "tempfile",
  "thiserror 2.0.18",
@@ -13490,7 +13240,7 @@ dependencies = [
  "commonware-math",
  "commonware-utils",
  "modular-bitfield",
- "rand 0.10.2",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -13515,9 +13265,8 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "jsonrpsee",
- "rand 0.10.2",
  "rand 0.8.6",
- "rand_core 0.10.1",
+ "rand_core 0.6.4",
  "reth-chainspec",
  "reth-config",
  "reth-db",
@@ -13542,7 +13291,7 @@ dependencies = [
  "tempo-primitives",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -13569,7 +13318,7 @@ dependencies = [
  "eyre",
  "indexmap 2.14.0",
  "insta",
- "rand 0.10.2",
+ "rand 0.8.6",
  "rayon",
  "reth-chainspec",
  "reth-consensus",
@@ -13674,7 +13423,7 @@ dependencies = [
  "jiff",
  "jsonrpsee",
  "metrics",
- "p256 0.13.2",
+ "p256",
  "rand 0.9.4",
  "reqwest 0.13.3",
  "reth-chainspec",
@@ -13794,7 +13543,7 @@ dependencies = [
  "commonware-cryptography",
  "derive_more",
  "eyre",
- "p256 0.13.2",
+ "p256",
  "paste",
  "proptest",
  "rand 0.8.6",
@@ -13841,11 +13590,11 @@ dependencies = [
  "arbitrary",
  "aws-lc-rs",
  "base64 0.22.1",
- "commonware-cryptography",
  "derive_more",
+ "ed25519-consensus",
  "modular-bitfield",
  "once_cell",
- "p256 0.13.2",
+ "p256",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.9.4",
@@ -13859,7 +13608,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tempo-contracts",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -13878,7 +13627,7 @@ dependencies = [
  "base64 0.22.1",
  "derive_more",
  "eyre",
- "p256 0.13.2",
+ "p256",
  "proptest",
  "reth-evm",
  "reth-rpc-eth-types",
@@ -13917,7 +13666,7 @@ dependencies = [
  "tempo-telemetry-util",
  "tokio",
  "tracing",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -14007,7 +13756,6 @@ dependencies = [
  "eyre",
  "indicatif",
  "itertools 0.14.0",
- "rand 0.10.2",
  "rand 0.8.6",
  "rayon",
  "reth-db",
@@ -14531,7 +14279,7 @@ dependencies = [
  "symlink",
  "thiserror 2.0.18",
  "time",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -14553,7 +14301,7 @@ checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
 dependencies = [
  "serde_json",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -14584,7 +14332,7 @@ checksum = "2d3a81ed245bfb62592b1e2bc153e77656d94ee6a0497683a65a12ccaf2438d0"
 dependencies = [
  "libc",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -14607,7 +14355,23 @@ dependencies = [
  "time",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry 0.31.0",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -14622,7 +14386,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "web-time",
 ]
 
@@ -14639,7 +14403,7 @@ dependencies = [
  "memmap2",
  "smallvec",
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -14649,15 +14413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
 dependencies = [
  "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
  "tracing-core",
 ]
 
@@ -14689,7 +14444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eaa1852afa96e0fe9e44caa53dc0bd2d9d05e0f2611ce09f97f8677af56e4ba"
 dependencies = [
  "tracing-core",
- "tracing-subscriber 0.3.23",
+ "tracing-subscriber",
  "tracy-client",
 ]
 
@@ -14998,7 +14753,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.3",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -15117,7 +14872,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -15176,6 +14940,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15186,6 +14972,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -15769,19 +15567,96 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wnaf"
-version = "0.14.0"
+name = "wit-bindgen-core"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
- "ff 0.14.0",
- "group 0.14.0",
- "hybrid-array",
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver 1.0.28",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -15830,20 +15705,9 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek 4.1.3",
+ "curve25519-dalek",
  "rand_core 0.6.4",
  "serde",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
-dependencies = [
- "curve25519-dalek 5.0.0",
- "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "bech32",
  "chacha20poly1305",
  "cookie-factory",
- "hmac",
+ "hmac 0.12.1",
  "i18n-embed",
  "i18n-embed-fl",
  "lazy_static",
@@ -80,7 +80,7 @@ dependencies = [
  "scrypt",
  "sha2 0.10.9",
  "subtle",
- "x25519-dalek",
+ "x25519-dalek 2.0.1",
  "zeroize",
 ]
 
@@ -520,7 +520,7 @@ dependencies = [
  "derive_more",
  "fixed-cache",
  "foldhash 0.2.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
@@ -848,7 +848,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "k256",
  "thiserror 2.0.18",
 ]
@@ -867,7 +867,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-kms",
  "k256",
- "spki",
+ "spki 0.7.3",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -885,7 +885,7 @@ dependencies = [
  "async-trait",
  "gcloud-sdk",
  "k256",
- "spki",
+ "spki 0.7.3",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -1860,7 +1860,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
@@ -2132,6 +2132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,15 +2301,6 @@ dependencies = [
  "constant_time_eq",
  "cpufeatures 0.3.0",
  "zeroize",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -2852,9 +2849,15 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.0-pre.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codspeed"
@@ -2923,7 +2926,7 @@ dependencies = [
  "bs58",
  "coins-core",
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
  "k256",
  "serde",
  "sha2 0.10.9",
@@ -2938,7 +2941,7 @@ checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
 dependencies = [
  "bitvec",
  "coins-bip32",
- "hmac",
+ "hmac 0.12.1",
  "once_cell",
  "pbkdf2",
  "rand 0.8.6",
@@ -3025,39 +3028,71 @@ dependencies = [
 ]
 
 [[package]]
-name = "commonware-broadcast"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+name = "commonware-actor"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "beac6262223b45c6843ab70b245b526b28836a8257b1759a509ba5fab24fa4a6"
 dependencies = [
+ "cfg-if",
+ "commonware-macros",
+ "commonware-runtime",
+ "crossbeam-queue",
+ "futures-util",
+ "parking_lot",
+]
+
+[[package]]
+name = "commonware-broadcast"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2d7e56dc894ad3f55dbe5726468915492ae8e4650ad2a45c1bcfd138c2037f"
+dependencies = [
+ "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
  "commonware-p2p",
  "commonware-runtime",
  "commonware-utils",
- "prometheus-client",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-codec"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8eb7efe071cea13e8b23a0a7f584398870c401d2b2aabfb6b9ab3634ebcba3a"
 dependencies = [
+ "arbitrary",
  "bytes",
  "cfg-if",
+ "commonware-codec-macros",
+ "commonware-conformance",
  "commonware-macros",
  "paste",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "thiserror 2.0.18",
 ]
 
 [[package]]
+name = "commonware-codec-macros"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a876bec347344381948901d0f5ec2e9443ebc8dbab99a63bc2db78c2fc2efbdd"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "commonware-coding"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409e9997c1bb3273b9570c26ddef4f252327c9bf18968d4439a83cfd1d3e5661"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3068,24 +3103,50 @@ dependencies = [
  "commonware-storage",
  "commonware-utils",
  "num-rational",
- "rand 0.8.6",
- "rand_core 0.6.4",
  "rayon",
- "reed-solomon-simd",
  "thiserror 2.0.18",
 ]
 
 [[package]]
+name = "commonware-conformance"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0840a6116d784b84ec0c64244f310a2f325af79fbe7b093fc812e8ac8efd12"
+dependencies = [
+ "commonware-conformance-macros",
+ "commonware-formatting",
+ "commonware-macros",
+ "futures",
+ "serde",
+ "sha2 0.11.0",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "commonware-conformance-macros"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95c8b6096c3820f9e3f01be1954e49509c75a53598a465b8adb6c87ad3f4d308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "commonware-consensus"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acf15e3402e26f062695d4dd5e4b5967f601dc7303d06b9fafdb20a6485a3a0a"
 dependencies = [
  "bytes",
  "cfg-if",
+ "commonware-actor",
  "commonware-broadcast",
  "commonware-codec",
  "commonware-coding",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-p2p",
@@ -3096,10 +3157,8 @@ dependencies = [
  "commonware-utils",
  "futures",
  "pin-project",
- "prometheus-client",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_distr 0.4.3",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rayon",
  "thiserror 2.0.18",
  "tracing",
@@ -3107,10 +3166,13 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b842f31e1aaa1af284a1f9dc4f1234761f72d07e70d53cf3f1521b0870ade094"
 dependencies = [
+ "ahash",
  "anyhow",
+ "arbitrary",
  "aws-lc-rs",
  "blake3",
  "blst",
@@ -3118,31 +3180,62 @@ dependencies = [
  "cfg-if",
  "chacha20poly1305",
  "commonware-codec",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
+ "cpufeatures 0.2.17",
  "crc-fast",
- "ctutils",
- "ecdsa",
- "ed25519-consensus",
+ "ctutils 0.3.1",
+ "curve25519-dalek 5.0.0",
+ "ecdsa 0.17.0",
+ "fixedbitset",
  "getrandom 0.2.17",
+ "getrandom 0.4.3",
+ "hashbrown 0.16.1",
  "num-rational",
  "num-traits",
- "p256",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "sha2 0.10.9",
+ "once_cell",
+ "p256 0.14.0",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
 [[package]]
+name = "commonware-formatting"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab01b7f2798e29b0a4f7b47da5b7f3c106881578af3e69e8d2ee9d89d7c1d4fd"
+dependencies = [
+ "commonware-macros",
+ "const-hex",
+]
+
+[[package]]
+name = "commonware-invariants"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7626b0950e91aad9e954163daa74cbab108825ac6fe5f9967c4ab9e1cedd87a5"
+dependencies = [
+ "arbitrary",
+ "commonware-formatting",
+ "commonware-macros",
+ "rand 0.10.2",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "commonware-macros"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e37a17d5c99ec6711098c6614af1023fd32926aa0414ec0f0613f6bb940278"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3150,8 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d44bceee874226efca172f0e9ec9ec4eb486788ba6be1d98710f3f159b807af"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3162,22 +3256,27 @@ dependencies = [
 
 [[package]]
 name = "commonware-math"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593fa0c5aa8bd8d350724b9b1ad4e85072845aa85a06b39ca4598998bbec1e00"
 dependencies = [
+ "arbitrary",
  "bytes",
  "commonware-codec",
+ "commonware-invariants",
  "commonware-macros",
  "commonware-parallel",
  "commonware-utils",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "commonware-p2p"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f974fcd27c0dad7ae73caeaf00c8330fd29c60f5ff1f679ccc1a51c8ed95bc"
 dependencies = [
+ "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -3191,30 +3290,34 @@ dependencies = [
  "num-integer",
  "num-rational",
  "num-traits",
- "prometheus-client",
- "rand 0.8.6",
- "rand_core 0.6.4",
- "rand_distr 0.4.3",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
+ "rand_distr 0.6.0",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7109817274c671f1fb0ba17cf8aecfbb70672d29379284feeac43fa1b1dc0201"
 dependencies = [
  "cfg-if",
  "commonware-macros",
+ "dashmap",
+ "futures",
  "rayon",
 ]
 
 [[package]]
 name = "commonware-resolver"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a497cc9e9a2cd205d96474d0d40c7731f29085cd467adbe9ff0f94719659582"
 dependencies = [
  "bytes",
+ "commonware-actor",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-macros",
@@ -3223,52 +3326,70 @@ dependencies = [
  "commonware-stream",
  "commonware-utils",
  "futures",
- "prometheus-client",
- "rand 0.8.6",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a84bc6cefb099b1ffce3e04705a1e61e91d895b9f09b9e1be14c8ec5823c181"
 dependencies = [
+ "ahash",
  "axum",
  "bytes",
  "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-parallel",
+ "commonware-runtime-macros",
  "commonware-utils",
  "criterion",
- "crossbeam-queue",
+ "crossbeam-utils",
  "futures",
  "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "governor",
  "libc",
- "opentelemetry 0.31.0",
- "opentelemetry-otlp 0.31.1",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry 0.32.0",
+ "opentelemetry-otlp 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "pin-project",
  "prometheus-client",
- "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "rayon",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "sysinfo 0.37.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
 [[package]]
+name = "commonware-runtime-macros"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13f7b39ef9fd9f1df4fe4445c9a5ec5ba012d90d1602b12a8b8626a8563ab02c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "commonware-storage"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac18e2b696ab7bbecf1059bc3b8d39fc0af002180906d65c7df3112fd9385de"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3276,14 +3397,14 @@ dependencies = [
  "cfg-if",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-parallel",
  "commonware-runtime",
  "commonware-utils",
  "futures",
  "futures-util",
- "prometheus-client",
- "rayon",
+ "hashbrown 0.16.1",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -3291,34 +3412,41 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8890b69e3fa209bc9e87d199ff60ca5a21c88322d32914847511887e6dc5364b"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
  "commonware-cryptography",
+ "commonware-formatting",
  "commonware-macros",
  "commonware-runtime",
  "commonware-utils",
  "futures",
- "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "thiserror 2.0.18",
- "x25519-dalek",
+ "x25519-dalek 3.0.0",
  "zeroize",
 ]
 
 [[package]]
 name = "commonware-utils"
-version = "2026.4.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=2a7dd423f0a241276a5a38db8cc3d05f11de0c03#2a7dd423f0a241276a5a38db8cc3d05f11de0c03"
+version = "2026.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a484dd46b738d9b5ba892312425e71e6afaf4320e388d74449bd9ca0ea14cd76"
 dependencies = [
+ "ahash",
+ "arbitrary",
  "bytes",
  "cfg-if",
  "commonware-codec",
+ "commonware-formatting",
  "commonware-macros",
  "futures",
  "getrandom 0.2.17",
+ "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hashbrown 0.16.1",
  "num-bigint",
  "num-integer",
@@ -3326,9 +3454,10 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "pin-project",
- "rand 0.8.6",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "zeroize",
 ]
 
@@ -3404,6 +3533,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-str"
@@ -3496,6 +3631,12 @@ checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -3687,6 +3828,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils 0.4.2",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3703,7 +3860,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3723,11 +3882,21 @@ dependencies = [
 
 [[package]]
 name = "ctutils"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
 dependencies = [
- "cmov",
+ "cmov 0.4.6",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov 0.5.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3740,7 +3909,23 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -3755,19 +3940,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "curve25519-dalek-ng"
-version = "4.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
-dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.6.4",
- "subtle-ng",
- "zeroize",
 ]
 
 [[package]]
@@ -3879,8 +4051,18 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -3971,7 +4153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -3983,7 +4165,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils 0.4.2",
 ]
 
 [[package]]
@@ -4108,13 +4292,28 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "serdect 0.2.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -4123,22 +4322,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-consensus"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
-dependencies = [
- "curve25519-dalek-ng",
- "hex",
- "rand_core 0.6.4",
- "sha2 0.9.9",
- "thiserror 1.0.69",
- "zeroize",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -4147,7 +4332,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "ed25519",
  "rand_core 0.6.4",
  "serde",
@@ -4183,17 +4368,37 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.3",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "subtle",
  "zeroize",
 ]
@@ -4407,10 +4612,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -4824,16 +5045,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4945,8 +5166,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -5009,15 +5241,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
 
 [[package]]
 name = "hashbrown"
@@ -5128,7 +5351,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand 0.10.1",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -5148,7 +5371,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ring",
  "serde",
  "thiserror 2.0.18",
@@ -5174,7 +5397,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "resolv-conf",
  "serde",
  "smallvec",
@@ -5202,7 +5425,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -5212,6 +5435,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5311,11 +5543,13 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -5572,12 +5806,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -6231,7 +6459,7 @@ dependencies = [
  "pem",
  "serde",
  "serde_json",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -6243,12 +6471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -6331,12 +6559,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "left-right"
@@ -7060,6 +7282,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
+ "arbitrary",
  "num-integer",
  "num-traits",
  "serde",
@@ -7250,7 +7473,6 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -7311,15 +7533,12 @@ version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "http 1.4.0",
  "opentelemetry 0.31.0",
  "opentelemetry-http 0.31.0",
  "opentelemetry-proto 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -7349,9 +7568,6 @@ checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry 0.31.0",
  "opentelemetry_sdk 0.31.0",
- "prost 0.14.3",
- "tonic",
- "tonic-prost",
 ]
 
 [[package]]
@@ -7383,11 +7599,7 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
  "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -7404,6 +7616,8 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -7418,11 +7632,24 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "serdect",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
+ "primeorder 0.13.6",
+ "serdect 0.2.0",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "p256"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
+dependencies = [
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
+ "primeorder 0.14.0",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -7506,7 +7733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -7677,8 +7904,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -7897,13 +8134,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
- "serdect",
+ "elliptic-curve 0.13.8",
+ "serdect 0.2.0",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect 0.4.3",
+ "wnaf",
 ]
 
 [[package]]
@@ -8319,12 +8583,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.0",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -8346,6 +8610,16 @@ checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -8375,22 +8649,22 @@ checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
-dependencies = [
- "num-traits",
- "rand 0.8.6",
-]
-
-[[package]]
-name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.4",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -8514,12 +8788,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "readme-rustdocifier"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
-
-[[package]]
 name = "recvmsg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8543,18 +8811,6 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "reed-solomon-simd"
-version = "3.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffef0520d30fbd4151fb20e262947ae47fb0ab276a744a19b6398438105a072"
-dependencies = [
- "cpufeatures 0.2.17",
- "fixedbitset",
- "once_cell",
- "readme-rustdocifier",
 ]
 
 [[package]]
@@ -8716,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8743,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8774,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8794,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -8807,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -8891,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -8901,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8954,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -8971,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -8985,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8998,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9023,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9052,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9078,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9108,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9123,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9148,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9172,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9196,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9231,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9288,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9299,7 +9555,7 @@ dependencies = [
  "ctr",
  "digest 0.10.7",
  "futures",
- "hmac",
+ "hmac 0.12.1",
  "pin-project",
  "rand 0.8.6",
  "reth-network-peers",
@@ -9315,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9338,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9365,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9422,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9452,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9470,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9486,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9510,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9521,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9549,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9571,7 +9827,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9612,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "clap",
  "eyre",
@@ -9635,7 +9891,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9651,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9667,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9680,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9710,7 +9966,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9724,7 +9980,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9734,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9760,7 +10016,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9780,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -9798,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -9811,7 +10067,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9830,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9868,7 +10124,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9882,7 +10138,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "serde",
  "serde_json",
@@ -9892,7 +10148,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9918,7 +10174,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "bytes",
  "futures",
@@ -9938,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -9955,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "bindgen",
  "cc",
@@ -9964,7 +10220,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "futures",
  "libc",
@@ -9978,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -9987,7 +10243,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10001,7 +10257,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10060,7 +10316,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10085,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10109,7 +10365,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10124,7 +10380,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10138,7 +10394,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10155,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10179,7 +10435,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10247,7 +10503,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10302,7 +10558,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10351,7 +10607,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10375,7 +10631,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10399,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "bytes",
  "eyre",
@@ -10428,7 +10684,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10440,7 +10696,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10464,7 +10720,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10476,7 +10732,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10499,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10542,7 +10798,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10591,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10618,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10634,7 +10890,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10649,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10725,7 +10981,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -10755,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -10798,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -10818,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10849,7 +11105,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10896,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -10947,7 +11203,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -10961,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10992,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11043,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11071,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11085,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11105,7 +11361,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11120,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11146,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11163,7 +11419,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11189,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11210,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11226,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11236,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "clap",
  "eyre",
@@ -11256,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11267,7 +11523,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk 0.32.1",
  "tracing",
- "tracing-opentelemetry 0.33.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
 ]
@@ -11275,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11318,7 +11574,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11344,7 +11600,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11371,7 +11627,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11387,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11412,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3e9b1cb#3e9b1cb1f49417d98ea3bd372b228cc9ea5304cf"
+source = "git+https://github.com/paradigmxyz/reth?rev=92855d2#92855d2643e407fa2a84c29a48c6c199a7e6ff52"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11622,7 +11878,7 @@ dependencies = [
  "c-kzg",
  "cfg-if",
  "k256",
- "p256",
+ "p256 0.13.2",
  "revm-context-interface",
  "revm-primitives",
  "ripemd 0.2.0",
@@ -11661,8 +11917,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -12187,11 +12453,25 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils 0.4.2",
+ "der 0.8.1",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -12460,7 +12740,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -12473,19 +12763,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -12594,6 +12871,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -12736,7 +13023,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -12793,12 +13090,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "subtle-ng"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "symbolic-common"
@@ -12968,7 +13259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -13007,7 +13298,7 @@ dependencies = [
  "opentelemetry-otlp 0.31.1",
  "pyroscope",
  "pyroscope_pprofrs",
- "rand 0.8.6",
+ "rand 0.10.2",
  "reqwest 0.13.3",
  "reth-chainspec",
  "reth-cli",
@@ -13092,7 +13383,7 @@ dependencies = [
  "eyre",
  "futures",
  "http 1.4.0",
- "p256",
+ "p256 0.13.2",
  "reqwest 0.13.3",
  "reth-evm",
  "reth-primitives-traits",
@@ -13150,6 +13441,7 @@ dependencies = [
  "axum",
  "bytes",
  "clap",
+ "commonware-actor",
  "commonware-broadcast",
  "commonware-codec",
  "commonware-consensus",
@@ -13171,8 +13463,9 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prometheus-client",
+ "rand 0.10.2",
  "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-ethereum",
@@ -13209,8 +13502,8 @@ dependencies = [
  "commonware-math",
  "commonware-utils",
  "const-hex",
- "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "secrecy",
  "tempfile",
  "thiserror 2.0.18",
@@ -13240,7 +13533,7 @@ dependencies = [
  "commonware-math",
  "commonware-utils",
  "modular-bitfield",
- "rand 0.8.6",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -13265,8 +13558,9 @@ dependencies = [
  "futures",
  "itertools 0.14.0",
  "jsonrpsee",
+ "rand 0.10.2",
  "rand 0.8.6",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "reth-chainspec",
  "reth-config",
  "reth-db",
@@ -13318,7 +13612,7 @@ dependencies = [
  "eyre",
  "indexmap 2.14.0",
  "insta",
- "rand 0.8.6",
+ "rand 0.10.2",
  "rayon",
  "reth-chainspec",
  "reth-consensus",
@@ -13423,7 +13717,7 @@ dependencies = [
  "jiff",
  "jsonrpsee",
  "metrics",
- "p256",
+ "p256 0.13.2",
  "rand 0.9.4",
  "reqwest 0.13.3",
  "reth-chainspec",
@@ -13543,7 +13837,7 @@ dependencies = [
  "commonware-cryptography",
  "derive_more",
  "eyre",
- "p256",
+ "p256 0.13.2",
  "paste",
  "proptest",
  "rand 0.8.6",
@@ -13590,11 +13884,11 @@ dependencies = [
  "arbitrary",
  "aws-lc-rs",
  "base64 0.22.1",
+ "commonware-cryptography",
  "derive_more",
- "ed25519-consensus",
  "modular-bitfield",
  "once_cell",
- "p256",
+ "p256 0.13.2",
  "proptest",
  "proptest-arbitrary-interop",
  "rand 0.9.4",
@@ -13627,7 +13921,7 @@ dependencies = [
  "base64 0.22.1",
  "derive_more",
  "eyre",
- "p256",
+ "p256 0.13.2",
  "proptest",
  "reth-evm",
  "reth-rpc-eth-types",
@@ -13756,6 +14050,7 @@ dependencies = [
  "eyre",
  "indicatif",
  "itertools 0.14.0",
+ "rand 0.10.2",
  "rand 0.8.6",
  "rayon",
  "reth-db",
@@ -14360,22 +14655,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
-dependencies = [
- "js-sys",
- "opentelemetry 0.31.0",
- "smallvec",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
- "web-time",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
@@ -14746,7 +15025,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -14865,16 +15144,7 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -14933,28 +15203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
 name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14965,18 +15213,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -15560,96 +15796,19 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
+name = "wnaf"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
 dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -15698,9 +15857,20 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e8131a03190127fb2263afc72b322ecadae46b6ff8c6f399ff5d02f5559af6"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "rand_core 0.10.1",
  "zeroize",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "clap",
  "eyre",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "serde",
  "serde_json",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "bytes",
  "futures",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "bindgen",
  "cc",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "futures",
  "libc",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10395,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "bytes",
  "eyre",
@@ -10685,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10697,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10848,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11153,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11377,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11403,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11428,6 +11428,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-chain-state",
+ "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-metrics",
@@ -11446,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11467,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11483,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11493,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "clap",
  "eyre",
@@ -11513,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11532,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11575,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11601,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11628,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11644,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11669,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=db18362#db183628a981c805e8d79c84133223472f6b9765"
+source = "git+https://github.com/paradigmxyz/reth?rev=b8f775a#b8f775a90f3543f69fe12b299603cfdc040d20be"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -13435,10 +13436,12 @@ dependencies = [
  "age",
  "alloy-consensus",
  "alloy-primitives",
+ "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-client",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
+ "alloy-transport",
  "axum",
  "bytes",
  "clap",
@@ -13477,6 +13480,7 @@ dependencies = [
  "reth-provider",
  "reth-revm",
  "tempfile",
+ "tempo-alloy",
  "tempo-chainspec",
  "tempo-consensus-config",
  "tempo-dkg-onchain-artifacts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "clap",
  "eyre",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "serde",
  "serde_json",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "bytes",
  "futures",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "bindgen",
  "cc",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "futures",
  "libc",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10395,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "bytes",
  "eyre",
@@ -10685,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10697,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10848,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11153,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11377,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11403,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11447,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11484,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "clap",
  "eyre",
@@ -11514,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11533,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11645,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11670,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9dd31ea#9dd31ea6a8b3aff565fa6064ef3e93b13a5b40d3"
+source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9227,7 +9227,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9241,7 +9241,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9279,7 +9279,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9308,7 +9308,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9334,7 +9334,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9364,7 +9364,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9379,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9404,7 +9404,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9428,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9487,7 +9487,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9544,7 +9544,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9571,7 +9571,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9621,7 +9621,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9708,7 +9708,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9726,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9766,7 +9766,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9777,7 +9777,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9805,7 +9805,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9828,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9869,7 +9869,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "clap",
  "eyre",
@@ -9892,7 +9892,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9937,7 +9937,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9967,7 +9967,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9981,7 +9981,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9991,7 +9991,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10017,7 +10017,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10037,7 +10037,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10055,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10068,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10125,7 +10125,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10139,7 +10139,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "serde",
  "serde_json",
@@ -10149,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "bytes",
  "futures",
@@ -10195,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "bindgen",
  "cc",
@@ -10221,7 +10221,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "futures",
  "libc",
@@ -10235,7 +10235,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10244,7 +10244,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10258,7 +10258,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10317,7 +10317,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10342,7 +10342,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10366,7 +10366,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10381,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10395,7 +10395,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10436,7 +10436,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10504,7 +10504,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10559,7 +10559,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10608,7 +10608,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "bytes",
  "eyre",
@@ -10685,7 +10685,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10697,7 +10697,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10721,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10756,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10799,7 +10799,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10848,7 +10848,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10875,7 +10875,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10891,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10906,7 +10906,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10982,7 +10982,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11012,7 +11012,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11055,7 +11055,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11075,7 +11075,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11106,7 +11106,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11153,7 +11153,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11204,7 +11204,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11218,7 +11218,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11249,7 +11249,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11300,7 +11300,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11342,7 +11342,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11377,7 +11377,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11403,7 +11403,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11420,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11447,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11484,7 +11484,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "clap",
  "eyre",
@@ -11514,7 +11514,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11533,7 +11533,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11629,7 +11629,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11645,7 +11645,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11670,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=c7d94e6#c7d94e622e0cd240961de7fa15d71d33ac900d07"
+source = "git+https://github.com/paradigmxyz/reth?rev=1c6945c#1c6945c561d37a79857c97ee65c77338223ef639"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,30 +219,30 @@ alloy-json-abi = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false }
 alloy-sol-types = { version = "1.6.1", default-features = false }
 
-alloy = { version = "2.1.1", default-features = false }
-alloy-consensus = { version = "2.1.1", default-features = false }
-alloy-contract = { version = "2.1.1", default-features = false }
+alloy = { version = "2.2.0", default-features = false }
+alloy-consensus = { version = "2.2.0", default-features = false }
+alloy-contract = { version = "2.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
-alloy-eips = { version = "2.1.1", default-features = false }
+alloy-eips = { version = "2.2.0", default-features = false }
 alloy-evm = { version = "0.37.1", default-features = false }
-alloy-genesis = { version = "2.1.1", default-features = false }
+alloy-genesis = { version = "2.2.0", default-features = false }
 alloy-hardforks = "0.4.7"
-alloy-json-rpc = "2.1.1"
-alloy-network = { version = "2.1.1", default-features = false }
-alloy-provider = { version = "2.1.1", default-features = false }
+alloy-json-rpc = "2.2.0"
+alloy-network = { version = "2.2.0", default-features = false }
+alloy-provider = { version = "2.2.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-client = { version = "2.1.1", default-features = false }
-alloy-rpc-types-admin = "2.1.1"
-alloy-rpc-types-engine = "2.1.1"
-alloy-rpc-types-eth = { version = "2.1.1" }
-alloy-serde = { version = "2.1.1", default-features = false }
-alloy-signer = "2.1.1"
-alloy-signer-aws = "2.1.1"
-alloy-signer-gcp = "2.1.1"
-alloy-signer-ledger = "2.1.1"
-alloy-signer-local = "2.1.1"
-alloy-signer-trezor = "2.1.1"
-alloy-transport = "2.1.1"
+alloy-rpc-client = { version = "2.2.0", default-features = false }
+alloy-rpc-types-admin = "2.2.0"
+alloy-rpc-types-engine = "2.2.0"
+alloy-rpc-types-eth = { version = "2.2.0" }
+alloy-serde = { version = "2.2.0", default-features = false }
+alloy-signer = "2.2.0"
+alloy-signer-aws = "2.2.0"
+alloy-signer-gcp = "2.2.0"
+alloy-signer-ledger = "2.2.0"
+alloy-signer-local = "2.2.0"
+alloy-signer-trezor = "2.2.0"
+alloy-transport = "2.2.0"
 
 commonware-actor = "2026.7.0"
 commonware-broadcast = "2026.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-codecs = { version = "0.5.2", default-features = false }
+reth-codecs = { version = "0.6.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
@@ -185,7 +185,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-primitives-traits = { version = "0.5.2", default-features = false }
+reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
@@ -212,8 +212,8 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "41.0.0", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "=0.41.0"
+revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
+revm-inspectors = "=0.42.0"
 
 alloy-json-abi = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false }
@@ -224,7 +224,7 @@ alloy-consensus = { version = "2.2.0", default-features = false }
 alloy-contract = { version = "2.2.0", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.2.0", default-features = false }
-alloy-evm = { version = "0.37.1", default-features = false }
+alloy-evm = { version = "0.38.0", default-features = false }
 alloy-genesis = { version = "2.2.0", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-rpc = "2.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9253c0f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,30 +219,30 @@ alloy-json-abi = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false }
 alloy-sol-types = { version = "1.6.1", default-features = false }
 
-alloy = { version = "2.2.0", default-features = false }
-alloy-consensus = { version = "2.2.0", default-features = false }
-alloy-contract = { version = "2.2.0", default-features = false }
+alloy = { version = "2.3.0", default-features = false }
+alloy-consensus = { version = "2.3.0", default-features = false }
+alloy-contract = { version = "2.3.0", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
-alloy-eips = { version = "2.2.0", default-features = false }
+alloy-eips = { version = "2.3.0", default-features = false }
 alloy-evm = { version = "0.38.0", default-features = false }
-alloy-genesis = { version = "2.2.0", default-features = false }
+alloy-genesis = { version = "2.3.0", default-features = false }
 alloy-hardforks = "0.4.7"
-alloy-json-rpc = "2.2.0"
-alloy-network = { version = "2.2.0", default-features = false }
-alloy-provider = { version = "2.2.0", default-features = false }
+alloy-json-rpc = "2.3.0"
+alloy-network = { version = "2.3.0", default-features = false }
+alloy-provider = { version = "2.3.0", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-client = { version = "2.2.0", default-features = false }
-alloy-rpc-types-admin = "2.2.0"
-alloy-rpc-types-engine = "2.2.0"
-alloy-rpc-types-eth = { version = "2.2.0" }
-alloy-serde = { version = "2.2.0", default-features = false }
-alloy-signer = "2.2.0"
-alloy-signer-aws = "2.2.0"
-alloy-signer-gcp = "2.2.0"
-alloy-signer-ledger = "2.2.0"
-alloy-signer-local = "2.2.0"
-alloy-signer-trezor = "2.2.0"
-alloy-transport = "2.2.0"
+alloy-rpc-client = { version = "2.3.0", default-features = false }
+alloy-rpc-types-admin = "2.3.0"
+alloy-rpc-types-engine = "2.3.0"
+alloy-rpc-types-eth = { version = "2.3.0" }
+alloy-serde = { version = "2.3.0", default-features = false }
+alloy-signer = "2.3.0"
+alloy-signer-aws = "2.3.0"
+alloy-signer-gcp = "2.3.0"
+alloy-signer-ledger = "2.3.0"
+alloy-signer-local = "2.3.0"
+alloy-signer-trezor = "2.3.0"
+alloy-transport = "2.3.0"
 
 commonware-actor = "2026.7.0"
 commonware-broadcast = "2026.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,103 +146,103 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-codecs = { version = "0.5.2", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-primitives-traits = { version = "0.5.2", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c505ed2", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "0.42.0"
+revm = { version = "41.0.0", features = ["optional_fee_charge"], default-features = false }
+revm-inspectors = "=0.41.0"
 
 alloy-json-abi = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false }
 alloy-sol-types = { version = "1.6.1", default-features = false }
 
-alloy = { version = "2.3.0", default-features = false }
-alloy-consensus = { version = "2.3.0", default-features = false }
-alloy-contract = { version = "2.3.0", default-features = false }
+alloy = { version = "2.1.1", default-features = false }
+alloy-consensus = { version = "2.1.1", default-features = false }
+alloy-contract = { version = "2.1.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
-alloy-eips = { version = "2.3.0", default-features = false }
-alloy-evm = { version = "0.38.0", default-features = false }
-alloy-genesis = { version = "2.3.0", default-features = false }
+alloy-eips = { version = "2.1.1", default-features = false }
+alloy-evm = { version = "0.37.1", default-features = false }
+alloy-genesis = { version = "2.1.1", default-features = false }
 alloy-hardforks = "0.4.7"
-alloy-json-rpc = "2.3.0"
-alloy-network = { version = "2.3.0", default-features = false }
-alloy-provider = { version = "2.3.0", default-features = false }
+alloy-json-rpc = "2.1.1"
+alloy-network = { version = "2.1.1", default-features = false }
+alloy-provider = { version = "2.1.1", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-client = { version = "2.3.0", default-features = false }
-alloy-rpc-types-admin = "2.3.0"
-alloy-rpc-types-engine = "2.3.0"
-alloy-rpc-types-eth = { version = "2.3.0" }
-alloy-serde = { version = "2.3.0", default-features = false }
-alloy-signer = "2.3.0"
-alloy-signer-aws = "2.3.0"
-alloy-signer-gcp = "2.3.0"
-alloy-signer-ledger = "2.3.0"
-alloy-signer-local = "2.3.0"
-alloy-signer-trezor = "2.3.0"
-alloy-transport = "2.3.0"
+alloy-rpc-client = { version = "2.1.1", default-features = false }
+alloy-rpc-types-admin = "2.1.1"
+alloy-rpc-types-engine = "2.1.1"
+alloy-rpc-types-eth = { version = "2.1.1" }
+alloy-serde = { version = "2.1.1", default-features = false }
+alloy-signer = "2.1.1"
+alloy-signer-aws = "2.1.1"
+alloy-signer-gcp = "2.1.1"
+alloy-signer-ledger = "2.1.1"
+alloy-signer-local = "2.1.1"
+alloy-signer-trezor = "2.1.1"
+alloy-transport = "2.1.1"
 
 commonware-actor = "2026.7.0"
 commonware-broadcast = "2026.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-codecs = { version = "0.5.2", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 reth-primitives-traits = { version = "0.5.2", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9d25749", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8bfea20", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3e9b1cb", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b8f775a", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "db18362" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "92855d2", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "db18362", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9dd31ea", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "c7d94e6", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1c6945c", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/src/regenesis.rs
+++ b/bin/tempo/src/regenesis.rs
@@ -371,13 +371,13 @@ fn replacement_hashed_post_state(replacements: &[GenesisAccountReplacement]) -> 
                 .map(|replacement| (replacement.hashed_address, Some(replacement.account))),
         )
         .with_storages(replacements.iter().map(|replacement| {
-            let storage = HashedStorage::from_iter(
-                true,
+            let mut storage = HashedStorage::from_iter(
                 replacement
                     .hashed_storage
                     .iter()
                     .map(|entry| (entry.key, entry.value)),
             );
+            storage.wiped = true;
             (replacement.hashed_address, storage)
         }))
 }

--- a/crates/alloy/Cargo.toml
+++ b/crates/alloy/Cargo.toml
@@ -66,6 +66,7 @@ eyre.workspace = true
 serde_json.workspace = true
 test-case.workspace = true
 tokio.workspace = true
+rustls.workspace = true
 
 [features]
 default = []

--- a/crates/alloy/tests/relay_transport.rs
+++ b/crates/alloy/tests/relay_transport.rs
@@ -47,6 +47,9 @@ async fn relay_transport_sponsors_tx_on_testnet() -> eyre::Result<()> {
         }
     };
 
+    // Reqwest is provider-neutral, so standalone test binaries must select a Rustls provider.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     let signer: alloy_signer_local::PrivateKeySigner = TEST_PRIVATE_KEY.parse()?;
     let sender = signer.address();
 

--- a/crates/alloy/tests/relay_transport.rs
+++ b/crates/alloy/tests/relay_transport.rs
@@ -97,6 +97,8 @@ async fn relay_transport_sponsors_tx_on_testnet() -> eyre::Result<()> {
                 println!(
                     "Sponsor relay broadcast failed because the sponsor's fee payer account is unfunded: {err_str}"
                 );
+            } else if err_str.contains("too many connections from this IP") {
+                println!("Sponsor relay broadcast was rate limited by the testnet RPC: {err_str}");
             } else {
                 return Err(e.into());
             }

--- a/crates/evm/benches/common/mod.rs
+++ b/crates/evm/benches/common/mod.rs
@@ -203,8 +203,11 @@ impl StateProofProvider for InMemoryStateProvider {
     }
 }
 impl HashedPostStateProvider for InMemoryStateProvider {
-    fn hashed_post_state(&self, _bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
-        HashedPostState::default()
+    fn hashed_post_state(
+        &self,
+        _bundle_state: &reth_revm::db::BundleState,
+    ) -> ProviderResult<HashedPostState> {
+        Ok(HashedPostState::default())
     }
 }
 

--- a/crates/faucet/src/faucet.rs
+++ b/crates/faucet/src/faucet.rs
@@ -13,6 +13,7 @@ use tempo_precompiles::tip20::ITIP20;
 #[rpc(server, namespace = "tempo")]
 pub trait TempoFaucetExtApi {
     #[method(name = "fundAddress")]
+    #[must_use = "the faucet request does nothing unless awaited"]
     async fn fund_address(&self, address: Address) -> RpcResult<Vec<B256>>;
 }
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -16,7 +16,9 @@ pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
 use futures::{TryFutureExt, future::Either};
 pub use operator::{TempoOperatorApiServer, TempoOperatorRpc};
 use reth_errors::RethError;
-use reth_primitives_traits::{HeaderTy, Recovered, TransactionMeta, WithEncoded};
+use reth_primitives_traits::{
+    BlockTy, HeaderTy, Recovered, SealedBlock, SealedHeaderFor, TransactionMeta, WithEncoded,
+};
 use reth_rpc_eth_api::{FromEthApiError, IntoEthApiError, RpcTxReq};
 use reth_transaction_pool::{PoolTransaction, PoolTx, TransactionOrigin, TransactionPool};
 pub use simulate::{TempoSimulate, TempoSimulateApiServer, TempoSimulateV1Response};
@@ -568,15 +570,26 @@ where
     ChainSpec: EthChainSpec + 'static,
 {
     type RpcReceipt = TempoTransactionReceipt;
+    type RpcLog = Log;
     type Error = EthApiError;
+
+    fn convert_log(
+        &self,
+        log: Log,
+        _receipt: &TempoReceipt,
+        _header: &SealedHeaderFor<TempoPrimitives>,
+    ) -> Result<Self::RpcLog, Self::Error> {
+        Ok(log)
+    }
 
     fn convert_receipts(
         &self,
         receipts: Vec<ConvertReceiptInput<'_, TempoPrimitives>>,
+        block: &SealedBlock<BlockTy<TempoPrimitives>>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let receipt_context = receipts.iter().map(|r| r.tx).collect::<Vec<_>>();
         self.inner
-            .convert_receipts(receipts)?
+            .convert_receipts(receipts, block)?
             .into_iter()
             .zip(receipt_context)
             .map(|(inner, tx)| {

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -16,9 +16,7 @@ pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
 use futures::{TryFutureExt, future::Either};
 pub use operator::{TempoOperatorApiServer, TempoOperatorRpc};
 use reth_errors::RethError;
-use reth_primitives_traits::{
-    BlockTy, HeaderTy, Recovered, SealedBlock, SealedHeaderFor, TransactionMeta, WithEncoded,
-};
+use reth_primitives_traits::{HeaderTy, Recovered, SealedHeaderFor, TransactionMeta, WithEncoded};
 use reth_rpc_eth_api::{FromEthApiError, IntoEthApiError, RpcTxReq};
 use reth_transaction_pool::{PoolTransaction, PoolTx, TransactionOrigin, TransactionPool};
 pub use simulate::{TempoSimulate, TempoSimulateApiServer, TempoSimulateV1Response};
@@ -585,11 +583,10 @@ where
     fn convert_receipts(
         &self,
         receipts: Vec<ConvertReceiptInput<'_, TempoPrimitives>>,
-        block: &SealedBlock<BlockTy<TempoPrimitives>>,
     ) -> Result<Vec<Self::RpcReceipt>, Self::Error> {
         let receipt_context = receipts.iter().map(|r| r.tx).collect::<Vec<_>>();
         self.inner
-            .convert_receipts(receipts, block)?
+            .convert_receipts(receipts)?
             .into_iter()
             .zip(receipt_context)
             .map(|(inner, tx)| {

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1029,7 +1029,7 @@ where
         {
             hashed_state
         } else {
-            Arc::new(finish_provider.hashed_post_state(&db.bundle_state))
+            Arc::new(finish_provider.hashed_post_state(&db.bundle_state)?)
         };
 
         let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -211,7 +211,10 @@ reth_storage_api::delegate_impls_to_as_ref!(
 );
 
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
-    fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
+    fn hashed_post_state(
+        &self,
+        bundle_state: &reth_revm::db::BundleState,
+    ) -> ProviderResult<HashedPostState> {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
         let result = self.inner.hashed_post_state(bundle_state);

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -155,7 +155,7 @@ fn fill_state_gas(output: &mut PrecompileOutput, storage: &StorageCtx) {
         // spilled portion back to regular gas and restores the reservoir to the
         // value this call inherited.
         output.reservoir = storage.reservoir();
-        output.state_gas_used = storage.state_gas_used() as i64;
+        output.state_gas_used = storage.state_gas_used();
         output.state_gas_spilled = storage.state_gas_spilled();
     }
 }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -517,9 +517,13 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     }
 
     #[inline]
-    fn state_gas_used(&self) -> u64 {
-        // SAFETY: we never decrement the state gas spent counter
-        self.gas_tracker.state_gas_spent() as u64
+    fn state_gas_used(&self) -> i64 {
+        self.gas_tracker.state_gas_spent()
+    }
+
+    #[inline]
+    fn state_gas_spilled(&self) -> u64 {
+        self.gas_tracker.state_gas_spilled()
     }
 
     #[inline]
@@ -1216,8 +1220,8 @@ mod tests {
         assert_eq!(
             provider.state_gas_used(),
             state_gas_before_code
-                + gas_params.create_state_gas()
-                + gas_params.code_deposit_state_gas(1),
+                + gas_params.create_state_gas() as i64
+                + gas_params.code_deposit_state_gas(1) as i64,
             "set_code(new account, 1 byte) should add CREATE state gas plus 2,300 code deposit state gas"
         );
 
@@ -1234,7 +1238,7 @@ mod tests {
         // but the 3rd SSTORE (230k) must spill 190k into regular gas.
         let gas_limit = 1_000_000u64;
         let reservoir = 500_000u64;
-        let state_gas_per_sstore = 230_000u64;
+        let state_gas_per_sstore = 230_000i64;
         let mut provider = evm.provider_with_gas_limit(gas_limit, reservoir);
         let address = Address::random();
 
@@ -1249,7 +1253,7 @@ mod tests {
         );
         assert_eq!(
             provider.reservoir(),
-            reservoir - state_gas_per_sstore,
+            reservoir - state_gas_per_sstore as u64,
             "reservoir should decrease by state gas cost"
         );
 
@@ -1263,7 +1267,7 @@ mod tests {
         );
         assert_eq!(
             provider.reservoir(),
-            reservoir - 2 * state_gas_per_sstore,
+            reservoir - 2 * state_gas_per_sstore as u64,
             "reservoir should have 40k left after 2 SSTOREs"
         );
         let remaining_reservoir = provider.reservoir(); // 40k
@@ -1284,7 +1288,7 @@ mod tests {
         );
 
         // Regular gas increase = normal sstore cost + spill from reservoir
-        let spill = state_gas_per_sstore - remaining_reservoir; // 230k - 40k = 190k
+        let spill = state_gas_per_sstore as u64 - remaining_reservoir; // 230k - 40k = 190k
         let expected_regular_after = regular_gas_before_spill + regular_gas_per_sstore + spill;
         assert_eq!(
             provider.gas_used(),
@@ -1354,7 +1358,7 @@ mod tests {
         );
         assert_eq!(
             provider.state_gas_used(),
-            expected_state_gas,
+            expected_state_gas as i64,
             "set_code on a new account should charge CREATE state gas plus code deposit state gas"
         );
 
@@ -1564,7 +1568,7 @@ mod tests {
         provider.sstore(address, slot, U256::ZERO)?;
         assert_eq!(provider.gas_refunded(), 247_800);
         let net_gas_after_refund =
-            provider.gas_used() + provider.state_gas_used() - provider.gas_refunded() as u64;
+            provider.gas_used() as i64 + provider.state_gas_used() - provider.gas_refunded();
         assert_eq!(
             net_gas_after_refund, 100,
             "TIP-1016 says 0->X->0 should net to GAS_WARM_ACCESS (100)"

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -527,11 +527,6 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     }
 
     #[inline]
-    fn state_gas_spilled(&self) -> u64 {
-        self.gas_tracker.state_gas_spilled()
-    }
-
-    #[inline]
     fn gas_refunded(&self) -> i64 {
         self.gas_tracker.refunded()
     }

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -228,10 +228,6 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         0
     }
 
-    fn state_gas_spilled(&self) -> u64 {
-        0
-    }
-
     fn gas_refunded(&self) -> i64 {
         0
     }

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -220,7 +220,11 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
         0
     }
 
-    fn state_gas_used(&self) -> u64 {
+    fn state_gas_used(&self) -> i64 {
+        0
+    }
+
+    fn state_gas_spilled(&self) -> u64 {
         0
     }
 

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -127,7 +127,10 @@ pub trait PrecompileStorageProvider {
     fn gas_used(&self) -> u64;
 
     /// Returns the state-creating gas used so far (cold SSTORE zero->non-zero, code deposit).
-    fn state_gas_used(&self) -> u64;
+    fn state_gas_used(&self) -> i64;
+
+    /// Returns state gas drawn from regular gas after exhausting the reservoir.
+    fn state_gas_spilled(&self) -> u64;
 
     /// Returns the state gas that was drawn from regular gas because the reservoir was empty
     /// (EIP-8037's `state_gas_from_gas_left`).

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -129,9 +129,6 @@ pub trait PrecompileStorageProvider {
     /// Returns the state-creating gas used so far (cold SSTORE zero->non-zero, code deposit).
     fn state_gas_used(&self) -> i64;
 
-    /// Returns state gas drawn from regular gas after exhausting the reservoir.
-    fn state_gas_spilled(&self) -> u64;
-
     /// Returns the state gas that was drawn from regular gas because the reservoir was empty
     /// (EIP-8037's `state_gas_from_gas_left`).
     fn state_gas_spilled(&self) -> u64;

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -214,7 +214,7 @@ impl StorageCtx {
     }
 
     /// Returns the state-creating gas used so far (cold SSTORE zero->non-zero, code deposit).
-    pub fn state_gas_used(&self) -> u64 {
+    pub fn state_gas_used(&self) -> i64 {
         Self::with_storage(|s| s.state_gas_used())
     }
 

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -379,7 +379,7 @@ where
         unreachable!("'gas_used' not implemented in read-only context yet")
     }
 
-    fn state_gas_used(&self) -> u64 {
+    fn state_gas_used(&self) -> i64 {
         unreachable!("'state_gas_used' not implemented in read-only context yet")
     }
 

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -3,12 +3,12 @@ use alloy_evm::{Database, precompiles::PrecompilesMap};
 use alloy_primitives::{Address, U256};
 use revm::{
     Context, Inspector,
-    context::{Cfg, CfgEnv, ContextError, Evm, FrameStack},
+    context::{CfgEnv, ContextError, Evm, FrameStack},
     handler::{
         EthFrame, EvmTr, FrameInitOrResult, FrameTr, ItemOrResult, instructions::EthInstructions,
     },
     inspector::InspectorEvmTr,
-    interpreter::{InitialAndFloorGas, interpreter::EthInterpreter},
+    interpreter::interpreter::EthInterpreter,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use tempo_chainspec::hardfork::TempoHardfork;
@@ -162,22 +162,6 @@ impl<DB: Database, I> TempoEvm<DB, I> {
             actions,
             non_creditable_slots,
             fee_manager,
-        }
-    }
-
-    /// Computes initial gas limit and reservoir for a transaction given its initial gas spending.
-    pub(crate) fn initial_gas_and_reservoir(
-        &self,
-        init_and_floor_gas: &InitialAndFloorGas,
-    ) -> (u64, u64) {
-        // Pre-T0 it could happen that the initial gas spending is greater than the gas limit due to faulty validation.
-        //
-        // Before that it would overflow, so we are reproducing this behavior here by setting the gas limit to u64::MAX and the reservoir to 0.
-        if !self.cfg.spec.is_t0() && init_and_floor_gas.initial_total_gas() > self.tx.gas_limit {
-            (u64::MAX, 0)
-        } else {
-            init_and_floor_gas
-                .initial_gas_and_reservoir(self.tx.gas_limit, self.cfg.tx_gas_limit_cap())
         }
     }
 }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -854,18 +854,24 @@ where
     /// Upstream's [`Handler::tx_gas`] subtracts the intrinsic gas unguarded,
     /// which would underflow for pre-T0 (Genesis) transactions that pass
     /// validation with `gas_limit < intrinsic` (nonce gas is added after
-    /// validation). `TempoEvm::initial_gas_and_reservoir` falls back to
-    /// `(u64::MAX, 0)` in that case, matching the historic behavior.
+    /// validation). This implementation falls back to `(u64::MAX, 0)` in that
+    /// case, matching the historic behavior.
     ///
     /// This is also the last hook that still sees `init_and_floor_gas`, so it
     /// records whether the intrinsic gas ended up above the gas limit for
     /// [`Handler::execution`] — see `TempoEvm::intrinsic_gas_exceeds_limit`.
     #[inline]
     fn tx_gas(&self, evm: &mut Self::Evm, init_and_floor_gas: &InitialAndFloorGas) -> GasTracker {
-        let tx_gas_limit = evm.ctx_ref().tx().gas_limit();
-        evm.intrinsic_gas_exceeds_limit = evm.ctx_ref().cfg().spec().is_t0()
-            && tx_gas_limit < init_and_floor_gas.initial_total_gas();
-        let (remaining, reservoir) = evm.initial_gas_and_reservoir(init_and_floor_gas);
+        let ctx = evm.ctx_ref();
+        let tx_gas_limit = ctx.tx().gas_limit();
+        let is_t0 = ctx.cfg().spec().is_t0();
+        let intrinsic_gas_exceeds_limit = tx_gas_limit < init_and_floor_gas.initial_total_gas();
+        let (remaining, reservoir) = if !is_t0 && intrinsic_gas_exceeds_limit {
+            (u64::MAX, 0)
+        } else {
+            init_and_floor_gas.initial_gas_and_reservoir(tx_gas_limit, ctx.cfg().tx_gas_limit_cap())
+        };
+        evm.intrinsic_gas_exceeds_limit = is_t0 && intrinsic_gas_exceeds_limit;
         GasTracker::new(tx_gas_limit, remaining, reservoir)
     }
 

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -4439,7 +4439,8 @@ fn test_state_gas_failed_batch_preserves_upfront_create_intrinsic_gas() {
         test.gas_params().create_state_gas(),
         "first-call CREATE should contribute create_state_gas to AA intrinsic gas"
     );
-    let (gas_limit, reservoir) = test.evm.initial_gas_and_reservoir(&init_gas);
+    let (gas_limit, reservoir) = init_gas
+        .initial_gas_and_reservoir(tx_gas_limit, test.evm.ctx_ref().cfg().tx_gas_limit_cap());
 
     let mut call_idx = 0usize;
     let result = test

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -110,12 +110,7 @@ impl TempoPooledTransaction {
                 .saturating_add(value);
         let fee_token_cost = cost - value;
         Self {
-            inner: EthPooledTransaction {
-                cost,
-                encoded_length,
-                blob_sidecar: EthBlobTransactionSidecar::None,
-                transaction,
-            },
+            inner: EthPooledTransaction::new(transaction, encoded_length),
             fee_token_cost,
             is_payment,
             expiring_nonce_hash,

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -109,8 +109,10 @@ impl TempoPooledTransaction {
             calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas())
                 .saturating_add(value);
         let fee_token_cost = cost - value;
+        let mut inner = EthPooledTransaction::new(transaction, encoded_length);
+        inner.cost = cost;
         Self {
-            inner: EthPooledTransaction::new(transaction, encoded_length),
+            inner,
             fee_token_cost,
             is_payment,
             expiring_nonce_hash,

--- a/scripts/foundry-patch.sh
+++ b/scripts/foundry-patch.sh
@@ -21,6 +21,13 @@ FOUNDRY_ROOT="${2:?Usage: $0 <tempo_root> <foundry_root>}"
 TEMPO_CARGO="$TEMPO_ROOT/Cargo.toml"
 FOUNDRY_CARGO="$FOUNDRY_ROOT/Cargo.toml"
 
+# Foundry's current MPP revision pins tokio-tungstenite 0.28 in
+# alloy-transport-mpp, but Alloy 2.3 uses tokio-tungstenite 0.29. Retarget the
+# two MPP workspace dependencies to the upstream compatibility fix. Match the
+# broken revision exactly so this becomes a no-op once Foundry updates its pin.
+BROKEN_MPP_REV="9808dede7ad8d388d519fbaeb8aadedfbe7e7ec8"
+FIXED_MPP_REV="cc95fb153e1848f844f6d5110a8a62ac7dc34b9b"
+
 if [[ ! -f "$TEMPO_CARGO" ]]; then
   echo "ERROR: Tempo Cargo.toml not found at $TEMPO_CARGO" >&2
   exit 1
@@ -29,6 +36,10 @@ if [[ ! -f "$FOUNDRY_CARGO" ]]; then
   echo "ERROR: Foundry Cargo.toml not found at $FOUNDRY_CARGO" >&2
   exit 1
 fi
+
+sed -i \
+  "/git = \"https:\/\/github.com\/tempoxyz\/mpp-rs\"/s/rev = \"$BROKEN_MPP_REV\"/rev = \"$FIXED_MPP_REV\"/" \
+  "$FOUNDRY_CARGO"
 
 has_tempo_git_patch=false
 if grep -q '^\[patch\."https://github.com/tempoxyz/tempo"\]' "$FOUNDRY_CARGO"; then

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -560,7 +560,11 @@ where
         0
     }
 
-    fn state_gas_used(&self) -> u64 {
+    fn state_gas_used(&self) -> i64 {
+        0
+    }
+
+    fn state_gas_spilled(&self) -> u64 {
         0
     }
 

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -568,10 +568,6 @@ where
         0
     }
 
-    fn state_gas_spilled(&self) -> u64 {
-        0
-    }
-
     fn gas_refunded(&self) -> i64 {
         0
     }


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`10aa6a5...1c6945c`](https://github.com/paradigmxyz/reth/compare/10aa6a512ba7c4f5f01ff489b1f513da0745821f...1c6945c)

🔗 Amp thread: https://ampcode.com/threads/T-019ff03e-7be0-74da-a42c-eab043c2c449
- **Engine**
  - Improved payload building across reorgs by anchoring overlays centrally, building on canonical ancestors above finality, and deferring persistence handoff during active builds ([#26580](https://github.com/paradigmxyz/reth/pull/26580), [#26567](https://github.com/paradigmxyz/reth/pull/26567), [#26559](https://github.com/paradigmxyz/reth/pull/26559)).

- **RPC**
  - Added network-specific log responses and `BlockId` support for execution witnesses ([#26491](https://github.com/paradigmxyz/reth/pull/26491), [#26572](https://github.com/paradigmxyz/reth/pull/26572)).
  - Fixed cancellation of payload body hash requests and restored optional receipt conversion with reusable cached blocks ([#26569](https://github.com/paradigmxyz/reth/pull/26569), [#26596](https://github.com/paradigmxyz/reth/pull/26596), [#26599](https://github.com/paradigmxyz/reth/pull/26599)).
  - Unified EVM environment preparation for `eth_createAccessList` and reused EVM instances for block-level tracing ([#26598](https://github.com/paradigmxyz/reth/pull/26598), [#26614](https://github.com/paradigmxyz/reth/pull/26614)).
  - Made testing RPC handlers generic over node types and honored `targetGasLimit` in `testing_buildBlockV1` ([#26547](https://github.com/paradigmxyz/reth/pull/26547), [#26632](https://github.com/paradigmxyz/reth/pull/26632)).

- **Trie & Stages**
  - Added partial trie unwind and persistence support, including changeset cache handling, and removed the obsolete `HashedPostState.wiped` field ([#26543](https://github.com/paradigmxyz/reth/pull/26543), [#26612](https://github.com/paradigmxyz/reth/pull/26612), [#26524](https://github.com/paradigmxyz/reth/pull/26524)).

- **Storage & Providers**
  - Added a RocksDB-backed BAL store ([#25476](https://github.com/paradigmxyz/reth/pull/25476)).
  - Simplified storage providers by removing `ConsistentDbView`, moving `OverlayStateProvider` to use a provider reference, and dropping unused `AccountReader` bounds ([#26581](https://github.com/paradigmxyz/reth/pull/26581), [#26611](https://github.com/paradigmxyz/reth/pull/26611), [#26591](https://github.com/paradigmxyz/reth/pull/26591)).
  - Reverted returning transaction metadata alongside provider headers ([#26571](https://github.com/paradigmxyz/reth/pull/26571), [#26595](https://github.com/paradigmxyz/reth/pull/26595)).
  - Fixed static-file consistency checks to respect prune checkpoints ([#26565](https://github.com/paradigmxyz/reth/pull/26565)).

- **Txpool**
  - Added tracking for blob cell availability ([#25463](https://github.com/paradigmxyz/reth/pull/25463)).

- **Networking & DNS**
  - Added bootnode configuration to `reth.toml` ([#26551](https://github.com/paradigmxyz/reth/pull/26551)).
  - Preserved eth/72 announcement cell masks and validated ECIES IDs during the hello handshake ([#26573](https://github.com/paradigmxyz/reth/pull/26573), [#26639](https://github.com/paradigmxyz/reth/pull/26639)).
  - Improved EIP-1459 DNS handling by rejoining long TXT character strings and ignoring unrelated TXT records ([#26602](https://github.com/paradigmxyz/reth/pull/26602), [#26603](https://github.com/paradigmxyz/reth/pull/26603)).
  - Shared the snap/2 slim-account codec between client and server ([#26587](https://github.com/paradigmxyz/reth/pull/26587)).

- **Snapshots & CLI**
  - Added base-URL resolution for static snapshot files and ensured enough history is downloaded when the final snapshot chunk is partial ([#26576](https://github.com/paradigmxyz/reth/pull/26576), [#26607](https://github.com/paradigmxyz/reth/pull/26607)).

- **Testing & Benchmarks**
  - Improved engine reorg tests by explicitly managing finality and added execute-blob coverage to Hive workflows ([#26584](https://github.com/paradigmxyz/reth/pull/26584), [#26606](https://github.com/paradigmxyz/reth/pull/26606)).
  - Fixed benchmark run configurations to expose metrics ([#26461](https://github.com/paradigmxyz/reth/pull/26461)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-019ff03e-c08f-76c2-80b2-0296d515c6ab
- Upgraded all Reth git dependencies from `10aa6a…` to `1c6945c`, pinning `revm-inspectors` to `=0.42.0` for dependency compatibility.
- Migrated `HashedStorage::from_iter` to its new signature without the `wiped` argument, setting `storage.wiped = true` explicitly.
- Updated `HashedPostStateProvider::hashed_post_state` implementations and callers to return and propagate `ProviderResult<HashedPostState>`.
- Added the required `RpcLog` associated type and `convert_log` implementation to the receipt converter for the updated Reth RPC API.
- Migrated `EthPooledTransaction` construction from direct field initialization to `EthPooledTransaction::new`, then preserved Tempo’s custom calculated cost.
- Changed state-gas accounting from `u64` to `i64` across storage providers, dispatch, and tests to match the updated REVM gas tracker API.
- Removed `TempoEvm::initial_gas_and_reservoir` and moved its pre-T0 underflow compatibility logic into the handler’s `tx_gas` hook.
- Updated the state-gas test to call `InitialAndFloorGas::initial_gas_and_reservoir` directly after removing the Tempo wrapper.
- Added `#[must_use]` to the async faucet RPC method so ignored, unawaited requests produce a warning.
- Added and initialized the Rustls ring crypto provider in the standalone relay transport test, and treated testnet RPC connection-rate limiting as an expected external failure.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/31455628774)
