### PR TITLE
fix(faucet): require at least one faucet address

### DIFF
--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -40,7 +40,7 @@ pub struct FaucetArgs {
         long = "faucet.address",
         requires = "faucet.enabled",
         required_if_eq("faucet.enabled", "true"),
-        num_args(0..)
+        num_args(1..)
     )]
     pub token_addresses: Option<Vec<Address>>,
 
@@ -96,8 +96,48 @@ mod tests {
         args: FaucetArgs,
     }
 
+    const PRIVATE_KEY: &str =
+        "0x0000000000000000000000000000000000000000000000000000000000000001";
+    const TOKEN_A: &str = "0x0000000000000000000000000000000000000001";
+    const TOKEN_B: &str = "0x0000000000000000000000000000000000000002";
+
+    fn faucet_args() -> Vec<&'static str> {
+        vec![
+            "tempo",
+            "--faucet.enabled",
+            "--faucet.private-key",
+            PRIVATE_KEY,
+            "--faucet.amount",
+            "1",
+            "--faucet.address",
+        ]
+    }
+
     #[test]
     fn faucet_args_default_sanity_test() {
         assert!(CommandParser::try_parse_from(["tempo"]).is_ok());
+    }
+
+    #[test]
+    fn faucet_enabled_rejects_empty_address_list() {
+        assert!(CommandParser::try_parse_from(faucet_args()).is_err());
+    }
+
+    #[test]
+    fn faucet_enabled_accepts_single_address() {
+        let mut args = faucet_args();
+        args.push(TOKEN_A);
+
+        let parsed = CommandParser::try_parse_from(args).expect("single faucet address should parse");
+        assert_eq!(parsed.args.addresses().len(), 1);
+    }
+
+    #[test]
+    fn faucet_enabled_accepts_multiple_addresses() {
+        let mut args = faucet_args();
+        args.extend([TOKEN_A, TOKEN_B]);
+
+        let parsed = CommandParser::try_parse_from(args).expect("multiple faucet addresses should parse");
+        assert_eq!(parsed.args.addresses().len(), 2);
     }
 }


### PR DESCRIPTION
Fixes #6951.

When the faucet is enabled, `--faucet.address` is required, but the current `num_args(0..)` declaration allows the flag to be present with no values and parses it as an empty list.

This change:
- requires at least one value with `num_args(1..)`;
- adds parser coverage that rejects an empty address list;
- verifies that single- and multi-token faucet configurations still parse successfully.

The RPC behavior for valid faucet configurations is unchanged.