### PR TITLE
fix(tip20): re-read from_balance after handle_rewards_on_transfer in pre-T8 path

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1210,8 +1210,11 @@ impl TIP20Token {
 
         // Adjust balances
         //
-        // We can't just use `decrement_balance` in both pre- and post-T8 codepaths, because `decrement_balance`
-        // charges gas for balance SLOAD that we already do above for pre-T8.
+        // We use `decrement_balance` only in the post-T8 path because it charges gas for a balance
+        // SLOAD. In the pre-T8 path we perform two SLOADs: the first above (for the over-spend
+        // check) and a second below (to obtain the post-rewards balance after
+        // `handle_rewards_on_transfer` may have mutated it). A future optimization could have
+        // `handle_rewards_on_transfer` return the updated balance to avoid the extra read.
         if from_balance.is_some() {
             // pre-T8 path: re-read balance after handle_rewards_on_transfer to avoid
             // silently overwriting any mutations it applied to the sender's balance

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -1212,9 +1212,11 @@ impl TIP20Token {
         //
         // We can't just use `decrement_balance` in both pre- and post-T8 codepaths, because `decrement_balance`
         // charges gas for balance SLOAD that we already do above for pre-T8.
-        if let Some(from_balance) = from_balance {
-            // pre-T8 path
-            let new_from_balance = from_balance
+        if from_balance.is_some() {
+            // pre-T8 path: re-read balance after handle_rewards_on_transfer to avoid
+            // silently overwriting any mutations it applied to the sender's balance
+            let current_balance = self.get_balance(from)?;
+            let new_from_balance = current_balance
                 .checked_sub(amount)
                 .ok_or(TempoPrecompileError::under_overflow())?;
 


### PR DESCRIPTION
## Summary

Fixes a stale-read bug in the pre-T8 `_transfer` code path in `crates/precompiles/src/tip20/mod.rs`.

## Problem

`_transfer` reads `from_balance` at line 1202, then calls `handle_rewards_on_transfer` at line 1213 which can mutate the sender's balance. The pre-T8 path then computed `new_from_balance = from_balance - amount` using the **stale** pre-mutation value and called `set_balance`, silently overwriting whatever reward credits `handle_rewards_on_transfer` had written.

The post-T8 path correctly avoids this via `decrement_balance` (atomic read + decrement).

## Fix

Re-read the sender's balance after `handle_rewards_on_transfer` completes, so the deduction is applied to the correct post-rewards balance.

## Related

Closes #7111