### PR TITLE
feat(tip-1093): activate expanded nonce window at T11

### DIFF
--- a/.changelog/tip-1093.md
+++ b/.changelog/tip-1093.md
@@ -2,4 +2,4 @@
 tempo-primitives: minor
 ---
 
-Implemented TIP-1093 by extending the expiring nonce validity window to five minutes and the replay-protection ring to 3,000,000 entries at T10 activation.
+Implemented TIP-1093 by extending the expiring nonce validity window to five minutes and the replay-protection ring to 3,000,000 entries at T11 activation.

--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -292,25 +292,25 @@ impl TempoHardfork {
 
     /// Returns the expiring nonce replay-protection capacity.
     pub const fn expiring_nonce_set_capacity(&self) -> u32 {
-        const PRE_T10_CAPACITY: u32 = 300_000;
-        const POST_T10_CAPACITY: u32 = 3_000_000;
+        const PRE_T11_CAPACITY: u32 = 300_000;
+        const POST_T11_CAPACITY: u32 = 3_000_000;
 
-        if self.is_t10() {
-            POST_T10_CAPACITY
+        if self.is_t11() {
+            POST_T11_CAPACITY
         } else {
-            PRE_T10_CAPACITY
+            PRE_T11_CAPACITY
         }
     }
 
     /// Returns the maximum expiring nonce validity window in seconds.
     pub const fn expiring_nonce_max_expiry_secs(&self) -> u64 {
-        const PRE_T10_MAX_EXPIRY_SECS: u64 = 30;
-        const POST_T10_MAX_EXPIRY_SECS: u64 = 300;
+        const PRE_T11_MAX_EXPIRY_SECS: u64 = 30;
+        const POST_T11_MAX_EXPIRY_SECS: u64 = 300;
 
-        if self.is_t10() {
-            POST_T10_MAX_EXPIRY_SECS
+        if self.is_t11() {
+            POST_T11_MAX_EXPIRY_SECS
         } else {
-            PRE_T10_MAX_EXPIRY_SECS
+            PRE_T11_MAX_EXPIRY_SECS
         }
     }
 

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -183,11 +183,13 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
 
     #[test]
-    fn test_expiring_nonce_parameters_activate_at_t10() {
+    fn test_expiring_nonce_parameters_activate_at_t11() {
         assert_eq!(TempoHardfork::T9.expiring_nonce_max_expiry_secs(), 30);
         assert_eq!(TempoHardfork::T9.expiring_nonce_set_capacity(), 300_000);
-        assert_eq!(TempoHardfork::T10.expiring_nonce_max_expiry_secs(), 300);
-        assert_eq!(TempoHardfork::T10.expiring_nonce_set_capacity(), 3_000_000);
+        assert_eq!(TempoHardfork::T10.expiring_nonce_max_expiry_secs(), 30);
+        assert_eq!(TempoHardfork::T10.expiring_nonce_set_capacity(), 300_000);
+        assert_eq!(TempoHardfork::T11.expiring_nonce_max_expiry_secs(), 300);
+        assert_eq!(TempoHardfork::T11.expiring_nonce_set_capacity(), 3_000_000);
     }
 
     #[test]
@@ -342,14 +344,14 @@ mod tests {
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
-            // valid_before too far in future should fail before T10.
+            // valid_before too far in future should fail before T11.
             let result = mgr.check_and_mark_expiring_nonce(tx_hash, now + 31);
             assert_eq!(
                 result.unwrap_err(),
                 TempoPrecompileError::NonceError(NonceError::invalid_expiring_nonce_expiry())
             );
 
-            // valid_before at exactly the pre-T10 maximum should succeed
+            // valid_before at exactly the pre-T11 maximum should succeed
             mgr.check_and_mark_expiring_nonce(tx_hash, now + 30)?;
 
             Ok(())
@@ -357,8 +359,8 @@ mod tests {
     }
 
     #[test]
-    fn test_t10_expiring_nonce_expiry_validation() -> eyre::Result<()> {
-        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+    fn test_t11_expiring_nonce_expiry_validation() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
         let now = 1000u64;
         storage.set_timestamp(U256::from(now));
         StorageCtx::enter(&mut storage, || {
@@ -448,13 +450,13 @@ mod tests {
     }
 
     #[test]
-    fn test_ring_buffer_pointer_wraps_at_pre_t10_capacity() -> eyre::Result<()> {
-        assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T9)
+    fn test_ring_buffer_pointer_wraps_at_pre_t11_capacity() -> eyre::Result<()> {
+        assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T10)
     }
 
     #[test]
-    fn test_ring_buffer_pointer_wraps_at_t10_capacity() -> eyre::Result<()> {
-        assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T10)
+    fn test_ring_buffer_pointer_wraps_at_t11_capacity() -> eyre::Result<()> {
+        assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T11)
     }
 
     #[test]

--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -5,7 +5,7 @@ description: Extends the expiring nonce validity window from 30 seconds to five 
 authors: @shekhirin
 status: Draft
 related: TIP-1009, TIP-0001
-protocolVersion: T10
+protocolVersion: T11
 ---
 
 # TIP-1093: Extend Expiring Nonce Window to Five Minutes
@@ -84,7 +84,7 @@ clear the old `expiringNonceSeen` entry and insert the new hash and expiry.
 
 ## Activation and Compatibility
 
-The new constants MUST activate atomically at T10. Pool validation, transaction
+The new constants MUST activate atomically at T11. Pool validation, transaction
 execution, action replay, transaction builders, and test helpers MUST use the
 same 300-second maximum.
 

--- a/tips/verify/test/TempoTransactionInvariant.t.sol
+++ b/tips/verify/test/TempoTransactionInvariant.t.sol
@@ -4027,15 +4027,15 @@ contract TempoTransactionInvariantTest is InvariantChecker {
 
     /// @dev Expiring nonce key constant (TIP-1009)
     uint256 private constant EXPIRING_NONCE_KEY = type(uint256).max;
-    /// @dev Maximum expiry windows in seconds before and after T10 (TIP-1009, TIP-1093)
-    uint64 private constant PRE_T10_MAX_EXPIRY_SECS = 30;
-    uint64 private constant T10_MAX_EXPIRY_SECS = 300;
+    /// @dev Maximum expiry windows in seconds before and after T11 (TIP-1009, TIP-1093)
+    uint64 private constant PRE_T11_MAX_EXPIRY_SECS = 30;
+    uint64 private constant POST_T11_MAX_EXPIRY_SECS = 300;
 
     function _maxExpirySecs() internal view returns (uint64) {
-        bytes32 hardfork = keccak256(bytes(vm.getEvmVersion()));
-        return hardfork == keccak256(bytes("t10")) || hardfork == keccak256(bytes("t11"))
-            ? T10_MAX_EXPIRY_SECS
-            : PRE_T10_MAX_EXPIRY_SECS;
+        string memory hardfork = vm.getEvmVersion();
+        return keccak256(bytes(hardfork)) == keccak256(bytes("t10"))
+            ? PRE_T11_MAX_EXPIRY_SECS
+            : POST_T11_MAX_EXPIRY_SECS;
     }
 
     /// @notice Build an expiring nonce transaction


### PR DESCRIPTION
Moves TIP-1093’s expanded expiring-nonce validity window and replay-protection capacity from T10 to T11. T10 retains the existing 30-second/300,000-entry limits; T11 activates 300 seconds/3,000,000 entries.