### PR TITLE
fix(tempoup): name the correct unsigned release boundary

### DIFF
--- a/tempoup/tempoup
+++ b/tempoup/tempoup
@@ -6,11 +6,14 @@ set -e
 
 # NOTE: if you make modifications to this script, please increment the version number.
 # WARNING: the SemVer pattern: major.minor.patch must be followed as we use it to determine if the script is up to date.
-TEMPOUP_INSTALLER_VERSION="0.0.14"
+TEMPOUP_INSTALLER_VERSION="0.0.15"
 
 REPO="tempoxyz/tempo"
 # GPG key fingerprint for release signing verification
 GPG_KEY_FINGERPRINT="EE3C5D41EA963E896F310EC3CBBFA54B20D33446"
+# Releases up to and including this version were published without a detached
+# GPG signature, so there is no `.asc` asset to verify for them.
+LAST_UNSIGNED_VERSION="1.1.2"
 BIN_DIR="${TEMPO_BIN_DIR:-$HOME/.tempo/bin}"
 TEMPOUP_BIN_URL="https://raw.githubusercontent.com/tempoxyz/tempo/main/tempoup/tempoup"
 TEMPOUP_BIN_PATH="$BIN_DIR/tempoup"
@@ -520,7 +523,7 @@ main() {
         warn "Release integrity verification skipped (--unsafe-skip-verify)."
     elif gh_authenticated; then
         verify_attestation "$ARCHIVE_PATH"
-    elif version_gt "$VERSION_TAG" "1.1.2"; then
+    elif version_gt "$VERSION_TAG" "$LAST_UNSIGNED_VERSION"; then
         if command -v gpg >/dev/null 2>&1; then
             info "Verifying GPG signature..."
             download_file "$VERSION_TAG" "${ARCHIVE_NAME}.asc" "$TMP_DIR"
@@ -549,7 +552,7 @@ main() {
             error "gh is unavailable or unauthenticated, and gpg was not found. Run 'gh auth login', install gpg, or re-run with --unsafe-skip-verify to bypass integrity verification."
         fi
     else
-        info "Skipping GPG signature verification (not available for versions <= 1.1.1)"
+        warn "Skipping GPG signature verification: releases up to and including v${LAST_UNSIGNED_VERSION} were published without a .asc signature. Only the SHA256 checksum was verified."
     fi
 
     # Extract archive

--- a/tempoup/test-tempoup.sh
+++ b/tempoup/test-tempoup.sh
@@ -208,3 +208,41 @@ fi
 [[ "$(cat "$ROLLBACK_DIR/tempo")" == "old tempo" ]] || fail "failed upgrade did not restore old tempo"
 [[ ! -e "$ROLLBACK_DIR/tempo.old" ]] || fail "failed upgrade left backup behind"
 ok "failed upgrade restores old tempo"
+
+# `version_gt` gates GPG signature verification, so its boundary behaviour is
+# security relevant: a version that is wrongly reported as older than
+# LAST_UNSIGNED_VERSION silently installs without a signature check.
+version_gt_case() {
+    local newer="$1" older="$2" expected="$3"
+    local actual
+
+    if run_tempoup "version_gt $(q "$newer") $(q "$older")"; then
+        actual="gt"
+    else
+        actual="not-gt"
+    fi
+
+    [[ "$actual" == "$expected" ]] ||
+        fail "version_gt $newer $older returned $actual, expected $expected"
+}
+
+version_gt_case "v1.1.3" "1.1.2" "gt"
+version_gt_case "v1.2.0" "1.1.2" "gt"
+version_gt_case "v1.12.0" "1.1.2" "gt"
+version_gt_case "v2.0.0" "1.1.2" "gt"
+version_gt_case "v1.1.2" "1.1.2" "not-gt"
+version_gt_case "v1.1.1" "1.1.2" "not-gt"
+version_gt_case "v1.0.9" "1.1.2" "not-gt"
+ok "version_gt orders release tags around the signing boundary"
+
+# The gate and the message it prints must reference the same constant,
+# otherwise the message names a different release than the one that actually
+# skips signature verification.
+TEMPOUP_SCRIPT="$ROOT_DIR/tempoup/tempoup"
+grep -q 'version_gt "$VERSION_TAG" "$LAST_UNSIGNED_VERSION"' "$TEMPOUP_SCRIPT" ||
+    fail "signature gate no longer compares against LAST_UNSIGNED_VERSION"
+grep -q 'Skipping GPG signature verification.*\${LAST_UNSIGNED_VERSION}' "$TEMPOUP_SCRIPT" ||
+    fail "skip message no longer names LAST_UNSIGNED_VERSION"
+grep -qE '^\s*warn "Skipping GPG signature verification' "$TEMPOUP_SCRIPT" ||
+    fail "unsigned-release skip is not reported at warn level"
+ok "unsigned-release skip message is tied to the gating version"


### PR DESCRIPTION
The GPG gate skips signature verification for releases at or below v1.1.2, but the skip message said signatures were unavailable for `<= 1.1.1`. Neither v1.1.1 nor v1.1.2 publishes a `.asc` asset, so the condition was correct and the message named a release one below the real boundary.

Both now read a single `LAST_UNSIGNED_VERSION` constant so they cannot drift apart again, and the skip is reported at warn level since `preflight_dependencies` has already told the user signature verification is enabled.

Added `version_gt` boundary cases and an assertion that the gate and its message reference the same constant. That assertion fails on `main` and passes here.
