### PR TITLE
refactor(consensus): decode certificates at construction

### DIFF
--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -20,6 +20,18 @@ use tempo_node::rpc::consensus::CertifiedBlock;
 
 use crate::{config::NAMESPACE, consensus::Digest, epoch::SchemeProvider};
 
+pub(crate) type CertifiedFinalization =
+    CertifiedBlock<Finalization<Scheme<PublicKey, MinSig>, Digest>>;
+
+pub(crate) fn decode_certified_finalization(
+    certified: CertifiedBlock,
+) -> Result<CertifiedFinalization, MalformedCertificateError> {
+    certified.try_map_certificate(|certificate| {
+        let bytes = alloy_primitives::hex::decode(certificate)?;
+        Finalization::decode(&*bytes).map_err(Into::into)
+    })
+}
+
 #[cfg(test)]
 mod test;
 
@@ -79,18 +91,13 @@ impl FinalizationVerifier {
         Ok(outcome)
     }
 
-    /// Decode and verify a certified block returned by the Tempo consensus RPC.
-    pub(crate) fn decode_and_verify(
+    /// Verify a decoded certified block returned by the Tempo consensus RPC.
+    pub(crate) fn verify(
         &self,
         rng: &mut impl CryptoRng,
-        certified: &CertifiedBlock,
+        certified: &CertifiedFinalization,
     ) -> Result<Finalization<Scheme<PublicKey, MinSig>, Digest>, Error> {
-        // TODO: Decode certificates when constructing `CertifiedBlock` instead of keeping their
-        // bytes opaque and decoding them at each consumer.
-        let bytes = alloy_primitives::hex::decode(&certified.certificate)
-            .map_err(|error| Error::MalformedCertificate(error.into()))?;
-        let finalization = Finalization::<Scheme<PublicKey, MinSig>, Digest>::decode(&*bytes)
-            .map_err(|error| Error::MalformedCertificate(error.into()))?;
+        let finalization = &certified.certificate;
 
         if finalization.proposal.payload.0 != certified.block.hash() {
             return Err(Error::BlockDigestMismatch);
@@ -134,7 +141,7 @@ impl FinalizationVerifier {
             self.scheme_provider.register(epoch, (*scheme).clone());
         }
 
-        Ok(finalization)
+        Ok(finalization.clone())
     }
 }
 

--- a/crates/consensus/src/finalization_verifier/test.rs
+++ b/crates/consensus/src/finalization_verifier/test.rs
@@ -4,7 +4,7 @@ use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 use tempo_chainspec::NetworkIdentity;
 
-use super::{Error, FinalizationVerifier};
+use super::{Error, FinalizationVerifier, decode_certified_finalization};
 use crate::follow::test_utils::{
     EPOCH_LENGTH, dkg_fixture, make_block, make_certified_block, make_finalization,
 };
@@ -24,9 +24,11 @@ fn tracks_boundary_identity() {
 
         let boundary = make_block(EPOCH_LENGTH.get() - 1, Some(&next.outcome));
         let finalization = make_finalization(&boundary, Epoch::zero(), &current.schemes);
-        let certified = make_certified_block(boundary.clone(), &finalization);
+        let certified =
+            decode_certified_finalization(make_certified_block(boundary.clone(), &finalization))
+                .unwrap();
         verifier
-            .decode_and_verify(&mut context, &certified)
+            .verify(&mut context, &certified)
             .expect("current identity should verify the boundary");
 
         verifier
@@ -35,9 +37,10 @@ fn tracks_boundary_identity() {
 
         let block = make_block(EPOCH_LENGTH.get(), None);
         let finalization = make_finalization(&block, Epoch::new(1), &next.schemes);
-        let certified = make_certified_block(block, &finalization);
+        let certified =
+            decode_certified_finalization(make_certified_block(block, &finalization)).unwrap();
         verifier
-            .decode_and_verify(&mut context, &certified)
+            .verify(&mut context, &certified)
             .expect("installed identity should verify the next epoch");
     });
 }
@@ -56,9 +59,10 @@ fn rejects_epoch_mismatching_block_height() {
 
         let block = make_block(EPOCH_LENGTH.get(), None);
         let finalization = make_finalization(&block, Epoch::zero(), &fixture.schemes);
-        let certified = make_certified_block(block, &finalization);
+        let certified =
+            decode_certified_finalization(make_certified_block(block, &finalization)).unwrap();
         assert!(matches!(
-            verifier.decode_and_verify(&mut context, &certified),
+            verifier.verify(&mut context, &certified),
             Err(Error::EpochMismatch {
                 height,
                 expected: 1,

--- a/crates/consensus/src/finalized_header_stream/mod.rs
+++ b/crates/consensus/src/finalized_header_stream/mod.rs
@@ -28,7 +28,9 @@ use tempo_node::rpc::consensus::{CertifiedBlock, Query};
 use tempo_primitives::TempoHeader;
 use tracing::{instrument, warn};
 
-use crate::finalization_verifier::{Error as VerificationError, FinalizationVerifier};
+use crate::finalization_verifier::{
+    Error as VerificationError, FinalizationVerifier, decode_certified_finalization,
+};
 
 #[cfg(test)]
 mod test;
@@ -153,13 +155,15 @@ where
                     // Always fetch identity from start block if it's the last block in its epoch.
                     verifier = verifier_from_start(&rpc, &epoch_strategy, start_after).await?;
                 } else {
-                    let latest_finalization = rpc.finalization(Query::Latest).await?;
+                    let latest_finalization =
+                        decode_certified_finalization(rpc.finalization(Query::Latest).await?)
+                            .map_err(VerificationError::MalformedCertificate)?;
 
                     // If the latest finalization we can obtain is older than the start block or it
                     // does not verify against the initial identity, always fetch identity via the start block.
                     if latest_finalization.block.number() < start_after.number
                         || verifier
-                            .decode_and_verify(&mut rng, &latest_finalization)
+                            .verify(&mut rng, &latest_finalization)
                             .is_err_and(|error| {
                                 matches!(error, VerificationError::VerificationFailed)
                             })
@@ -214,14 +218,16 @@ where
             }
 
             // If we don't have any more headers, advance by following the latest finalization.
-            let certified = self.rpc.finalization(Query::Latest).await?;
+            let certified =
+                decode_certified_finalization(self.rpc.finalization(Query::Latest).await?)
+                    .map_err(VerificationError::MalformedCertificate)?;
 
             if certified.block.number() <= self.cursor.number {
                 tokio::time::sleep(self.poll_interval).await;
                 continue;
             }
 
-            match self.verifier.decode_and_verify(&mut self.rng, &certified) {
+            match self.verifier.verify(&mut self.rng, &certified) {
                 Ok(_) => {
                     // If we can verify the latest finalization, trust it as the new chain tip.
                     self.plan = self.plan_to(certified.block.num_hash()).await?;
@@ -355,6 +361,8 @@ where
                     height: boundary,
                     source,
                 })?;
+            let certified = decode_certified_finalization(certified)
+                .map_err(VerificationError::MalformedCertificate)?;
             let actual = certified.block.number();
             if actual != boundary {
                 return Err(Error::TransitionHeightMismatch {
@@ -363,7 +371,7 @@ where
                 });
             }
 
-            match self.verifier.decode_and_verify(&mut self.rng, &certified) {
+            match self.verifier.verify(&mut self.rng, &certified) {
                 Ok(_) => {
                     return self
                         .plan_to(BlockNumHash::new(boundary, certified.block.hash()))

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -15,7 +15,10 @@ use tracing::{debug, instrument, warn};
 use super::{Config, ExecutionProvider, Mailbox, Marshal, ingress::Message};
 use crate::{
     consensus::Block,
-    finalization_verifier::{Error as VerificationError, FinalizationVerifier},
+    finalization_verifier::{
+        CertifiedFinalization, Error as VerificationError, FinalizationVerifier,
+        decode_certified_finalization,
+    },
 };
 
 pub(super) fn try_init<TContext, P, M>(
@@ -207,10 +210,13 @@ where
         err(Display)
     )]
     async fn process_event(&mut self, certified: CertifiedBlock) -> eyre::Result<()> {
-        let finalization = match self
-            .verifier
-            .decode_and_verify(&mut self.context, &certified)
-        {
+        let certified = decode_certified_finalization(certified)
+            .wrap_err("failed decoding finalization certificate")?;
+        self.process_finalization(certified).await
+    }
+
+    async fn process_finalization(&mut self, certified: CertifiedFinalization) -> eyre::Result<()> {
+        let finalization = match self.verifier.verify(&mut self.context, &certified) {
             Ok(finalization) => finalization,
             Err(error @ VerificationError::VerificationFailed) => {
                 debug!(%error, "failed to verify finalization certificate");

--- a/crates/consensus/src/follow/resolver/mod.rs
+++ b/crates/consensus/src/follow/resolver/mod.rs
@@ -11,13 +11,9 @@ use std::{
 };
 
 use bytes::Bytes;
-use commonware_codec::{DecodeExt as _, Encode as _};
-use commonware_consensus::{
-    marshal::resolver::handler,
-    simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
-    types::Height,
-};
-use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
+use commonware_codec::Encode as _;
+use commonware_consensus::{marshal::resolver::handler, types::Height};
+use commonware_cryptography::ed25519::PublicKey;
 use commonware_resolver::opaque;
 use commonware_runtime::{Clock, Metrics, Spawner, telemetry::metrics::Registered};
 use eyre::Report;
@@ -34,7 +30,10 @@ use tempo_node::{node::TempoNode, rpc::consensus::CertifiedBlock};
 use tempo_primitives::Block as TempoBlock;
 use tracing::{debug, error, instrument, warn};
 
-use crate::consensus::{Block, Digest};
+use crate::{
+    consensus::{Block, Digest},
+    finalization_verifier::decode_certified_finalization,
+};
 
 #[cfg(test)]
 mod test;
@@ -257,13 +256,11 @@ async fn resolve_block<P: BlockProvider, U: Upstream>(
 async fn resolve_finalized<U: Upstream>(upstream: &U, height: Height) -> Option<Bytes> {
     let certified_block = upstream.get_finalization(height).await?;
 
-    let finalization = alloy_primitives::hex::decode(&certified_block.certificate)
+    let certified_block = decode_certified_finalization(certified_block)
         .map_err(Report::new)
-        .and_then(|bytes| {
-            <Finalization<Scheme<PublicKey, MinSig>, Digest>>::decode(&*bytes).map_err(Report::new)
-        })
         .inspect_err(|error| warn!(%error, "failed decoding certificate"))
         .ok()?;
+    let finalization = certified_block.certificate;
 
     // Upstream finalization responses carry persisted EL blocks only; no p2p BAL
     // is available when reconstructing this consensus block.

--- a/crates/node/src/rpc/consensus/types.rs
+++ b/crates/node/src/rpc/consensus/types.rs
@@ -13,20 +13,36 @@ use tokio::sync::broadcast;
 /// A block with a threshold BLS certificate (notarization or finalization).
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct CertifiedBlock {
+pub struct CertifiedBlock<C = String> {
     pub epoch: u64,
     pub view: u64,
     pub digest: B256,
 
     /// Hex-encoded full notarization or finalization.
-    pub certificate: String,
+    pub certificate: C,
 
     /// The Tempo block.
     #[serde(with = "serde_sealed_or_recovered_block")]
     pub block: SealedOrRecoveredBlock<Block>,
 }
 
-impl Display for CertifiedBlock {
+impl<C> CertifiedBlock<C> {
+    /// Transform the certificate while preserving its associated consensus metadata and block.
+    pub fn try_map_certificate<T, E>(
+        self,
+        f: impl FnOnce(C) -> Result<T, E>,
+    ) -> Result<CertifiedBlock<T>, E> {
+        Ok(CertifiedBlock {
+            epoch: self.epoch,
+            view: self.view,
+            digest: self.digest,
+            certificate: f(self.certificate)?,
+            block: self.block,
+        })
+    }
+}
+
+impl<C: Serialize> Display for CertifiedBlock<C> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match serde_json::to_string(self) {
             Ok(s) => f.write_str(&s),


### PR DESCRIPTION
Makes `CertifiedBlock` generic over its certificate representation, allowing consensus consumers to construct a typed finalization once at the RPC boundary.

Verification and resolver paths now consume the decoded certificate instead of independently decoding opaque bytes.

Prompted by: @pepyakin