### PR TITLE
fix(stablecoin_dex): use checked_sub in partial_fill_order to prevent…

### DIFF
--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -997,7 +997,10 @@ impl StablecoinDEX {
         let orderbook = self.books[order.book_key()].read()?;
 
         // Update order remaining amount
-        let new_remaining = order.remaining() - fill_amount;
+        let new_remaining = order
+            .remaining()
+            .checked_sub(fill_amount)
+            .ok_or(TempoPrecompileError::under_overflow())?;
         self.orders[order.order_id()]
             .remaining()?
             .write(new_remaining)?;


### PR DESCRIPTION
## Summary
Fixes #7115 and #7116.

Replaces unchecked subtraction `order.remaining() - fill_amount` in `partial_fill_order` with `.checked_sub(fill_amount).ok_or(TempoPrecompileError::under_overflow())?`.

## Rationale
Prevents potential underflow panics or integer wrapping when partial fill amounts exceed remaining order balances in the DEX precompile.