### PR TITLE
docs: fix grammar in operator getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ While the execution environment mirrors Ethereum's, Tempo introduces some differ
 
 ## Getting Started
 
-### As a user
+### As an operator
 
 You can connect to Tempo's public testnet using the following details:
 


### PR DESCRIPTION
Corrected "As a operator" to "As an operator" in the README getting started section for grammar consistency.