### PR TITLE
fix(primitives): implement core::error::Error for InvalidPublicKey

### DIFF
--- a/crates/primitives/src/ed25519.rs
+++ b/crates/primitives/src/ed25519.rs
@@ -10,6 +10,8 @@ impl core::fmt::Display for InvalidPublicKey {
     }
 }
 
+impl core::error::Error for InvalidPublicKey {}
+
 /// Validated Ed25519 public key bytes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
Implemented core::error::Error for InvalidPublicKey in crates/primitives/src/ed25519.rs. This allows InvalidPublicKey to be seamlessly propagated using the ? operator into standard error handlers like eyre::Report or Box<dyn std::error::Error>.