### PR TITLE
fix(ci): use GitHub STS for upstream sync

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,7 +1,6 @@
 subject:
   - repo:tempoxyz/tempo-firedrill:ref:refs/heads/main
   - repo:tempoxyz/tempo-private-fork:ref:refs/heads/main
-  - repo:tempoxyz/tempo-wishfulcynic:ref:refs/heads/main
 permissions:
   contents: write
   workflows: write

--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,0 +1,7 @@
+subject:
+  - repo:tempoxyz/tempo-firedrill:ref:refs/heads/main
+  - repo:tempoxyz/tempo-private-fork:ref:refs/heads/main
+  - repo:tempoxyz/tempo-wishfulcynic:ref:refs/heads/main
+permissions:
+  contents: write
+  workflows: write

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -8,25 +8,24 @@ on:
     - cron: "0 * * * *" # hourly, backup in case the webhook fails
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   sync:
     if: ${{ github.repository != 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - name: Generate GitHub token
+        id: sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
         with:
-          client-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-workflows: write
+          policy: sync-from-upstream
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.sts.outputs.token }}
           fetch-depth: 0
 
       - name: Sync main with upstream
@@ -37,4 +36,4 @@ jobs:
           git reset --hard upstream/main
           git push origin main --force
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.sts.outputs.token }}


### PR DESCRIPTION
Replaces repository App credentials with Tempo GitHub STS for fork synchronization.

Adds a repository-owned policy for the known Tempo copies so the policy survives each force-sync from upstream.

Prompted by: @kamsz