### PR TITLE
chore(bench): run nightly multi-region TPS matrix

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -148,7 +148,11 @@ jobs:
   bench-e2e-multi-region:
     needs: resolve-refs
     if: needs.resolve-refs.outputs.should-run == 'true'
-    name: bench-e2e-multi-region-scheduled
+    name: bench-e2e-multi-region-scheduled-${{ matrix.tps }}-tps
+    strategy:
+      fail-fast: false
+      matrix:
+        tps: ${{ fromJSON(github.event_name == 'schedule' && '["500","2000","5000"]' || format('["{0}"]', inputs.tps)) }}
     uses: ./.github/workflows/bench-e2e-multi-region.yml
     permissions:
       actions: read
@@ -165,11 +169,13 @@ jobs:
       bloat: ${{ inputs.bloat || '100' }}
       validator-count: ${{ inputs['validator-count'] || '10' }}
       regions: ${{ inputs.regions || '' }}
-      tps: ${{ inputs.tps || '50000' }}
+      tps: ${{ matrix.tps }}
       accounts: ${{ inputs.accounts || '1000' }}
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '5000' }}
       run-pairs: ${{ inputs['run-pairs'] || '3' }}
       clickhouse-run: feature-1
+      benchmark-id-suffix: ${{ matrix.tps }}-tps
+      artifact-name: tempo-bench-e2e-multi-region-results-${{ matrix.tps }}-tps
       otlp: true
     secrets:
       BENCH_LOGS_PUSH_URL: ${{ secrets.BENCH_LOGS_PUSH_URL }}

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -63,6 +63,14 @@ on:
         type: string
         required: false
         default: "feature-1"
+      benchmark-id-suffix:
+        type: string
+        required: false
+        default: ""
+      artifact-name:
+        type: string
+        required: false
+        default: tempo-bench-e2e-multi-region-results
       otlp:
         type: boolean
         required: false
@@ -241,7 +249,6 @@ on:
         type: string
         required: false
         default: "feature-1"
-
 permissions:
   actions: read
   contents: read
@@ -259,7 +266,7 @@ jobs:
       TF_INPUT: "0"
       BENCH_REPO_DIR: tempo-multi-region-benchmark
       TERRAFORM_DIR: ${{ (inputs.cloud || 'aws') == 'gcp' && 'tempo-multi-region-benchmark/terraform/gcp' || 'tempo-multi-region-benchmark/terraform' }}
-      BENCHMARK_ID: bench-e2e-multi-region-${{ github.run_id }}-${{ github.run_attempt }}
+      BENCHMARK_ID: bench-e2e-multi-region-${{ github.run_id }}-${{ github.run_attempt }}${{ inputs['benchmark-id-suffix'] && format('-{0}', inputs['benchmark-id-suffix']) || '' }}
       BENCH_RESULTS_DIR: tempo-bench-e2e-multi-region-results
       BENCH_INPUT_CLOUD: ${{ inputs.cloud || 'aws' }}
       BENCH_GCP_PROJECT_ID: chain-benchmarking-zygis
@@ -735,7 +742,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: tempo-bench-e2e-multi-region-results
+          name: ${{ inputs['artifact-name'] || 'tempo-bench-e2e-multi-region-results' }}
           path: ${{ env.BENCH_RESULTS_DIR }}
           if-no-files-found: warn
 


### PR DESCRIPTION
Run scheduled multi-region benchmarks at 500, 2,000, and 5,000 TPS. Give concurrent runs unique benchmark IDs and artifact names while preserving single-TPS manual dispatches.

Prompted by: @shekhirin