### PR TITLE
fix(stablecoin_dex): use checked_sub in partial_fill_order

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -997,7 +997,9 @@ impl StablecoinDEX {
         let orderbook = self.books[order.book_key()].read()?;
 
         // Update order remaining amount
-        let new_remaining = order.remaining() - fill_amount;
+        let new_remaining = order.remaining()
+            .checked_sub(fill_amount)
+            .ok_or(TempoPrecompileError::under_overflow())?;
         self.orders[order.order_id()]
             .remaining()?
             .write(new_remaining)?;


### PR DESCRIPTION
## Summary

Fixes an unchecked subtraction in `partial_fill_order` in `crates/precompiles/src/stablecoin_dex/mod.rs`.

## Problem

`order.remaining() - fill_amount` used plain `-` instead of `checked_sub`. If `fill_amount` exceeds the order's remaining amount, this panics in debug builds and silently wraps to a very large `u128` value in release builds, corrupting the order's remaining amount in storage.

Every other arithmetic operation in this file uses `checked_sub` / `checked_add` this was an inconsistency.

## Fix

Replace with `checked_sub(...).ok_or(TempoPrecompileError::under_overflow())?` to match the rest of the codebase.

## Related

Closes #7115