### PR TITLE
ci: replace personal GitHub tokens with STS

### DIFF
--- a/.github/sts/bench.sts.yaml
+++ b/.github/sts/bench.sts.yaml
@@ -1,0 +1,8 @@
+# Allow the benchmark comment controller on Tempo's default branch to mint a
+# short-lived token for membership checks and PR comment updates.
+subject: repo:tempoxyz@211589300/tempo@994992847:ref:refs/heads/main
+permissions:
+  contents: read
+  issues: write
+  members: read
+  pull_requests: read

--- a/.github/sts/update-reth.sts.yaml
+++ b/.github/sts/update-reth.sts.yaml
@@ -1,0 +1,10 @@
+# Allow the scheduled and manually dispatched reth updater on Tempo's default
+# branch to maintain its branch and pull request without a personal token.
+subject: repo:tempoxyz@211589300/tempo@994992847:ref:refs/heads/main
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  issues: write
+  pull_requests: write
+  statuses: read

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
       issues: write
       pull-requests: write
     outputs:
@@ -89,11 +90,18 @@ jobs:
             core.setOutput('is-bench-command', String(isBenchCommand));
             core.setOutput('is-clear-command', String(isClearCommand));
 
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        if: steps.command.outputs.is-bench-command == 'true' || steps.command.outputs.is-clear-command == 'true'
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        with:
+          policy: bench
+
       - name: Check org membership
         if: steps.command.outputs.is-bench-command == 'true' || steps.command.outputs.is-clear-command == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_ACK_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             const org = 'tempoxyz';
             const checkMembership = async (username) => {
@@ -125,7 +133,7 @@ jobs:
         if: steps.command.outputs.is-clear-command == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             await github.rest.reactions.createForIssueComment({
               owner: context.repo.owner,
@@ -171,7 +179,7 @@ jobs:
         env:
           INPUT_REF_NAME: ${{ github.ref_name }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             let pr, actor, mode, preset, duration, bloat, tokenCount, tps, accounts, maxConcurrentRequests, baseline, feature, baselineHardfork, featureHardfork, baselineFeatures, featureFeatures, txgenRef, samply, tracy, tracySeconds, tracyOffset, otlp, valscope, skipStateRoot, baselineArgs, featureArgs, gasLimit, generalGasLimit, runType, forceBloat, noCache, noSlack, metrics, benchArgs, benchEnv, baselineEnv, featureEnv, blocks, warmup, runPairs, runSide;
             let explicitWarmup = false;
@@ -546,7 +554,7 @@ jobs:
           ACK_RUN_SIDE: ${{ steps.args.outputs.run-side }}
           ACK_NO_CACHE: ${{ steps.args.outputs.no-cache }}
         with:
-          github-token: ${{ secrets.DEREK_BENCH_TOKEN }}
+          github-token: ${{ steps.github-sts.outputs.token }}
           script: |
             if (context.eventName === 'issue_comment') {
               await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -34,16 +35,22 @@ jobs:
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 120
     steps:
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        with:
+          policy: update-reth
+
       # ── checkout ───────────────────────────────────────────────
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
-          token: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          token: ${{ steps.github-sts.outputs.token }}
 
-      # ── git identity (use Derek's account) ─────────────────────
+      # ── GitHub App git identity ────────────────────────────────
       - name: Configure git
         env:
-          GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}
         run: |
           USER_JSON=$(gh api /user)
           GIT_NAME=$(echo "$USER_JSON" | jq -r '.name // .login')
@@ -56,7 +63,7 @@ jobs:
       - name: Setup working branch
         id: detect
         env:
-          GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}
         run: |
           EXISTING_PR=$(gh pr list --head reth-auto-bump --base main --state open --json number --jq '.[0].number // empty')
           if [ -n "$EXISTING_PR" ]; then
@@ -154,7 +161,7 @@ jobs:
       - name: Update reth rev in Cargo.toml
         id: update
         env:
-          GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}
         run: |
           # Base rev from main branch (what we're upgrading FROM)
           BASE_REV=$(git show origin/main:Cargo.toml | grep -m1 'paradigmxyz/reth' | sed 's/.*rev = "\([^"]*\)".*/\1/')
@@ -366,7 +373,7 @@ jobs:
       # ── create / update PR ─────────────────────────────────────
       - name: Create or update PR
         env:
-          GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}
           AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
           DETECT_EXISTING_PR: ${{ steps.detect.outputs.existing_pr }}
         run: |
@@ -503,7 +510,7 @@ jobs:
       # ── wait for CI and fix failures ─────────────────────────
       - name: Wait for CI and fix failures
         env:
-          GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}
           AMP_API_KEY: ${{ secrets.AMP_API_KEY }}
         run: |
           PR_BRANCH="reth-auto-bump"
@@ -660,7 +667,7 @@ jobs:
       - name: Notify Slack
         if: always()
         env:
-          GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENG_TEMPO_WORKFLOWS_WEBHOOK_URL }}
           OLD_REV_IN: ${{ steps.update.outputs.old_rev }}
           NEW_REV_IN: ${{ steps.update.outputs.new_rev }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -13,6 +13,6 @@ rules:
       - update-reth.yml
   artipacked:
     ignore:
-      # update-reth intentionally persists its Derek token for authenticated git
+      # update-reth intentionally persists its short-lived STS token for authenticated git
       # pushes after checkout.
-      - update-reth.yml:37
+      - update-reth.yml:44


### PR DESCRIPTION
Replaces the expired personal tokens used by benchmark comment handling and the reth updater with short-lived, least-privilege GitHub STS tokens. Other token-secret usages are either GitHub's ephemeral built-in token, non-GitHub service credentials, or `DEREK_TOKEN` access to the separate `decofe/tempo-bench-charts` repository, which cannot be covered by a policy in this repository.

Prompted by: @shekhirin