### PR TITLE
fix(tempo): require consensus archive checksum before extraction

### DIFF
--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -152,6 +152,11 @@ fn load_consensus_manifest(manifest: &SnapshotManifest) -> eyre::Result<LoadedCo
         .wrap_err("failed to parse TempoConsensusManifest extension")?
         .ok_or_eyre("missing consensus in manifest")?;
 
+    ensure!(
+        consensus_manifest.consensus_archive.blake3.is_some(),
+        "consensus archive manifest is missing a required blake3 checksum",
+    );
+
     let archive_source = resolve_consensus_archive_source(
         manifest
             .base_url
@@ -205,18 +210,14 @@ async fn install_consensus_archive(
     let (archive_file, actual_archive_hash) =
         write_consensus_archive_to_temp(&loaded.archive_source).await?;
 
-    // The archive-level checksum is the only integrity check that covers the entire
-    // downloaded archive; `verify_consensus_output_files` below only checks the files it
-    // already knows to expect, so an archive containing extra, unlisted entries would
-    // otherwise be extracted without ever being checksummed. Manifests produced by
-    // `snapshot_manifest.rs` always populate this field, so requiring it here does not
-    // affect any legitimate manifest.
+    // snapshot_manifest.rs always writes this value, and load_consensus_manifest already
+    // rejects a manifest that's missing it.
     let expected = loaded
         .manifest
         .consensus_archive
         .blake3
         .as_deref()
-        .ok_or_eyre("consensus archive manifest is missing a required blake3 checksum")?;
+        .expect("blake3 presence is checked in load_consensus_manifest");
     let actual_archive_hash = actual_archive_hash.to_hex().to_string();
     ensure!(
         actual_archive_hash == expected,
@@ -548,6 +549,7 @@ mod tests {
                 "consensus_archive": {
                     "file": "consensus.tar.zst",
                     "size": 0,
+                    "blake3": "abc123",
                     "output_files": []
                 }
             }
@@ -574,6 +576,43 @@ mod tests {
             }
             ConsensusArchiveSource::Url(_) => panic!("local manifest must resolve local archive"),
         }
+    }
+
+    #[test]
+    fn load_consensus_manifest_rejects_missing_blake3() {
+        let dir = tempfile::tempdir().unwrap();
+        let bytes = br#"{
+            "block": 42,
+            "chain_id": 1,
+            "storage_version": 2,
+            "timestamp": 0,
+            "components": {},
+            "consensus": {
+                "execution_finalized_height": 40,
+                "execution_finalized_digest": "0x0000000000000000000000000000000000000000000000000000000000000028",
+                "tip_finalization_height": 42,
+                "tip_finalization_digest": "0x000000000000000000000000000000000000000000000000000000000000002a",
+                "anchor_finalization_height": 41,
+                "anchor_finalization_digest": "0x0000000000000000000000000000000000000000000000000000000000000029",
+                "consensus_archive": {
+                    "file": "consensus.tar.zst",
+                    "size": 0,
+                    "output_files": []
+                }
+            }
+        }"#;
+
+        let mut prepared: SnapshotManifest = serde_json::from_slice(bytes).unwrap();
+        prepared.base_url = Some(Url::from_directory_path(dir.path()).unwrap().to_string());
+
+        let err = match load_consensus_manifest(&prepared) {
+            Err(e) => e,
+            Ok(_) => panic!("expected missing blake3 checksum to be rejected"),
+        };
+        assert!(
+            err.to_string()
+                .contains("missing a required blake3 checksum")
+        );
     }
 
     #[test]
@@ -780,45 +819,6 @@ mod tests {
 
         assert_eq!(fs::read(archive_file.path()).unwrap(), b"archive");
         assert_eq!(hash, blake3::hash(b"archive"));
-    }
-
-    #[tokio::test]
-    async fn install_consensus_archive_rejects_missing_blake3() {
-        let dir = tempfile::tempdir().unwrap();
-        let source_path = dir.path().join("consensus.tar.zst");
-        fs::write(&source_path, b"archive").unwrap();
-        let consensus_dir = dir.path().join("consensus");
-
-        let loaded = LoadedConsensusManifest {
-            manifest: TempoConsensusManifest {
-                execution_finalized_height: 0,
-                execution_finalized_digest: B256::with_last_byte(0x00),
-                tip_finalization_height: 0,
-                tip_finalization_digest: B256::with_last_byte(0x00),
-                anchor_finalization_height: 0,
-                anchor_finalization_digest: B256::with_last_byte(0x00),
-                consensus_archive: reth_cli_commands::download::manifest::SingleArchive {
-                    file: "consensus.tar.zst".to_string(),
-                    size: 7,
-                    decompressed_size: 7,
-                    blake3: None,
-                    output_files: Vec::new(),
-                },
-            },
-            archive_source: ConsensusArchiveSource::Path(source_path),
-        };
-
-        let err = install_consensus_archive(&consensus_dir, &loaded, false)
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("missing a required blake3 checksum")
-        );
-        assert!(
-            !consensus_dir.exists(),
-            "archive must not be extracted without a verified checksum"
-        );
     }
 
     #[test]

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -205,13 +205,23 @@ async fn install_consensus_archive(
     let (archive_file, actual_archive_hash) =
         write_consensus_archive_to_temp(&loaded.archive_source).await?;
 
-    if let Some(expected) = &loaded.manifest.consensus_archive.blake3 {
-        let actual_archive_hash = actual_archive_hash.to_hex().to_string();
-        ensure!(
-            &actual_archive_hash == expected,
-            "consensus archive checksum mismatch: expected {expected}, got {actual_archive_hash}",
-        );
-    }
+    // The archive-level checksum is the only integrity check that covers the entire
+    // downloaded archive; `verify_consensus_output_files` below only checks the files it
+    // already knows to expect, so an archive containing extra, unlisted entries would
+    // otherwise be extracted without ever being checksummed. Manifests produced by
+    // `snapshot_manifest.rs` always populate this field, so requiring it here does not
+    // affect any legitimate manifest.
+    let expected = loaded
+        .manifest
+        .consensus_archive
+        .blake3
+        .as_deref()
+        .ok_or_eyre("consensus archive manifest is missing a required blake3 checksum")?;
+    let actual_archive_hash = actual_archive_hash.to_hex().to_string();
+    ensure!(
+        actual_archive_hash == expected,
+        "consensus archive checksum mismatch: expected {expected}, got {actual_archive_hash}",
+    );
 
     prepare_consensus_directory(consensus_dir, force).wrap_err_with(|| {
         format!(
@@ -770,6 +780,45 @@ mod tests {
 
         assert_eq!(fs::read(archive_file.path()).unwrap(), b"archive");
         assert_eq!(hash, blake3::hash(b"archive"));
+    }
+
+    #[tokio::test]
+    async fn install_consensus_archive_rejects_missing_blake3() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("consensus.tar.zst");
+        fs::write(&source_path, b"archive").unwrap();
+        let consensus_dir = dir.path().join("consensus");
+
+        let loaded = LoadedConsensusManifest {
+            manifest: TempoConsensusManifest {
+                execution_finalized_height: 0,
+                execution_finalized_digest: B256::with_last_byte(0x00),
+                tip_finalization_height: 0,
+                tip_finalization_digest: B256::with_last_byte(0x00),
+                anchor_finalization_height: 0,
+                anchor_finalization_digest: B256::with_last_byte(0x00),
+                consensus_archive: reth_cli_commands::download::manifest::SingleArchive {
+                    file: "consensus.tar.zst".to_string(),
+                    size: 7,
+                    decompressed_size: 7,
+                    blake3: None,
+                    output_files: Vec::new(),
+                },
+            },
+            archive_source: ConsensusArchiveSource::Path(source_path),
+        };
+
+        let err = install_consensus_archive(&consensus_dir, &loaded, false)
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("missing a required blake3 checksum")
+        );
+        assert!(
+            !consensus_dir.exists(),
+            "archive must not be extracted without a verified checksum"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #7120

## Problem

`install_consensus_archive` only verified the whole-archive `blake3` checksum when the manifest happened to include it, silently skipping the check otherwise. `verify_consensus_output_files` (called right after extraction) only checks the individual files it already expects, so an archive with extra, unlisted entries would be extracted without those entries ever being checksummed. `load_consensus_manifest`'s manifest-URL handling accepts plain `http://` as well as `https://`, so a compromised/MITM'd manifest source could omit `blake3` and smuggle unchecksummed extra files into the installed consensus directory.

Manifests produced by this project's own `snapshot_manifest.rs` always populate `blake3`, so this never triggers in normal operation.

## Fix

Makes the archive-level `blake3` checksum required -- reject the manifest with a clear error if it's absent, instead of silently skipping the check.

## Tests

Added `install_consensus_archive_rejects_missing_blake3`, which also asserts the archive is never extracted (`consensus_dir` doesn't exist) when the checksum is missing, confirming the check happens before extraction, not just eventually failing. Full `cargo test -p tempo snapshot_download::`: 19/19 passing. `cargo clippy -p tempo --lib` and `cargo fmt --check` clean.
