### PR TITLE
ci(docker): build partial persistence nightly image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -103,6 +103,19 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=pr
 
+      - name: Docker metadata for tempo partial persistence
+        id: meta-tempo-partial-persistence
+        if: ${{ github.event_name == 'schedule' || github.event.inputs.nightly == 'true' }}
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: |
+            ${{ env.REGISTRY }}/tempo
+            docker.io/tempoxyz/tempo
+          bake-target: tempo-partial-persistence
+          labels: ${{ steps.docker-labels.outputs.value }}
+          tags: |
+            type=raw,value=nightly-partial-persistence
+
       - name: Docker metadata for tempo-xtask
         id: meta-tempo-xtask
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -149,7 +162,8 @@ jobs:
             ${{ steps.meta-tempo.outputs.bake-file }}
             ${{ steps.meta-tempo-sidecar.outputs.bake-file }}
             ${{ steps.meta-tempo-xtask.outputs.bake-file }}
-          targets: default
+            ${{ steps.meta-tempo-partial-persistence.outputs.bake-file }}
+          targets: ${{ (github.event_name == 'schedule' || github.event.inputs.nightly == 'true') && 'nightly' || 'default' }}
           project: 0c6tg19qsp
           push: true
           no-cache: ${{ startsWith(github.ref, 'refs/tags/v') }}
@@ -168,6 +182,7 @@ jobs:
           TEMPO_TAGS: ${{ steps.meta-tempo.outputs.tags }}
           TEMPO_SIDECAR_TAGS: ${{ steps.meta-tempo-sidecar.outputs.tags }}
           TEMPO_XTASK_TAGS: ${{ steps.meta-tempo-xtask.outputs.tags }}
+          TEMPO_PARTIAL_PERSISTENCE_TAGS: ${{ steps.meta-tempo-partial-persistence.outputs.tags }}
         run: |
           set -euo pipefail
           sign_image() {
@@ -194,6 +209,7 @@ jobs:
             "$TEMPO_TAGS"
             "$TEMPO_SIDECAR_TAGS"
             "$TEMPO_XTASK_TAGS"
+            "$TEMPO_PARTIAL_PERSISTENCE_TAGS"
           )
           for tags in "${images[@]}"; do
             while IFS= read -r image; do
@@ -282,6 +298,7 @@ jobs:
           TEMPO_TAGS: ${{ steps.meta-tempo.outputs.tags }}
           TEMPO_SIDECAR_TAGS: ${{ steps.meta-tempo-sidecar.outputs.tags }}
           TEMPO_XTASK_TAGS: ${{ steps.meta-tempo-xtask.outputs.tags }}
+          TEMPO_PARTIAL_PERSISTENCE_TAGS: ${{ steps.meta-tempo-partial-persistence.outputs.tags }}
           SHORT_SHA: ${{ steps.shortsha.outputs.shortsha }}
           BUILD_OUTCOME: ${{ steps.build-and-push.outcome }}
           SIGN_OUTCOME: ${{ steps.sign-images.outcome }}
@@ -345,6 +362,7 @@ jobs:
           summarize_tags "tempo" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo" "$TEMPO_TAGS"
           summarize_tags "tempo-sidecar" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo-sidecar" "$TEMPO_SIDECAR_TAGS"
           summarize_tags "tempo-xtask" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo-xtask" "$TEMPO_XTASK_TAGS"
+          summarize_tags "tempo partial persistence" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo" "$TEMPO_PARTIAL_PERSISTENCE_TAGS"
 
           {
             echo

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -147,6 +147,7 @@ otlp = [
 ]
 
 pyroscope = ["dep:pyroscope", "dep:pyroscope_pprofrs"]
+partial-persistence = ["tempo-node/partial-persistence"]
 js-tracer = [
 	"reth-node-builder/js-tracer",
 	"reth-ethereum/js-tracer",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -148,6 +148,7 @@ min-warn-logs = ["reth-node-core/min-warn-logs"]
 min-info-logs = ["reth-node-core/min-info-logs"]
 min-debug-logs = ["reth-node-core/min-debug-logs"]
 min-trace-logs = ["reth-node-core/min-trace-logs"]
+partial-persistence = ["reth-node-core/partial-persistence"]
 trie-debug = [
 	"reth-node-builder/trie-debug",
 	"reth-node-core/trie-debug",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,6 +10,10 @@ group "default" {
   targets = ["tempo", "tempo-sidecar", "tempo-xtask"]
 }
 
+group "nightly" {
+  targets = ["tempo", "tempo-sidecar", "tempo-xtask", "tempo-partial-persistence"]
+}
+
 target "docker-metadata" {}
 
 # Base image with all dependencies pre-compiled
@@ -42,6 +46,14 @@ target "_common" {
 target "tempo" {
   inherits = ["_common", "docker-metadata"]
   target = "tempo"
+}
+
+target "tempo-partial-persistence" {
+  inherits = ["_common", "docker-metadata"]
+  target = "tempo"
+  args = {
+    RUST_FEATURES = "asm-keccak,jemalloc,otlp,partial-persistence"
+  }
 }
 
 target "tempo-sidecar" {


### PR DESCRIPTION
## Summary

- propagate the `partial-persistence` Cargo feature through the Tempo node
- add a nightly-only `nightly-partial-persistence` Tempo image
- sign and report the additional image alongside the existing nightly matrix

Prompted by: @shekhirin
