### PR TITLE
chore: allow unmaintained bitmaps advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,10 @@ ignore = [
   # https://rustsec.org/advisories/RUSTSEC-2026-0173 proc-macro-error2 is unmaintained
   # and is pulled in transitively by upstream crates with no safe upgrade available.
   "RUSTSEC-2026-0173",
+  # https://rustsec.org/advisories/RUSTSEC-2026-0247 bitmaps is unmaintained.
+  # It is pulled in transitively by reth-transaction-pool through imbl, which has
+  # no release that removes bitmaps. This advisory does not report a vulnerability.
+  "RUSTSEC-2026-0247",
   # https://rustsec.org/advisories/RUSTSEC-2025-0055 tracing-subscriber 0.2
   # is pulled in by ark-relations 0.5.1, which is pinned by commonware-cryptography.
   # ark-relations 0.5.1 requires tracing-subscriber ^0.2, so this cannot be upgraded


### PR DESCRIPTION
Allows RUSTSEC-2026-0247 so the dependency advisory gate no longer fails solely because `bitmaps` is unmaintained. The advisory does not identify a vulnerability; `bitmaps` is currently pulled in transitively by `reth-transaction-pool 2.4.1` through `imbl`, and neither `imbl 7.0.0` nor 7.0.1 removes it.

There is no safe dependency-only upgrade today. This is a temporary exception while upstream evaluates replacing `imbl::OrdMap` or removing its `bitmaps` dependency.

Validation: `cargo deny check advisories`

Failure: https://github.com/tempoxyz/tempo/actions/runs/31425242640/job/93575272083
Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0247
Upstream dependency rationale: https://github.com/paradigmxyz/reth/pull/23621

Prompted by: @pepyakin
