### PR TITLE
ci(bench): report total fees in benchmark summaries

### DIFF
--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -191,6 +191,35 @@ function fmtKiB(value) {
   return Number.isFinite(value) ? (value / 1024).toFixed(1) : '-';
 }
 
+function sumFees(runs) {
+  const fees = runs
+    .map(run => run.total_fees_paid)
+    .filter(value => typeof value === 'string' && /^\d+$/.test(value));
+  if (fees.length === 0) return null;
+  return fees.reduce((total, value) => total + BigInt(value), 0n).toString();
+}
+
+function fmtFees(value) {
+  if (typeof value !== 'string' || !/^\d+$/.test(value)) return '-';
+  const microdollars = BigInt(value);
+  const dollars = microdollars / 1_000_000n;
+  const fraction = (microdollars % 1_000_000n)
+    .toString()
+    .padStart(6, '0')
+    .replace(/0+$/, '')
+    .padEnd(2, '0');
+  return `$${dollars.toLocaleString('en-US')}.${fraction}`;
+}
+
+function fmtFeeChange(base, feature) {
+  if (typeof base !== 'string' || typeof feature !== 'string') return '';
+  const baseline = BigInt(base);
+  const candidate = BigInt(feature);
+  if (baseline === 0n) return candidate === 0n ? '0.00%' : 'n/a';
+  const basisPoints = ((candidate - baseline) * 1_000_000n) / baseline;
+  return `${basisPoints >= 0n ? '+' : ''}${(Number(basisPoints) / 10_000).toFixed(2)}%`;
+}
+
 function fmtChange(change) {
   if (!change || change.pct == null) return '';
   const sign = change.pct >= 0 ? '+' : '';
@@ -262,6 +291,11 @@ function buildMarkdown(summary) {
       const f = formatter(summary.results.feature[axis]);
       lines.push(`| ${label} | ${b} | ${f} | ${fmtChange(summary.results.changes[axis])} |`);
     }
+    if (section.title === 'Tempo Metrics') {
+      const b = summary.results.baseline.total_fees_paid;
+      const f = summary.results.feature.total_fees_paid;
+      lines.push(`| Total Fees Paid [USD] | ${fmtFees(b)} | ${fmtFees(f)} | ${fmtFeeChange(b, f)} |`);
+    }
     if (section.title === 'Builder') appendBuilderDetails(lines, summary);
     lines.push('');
   }
@@ -279,6 +313,8 @@ function main(resultsDir = process.argv[2]) {
   const runs = summary.per_run || [];
   const baselineRuns = runs.filter(r => /^baseline/.test(r.label));
   const featureRuns = runs.filter(r => /^feature/.test(r.label));
+  summary.results.baseline.total_fees_paid = sumFees(baselineRuns);
+  summary.results.feature.total_fees_paid = sumFees(featureRuns);
   const rand = rng(42);
 
   const changes = {};

--- a/.github/scripts/bench-e2e-classify.js
+++ b/.github/scripts/bench-e2e-classify.js
@@ -201,13 +201,10 @@ function sumFees(runs) {
 
 function fmtFees(value) {
   if (typeof value !== 'string' || !/^\d+$/.test(value)) return '-';
-  const microdollars = BigInt(value);
-  const dollars = microdollars / 1_000_000n;
-  const fraction = (microdollars % 1_000_000n)
-    .toString()
-    .padStart(6, '0')
-    .replace(/0+$/, '')
-    .padEnd(2, '0');
+  const attodollars = BigInt(value);
+  const cents = (attodollars + 5_000_000_000_000_000n) / 10_000_000_000_000_000n;
+  const dollars = cents / 100n;
+  const fraction = (cents % 100n).toString().padStart(2, '0');
   return `$${dollars.toLocaleString('en-US')}.${fraction}`;
 }
 

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -68,13 +68,10 @@ function fmtVal(v, suffix = '', precision = 2) { return v != null ? v.toFixed(pr
 function fmtS(v) { return v != null ? v.toFixed(2) + 's' : '-'; }
 function fmtFees(v) {
   if (typeof v !== 'string' || !/^\d+$/.test(v)) return '-';
-  const microdollars = BigInt(v);
-  const dollars = microdollars / 1_000_000n;
-  const fraction = (microdollars % 1_000_000n)
-    .toString()
-    .padStart(6, '0')
-    .replace(/0+$/, '')
-    .padEnd(2, '0');
+  const attodollars = BigInt(v);
+  const cents = (attodollars + 5_000_000_000_000_000n) / 10_000_000_000_000_000n;
+  const dollars = cents / 100n;
+  const fraction = (cents % 100n).toString().padStart(2, '0');
   return `$${dollars.toLocaleString('en-US')}.${fraction}`;
 }
 

--- a/.github/scripts/bench-slack-notify.js
+++ b/.github/scripts/bench-slack-notify.js
@@ -66,6 +66,17 @@ function cell(text) {
 function fmtMs(v) { return v != null ? v.toFixed(2) + 'ms' : '-'; }
 function fmtVal(v, suffix = '', precision = 2) { return v != null ? v.toFixed(precision) + suffix : '-'; }
 function fmtS(v) { return v != null ? v.toFixed(2) + 's' : '-'; }
+function fmtFees(v) {
+  if (typeof v !== 'string' || !/^\d+$/.test(v)) return '-';
+  const microdollars = BigInt(v);
+  const dollars = microdollars / 1_000_000n;
+  const fraction = (microdollars % 1_000_000n)
+    .toString()
+    .padStart(6, '0')
+    .replace(/0+$/, '')
+    .padEnd(2, '0');
+  return `$${dollars.toLocaleString('en-US')}.${fraction}`;
+}
 
 function classifyPctChange(pct, lowerIsBetter) {
   if (pct == null || Math.abs(pct) < THRESHOLD_PCT) return 'neutral';
@@ -142,6 +153,7 @@ function buildMetricRows(summary) {
   return [
     { label: 'TPS Mean',        baseline: fmtVal(b.tps, '', 0),     feature: fmtVal(f.tps, '', 0),     change: fmtChange(c.tps) },
     { label: 'Gas/s',           baseline: fmtVal(b.mgas_s, ' Mgas/s', 1), feature: fmtVal(f.mgas_s, ' Mgas/s', 1), change: fmtChange(c.mgas_s) },
+    { label: 'Total Fees',      baseline: fmtFees(b.total_fees_paid), feature: fmtFees(f.total_fees_paid), change: '' },
     { label: 'Block Time Mean', baseline: fmtMs(b.block_time_mean), feature: fmtMs(f.block_time_mean), change: fmtChange(c.block_time_mean) },
     { label: 'Block P50',       baseline: fmtMs(b.block_time_p50),  feature: fmtMs(f.block_time_p50),  change: fmtChange(c.block_time_p50) },
     { label: 'Block P90',       baseline: fmtMs(b.block_time_p90),  feature: fmtMs(f.block_time_p90),  change: fmtChange(c.block_time_p90) },
@@ -365,6 +377,81 @@ async function failure({ core, context, failedStep }) {
   } else {
     core.info(`No Slack user mapping for GitHub user '${actor}', skipping DM`);
   }
+}
+
+function multiRegionFeeTotals(resultsDir) {
+  const totals = { baseline: null, feature: null };
+  const sums = { baseline: 0n, feature: 0n };
+  const counts = { baseline: 0, feature: 0 };
+
+  for (const name of fs.readdirSync(resultsDir)) {
+    const match = /^report-(baseline|feature)[^.]*\.json$/.exec(name);
+    if (!match) continue;
+    const side = match[1];
+    const wrapper = JSON.parse(fs.readFileSync(path.join(resultsDir, name), 'utf8'));
+    const label = name.slice('report-'.length, -'.json'.length);
+    const txgenPath = path.join(resultsDir, label, wrapper.txgen_report || 'txgen-report.json');
+    if (!fs.existsSync(txgenPath)) continue;
+    const value = JSON.parse(fs.readFileSync(txgenPath, 'utf8')).total_fees_paid;
+    if (typeof value !== 'string' || !/^\d+$/.test(value)) continue;
+    sums[side] += BigInt(value);
+    counts[side] += 1;
+  }
+  for (const side of ['baseline', 'feature']) {
+    if (counts[side] > 0) totals[side] = sums[side].toString();
+  }
+  return totals;
+}
+
+function addMultiRegionFees(resultsDir) {
+  const summaryPath = path.join(resultsDir, 'summary.json');
+  const markdownPath = path.join(resultsDir, 'summary.md');
+  const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+  summary.fees = multiRegionFeeTotals(resultsDir);
+  fs.writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+
+  let markdown = fs.readFileSync(markdownPath, 'utf8').replace(/\n## Fees\n[\s\S]*?(?=\n## |$)/, '');
+  markdown = `${markdown.trimEnd()}\n\n## Fees\n\n| Metric | Baseline | Feature |\n|--------|----------|---------|\n| Total Fees Paid [USD] | ${fmtFees(summary.fees.baseline)} | ${fmtFees(summary.fees.feature)} |\n`;
+  fs.writeFileSync(markdownPath, markdown);
+  return summary;
+}
+
+async function multiRegionSuccess({ core, context }) {
+  const token = process.env.SLACK_BENCH_BOT_TOKEN;
+  const channel = process.env.SLACK_BENCH_CHANNEL;
+  if (!token || !channel) {
+    core.info('Slack credentials not set, skipping multi-region notification');
+    return;
+  }
+  const summary = addMultiRegionFees(process.env.BENCH_WORK_DIR);
+  const repo = `${context.repo.owner}/${context.repo.repo}`;
+  const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${repo}/actions/runs/${context.runId}`;
+  const baseline = summary.aggregate?.baseline || {};
+  const feature = summary.aggregate?.feature || {};
+  const number = (value, precision = 1, suffix = '') =>
+    Number.isFinite(value) ? `${value.toFixed(precision)}${suffix}` : '-';
+  const rows = [
+    ['TPS Mean', number(baseline.chain_tps_mean), number(feature.chain_tps_mean)],
+    ['Success Rate', number(baseline.success_rate, 2, '%'), number(feature.success_rate, 2, '%')],
+    ['Block Time P50', number(baseline.block_time_p50_ms, 1, 'ms'), number(feature.block_time_p50_ms, 1, 'ms')],
+    ['Block Time P90', number(baseline.block_time_p90_ms, 1, 'ms'), number(feature.block_time_p90_ms, 1, 'ms')],
+    ['Block Time P99', number(baseline.block_time_p99_ms, 1, 'ms'), number(feature.block_time_p99_ms, 1, 'ms')],
+    ['Total Fees', fmtFees(summary.fees.baseline), fmtFees(summary.fees.feature)],
+  ];
+  const blocks = [
+    { type: 'header', text: { type: 'plain_text', text: ':white_check_mark: Tempo Multi-Region Bench', emoji: true } },
+    { type: 'section', text: { type: 'mrkdwn', text: `*Repo:* ${repoLink(repo)}\n*Triggered by:* @${process.env.BENCH_ACTOR || context.actor}` } },
+    {
+      type: 'table',
+      column_settings: [{ align: 'left' }, { align: 'right' }, { align: 'right' }],
+      rows: [
+        [cell('Metric'), cell('Baseline'), cell('Feature')],
+        ...rows.map(row => row.map(cell)),
+      ],
+    },
+    { type: 'actions', elements: [{ type: 'button', text: { type: 'plain_text', text: 'CI :github:', emoji: true }, url: jobUrl, action_id: 'ci_button' }] },
+  ];
+  await postToSlack(token, channel, blocks, 'Tempo multi-region benchmark fees', core);
 }
 
 function shortRef(ref) {
@@ -629,6 +716,10 @@ module.exports = {
   e2e: {
     success,
     failure,
+  },
+  multiRegion: {
+    addFees: addMultiRegionFees,
+    success: multiRegionSuccess,
   },
   replay: {
     success: replaySuccess,

--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -180,6 +180,8 @@ jobs:
       CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
       VICTORIALOGS_URL: ${{ secrets.VICTORIALOGS_URL }}
       VICTORIAMETRICS_URL: ${{ secrets.VICTORIAMETRICS_URL }}
+      SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+      SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
 
   save-state:
     needs: [resolve-refs, bench-e2e-multi-region]

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -84,6 +84,10 @@ on:
         required: false
       VICTORIAMETRICS_URL:
         required: false
+      SLACK_BENCH_BOT_TOKEN:
+        required: false
+      SLACK_BENCH_CHANNEL:
+        required: false
   workflow_dispatch:
     inputs:
       cloud:
@@ -293,6 +297,8 @@ jobs:
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
       CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
+      SLACK_BENCH_BOT_TOKEN: ${{ secrets.SLACK_BENCH_BOT_TOKEN }}
+      SLACK_BENCH_CHANNEL: ${{ secrets.SLACK_BENCH_CHANNEL }}
 
     steps:
       - name: Fetch GitHub token via STS
@@ -320,26 +326,31 @@ jobs:
 
             core.setFailed(`@${username} is not a member of ${org}`);
 
-      - name: Fetch ClickHouse metric allowlist
+      - name: Fetch benchmark support files
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
-            const path = 'contrib/bench/clickhouse-metrics.txt';
-            const { data } = await github.rest.repos.getContent({
-              owner: 'tempoxyz',
-              repo: 'tempo',
-              path,
-              ref: context.repo.owner === 'tempoxyz' && context.repo.repo === 'tempo' ? context.sha : 'main',
-            });
+            const paths = [
+              'contrib/bench/clickhouse-metrics.txt',
+              '.github/scripts/bench-slack-notify.js',
+            ];
+            for (const path of paths) {
+              const { data } = await github.rest.repos.getContent({
+                owner: 'tempoxyz',
+                repo: 'tempo',
+                path,
+                ref: context.repo.owner === 'tempoxyz' && context.repo.repo === 'tempo' ? context.sha : 'main',
+              });
 
-            if (Array.isArray(data) || data.type !== 'file' || !data.content) {
-              core.setFailed(`Expected ${path} to be a file at ${context.sha}`);
-              return;
+              if (Array.isArray(data) || data.type !== 'file' || !data.content) {
+                core.setFailed(`Expected ${path} to be a file at ${context.sha}`);
+                return;
+              }
+
+              fs.mkdirSync(require('path').dirname(path), { recursive: true });
+              fs.writeFileSync(path, Buffer.from(data.content, 'base64'));
             }
-
-            fs.mkdirSync('contrib/bench', { recursive: true });
-            fs.writeFileSync(path, Buffer.from(data.content, 'base64'));
 
       - name: Checkout benchmark repo
         id: checkout_benchmark_repo
@@ -710,6 +721,16 @@ jobs:
           echo "path=$results_dir" >> "$GITHUB_OUTPUT"
           echo "Results directory: $results_dir"
 
+      - name: Add fees to summary
+        if: steps.results-dir.outputs.path != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BENCH_RESULTS_DIR: ${{ steps.results-dir.outputs.path }}
+        with:
+          script: |
+            const notify = require('./.github/scripts/bench-slack-notify.js');
+            notify.multiRegion.addFees(process.env.BENCH_RESULTS_DIR);
+
       - name: Upload artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -774,6 +795,22 @@ jobs:
 
             const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}`;
             await core.summary.addRaw(body).write();
+
+      - name: Send Slack notification
+        if: >-
+          steps.results-dir.outputs.path != '' &&
+          steps.fetch_tempo_binaries.outcome == 'success' &&
+          steps.generate_initial_validator_state.outcome == 'success' &&
+          steps.initialize_validator_state.outcome == 'success' &&
+          steps.benchmark.outcome == 'success'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          BENCH_ACTOR: ${{ github.actor }}
+          BENCH_WORK_DIR: ${{ steps.results-dir.outputs.path }}
+        with:
+          script: |
+            const notify = require('./.github/scripts/bench-slack-notify.js');
+            await notify.multiRegion.success({ core, context });
 
       - name: Wait for infrastructure teardown
         if: always() && steps.checkout_benchmark_repo.outcome == 'success'

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -682,6 +682,7 @@ def txgen-run-preset-pipeline [
         "--tps" $tps
         "--max-concurrent" $max_concurrent_requests
         "--retries" 0
+        "--collect-receipt-metrics"
         "--scrape-interval-ms" $TXGEN_HELPER_SCRAPE_INTERVAL_MS
     ]
     let bench_base_cmd = [

--- a/contrib/bench/txgen/presets/dex.yml
+++ b/contrib/bench/txgen/presets/dex.yml
@@ -2,7 +2,7 @@ chain_id: 1337
 
 gas:
   max_fee_per_gas: 100000000000
-  max_priority_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 0
 
 accounts:
   users:
@@ -127,7 +127,7 @@ templates:
       select: random
     gas_limit: 8000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 25
@@ -166,7 +166,7 @@ templates:
       select: random
     gas_limit: 8000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 25

--- a/contrib/bench/txgen/presets/mix.yml
+++ b/contrib/bench/txgen/presets/mix.yml
@@ -2,7 +2,7 @@ chain_id: 1337
 
 gas:
   max_fee_per_gas: 100000000000
-  max_priority_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 0
 
 accounts:
   users:
@@ -83,7 +83,7 @@ templates:
       select: random
     gas_limit: 300000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 25
@@ -105,7 +105,7 @@ templates:
       select: random
     gas_limit: 300000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     call:
       to: "0x20c0000000000000000000000000000000000000"
       abi: ERC20
@@ -120,7 +120,7 @@ templates:
     type: tempo
     gas_limit: 8000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 25
@@ -132,7 +132,7 @@ templates:
       select: random
     gas_limit: 5000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 25

--- a/contrib/bench/txgen/presets/mpp.yml
+++ b/contrib/bench/txgen/presets/mpp.yml
@@ -2,7 +2,7 @@ chain_id: 1337
 
 gas:
   max_fee_per_gas: 100000000000
-  max_priority_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 0
 
 accounts:
   users:
@@ -34,7 +34,7 @@ templates:
     type: tempo
     gas_limit: 2000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     call:
       to: "0x20c0000000000000000000000000000000000001"
@@ -46,7 +46,7 @@ templates:
     type: tempo
     gas_limit: 2000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     call:
       abi: MPPChannel
@@ -57,7 +57,7 @@ templates:
     type: tempo
     gas_limit: 2000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     call:
       abi: MPPChannel

--- a/contrib/bench/txgen/presets/neobank-swap.yml
+++ b/contrib/bench/txgen/presets/neobank-swap.yml
@@ -7,7 +7,7 @@ chain_id: 1337
 
 gas:
   max_fee_per_gas: 100000000000
-  max_priority_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 0
 
 accounts:
   users:
@@ -170,7 +170,7 @@ templates:
       select: { index: 0 }
     gas_limit: 8000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 10
@@ -186,7 +186,7 @@ templates:
       select: { index: 0 }
     gas_limit: 8000000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 10

--- a/contrib/bench/txgen/presets/neobank-withdraw.yml
+++ b/contrib/bench/txgen/presets/neobank-withdraw.yml
@@ -18,7 +18,7 @@ append:
             select: { index: 0 }
           gas_limit: 8000000
           max_fee_per_gas: 100000000000
-          max_priority_fee_per_gas: 100000000000
+          max_priority_fee_per_gas: 0
           fee_token: "0x20c0000000000000000000000000000000000000"
           calls:
             - to: "0x20c0000000000000000000000000000000000000"

--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -2,7 +2,7 @@ chain_id: 1337
 
 gas:
   max_fee_per_gas: 100000000000
-  max_priority_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 0
 
 accounts:
   users:
@@ -22,7 +22,7 @@ templates:
       select: random
     gas_limit: 300000
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
     valid_for_secs: 5

--- a/contrib/bench/txgen/presets/tip20/base.yml
+++ b/contrib/bench/txgen/presets/tip20/base.yml
@@ -3,7 +3,7 @@ merge:
 
   gas:
     max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    max_priority_fee_per_gas: 0
 
   accounts:
     users:
@@ -22,7 +22,7 @@ merge:
         pool: users
         select: random
       max_fee_per_gas: 100000000000
-      max_priority_fee_per_gas: 100000000000
+      max_priority_fee_per_gas: 0
       call:
         to:
           choice: ${TXGEN_TIP20_TOKENS}

--- a/contrib/bench/txgen/presets/tip20/fee-amm-liquidity.yml
+++ b/contrib/bench/txgen/presets/tip20/fee-amm-liquidity.yml
@@ -13,7 +13,7 @@ append:
             select: { index: 0 }
           gas_limit: 1000000
           max_fee_per_gas: 100000000000
-          max_priority_fee_per_gas: 100000000000
+          max_priority_fee_per_gas: 0
           fee_token: "0x20c0000000000000000000000000000000000000"
           call:
             to: "0xfeec000000000000000000000000000000000000"
@@ -32,7 +32,7 @@ append:
             select: { index: 0 }
           gas_limit: 1000000
           max_fee_per_gas: 100000000000
-          max_priority_fee_per_gas: 100000000000
+          max_priority_fee_per_gas: 0
           fee_token: "0x20c0000000000000000000000000000000000000"
           call:
             to: "0xfeec000000000000000000000000000000000000"
@@ -51,7 +51,7 @@ append:
             select: { index: 0 }
           gas_limit: 1000000
           max_fee_per_gas: 100000000000
-          max_priority_fee_per_gas: 100000000000
+          max_priority_fee_per_gas: 0
           fee_token: "0x20c0000000000000000000000000000000000000"
           call:
             to: "0xfeec000000000000000000000000000000000000"

--- a/tempo.nu
+++ b/tempo.nu
@@ -1363,6 +1363,7 @@ def generate-summary [
 
         $run_data = ($run_data | append [{
             label: $label
+            total_fees_paid: ($report | get -o total_fees_paid | default null)
             summary_warmup_blocks: $warmup_blocks
             blocks: $num_blocks
             total_tx: $total_tx


### PR DESCRIPTION
Adds total fees paid to benchmark summaries and Slack notifications, including aggregation across multi-region runs. Fee values are formatted from microdollars and the multi-region workflow now passes Slack credentials and sends success notifications.