### PR TITLE
ci: add Cyclops super-fast audit trigger

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -84,7 +84,7 @@ jobs:
           github-token: ${{ github.token }}
           script: |
             const usage = [
-              '**Usage:** `cyclops audit [fast] [perf] [iterations=N] [hours=N] [config=pr-review.yaml] ',
+              '**Usage:** `cyclops audit [super-fast] [fast] [perf] [iterations=N] [hours=N] [config=pr-review.yaml] ',
               '[models="anthropic/claude-opus-4-7,openai/gpt-5.5"] [run-label=LABEL] ',
               '[dry-run] [note="per-run audit guidance"]`',
             ].join('');
@@ -111,8 +111,13 @@ jobs:
             const boolArgs = new Set(['dry-run', 'perf']);
             const unknown = [];
             const invalid = [];
+            let superFast = false;
 
             for (const part of parts) {
+              if (part === 'super-fast') {
+                superFast = true;
+                continue;
+              }
               if (part === 'fast') {
                 defaults.iterations = '1';
                 continue;
@@ -157,6 +162,11 @@ jobs:
               } else {
                 unknown.push(key);
               }
+            }
+
+            if (superFast) {
+              defaults.config = 'pr-review-super-fast.yaml';
+              defaults.iterations = '1';
             }
 
             const errors = [];


### PR DESCRIPTION
## Summary

- accept `cyclops audit super-fast` in the repository-local comment parser
- force `pr-review-super-fast.yaml` and one iteration
- keep the super-fast profile fixed even when conflicting `config` or `iterations` arguments are supplied

## Validation

- parsed the workflow as YAML
- compiled the embedded GitHub Script as JavaScript
- `git diff --check`

Canonical behavior: https://github.com/tempoxyz/gh-actions/pull/54