### PR TITLE
refactor: centralize transaction time-bound checks

### DIFF
--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -217,12 +217,7 @@ impl BestTransactionsPrewarming {
                 .transaction
                 .is_expiring_nonce()
                 .then(|| {
-                    let valid_before = tx
-                        .transaction
-                        .tx_env()
-                        .tempo_tx_env
-                        .as_ref()?
-                        .valid_before?;
+                    let valid_before = tx.transaction.inner().valid_before()?;
                     Some(ExpiringNonceReplay {
                         hash: tx.transaction.expiring_nonce_hash()?,
                         valid_before,

--- a/crates/primitives/src/subblock.rs
+++ b/crates/primitives/src/subblock.rs
@@ -248,13 +248,9 @@ impl RecoveredSubBlock {
 
     /// Returns true if this subblock has any expired transactions for the given timestamp.
     pub fn has_expired_transactions(&self, timestamp: u64) -> bool {
-        self.transactions.iter().any(|tx| {
-            tx.as_aa().is_some_and(|tx| {
-                tx.tx()
-                    .valid_before
-                    .is_some_and(|valid| valid.get() <= timestamp)
-            })
-        })
+        self.transactions
+            .iter()
+            .any(|tx| tx.ensure_valid_before(timestamp).is_err())
     }
 
     /// Returns the validator that submitted the subblock.

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -1,4 +1,8 @@
-use super::{tt_signed::AASigned, unique_tx_identifier_from_signable};
+use super::{
+    tempo_transaction::{InvalidValidAfter, InvalidValidBefore},
+    tt_signed::AASigned,
+    unique_tx_identifier_from_signable,
+};
 use crate::{TempoAddressExt, TempoTransaction, subblock::PartialValidatorKey};
 use alloy_consensus::{
     EthereumTxEnvelope, SignableTransaction, Signed, Transaction, TxEip1559, TxEip2930, TxEip7702,
@@ -98,6 +102,27 @@ impl alloy_consensus::InMemorySize for TempoTxType {
 }
 
 impl TempoTxEnvelope {
+    /// Ensures an AA transaction's `valid_before`, when present, is strictly greater than
+    /// `min_allowed`.
+    ///
+    /// Other transaction types do not carry this bound and always pass.
+    pub fn ensure_valid_before(&self, min_allowed: u64) -> Result<(), InvalidValidBefore> {
+        match self {
+            Self::AA(tx) => tx.tx().ensure_valid_before(min_allowed),
+            _ => Ok(()),
+        }
+    }
+
+    /// Ensures an AA transaction's `valid_after`, when present, does not exceed `max_allowed`.
+    ///
+    /// Other transaction types do not carry this bound and always pass.
+    pub fn ensure_valid_after(&self, max_allowed: u64) -> Result<(), InvalidValidAfter> {
+        match self {
+            Self::AA(tx) => tx.tx().ensure_valid_after(max_allowed),
+            _ => Ok(()),
+        }
+    }
+
     /// Returns the fee token preference if this is a fee token transaction
     pub fn fee_token(&self) -> Option<Address> {
         match self {
@@ -555,6 +580,7 @@ mod tests {
     };
     use alloy_primitives::{Bytes, Signature, TxKind, U256, address, aliases::U96};
     use alloy_sol_types::SolCall;
+    use core::num::NonZeroU64;
     use tempo_contracts::precompiles::ITIP20ChannelReserve;
 
     const PAYMENT_TKN: Address = address!("20c0000000000000000000000000000000000001");
@@ -669,6 +695,44 @@ mod tests {
         assert_eq!(envelope.fee_token(), None);
         assert!(!envelope.is_aa());
         assert!(envelope.as_aa().is_none());
+    }
+
+    #[test]
+    fn test_time_bounds_delegate_for_aa_transactions() {
+        let envelope = TempoTxEnvelope::AA(
+            TempoTransaction {
+                valid_before: NonZeroU64::new(100),
+                valid_after: NonZeroU64::new(50),
+                ..Default::default()
+            }
+            .into_signed(Signature::test_signature().into()),
+        );
+
+        assert_eq!(
+            envelope.ensure_valid_before(100),
+            Err(InvalidValidBefore {
+                valid_before: 100,
+                min_allowed: 100,
+            })
+        );
+        assert_eq!(
+            envelope.ensure_valid_after(49),
+            Err(InvalidValidAfter {
+                valid_after: 50,
+                max_allowed: 49,
+            })
+        );
+    }
+
+    #[test]
+    fn test_time_bounds_ignore_non_aa_transactions() {
+        let envelope = TempoTxEnvelope::Legacy(Signed::new_unhashed(
+            TxLegacy::default(),
+            Signature::test_signature(),
+        ));
+
+        assert_eq!(envelope.ensure_valid_before(100), Ok(()));
+        assert_eq!(envelope.ensure_valid_after(100), Ok(()));
     }
 
     #[test]

--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -13,7 +13,7 @@ use alloy_consensus::{
 };
 use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256};
 use alloy_rlp::Encodable;
-use core::fmt;
+use core::{fmt, num::NonZeroU64};
 use tempo_contracts::precompiles::{ITIP20, ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS};
 
 /// Maximum RLP-encoded size of a `key_authorization` permitted in a payment transaction
@@ -102,6 +102,26 @@ impl alloy_consensus::InMemorySize for TempoTxType {
 }
 
 impl TempoTxEnvelope {
+    /// Returns an AA transaction's `valid_before` timestamp, if set.
+    ///
+    /// Other transaction types do not carry this bound.
+    pub fn valid_before(&self) -> Option<u64> {
+        match self {
+            Self::AA(tx) => tx.tx().valid_before.map(NonZeroU64::get),
+            _ => None,
+        }
+    }
+
+    /// Returns an AA transaction's `valid_after` timestamp, if set.
+    ///
+    /// Other transaction types do not carry this bound.
+    pub fn valid_after(&self) -> Option<u64> {
+        match self {
+            Self::AA(tx) => tx.tx().valid_after.map(NonZeroU64::get),
+            _ => None,
+        }
+    }
+
     /// Ensures an AA transaction's `valid_before`, when present, is strictly greater than
     /// `min_allowed`.
     ///

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -20,9 +20,10 @@ pub use key_authorization::{
     SignedKeyAuthorization, TokenLimit,
 };
 pub use tempo_transaction::{
-    Call, FEE_PAYER_SIGNATURE_MARKER, MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH,
-    SECP256K1_SIGNATURE_LENGTH, SignatureType, TEMPO_EXPIRING_NONCE_KEY,
-    TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS, TEMPO_TX_TYPE_ID, TempoTransaction, validate_calls,
+    Call, FEE_PAYER_SIGNATURE_MARKER, InvalidValidAfter, InvalidValidBefore,
+    MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH,
+    SignatureType, TEMPO_EXPIRING_NONCE_KEY, TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS,
+    TEMPO_TX_TYPE_ID, TempoTransaction, validate_calls,
 };
 pub use tt_signed::AASigned;
 

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -34,6 +34,49 @@ pub const TEMPO_EXPIRING_NONCE_KEY: U256 = U256::MAX;
 /// Maximum allowed expiry window for expiring nonce transactions (30 seconds).
 pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
 
+/// Error returned when a transaction's `valid_before` timestamp is not strictly greater than the
+/// required minimum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidValidBefore {
+    /// The transaction's `valid_before` timestamp.
+    pub valid_before: u64,
+    /// The exclusive lower timestamp bound supplied by the caller.
+    pub min_allowed: u64,
+}
+
+impl core::fmt::Display for InvalidValidBefore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "'valid_before' {} is too close to current time (min allowed: {})",
+            self.valid_before, self.min_allowed
+        )
+    }
+}
+
+impl core::error::Error for InvalidValidBefore {}
+
+/// Error returned when a transaction's `valid_after` timestamp exceeds the allowed maximum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidValidAfter {
+    /// The transaction's `valid_after` timestamp.
+    pub valid_after: u64,
+    /// The inclusive upper timestamp bound supplied by the caller.
+    pub max_allowed: u64,
+}
+
+impl core::fmt::Display for InvalidValidAfter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "'valid_after' {} is too far in the future (max allowed: {})",
+            self.valid_after, self.max_allowed
+        )
+    }
+}
+
+impl core::error::Error for InvalidValidAfter {}
+
 /// Signature type enumeration
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -327,6 +370,38 @@ impl TempoTransaction {
     #[inline]
     pub fn is_expiring_nonce_tx(&self) -> bool {
         self.nonce_key == TEMPO_EXPIRING_NONCE_KEY
+    }
+
+    /// Ensures `valid_before`, when present, is strictly greater than `min_allowed`.
+    pub fn ensure_valid_before(&self, min_allowed: u64) -> Result<(), InvalidValidBefore> {
+        let Some(valid_before) = self.valid_before.map(NonZeroU64::get) else {
+            return Ok(());
+        };
+
+        if valid_before <= min_allowed {
+            return Err(InvalidValidBefore {
+                valid_before,
+                min_allowed,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Ensures `valid_after`, when present, does not exceed `max_allowed`.
+    pub fn ensure_valid_after(&self, max_allowed: u64) -> Result<(), InvalidValidAfter> {
+        let Some(valid_after) = self.valid_after.map(NonZeroU64::get) else {
+            return Ok(());
+        };
+
+        if valid_after > max_allowed {
+            return Err(InvalidValidAfter {
+                valid_after,
+                max_allowed,
+            });
+        }
+
+        Ok(())
     }
 
     /// Validates the transaction according to invariant rules.
@@ -1048,6 +1123,64 @@ mod tests {
             ..Default::default()
         };
         assert!(tx5.validate().is_err());
+    }
+
+    #[test]
+    fn test_ensure_valid_before() {
+        let mut tx = TempoTransaction::default();
+        assert_eq!(tx.ensure_valid_before(100), Ok(()));
+
+        tx.valid_before = Some(nz(99));
+        assert!(tx.ensure_valid_before(100).is_err());
+
+        tx.valid_before = Some(nz(100));
+        let err = tx.ensure_valid_before(100).unwrap_err();
+        assert_eq!(
+            err,
+            InvalidValidBefore {
+                valid_before: 100,
+                min_allowed: 100
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "'valid_before' 100 is too close to current time (min allowed: 100)"
+        );
+
+        tx.valid_before = Some(nz(101));
+        assert_eq!(tx.ensure_valid_before(100), Ok(()));
+
+        tx.valid_before = Some(nz(u64::MAX));
+        assert!(tx.ensure_valid_before(u64::MAX).is_err());
+    }
+
+    #[test]
+    fn test_ensure_valid_after() {
+        let mut tx = TempoTransaction::default();
+        assert_eq!(tx.ensure_valid_after(100), Ok(()));
+
+        tx.valid_after = Some(nz(99));
+        assert_eq!(tx.ensure_valid_after(100), Ok(()));
+
+        tx.valid_after = Some(nz(100));
+        assert_eq!(tx.ensure_valid_after(100), Ok(()));
+
+        tx.valid_after = Some(nz(101));
+        let err = tx.ensure_valid_after(100).unwrap_err();
+        assert_eq!(
+            err,
+            InvalidValidAfter {
+                valid_after: 101,
+                max_allowed: 100
+            }
+        );
+        assert_eq!(
+            err.to_string(),
+            "'valid_after' 101 is too far in the future (max allowed: 100)"
+        );
+
+        tx.valid_after = Some(nz(u64::MAX));
+        assert_eq!(tx.ensure_valid_after(u64::MAX), Ok(()));
     }
 
     #[test]

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -34,49 +34,6 @@ pub const TEMPO_EXPIRING_NONCE_KEY: U256 = U256::MAX;
 /// Maximum allowed expiry window for expiring nonce transactions (30 seconds).
 pub const TEMPO_EXPIRING_NONCE_MAX_EXPIRY_SECS: u64 = 30;
 
-/// Error returned when a transaction's `valid_before` timestamp is not strictly greater than the
-/// required minimum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct InvalidValidBefore {
-    /// The transaction's `valid_before` timestamp.
-    pub valid_before: u64,
-    /// The exclusive lower timestamp bound supplied by the caller.
-    pub min_allowed: u64,
-}
-
-impl core::fmt::Display for InvalidValidBefore {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "'valid_before' {} is too close to current time (min allowed: {})",
-            self.valid_before, self.min_allowed
-        )
-    }
-}
-
-impl core::error::Error for InvalidValidBefore {}
-
-/// Error returned when a transaction's `valid_after` timestamp exceeds the allowed maximum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct InvalidValidAfter {
-    /// The transaction's `valid_after` timestamp.
-    pub valid_after: u64,
-    /// The inclusive upper timestamp bound supplied by the caller.
-    pub max_allowed: u64,
-}
-
-impl core::fmt::Display for InvalidValidAfter {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(
-            f,
-            "'valid_after' {} is too far in the future (max allowed: {})",
-            self.valid_after, self.max_allowed
-        )
-    }
-}
-
-impl core::error::Error for InvalidValidAfter {}
-
 /// Signature type enumeration
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1021,6 +978,49 @@ mod serde_input {
             .into_owned())
     }
 }
+
+/// Error returned when a transaction's `valid_before` timestamp is not strictly greater than the
+/// required minimum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidValidBefore {
+    /// The transaction's `valid_before` timestamp.
+    pub valid_before: u64,
+    /// The exclusive lower timestamp bound supplied by the caller.
+    pub min_allowed: u64,
+}
+
+impl core::fmt::Display for InvalidValidBefore {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "'valid_before' {} is too close to current time (min allowed: {})",
+            self.valid_before, self.min_allowed
+        )
+    }
+}
+
+impl core::error::Error for InvalidValidBefore {}
+
+/// Error returned when a transaction's `valid_after` timestamp exceeds the allowed maximum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidValidAfter {
+    /// The transaction's `valid_after` timestamp.
+    pub valid_after: u64,
+    /// The inclusive upper timestamp bound supplied by the caller.
+    pub max_allowed: u64,
+}
+
+impl core::fmt::Display for InvalidValidAfter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "'valid_after' {} is too far in the future (max allowed: {})",
+            self.valid_after, self.max_allowed
+        )
+    }
+}
+
+impl core::error::Error for InvalidValidAfter {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -419,10 +419,7 @@ struct TempoPoolState {
 impl TempoPoolState {
     /// Tracks an AA transaction with a `valid_before` timestamp.
     fn track(&mut self, tx: &TempoPooledTransaction) {
-        let valid_before = tx
-            .inner()
-            .as_aa()
-            .and_then(|tx| tx.tx().valid_before.map(|value| value.get()));
+        let valid_before = tx.inner().valid_before();
         let key_expiry = tx.key_expiry();
 
         let expiry = [valid_before, key_expiry].into_iter().flatten().min();
@@ -750,11 +747,7 @@ where
                             let entries: Vec<_> = removed_txs
                                 .into_iter()
                                 .map(|tx| {
-                                    let valid_before = tx
-                                        .transaction
-                                        .inner()
-                                        .as_aa()
-                                        .and_then(|aa| aa.tx().valid_before.map(|value| value.get()));
+                                    let valid_before = tx.transaction.inner().valid_before();
                                     PausedEntry { tx, valid_before }
                                 })
                                 .collect();

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -33,7 +33,10 @@ use tempo_precompiles::{
     tip20::{TIP20Token, tip20_slots},
     tip403_registry::tip403_registry_slots,
 };
-use tempo_primitives::{TempoTxEnvelope, transaction::calc_gas_balance_spending};
+use tempo_primitives::{
+    TempoTxEnvelope,
+    transaction::{InvalidValidAfter, InvalidValidBefore, calc_gas_balance_spending},
+};
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
 use thiserror::Error;
 
@@ -511,27 +514,15 @@ pub enum TempoPoolTransactionError {
     ///
     /// Thrown during pool admission when `valid_before` is less than or equal to
     /// the latest tip timestamp plus the pool's propagation buffer.
-    #[error(
-        "'valid_before' {valid_before} is too close to current time (min allowed: {min_allowed})"
-    )]
-    InvalidValidBefore {
-        /// The transaction's `valid_before` timestamp.
-        valid_before: u64,
-        /// The minimum timestamp accepted by the pool.
-        min_allowed: u64,
-    },
+    #[error(transparent)]
+    InvalidValidBefore(#[from] InvalidValidBefore),
 
     /// An AA transaction's `valid_after` is too far in the future.
     ///
     /// Thrown during pool admission when `valid_after` exceeds the wall-clock time
     /// plus the pool's configured future-validity window.
-    #[error("'valid_after' {valid_after} is too far in the future (max allowed: {max_allowed})")]
-    InvalidValidAfter {
-        /// The transaction's `valid_after` timestamp.
-        valid_after: u64,
-        /// The maximum timestamp accepted by the pool.
-        max_allowed: u64,
-    },
+    #[error(transparent)]
+    InvalidValidAfter(#[from] InvalidValidAfter),
 
     /// A pool-only keychain authorization limit failed.
     ///
@@ -688,8 +679,8 @@ impl PoolTransactionError for TempoPoolTransactionError {
         match self {
             Self::Evm(err) => err.is_bad_transaction(),
             Self::ExceedsNonPaymentLimit
-            | Self::InvalidValidBefore { .. }
-            | Self::InvalidValidAfter { .. }
+            | Self::InvalidValidBefore(_)
+            | Self::InvalidValidAfter(_)
             | Self::AccessKeyExpired { .. }
             | Self::KeyAuthorizationExpired { .. }
             | Self::Keychain(_) => false,
@@ -1143,17 +1134,17 @@ mod tests {
         let cases: &[(TempoPoolTransactionError, bool)] = &[
             (TempoPoolTransactionError::ExceedsNonPaymentLimit, false),
             (
-                TempoPoolTransactionError::InvalidValidBefore {
+                TempoPoolTransactionError::InvalidValidBefore(InvalidValidBefore {
                     valid_before: 100,
                     min_allowed: 200,
-                },
+                }),
                 false,
             ),
             (
-                TempoPoolTransactionError::InvalidValidAfter {
+                TempoPoolTransactionError::InvalidValidAfter(InvalidValidAfter {
                     valid_after: 200,
                     max_allowed: 100,
-                },
+                }),
                 false,
             ),
             (TempoPoolTransactionError::Keychain("test error"), false),

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -186,32 +186,18 @@ where
         // Reject AA txs where `valid_before` is too close to current time (or already expired).
         // The EVM checks `valid_before > block_timestamp` but the pool needs an extra
         // propagation buffer to prevent txs from expiring at peers with slightly newer tips.
-        if let Some(valid_before) = tx.valid_before {
-            let valid_before = valid_before.get();
-            let min_allowed = tip_timestamp.saturating_add(AA_VALID_BEFORE_MIN_SECS);
-            if valid_before <= min_allowed {
-                return Err(TempoPoolTransactionError::InvalidValidBefore {
-                    valid_before,
-                    min_allowed,
-                });
-            }
-        }
+        let min_allowed = tip_timestamp.saturating_add(AA_VALID_BEFORE_MIN_SECS);
+        tx.ensure_valid_before(min_allowed)?;
 
         // Reject AA txs where `valid_after` is too far in the future.
         // Uses wall-clock time to avoid rejecting valid txs when node is lagging.
-        if let Some(valid_after) = tx.valid_after {
-            let valid_after = valid_after.get();
+        if tx.valid_after.is_some() {
             let current_time = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
             let max_allowed = current_time.saturating_add(self.aa_valid_after_max_secs);
-            if valid_after > max_allowed {
-                return Err(TempoPoolTransactionError::InvalidValidAfter {
-                    valid_after,
-                    max_allowed,
-                });
-            }
+            tx.ensure_valid_after(max_allowed)?;
         }
 
         Ok(())
@@ -1344,7 +1330,7 @@ mod tests {
         if let TransactionValidationOutcome::Invalid(_, ref err) = outcome {
             assert!(!matches!(
                 err.downcast_other_ref::<TempoPoolTransactionError>(),
-                Some(TempoPoolTransactionError::InvalidValidBefore { .. })
+                Some(TempoPoolTransactionError::InvalidValidBefore(_))
             ));
         }
 
@@ -1358,10 +1344,13 @@ mod tests {
 
         match outcome {
             TransactionValidationOutcome::Invalid(_, ref err) => {
-                assert!(matches!(
-                    err.downcast_other_ref::<TempoPoolTransactionError>(),
-                    Some(TempoPoolTransactionError::InvalidValidBefore { .. })
-                ));
+                let Some(TempoPoolTransactionError::InvalidValidBefore(err)) =
+                    err.downcast_other_ref::<TempoPoolTransactionError>()
+                else {
+                    panic!("Expected InvalidValidBefore error, got: {err:?}");
+                };
+                assert_eq!(err.valid_before, current_time + AA_VALID_BEFORE_MIN_SECS);
+                assert_eq!(err.min_allowed, current_time + AA_VALID_BEFORE_MIN_SECS);
             }
             _ => panic!("Expected Invalid outcome with InvalidValidBefore error, got: {outcome:?}"),
         }
@@ -1377,7 +1366,7 @@ mod tests {
         if let TransactionValidationOutcome::Invalid(_, ref err) = outcome {
             assert!(!matches!(
                 err.downcast_other_ref::<TempoPoolTransactionError>(),
-                Some(TempoPoolTransactionError::InvalidValidBefore { .. })
+                Some(TempoPoolTransactionError::InvalidValidBefore(_))
             ));
         }
     }
@@ -1400,7 +1389,7 @@ mod tests {
         if let TransactionValidationOutcome::Invalid(_, ref err) = outcome {
             assert!(!matches!(
                 err.downcast_other_ref::<TempoPoolTransactionError>(),
-                Some(TempoPoolTransactionError::InvalidValidAfter { .. })
+                Some(TempoPoolTransactionError::InvalidValidAfter(_))
             ));
         }
 
@@ -1414,7 +1403,7 @@ mod tests {
         if let TransactionValidationOutcome::Invalid(_, ref err) = outcome {
             assert!(!matches!(
                 err.downcast_other_ref::<TempoPoolTransactionError>(),
-                Some(TempoPoolTransactionError::InvalidValidAfter { .. })
+                Some(TempoPoolTransactionError::InvalidValidAfter(_))
             ));
         }
 
@@ -1427,10 +1416,13 @@ mod tests {
 
         match outcome {
             TransactionValidationOutcome::Invalid(_, ref err) => {
-                assert!(matches!(
-                    err.downcast_other_ref::<TempoPoolTransactionError>(),
-                    Some(TempoPoolTransactionError::InvalidValidAfter { .. })
-                ));
+                let Some(TempoPoolTransactionError::InvalidValidAfter(err)) =
+                    err.downcast_other_ref::<TempoPoolTransactionError>()
+                else {
+                    panic!("Expected InvalidValidAfter error, got: {err:?}");
+                };
+                assert_eq!(err.valid_after, current_time + 300);
+                assert!(err.max_allowed < err.valid_after);
             }
             _ => panic!("Expected Invalid outcome with InvalidValidAfter error, got: {outcome:?}"),
         }
@@ -2027,8 +2019,8 @@ mod tests {
             assert!(
                 !matches!(
                     tempo_err,
-                    Some(TempoPoolTransactionError::InvalidValidAfter { .. })
-                        | Some(TempoPoolTransactionError::InvalidValidBefore { .. })
+                    Some(TempoPoolTransactionError::InvalidValidAfter(_))
+                        | Some(TempoPoolTransactionError::InvalidValidBefore(_))
                 ),
                 "Should not fail with validity window errors"
             );


### PR DESCRIPTION
Adds reusable `ensure_valid_before` and `ensure_valid_after` APIs for `TempoTransaction` and `TempoTxEnvelope`, backed by typed primitive errors. The pool and subblock expiry path now share those boundary checks while preserving existing pool error messages and classification.

Also adds `valid_before()`/`valid_after()` accessors on `TempoTxEnvelope` so call sites that only need the raw timestamps (pool expiry tracking, prewarming replay data) no longer unpack the AA envelope manually.

This lets downstream consumers such as tempoxyz/zones#999 validate timestamp readiness without manually unpacking AA envelopes.