### PR TITLE
refactor(consensus): generalize TempoConsensus over chain spec

### DIFF
--- a/crates/chainspec/src/lib.rs
+++ b/crates/chainspec/src/lib.rs
@@ -16,7 +16,7 @@ pub mod spec;
 #[cfg(feature = "reth")]
 pub use network_identity::NetworkIdentity;
 #[cfg(feature = "reth")]
-pub use spec::{TempoChainSpec, TempoHardforks};
+pub use spec::{TempoChainSpec, TempoConsensusSpec, TempoHardforks};
 
 pub use tempo_hardfork::{TempoHardfork, constants};
 

--- a/crates/chainspec/src/spec.rs
+++ b/crates/chainspec/src/spec.rs
@@ -211,20 +211,25 @@ impl TempoChainSpec {
         self.default_follow_url
     }
 
+    /// Returns the shared gas limit for the given timestamp and block gas limit.
+    ///
+    /// Prefer [`TempoConsensusSpec::shared_gas_limit_at`] when working with a generic Tempo
+    /// chain specification.
+    pub fn shared_gas_limit_at(&self, timestamp: u64, gas_limit: u64) -> u64 {
+        TempoConsensusSpec::shared_gas_limit_at(self, timestamp, gas_limit)
+    }
+
     /// Returns the general (non-payment) gas limit for the given timestamp and block.
-    /// - Genesis override: fixed at the configured value
-    /// - T1+: fixed at 30M gas
-    /// - Pre-T1: calculated as (gas_limit - shared_gas_limit) / 2
+    ///
+    /// Prefer [`TempoConsensusSpec::general_gas_limit_at`] when working with a generic Tempo
+    /// chain specification.
     pub fn general_gas_limit_at(
         &self,
         timestamp: u64,
         gas_limit: u64,
         shared_gas_limit: u64,
     ) -> u64 {
-        self.info
-            .general_gas_limit()
-            .or_else(|| self.tempo_hardfork_at(timestamp).general_gas_limit())
-            .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
+        TempoConsensusSpec::general_gas_limit_at(self, timestamp, gas_limit, shared_gas_limit)
     }
 
     /// Converts the given [`Genesis`] into a [`TempoChainSpec`].
@@ -453,13 +458,6 @@ macro_rules! tempo_hardforks_trait {
                 )*
             }
 
-            /// Returns the shared gas limit for the given timestamp and block.
-            /// - T4+: 0 gas
-            /// - Pre-T4: block_gas_limit / 10
-            fn shared_gas_limit_at(&self, timestamp: u64, gas_limit: u64) -> u64 {
-                self.tempo_hardfork_at(timestamp)
-                    .shared_gas_limit(gas_limit)
-            }
         }
     };
 }
@@ -469,6 +467,32 @@ tempo_hardfork::tempo_post_genesis_hardforks!(tempo_hardforks_trait);
 impl TempoHardforks for TempoChainSpec {
     fn tempo_fork_activation(&self, fork: TempoHardfork) -> ForkCondition {
         self.fork(fork)
+    }
+}
+
+/// Chain-spec policy for Tempo consensus header gas limits.
+///
+/// The hardfork schedule determines the default Tempo L1 policy, while chains that reuse the
+/// Tempo block format may define their own gas partitioning.
+pub trait TempoConsensusSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks {
+    /// Returns the shared gas limit for the given timestamp and block gas limit.
+    fn shared_gas_limit_at(&self, timestamp: u64, gas_limit: u64) -> u64;
+
+    /// Returns the general (non-payment) gas limit for the given timestamp and gas limits.
+    fn general_gas_limit_at(&self, timestamp: u64, gas_limit: u64, shared_gas_limit: u64) -> u64;
+}
+
+impl TempoConsensusSpec for TempoChainSpec {
+    fn shared_gas_limit_at(&self, timestamp: u64, gas_limit: u64) -> u64 {
+        self.tempo_hardfork_at(timestamp)
+            .shared_gas_limit(gas_limit)
+    }
+
+    fn general_gas_limit_at(&self, timestamp: u64, gas_limit: u64, shared_gas_limit: u64) -> u64 {
+        self.info
+            .general_gas_limit()
+            .or_else(|| self.tempo_hardfork_at(timestamp).general_gas_limit())
+            .unwrap_or_else(|| (gas_limit - shared_gas_limit) / 2)
     }
 }
 

--- a/crates/consensus/src/subblocks.rs
+++ b/crates/consensus/src/subblocks.rs
@@ -39,7 +39,6 @@ use std::{
     sync::{Arc, mpsc::RecvError},
     time::{Duration, Instant},
 };
-use tempo_chainspec::hardfork::TempoHardforks;
 use tempo_node::{TempoFullNode, evm::evm::TempoEvm};
 use tempo_primitives::{
     RecoveredSubBlock, SignedSubBlock, SubBlock, SubBlockVersion, TempoTxEnvelope,

--- a/crates/evm/src/consensus/mod.rs
+++ b/crates/evm/src/consensus/mod.rs
@@ -15,8 +15,8 @@ use reth_ethereum_consensus::EthBeaconConsensus;
 use reth_primitives_traits::{RecoveredBlock, SealedBlock, SealedHeader};
 use std::sync::Arc;
 use tempo_chainspec::{
-    hardfork::TempoHardforks,
-    spec::{SYSTEM_TX_ADDRESSES, SYSTEM_TX_COUNT, TempoChainSpec},
+    TempoChainSpec, TempoConsensusSpec,
+    spec::{SYSTEM_TX_ADDRESSES, SYSTEM_TX_COUNT},
 };
 use tempo_primitives::{
     Block, BlockBody, TempoHeader, TempoPrimitives, TempoReceipt, TempoTxEnvelope,
@@ -35,19 +35,22 @@ pub const TEMPO_MAXIMUM_EXTRA_DATA_SIZE: usize = 10 * 1_024; // 10KiB
 
 /// Tempo consensus implementation.
 #[derive(Debug, Clone)]
-pub struct TempoConsensus {
+pub struct TempoConsensus<C = TempoChainSpec> {
     /// Inner Ethereum consensus.
-    inner: EthBeaconConsensus<TempoChainSpec>,
+    inner: EthBeaconConsensus<C>,
 }
 
-impl TempoConsensus {
+impl<C> TempoConsensus<C>
+where
+    C: TempoConsensusSpec,
+{
     /// Creates a new [`TempoConsensus`] with the given chain spec.
-    pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
+    pub fn new(chain_spec: Arc<C>) -> Self {
         Self::new_with_bal_hashes(chain_spec, false)
     }
 
     /// Creates a new [`TempoConsensus`] with optional pre-Amsterdam BAL hash support.
-    pub fn new_with_bal_hashes(chain_spec: Arc<TempoChainSpec>, allow_bal_hashes: bool) -> Self {
+    pub fn new_with_bal_hashes(chain_spec: Arc<C>, allow_bal_hashes: bool) -> Self {
         Self {
             inner: EthBeaconConsensus::new(chain_spec)
                 .with_max_extra_data_size(TEMPO_MAXIMUM_EXTRA_DATA_SIZE)
@@ -109,7 +112,10 @@ impl TempoConsensus {
     }
 }
 
-impl HeaderValidator<TempoHeader> for TempoConsensus {
+impl<C> HeaderValidator<TempoHeader> for TempoConsensus<C>
+where
+    C: TempoConsensusSpec,
+{
     fn validate_header(&self, header: &SealedHeader<TempoHeader>) -> Result<(), ConsensusError> {
         let current_timestamp_millis = std::time::SystemTime::now()
             .duration_since(std::time::SystemTime::UNIX_EPOCH)
@@ -152,7 +158,10 @@ impl HeaderValidator<TempoHeader> for TempoConsensus {
     }
 }
 
-impl Consensus<Block> for TempoConsensus {
+impl<C> Consensus<Block> for TempoConsensus<C>
+where
+    C: TempoConsensusSpec,
+{
     fn validate_body_against_header(
         &self,
         body: &BlockBody,
@@ -227,7 +236,10 @@ impl Consensus<Block> for TempoConsensus {
     }
 }
 
-impl FullConsensus<TempoPrimitives> for TempoConsensus {
+impl<C> FullConsensus<TempoPrimitives> for TempoConsensus<C>
+where
+    C: TempoConsensusSpec,
+{
     fn validate_block_post_execution(
         &self,
         block: &RecoveredBlock<Block>,

--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -49,7 +49,6 @@ use alloy_hardforks::hardfork;
 ///   - `tempo_fork_activation()` (required — the only method implementors provide)
 ///   - `tempo_hardfork_at()` — walks `VARIANTS` in reverse to find the latest active fork
 ///   - `is_<fork>_active_at_timestamp()` — per-fork convenience helpers
-///   - `shared_gas_limit_at()` — shared gas limit lookup by timestamp
 /// * Generates a `#[cfg(test)] mod tests` with activation, naming, trait, and serde tests
 ///
 /// `Genesis` (first variant) is treated as the baseline and does not get `is_*()` methods.


### PR DESCRIPTION
Generalizes `TempoConsensus` over a Tempo-compatible chain spec and moves header gas-limit policy onto `TempoConsensusSpec`.

Keeps the existing `TempoChainSpec` behavior and concrete convenience methods intact, while allowing Zones to supply their own gas partitioning.