### PR TITLE
fix(faucet): validate --faucet.node-address at parse time

### DIFF
--- a/.changelog/faucet-node-address-validation.md
+++ b/.changelog/faucet-node-address-validation.md
@@ -1,0 +1,5 @@
+---
+tempo: patch
+---
+
+Reject a `--faucet.node-address` that is not a URL. The value was taken as an unvalidated string and parsed again in `FaucetArgs::provider`, where a malformed address panicked the node with `Failed to parse node address` instead of failing as a CLI error.

--- a/crates/faucet/src/args.rs
+++ b/crates/faucet/src/args.rs
@@ -3,9 +3,21 @@ use alloy::{
     primitives::{Address, B256, U256},
     providers::{DynProvider, Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
+    transports::http::reqwest::Url,
 };
 use clap::Args;
 use tempo_alloy::{TempoNetwork, provider::ext::TempoProviderBuilderExt};
+
+/// Validates that a faucet node address is an absolute URL.
+///
+/// [`FaucetArgs::provider`] parses this value again and panics if it is not a
+/// URL, so rejecting it here turns a node crash into a CLI error.
+fn parse_node_address(value: &str) -> Result<String, String> {
+    value
+        .parse::<Url>()
+        .map(|_| value.to_owned())
+        .map_err(|err| format!("invalid faucet node address: {err}"))
+}
 
 /// Faucet-specific CLI arguments
 #[derive(Debug, Clone, Default, Args, PartialEq, Eq)]
@@ -47,7 +59,8 @@ pub struct FaucetArgs {
     #[arg(
         long = "faucet.node-address",
         default_value = "http://localhost:8545",
-        requires = "faucet.enabled"
+        requires = "faucet.enabled",
+        value_parser = parse_node_address
     )]
     pub node_address: String,
 }
@@ -99,5 +112,60 @@ mod tests {
     #[test]
     fn faucet_args_default_sanity_test() {
         assert!(CommandParser::try_parse_from(["tempo"]).is_ok());
+    }
+
+    /// Arguments for an enabled faucet, with `node-address` supplied by the caller.
+    fn enabled_faucet_args(node_address: &str) -> [&str; 10] {
+        [
+            "tempo",
+            "--faucet.enabled",
+            "--faucet.private-key",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "--faucet.amount",
+            "1",
+            "--faucet.address",
+            "0x0000000000000000000000000000000000000001",
+            "--faucet.node-address",
+            node_address,
+        ]
+    }
+
+    #[test]
+    fn rejects_node_address_that_is_not_a_url() {
+        // `provider()` parses this value again and panics on failure, so an
+        // unparseable address must be refused while it is still a CLI error.
+        // Note that a scheme-less authority such as "localhost:8545" does
+        // parse — "localhost" is read as the scheme — so it is not covered
+        // here.
+        for address in ["not a url", "", "http://[::1"] {
+            let parsed = CommandParser::try_parse_from(enabled_faucet_args(address));
+            assert!(
+                parsed.is_err(),
+                "expected {address:?} to be rejected as a node address"
+            );
+        }
+    }
+
+    #[test]
+    fn accepts_valid_node_address() {
+        let parsed = CommandParser::try_parse_from(enabled_faucet_args("http://127.0.0.1:9545"))
+            .expect("valid node address should parse");
+        assert_eq!(parsed.args.node_address, "http://127.0.0.1:9545");
+    }
+
+    #[test]
+    fn default_node_address_is_a_valid_url() {
+        let parsed = CommandParser::try_parse_from([
+            "tempo",
+            "--faucet.enabled",
+            "--faucet.private-key",
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "--faucet.amount",
+            "1",
+            "--faucet.address",
+            "0x0000000000000000000000000000000000000001",
+        ])
+        .expect("default node address should parse");
+        assert_eq!(parsed.args.node_address, "http://localhost:8545");
     }
 }


### PR DESCRIPTION
## Problem

`--faucet.node-address` is accepted as an unvalidated `String` and parsed again inside `FaucetArgs::provider`:

```rust
self.node_address.parse().expect("Failed to parse node address")
```

So a malformed value passes the CLI and takes the node down later:

```
thread '...' panicked at crates/faucet/src/args.rs:81:22:
Failed to parse node address: RelativeUrlWithoutBase
```

Confirmed against `main` — `--faucet.node-address "not a url"` parses without complaint, and `provider()` then panics.

This is the same class as #6951: a faucet argument that passes validation and fails afterwards, applied to the adjacent flag. #7140 is fixing the empty-address case; this one is independent of it, but both touch `crates/faucet/src/args.rs`, so whichever lands second will want a trivial rebase in the tests module. Happy to be the one that rebases.

## Fix

Validate the address with a `value_parser`, so an unparseable value is refused while it is still a CLI error rather than a runtime panic.

Kept deliberately small:

- the field stays a `String`. Making it a `Url` would remove the second parse entirely, but `url::Url` has no `Default`, which breaks the `#[derive(Default)]` on `FaucetArgs`.
- no new dependency: `Url` comes from the `alloy` re-export already used elsewhere in the tree.
- `provider()` is untouched; its `expect` is now unreachable through the CLI.

## Tests

- unparseable values are rejected (`"not a url"`, `""`, `"http://[::1"`)
- a valid address parses and round-trips
- the default `http://localhost:8545` still parses

`cargo test -p tempo-faucet --lib` passes; `cargo fmt` and `cargo clippy -p tempo-faucet --lib --tests` are clean.

## One thing I left alone

A scheme-less authority such as `localhost:8545` *does* parse — `localhost` is read as the scheme — so it is not rejected here. It is a likely typo, and `connect_http` would fail on it later, though as an error rather than a panic. Requiring an `http`/`https` scheme would catch it, but that is a policy call about what the flag accepts rather than a crash fix, so I did not fold it in. Glad to add it if you want it.

Disclosure: I used an AI assistant while investigating and preparing this change; the analysis and conclusions are my own to defend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
