### PR TITLE
fix(stablecoin_dex): add cycle detection to find_path_to_root

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -1758,9 +1758,16 @@ impl StablecoinDEX {
     /// Returns a vector of addresses starting with the token and ending with pathUSD
     fn find_path_to_root(&self, mut token: Address) -> Result<Vec<Address>> {
         let mut path = vec![token];
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(token);
 
         while token != PATH_USD_ADDRESS {
             token = TIP20Token::from_address(token)?.quote_token()?;
+            // Detect cycles: if we've seen this token before, the quote_token
+            // chain never reaches PATH_USD_ADDRESS and would loop forever.
+            if !visited.insert(token) {
+                return Err(StablecoinDEXError::invalid_token().into());
+            }
             path.push(token);
         }
 


### PR DESCRIPTION
## Summary

Fixes an unbounded loop vulnerability in `find_path_to_root` in `crates/precompiles/src/stablecoin_dex/mod.rs`.

## Problem

`find_path_to_root` iterated through a token's `quote_token` chain with no cycle detection or depth limit. A token whose chain forms a cycle (A → B → A) or never reaches `PATH_USD_ADDRESS` would cause the function to loop forever, consuming all gas and guaranteeing OOG revert on every call.

## Fix

Track visited addresses in a `HashSet`. If a token is encountered a second time, return `StablecoinDEXError::invalid_token()` immediately, breaking the loop and surfacing a clear error to the caller.

## Related

Closes #7113