### PR TITLE
fix(TIP20ChannelReserve): enforce CEI pattern in topUp to prevent sta…

### DIFF
--- a/tips/verify/src/TIP20ChannelReserve.sol
+++ b/tips/verify/src/TIP20ChannelReserve.sol
@@ -147,17 +147,12 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
         ChannelState memory channel = _loadChannelState(channelId);
 
         if (msg.sender != descriptor.payer) revert NotPayer();
-
         if (additionalDeposit > type(uint96).max - channel.deposit) revert DepositOverflow();
 
+        // [SECURITY PATCH]: Enforcing Checks-Effects-Interactions (CEI)
+        // ---- EFFECTS (all state settled before any external interaction) ----
         if (additionalDeposit > 0) {
             channel.deposit += additionalDeposit;
-
-            // The reference contract keeps ERC-20-style allowance flow for local verification.
-            // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
-            bool success =
-                ITIP20(descriptor.token).transferFrom(msg.sender, address(this), additionalDeposit);
-            if (!success) revert TransferFailed();
         }
 
         if (channel.closeRequestedAt != 0) {
@@ -165,7 +160,17 @@ contract TIP20ChannelReserve is ITIP20ChannelReserve {
             emit CloseRequestCancelled(channelId, descriptor.payer, descriptor.payee);
         }
 
+        // Commit the updated channel state to persistent storage BEFORE making the external call.
         channelStates[channelId] = _encodeChannelState(channel);
+
+        // ---- INTERACTION (last; a false/failed transfer reverts and unwinds the write) ----
+        if (additionalDeposit > 0) {
+            // The reference contract keeps ERC-20-style allowance flow for local verification.
+            // The enshrined precompile should use TIP-20 `systemTransferFrom` semantics instead.
+            bool success =
+                ITIP20(descriptor.token).transferFrom(msg.sender, address(this), additionalDeposit);
+            if (!success) revert TransferFailed();
+        }
 
         emit TopUp(
             channelId, descriptor.payer, descriptor.payee, additionalDeposit, channel.deposit


### PR DESCRIPTION
…te staleness

This PR addresses a Checks-Effects-Interactions (CEI) invariant violation in the TIP-1034 reference contract and documents an informational cryptographic observation.

** Vulnerabilities Remediated:**
- **Checks-Effects-Interactions (CEI) Violation (Low-Medium):** In `TIP20ChannelReserve.sol`, the `topUp()` function previously performed its primary persistent state write *after* an external token call (`transferFrom`). While mitigated by `systemTransferFrom` non-reentrancy and strict `msg.sender` authorization guards, a reference contract must strictly adhere to CEI.

** Key Changes:**
- **State Hoisting in `topUp`:** Hoisted the deposit increment, close-request cancellation, and the `channelStates` struct commitment above the external `transferFrom` call. The interaction is now the final step; a failed transfer naturally reverts and unwinds the write, making it robust against arbitrary `ITIP20` tokens.

** Informational Note (No Action Required):**
- **Signature Malleability Asymmetry:** A workspace-wide audit noted that while the P256 recovery path (`crates/alloy/src/accounts/p256.rs:176`) correctly applies low-S normalization, the `secp256k1` path (`crates/precompiles/src/storage/mod.rs:209`) accepts high-S signatures by design to match EVM `ecrecover` semantics (TIP-1004). This is flagged purely as a design observation so callers do not key uniqueness/replay sets on raw signature bytes.