### PR TITLE
fix(scripts): match spaced internal deps in the publish guard

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -209,7 +209,7 @@ for crate_toml in "${CRATE_TOMLS[@]}"; do
 
     # No internal path-only workspace crates should remain
     for dep in $INTERNAL_PATH_DEPS; do
-        grep -qE "^\s*${dep}[\s.=]" "$crate_toml" && \
+        grep -qE "^[[:space:]]*${dep}[[:space:].=]" "$crate_toml" && \
             err "Internal dep '$dep' still in $crate_name/Cargo.toml"
     done
 done


### PR DESCRIPTION
`[\s.=]` is a bracket expression, so it matches the set `\`, `s`, `.`, `=` rather than whitespace. The internal-dependency guard therefore only sees `dep.workspace = true` and never `dep = { workspace = true }`, which is how 34 of the workspace's 75 internal dependency lines are written today.

Nothing leaks right now because `sanitize_toml.py` strips the current set, but a path-only crate reintroduced in the spaced form would pass the guard and ship to crates.io with a dependency that does not exist there, which is the regression this check exists to catch.

Repro, same result under GNU and BSD grep:

    printf '[dependencies]\ntempo-node = { workspace = true }\n' > leak.toml
    grep -qE "^\s*tempo-node[\s.=]" leak.toml                  # no match
    grep -qE "^[[:space:]]*tempo-node[[:space:].=]" leak.toml  # match

`[[:space:].=]` also drops the stray `s` from the class, which matched `tempo-nodes` while checking for `tempo-node`.
