### PR TITLE
feat(bench): benchmark integrated Flat MPT reads

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -288,7 +288,7 @@ jobs:
       BENCH_INPUT_VALSCOPE: ${{ github.event_name == 'workflow_dispatch' && (inputs.valscope == true || inputs.valscope == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BASELINE_ARGS: ${{ inputs['baseline-args'] || '' }}
       BENCH_INPUT_FEATURE_ARGS: ${{ inputs['feature-args'] || '' }}
-      BENCH_INPUT_FEATURE_ENV: ${{ (inputs['feature-flatmpt'] == true || inputs['feature-flatmpt'] == 'true') && 'TEMPO_FLATMPT=/opt/tempo/schelk/tempo_flatmpt TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_RAM_BUILD_GIB=24' || '' }}
+      BENCH_INPUT_FEATURE_ENV: ${{ (inputs['feature-flatmpt'] == true || inputs['feature-flatmpt'] == 'true') && 'TEMPO_FLATMPT=/opt/tempo/schelk/tempo_flatmpt TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_DIRECT_IO=1' || '' }}
       BENCH_INPUT_GAS_LIMIT: ${{ inputs['gas-limit'] || '5000000000' }}
       BENCH_INPUT_GENERAL_GAS_LIMIT: ${{ inputs['general-gas-limit'] || '' }}
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -67,6 +67,10 @@ on:
         type: boolean
         required: false
         default: true
+      feature-flatmpt:
+        type: boolean
+        required: false
+        default: false
     secrets:
       BENCH_LOGS_PUSH_URL:
         required: false
@@ -212,6 +216,11 @@ on:
         type: string
         required: false
         default: ""
+      feature-flatmpt:
+        description: Use Flat MPT for commitment and state reads in feature phases.
+        type: boolean
+        required: true
+        default: false
       gas-limit:
         description: Builder gas limit.
         type: string
@@ -232,11 +241,6 @@ on:
         type: string
         required: true
         default: "3"
-      clickhouse-run:
-        description: Benchmark phase that may use the direct ClickHouse reporter.
-        type: string
-        required: false
-        default: "feature-1"
 
 permissions:
   actions: read
@@ -284,6 +288,7 @@ jobs:
       BENCH_INPUT_VALSCOPE: ${{ github.event_name == 'workflow_dispatch' && (inputs.valscope == true || inputs.valscope == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BASELINE_ARGS: ${{ inputs['baseline-args'] || '' }}
       BENCH_INPUT_FEATURE_ARGS: ${{ inputs['feature-args'] || '' }}
+      BENCH_INPUT_FEATURE_ENV: ${{ (inputs['feature-flatmpt'] == true || inputs['feature-flatmpt'] == 'true') && 'TEMPO_FLATMPT=/opt/tempo/schelk/tempo_flatmpt TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1' || '' }}
       BENCH_INPUT_GAS_LIMIT: ${{ inputs['gas-limit'] || '5000000000' }}
       BENCH_INPUT_GENERAL_GAS_LIMIT: ${{ inputs['general-gas-limit'] || '' }}
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}
@@ -512,6 +517,7 @@ jobs:
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-env "$BENCH_INPUT_FEATURE_ENV" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -566,6 +572,7 @@ jobs:
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-env "$BENCH_INPUT_FEATURE_ENV" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -613,6 +620,7 @@ jobs:
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-env "$BENCH_INPUT_FEATURE_ENV" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -660,6 +668,7 @@ jobs:
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-env "$BENCH_INPUT_FEATURE_ENV" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -288,7 +288,7 @@ jobs:
       BENCH_INPUT_VALSCOPE: ${{ github.event_name == 'workflow_dispatch' && (inputs.valscope == true || inputs.valscope == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BASELINE_ARGS: ${{ inputs['baseline-args'] || '' }}
       BENCH_INPUT_FEATURE_ARGS: ${{ inputs['feature-args'] || '' }}
-      BENCH_INPUT_FEATURE_ENV: ${{ (inputs['feature-flatmpt'] == true || inputs['feature-flatmpt'] == 'true') && 'TEMPO_FLATMPT=/opt/tempo/schelk/tempo_flatmpt TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1' || '' }}
+      BENCH_INPUT_FEATURE_ENV: ${{ (inputs['feature-flatmpt'] == true || inputs['feature-flatmpt'] == 'true') && 'TEMPO_FLATMPT=/opt/tempo/schelk/tempo_flatmpt TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_RAM_BUILD_GIB=24' || '' }}
       BENCH_INPUT_GAS_LIMIT: ${{ inputs['gas-limit'] || '5000000000' }}
       BENCH_INPUT_GENERAL_GAS_LIMIT: ${{ inputs['general-gas-limit'] || '' }}
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1078,7 +1078,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
     let tracy_env_prefix = if $ctx.tracy != "off" { $"TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) " } else { "" }
     let flatmpt_common_env = if $run_type == "feature" and $ctx.feature_flatmpt {
-        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_RAM_BUILD_GIB=24"
+        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_RAM_BUILD_GIB=12"
     } else {
         ""
     }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1078,7 +1078,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
     let tracy_env_prefix = if $ctx.tracy != "off" { $"TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) " } else { "" }
     let flatmpt_common_env = if $run_type == "feature" and $ctx.feature_flatmpt {
-        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1"
+        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_RAM_BUILD_GIB=24"
     } else {
         ""
     }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1078,7 +1078,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
     let tracy_env_prefix = if $ctx.tracy != "off" { $"TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) " } else { "" }
     let flatmpt_common_env = if $run_type == "feature" and $ctx.feature_flatmpt {
-        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1"
+        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_DIRECT_IO=1"
     } else {
         ""
     }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1078,7 +1078,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
     let tracy_env_prefix = if $ctx.tracy != "off" { $"TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) " } else { "" }
     let flatmpt_common_env = if $run_type == "feature" and $ctx.feature_flatmpt {
-        "TEMPO_FLATMPT_MODE=root"
+        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1"
     } else {
         ""
     }

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1078,7 +1078,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     }
     let tracy_env_prefix = if $ctx.tracy != "off" { $"TRACY_SAMPLING_HZ=($TRACY_SAMPLING_HZ) " } else { "" }
     let flatmpt_common_env = if $run_type == "feature" and $ctx.feature_flatmpt {
-        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1 MPT_RAM_BUILD_GIB=12"
+        "TEMPO_FLATMPT_MODE=root TEMPO_FLATMPT_READS=1 TEMPO_NO_STATE_KV=1"
     } else {
         ""
     }

--- a/crates/flatmpt/examples/build_golden.rs
+++ b/crates/flatmpt/examples/build_golden.rs
@@ -9,8 +9,10 @@
 //!   each storage subtree region is written once and the per-range conversion
 //!   buffer stays ~2 GB. RAM-build spills between inserts.
 //!
-//!   MPT_RAM_BUILD_GIB=24 cargo run --release -p tempo-flatmpt \
-//!       --example build_golden -- <dump.bin> <out.flat>
+//! ```text
+//! MPT_RAM_BUILD_GIB=24 cargo run --release -p tempo-flatmpt \
+//!   --example build_golden -- <dump.bin> <out.flat>
+//! ```
 
 use alloy_primitives::{U256, keccak256};
 use mpt_flat_poc::{AccountSeed, Config, FlatMpt, Key};

--- a/crates/flatmpt/examples/replay_ops.rs
+++ b/crates/flatmpt/examples/replay_ops.rs
@@ -81,26 +81,26 @@ fn main() -> anyhow::Result<()> {
             // REPLAY_AUDIT_FROM=N: full forensic audit after each gc pass
             // from block N on — the first unclean audit names the corrupting
             // pass and the exact record.
-            if let Ok(from) = std::env::var("REPLAY_AUDIT_FROM") {
-                if block >= from.parse::<u64>().unwrap_or(u64::MAX) {
-                    let t_a = Instant::now();
-                    let audit = db.audit_hashes().map_err(|e| anyhow::anyhow!("{e:#}"))?;
-                    // Legacy golden records carry storage-relative prefixes;
-                    // bad_prefixes is expected on pre-composite files. Hash
-                    // consistency is the corruption oracle.
-                    let hash_clean = audit.bad_disk_roots == 0
-                        && audit.bad_mem_roots == 0
-                        && audit.stale_cells == 0
-                        && audit.bad_record_nrefs == 0
-                        && audit.bad_record_storage_roots == 0;
-                    eprintln!(
-                        "block {block}: audit hash_clean={hash_clean} ({}s) {:?}",
-                        t_a.elapsed().as_secs(),
-                        if hash_clean { None } else { Some(&audit) }
-                    );
-                    if !hash_clean {
-                        anyhow::bail!("audit hash-unclean after gc of block {block}");
-                    }
+            if let Ok(from) = std::env::var("REPLAY_AUDIT_FROM")
+                && block >= from.parse::<u64>().unwrap_or(u64::MAX)
+            {
+                let t_a = Instant::now();
+                let audit = db.audit_hashes().map_err(|e| anyhow::anyhow!("{e:#}"))?;
+                // Legacy golden records carry storage-relative prefixes;
+                // bad_prefixes is expected on pre-composite files. Hash
+                // consistency is the corruption oracle.
+                let hash_clean = audit.bad_disk_roots == 0
+                    && audit.bad_mem_roots == 0
+                    && audit.stale_cells == 0
+                    && audit.bad_record_nrefs == 0
+                    && audit.bad_record_storage_roots == 0;
+                eprintln!(
+                    "block {block}: audit hash_clean={hash_clean} ({}s) {:?}",
+                    t_a.elapsed().as_secs(),
+                    if hash_clean { None } else { Some(&audit) }
+                );
+                if !hash_clean {
+                    anyhow::bail!("audit hash-unclean after gc of block {block}");
                 }
             }
         }
@@ -131,7 +131,7 @@ fn main() -> anyhow::Result<()> {
                                     hex::encode(&key[..8]),
                                     hex::encode(&slot[..8]),
                                     hex::encode(value),
-                                    got.map(|v| hex::encode(v))
+                                    got.map(hex::encode)
                                 );
                             }
                         }

--- a/crates/flatmpt/examples/replay_ops.rs
+++ b/crates/flatmpt/examples/replay_ops.rs
@@ -114,7 +114,7 @@ fn main() -> anyhow::Result<()> {
             eprintln!("expected sparse root: {expected}");
             // Which side is right? If every op's value reads back exactly,
             // the flat state IS parent+ops and the flat root is the true
-            // root — the recorded sparse root was mis-computed.
+            // root — the recorded sparse root was computed incorrectly.
             let (mut checked, mut bad) = (0u64, 0u64);
             for (key, op) in &ops_copy {
                 match op {

--- a/crates/flatmpt/src/follower.rs
+++ b/crates/flatmpt/src/follower.rs
@@ -53,7 +53,7 @@ pub fn pending_root(parent_root: B256, ops: &mut [(Key, StateOp)]) -> Option<B25
     if !pending.iter().any(|(p, _, _)| *p == parent_root) {
         return None;
     }
-    ops.sort_by(|a, b| a.0.cmp(&b.0));
+    ops.sort_by_key(|a| a.0);
     let fp = crate::ops_fingerprint(ops);
     pending
         .iter()
@@ -280,6 +280,7 @@ pub fn follower(shadow: &'static RwLock<FlatShadow>) -> &'static Follower {
 
 /// Background GC: collect victim regions off the write lock (parallel reads
 /// + head rewrites against a pinned snapshot), then briefly take the writer
+///
 /// to re-verify and install the pointer swaps. Replaces the per-apply
 /// `gc_step` (whose region IO throttled the follower to ~4s/block at flood).
 ///
@@ -426,7 +427,7 @@ impl Follower {
         mut ops: Vec<(Key, StateOp)>,
         expected_root: B256,
     ) {
-        ops.sort_by(|a, b| a.0.cmp(&b.0));
+        ops.sort_by_key(|a| a.0);
         // TEMPO_FLATMPT_DUMP_OPS=<dir>: persist each block's canonical ops
         // (bincode) for offline divergence replay.
         if let Ok(dir) = std::env::var("TEMPO_FLATMPT_DUMP_OPS") {

--- a/crates/flatmpt/src/lib.rs
+++ b/crates/flatmpt/src/lib.rs
@@ -1030,6 +1030,87 @@ mod tests {
     }
 
     #[test]
+    fn bloat_streaming_preserves_genesis_precedence() {
+        use std::io::Write as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let dump = dir.path().join("state.bin");
+        let path = dir.path().join("bloat.flat");
+        let address = [7u8; 20];
+        let account = keccak256(address).0;
+        let slot_a = [1u8; 32];
+        let slot_b = [2u8; 32];
+        let value_a = U256::from(11u64);
+        let value_b = U256::from(22u64);
+        let genesis_value = U256::from(33u64);
+
+        let mut file = std::fs::File::create(&dump).unwrap();
+        let mut header = [0u8; 40];
+        header[..8].copy_from_slice(b"TEMPOSB\0");
+        header[8..10].copy_from_slice(&1u16.to_be_bytes());
+        header[12..32].copy_from_slice(&address);
+        header[32..40].copy_from_slice(&2u64.to_be_bytes());
+        file.write_all(&header).unwrap();
+        for (slot, value) in [(slot_a, value_a), (slot_b, value_b)] {
+            file.write_all(&slot).unwrap();
+            file.write_all(&value.to_be_bytes::<32>()).unwrap();
+        }
+        drop(file);
+
+        let genesis = vec![
+            acct(7, 9),
+            acct(8, 1),
+            (
+                account,
+                StateOp::SetStorage {
+                    slot: keccak256(slot_a).0,
+                    value: mpt_flat_poc::eth::storage_value_rlp(genesis_value),
+                },
+            ),
+        ];
+        let shadow = FlatShadow::init_with_bloat(
+            path.to_str().unwrap(),
+            genesis.clone(),
+            dump.to_str().unwrap(),
+        )
+        .unwrap();
+
+        let mut oracle = FlatMpt::create(
+            dir.path().join("oracle.flat"),
+            mpt_flat_poc::Config::default(),
+        )
+        .unwrap();
+        oracle
+            .apply_block(vec![
+                (
+                    account,
+                    StateOp::SetAccount {
+                        nonce: 0,
+                        balance: U256::ZERO,
+                        code_hash: mpt_flat_poc::eth::EMPTY_CODE_HASH.0,
+                    },
+                ),
+                (
+                    account,
+                    StateOp::SetStorage {
+                        slot: keccak256(slot_a).0,
+                        value: mpt_flat_poc::eth::storage_value_rlp(value_a),
+                    },
+                ),
+                (
+                    account,
+                    StateOp::SetStorage {
+                        slot: keccak256(slot_b).0,
+                        value: mpt_flat_poc::eth::storage_value_rlp(value_b),
+                    },
+                ),
+            ])
+            .unwrap();
+        let (want, _) = oracle.apply_block(genesis).unwrap();
+        assert_eq!(shadow.current_root(), B256::from(want));
+    }
+
+    #[test]
     fn prefetch_is_advisory_and_root_neutral() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("s.flat");

--- a/crates/flatmpt/src/lib.rs
+++ b/crates/flatmpt/src/lib.rs
@@ -331,7 +331,12 @@ impl FlatShadow {
                 }
             }
         }
-        let mut db = FlatMpt::create_ram_build(path, mpt_flat_poc::Config::default())
+        // Bloat checkpoints are intentionally disk-resident. RAM-build's
+        // spill duplicates the in-memory frontier while serializing it; on
+        // 64 GiB validators that transient peaked at 56.4 GiB and was OOM-
+        // killed even with a 12 GiB trigger. Incremental direct-disk inserts
+        // avoid that whole-frontier copy.
+        let mut db = FlatMpt::create(path, mpt_flat_poc::Config::default())
             .map_err(|e| anyhow::anyhow!("{e:#}"))?;
 
         // 1) Dump, streamed in bounded chunks. Repeated seeds for one account
@@ -340,9 +345,7 @@ impl FlatShadow {
         let mut f = std::io::BufReader::with_capacity(64 << 20, std::fs::File::open(dump)?);
         let mut header = [0u8; 40];
         let mut n_dump: usize = 0;
-        // Keep decode/sort scratch small relative to the engine's spill-time
-        // copy. On 64 GiB validators, 250k-slot chunks plus a 24 GiB frontier
-        // peaked at 56.4 GiB RSS and tripped the service's cgroup OOM limit.
+        // Keep decode/sort scratch bounded while streaming to disk.
         const SLOT_CHUNK: usize = 64_000;
         loop {
             match f.read_exact(&mut header) {

--- a/crates/flatmpt/src/lib.rs
+++ b/crates/flatmpt/src/lib.rs
@@ -299,11 +299,10 @@ impl FlatShadow {
 
     /// Bloat-mode init: genesis alloc + state-bloat dump.
     ///
-    /// Streams the dump straight into per-account seed maps (no intermediate op
-    /// vector — at 100M+ slots that alone is >10 GB), merges the genesis alloc
-    /// on top (genesis wins storage collisions, mirroring
-    /// `tempo init-from-binary-dump`), and loads through the engine's seeded
-    /// RAM-build path — the same one the mainnet loader used for 535M slots.
+    /// Streams bounded slot chunks directly into the engine, then merges the
+    /// genesis alloc on top (genesis wins storage collisions, mirroring
+    /// `tempo init-from-binary-dump`). This avoids retaining the entire bloat
+    /// dump in hash maps before the engine's own spill threshold can engage.
     /// Rebuilt every init: genesis regenerates per bench leg.
     fn init_with_bloat(
         path: &str,
@@ -332,13 +331,16 @@ impl FlatShadow {
                 }
             }
         }
-        let mut accs: std::collections::HashMap<Key, Acc> = std::collections::HashMap::new();
+        let mut db = FlatMpt::create_ram_build(path, mpt_flat_poc::Config::default())
+            .map_err(|e| anyhow::anyhow!("{e:#}"))?;
 
-        // 1) Dump, streamed. 2) Genesis alloc second — its inserts overwrite
-        //    colliding dump slots, which is exactly the node's collision rule.
+        // 1) Dump, streamed in bounded chunks. Repeated seeds for one account
+        // add slots without wiping earlier chunks. 2) Genesis alloc second —
+        // its inserts overwrite colliding dump slots, matching the node rule.
         let mut f = std::io::BufReader::with_capacity(64 << 20, std::fs::File::open(dump)?);
         let mut header = [0u8; 40];
         let mut n_dump: usize = 0;
+        const SLOT_CHUNK: usize = 250_000;
         loop {
             match f.read_exact(&mut header) {
                 Ok(()) => {}
@@ -352,7 +354,7 @@ impl FlatShadow {
             );
             let key: Key = keccak256(&header[12..32]).0;
             let pair_count = u64::from_be_bytes(header[32..40].try_into().unwrap());
-            let acc = accs.entry(key).or_default();
+            let mut slots = Vec::with_capacity(SLOT_CHUNK.min(pair_count as usize));
             let mut pair = [0u8; 64];
             for _ in 0..pair_count {
                 f.read_exact(&mut pair)?;
@@ -360,13 +362,41 @@ impl FlatShadow {
                 if value == U256::ZERO {
                     continue;
                 }
-                acc.slots.insert(
+                slots.push((
                     keccak256(&pair[0..32]).0,
                     mpt_flat_poc::eth::storage_value_rlp(value),
-                );
+                ));
                 n_dump += 1;
+                if slots.len() == SLOT_CHUNK {
+                    slots.sort_by(|a, b| a.0.cmp(&b.0));
+                    db.insert_batch_accounts(vec![(
+                        key,
+                        mpt_flat_poc::AccountSeed {
+                            nonce: 0,
+                            balance: U256::ZERO,
+                            code_hash: mpt_flat_poc::eth::EMPTY_CODE_HASH.0,
+                            slots: std::mem::take(&mut slots),
+                        },
+                    )])
+                    .map_err(|e| anyhow::anyhow!("bloat chunk insert: {e:#}"))?;
+                    slots = Vec::with_capacity(SLOT_CHUNK);
+                }
+            }
+            if !slots.is_empty() {
+                slots.sort_by(|a, b| a.0.cmp(&b.0));
+                db.insert_batch_accounts(vec![(
+                    key,
+                    mpt_flat_poc::AccountSeed {
+                        nonce: 0,
+                        balance: U256::ZERO,
+                        code_hash: mpt_flat_poc::eth::EMPTY_CODE_HASH.0,
+                        slots,
+                    },
+                )])
+                .map_err(|e| anyhow::anyhow!("bloat tail insert: {e:#}"))?;
             }
         }
+        let mut accs: std::collections::HashMap<Key, Acc> = std::collections::HashMap::new();
         let n_alloc = genesis_ops.len();
         for (key, op) in genesis_ops {
             match op {
@@ -405,8 +435,6 @@ impl FlatShadow {
             .collect();
         batch.sort_by(|a, b| a.0.cmp(&b.0));
 
-        let mut db = FlatMpt::create_ram_build(path, mpt_flat_poc::Config::default())
-            .map_err(|e| anyhow::anyhow!("{e:#}"))?;
         db.insert_batch_accounts(batch)
             .map_err(|e| anyhow::anyhow!("bloat seed insert: {e:#}"))?;
         db.persist().map_err(|e| anyhow::anyhow!("{e:#}"))?;

--- a/crates/flatmpt/src/lib.rs
+++ b/crates/flatmpt/src/lib.rs
@@ -7,7 +7,7 @@
 //! engine validator (block validation, via reth's `CustomStateRoot` seam).
 //!
 //! Activation is env-driven so stock binaries are unaffected:
-//!   TEMPO_FLATMPT=<path>          enable; flat file lives at <path> (wiped on init)
+//!   TEMPO_FLATMPT=path            enable; flat file lives at `path` (wiped on init)
 //!   TEMPO_FLATMPT_MODE=compare    compute flat root alongside the sparse trie and
 //!                                 assert parity per block (default; bring-up gate)
 //!   TEMPO_FLATMPT_MODE=root       flat MPT is the sole commitment: the builder
@@ -371,7 +371,7 @@ impl FlatShadow {
                 ));
                 n_dump += 1;
                 if slots.len() == SLOT_CHUNK {
-                    slots.sort_by(|a, b| a.0.cmp(&b.0));
+                    slots.sort_by_key(|a| a.0);
                     db.insert_batch_accounts(vec![(
                         key,
                         mpt_flat_poc::AccountSeed {
@@ -386,7 +386,7 @@ impl FlatShadow {
                 }
             }
             if !slots.is_empty() {
-                slots.sort_by(|a, b| a.0.cmp(&b.0));
+                slots.sort_by_key(|a| a.0);
                 db.insert_batch_accounts(vec![(
                     key,
                     mpt_flat_poc::AccountSeed {
@@ -424,7 +424,7 @@ impl FlatShadow {
             .into_iter()
             .map(|(key, acc)| {
                 let mut slots: Vec<(Key, Vec<u8>)> = acc.slots.into_iter().collect();
-                slots.sort_by(|a, b| a.0.cmp(&b.0));
+                slots.sort_by_key(|a| a.0);
                 (
                     key,
                     mpt_flat_poc::AccountSeed {
@@ -436,7 +436,7 @@ impl FlatShadow {
                 )
             })
             .collect();
-        batch.sort_by(|a, b| a.0.cmp(&b.0));
+        batch.sort_by_key(|a| a.0);
 
         db.insert_batch_accounts(batch)
             .map_err(|e| anyhow::anyhow!("bloat seed insert: {e:#}"))?;
@@ -514,7 +514,7 @@ impl FlatShadow {
         // Account interleaving differs between two executions of the same block
         // (bundle state is a hash map); per-account op sequences are what carry
         // ordering semantics. Stable-sort by account key → canonical fingerprint.
-        ops.sort_by(|a, b| a.0.cmp(&b.0));
+        ops.sort_by_key(|a| a.0);
 
         // Memo: the validator re-deriving the block the builder just applied.
         let fingerprint = ops_fingerprint(&ops);
@@ -523,13 +523,12 @@ impl FlatShadow {
             .iter()
             .rev()
             .find(|e| e.number == parent_number + 1 && e.parent_root == parent_root.0)
+            && e.ops_hash == fingerprint
         {
-            if e.ops_hash == fingerprint {
-                return Ok(B256::from(e.root));
-            }
-            // Same parent, different payload: a rebuilt candidate. Fall through —
-            // the rollback loop below unwinds to the shared parent state.
+            return Ok(B256::from(e.root));
         }
+        // Same parent, different payload: a rebuilt candidate. Fall through —
+        // the rollback loop below unwinds to the shared parent state.
 
         self.unwind_to(parent_root)?;
 
@@ -735,7 +734,7 @@ impl FlatShadow {
 ///
 /// With `TEMPO_FLATMPT_BLOAT=<file>` the state-bloat binary dump (the same one
 /// `tempo init-from-binary-dump` loads) is applied on top of the alloc, and the
-/// resulting checkpoint is cached as `<path>.golden*` — later inits with the
+/// resulting checkpoint is cached as `path.golden*` — later inits with the
 /// same dump restore by file copy instead of re-applying millions of slots.
 /// In bloat mode the genesis-root assertion is skipped here (the header root is
 /// only known post-dump); the first `root_for`/`begin_stream` parent check is
@@ -948,7 +947,7 @@ fn bundle_chunk_to_ops(
                 ));
             }
         }
-        slots.sort_by(|a, b| a.0.cmp(&b.0));
+        slots.sort_by_key(|a| a.0);
         ops.extend(slots.into_iter().map(|(_, op)| (key, op)));
     }
     ops
@@ -1232,6 +1231,12 @@ mod tests {
             state,
             ..Default::default()
         };
+        let destroyed_live: std::collections::BTreeSet<B256> = bundle
+            .state
+            .iter()
+            .filter(|(_, account)| account.status.was_destroyed() && account.info.is_some())
+            .map(|(address, _)| keccak256(address.as_slice()))
+            .collect();
 
         let ops = bundle_to_ops(&bundle);
         let ours = ops_to_post_state(&ops);
@@ -1256,7 +1261,10 @@ mod tests {
             let o = ours.storages.get(&acct);
             let r = reths.storages.get(&acct);
             let deleted = matches!(ours.accounts.get(&acct), Some(None));
-            if !deleted {
+            // Reth's from_bundle_state helper does not carry AccountStatus,
+            // so it cannot mark destroy-then-recreate storage as wiped. The
+            // Flat MPT ops intentionally retain that required semantic.
+            if !deleted && !destroyed_live.contains(&acct) {
                 assert_eq!(
                     o.map(|s| s.wiped).unwrap_or(false),
                     r.map(|s| s.wiped).unwrap_or(false),

--- a/crates/flatmpt/src/lib.rs
+++ b/crates/flatmpt/src/lib.rs
@@ -340,7 +340,10 @@ impl FlatShadow {
         let mut f = std::io::BufReader::with_capacity(64 << 20, std::fs::File::open(dump)?);
         let mut header = [0u8; 40];
         let mut n_dump: usize = 0;
-        const SLOT_CHUNK: usize = 250_000;
+        // Keep decode/sort scratch small relative to the engine's spill-time
+        // copy. On 64 GiB validators, 250k-slot chunks plus a 24 GiB frontier
+        // peaked at 56.4 GiB RSS and tripped the service's cgroup OOM limit.
+        const SLOT_CHUNK: usize = 64_000;
         loop {
             match f.read_exact(&mut header) {
                 Ok(()) => {}

--- a/crates/flatmpt/src/sparse.rs
+++ b/crates/flatmpt/src/sparse.rs
@@ -570,10 +570,7 @@ fn chunked_proofs(
     for slice in flat.chunks(chunk_size) {
         let mut t = MultiProofTargetsV2::default();
         for (acct, target) in slice {
-            t.storage_targets
-                .entry(*acct)
-                .or_default()
-                .push(target.clone());
+            t.storage_targets.entry(*acct).or_default().push(*target);
         }
         chunks.push(t);
     }
@@ -619,18 +616,6 @@ fn proof_threads() -> usize {
             .unwrap_or(8)
             .clamp(1, 128)
     })
-}
-
-/// Drop the pooled trie once it outgrows this (`TEMPO_FLATMPT_SPARSE_MEM_MB`).
-fn trie_mem_cap() -> usize {
-    static MB: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
-    *MB.get_or_init(|| {
-        std::env::var("TEMPO_FLATMPT_SPARSE_MEM_MB")
-            .ok()
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(4096)
-    }) * 1024
-        * 1024
 }
 
 enum Msg {
@@ -753,7 +738,7 @@ impl SparseWorker {
                         }
                         // Re-check the fast lane periodically inside deep drains.
                         in_batch += 1;
-                        if in_batch % 256 == 0 && let Ok(ops) = finish_rx.try_recv() {
+                        if in_batch.is_multiple_of(256) && let Ok(ops) = finish_rx.try_recv() {
                             w.stats.hook_dropped =
                                 dropped_w.load(std::sync::atomic::Ordering::Relaxed);
                             let _ = result_tx.send(w.finish(ops));
@@ -878,8 +863,10 @@ impl Worker {
         // Retain branch-node updates: finish() publishes them as the block's
         // overlay so descendants' proofs need not wait for the flat apply.
         trie.set_updates(true);
-        let mut stats = SparseStats::default();
-        stats.pool_hit = pool_hit;
+        let stats = SparseStats {
+            pool_hit,
+            ..Default::default()
+        };
         Self {
             shadow,
             parent_root,
@@ -899,20 +886,19 @@ impl Worker {
         }
     }
 
-    /// Return the trie to the pool as representing `root`, unless it has
-    /// outgrown the memory cap.
+    /// Return the trie to the pool as representing `root`.
+    ///
+    /// Prune nodes older than the current flat snapshot first. Pruning blinds
+    /// cold subtries at their already-computed hashes, retaining correctness
+    /// while bounding the cross-block pool to the recently touched working set.
     fn pool_put(&mut self, root: B256) {
-        // TODO: replace this conservative fallback once Reth exposes sparse-trie heap usage.
-        let mem = trie_mem_cap().saturating_add(1);
-        if mem <= trie_mem_cap() {
-            self.stats.trie_mem_mb = (mem >> 20) as u64;
-            let trie = std::mem::take(&mut self.trie);
-            *TRIE_POOL.lock() = Some((root, self.anchor, trie));
-        } else {
-            self.stats.trie_mem_mb = 0;
-            tracing::info!(target: "flatmpt", mem_mb = mem >> 20, "pooled sparse trie over cap; dropping");
-            *TRIE_POOL.lock() = None;
+        if self.snap_seq > 1 {
+            self.trie.prune(TrieNodeEpoch::new(self.snap_seq));
         }
+        // Reth does not currently expose heap usage for SparseStateTrie.
+        self.stats.trie_mem_mb = 0;
+        let trie = std::mem::take(&mut self.trie);
+        *TRIE_POOL.lock() = Some((root, self.anchor, trie));
     }
 
     /// A cancelled build's trie still represents plain parent state as long
@@ -1252,7 +1238,7 @@ impl Worker {
                         out.push((*acct, Vec::new()));
                         continue;
                     };
-                    let mut account = account.clone();
+                    let mut account = *account;
                     account.storage_root = if destroyed_ref.contains(acct) {
                         EMPTY_ROOT_HASH
                     } else if let Some(r) = sroots_ref.get(acct) {
@@ -1519,25 +1505,23 @@ impl Worker {
                     self.refresh_snap(true);
                     sound = self.snap_at_parent || (self.stats.pool_hit && self.anchor_ok());
                 }
-                if let Some(snap) = &self.snap {
-                    if sound {
-                        match direct_reveal(snap, &acct_targets, &storage_targets) {
-                            Ok(p) => direct = Some(p),
-                            Err(e)
-                                if std::env::var("TEMPO_FLATMPT_NO_PROOF_FALLBACK").as_deref()
-                                    == Ok("1") =>
-                            {
-                                return Err(anyhow::anyhow!(
-                                    "direct reveal failed (strict): {e:#}"
-                                ));
-                            }
-                            Err(e) => {
-                                tracing::warn!(
-                                    target: "flatmpt",
-                                    err = %format!("{e:#}"),
-                                    "direct reveal failed; using proof walk"
-                                );
-                            }
+                if let Some(snap) = &self.snap
+                    && sound
+                {
+                    match direct_reveal(snap, &acct_targets, &storage_targets) {
+                        Ok(p) => direct = Some(p),
+                        Err(e)
+                            if std::env::var("TEMPO_FLATMPT_NO_PROOF_FALLBACK").as_deref()
+                                == Ok("1") =>
+                        {
+                            return Err(anyhow::anyhow!("direct reveal failed (strict): {e:#}"));
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "flatmpt",
+                                err = %format!("{e:#}"),
+                                "direct reveal failed; using proof walk"
+                            );
                         }
                     }
                 }
@@ -1842,7 +1826,7 @@ mod stall_tests {
         let proof = Proof::new(tf, hf).multiproof(targets).unwrap();
 
         eprintln!("account subtree nodes:");
-        for (p, _) in proof.account_subtree.iter() {
+        for p in proof.account_subtree.keys() {
             eprintln!("  acct node path len={} {:?}", p.len(), p);
         }
         for (a, sp) in proof.storages.iter() {
@@ -1851,7 +1835,7 @@ mod stall_tests {
                 sp.root,
                 sp.subtree.iter().count()
             );
-            let mut paths: Vec<_> = sp.subtree.iter().map(|(p, _)| p).collect();
+            let mut paths: Vec<_> = sp.subtree.keys().collect();
             paths.sort();
             for p in paths.iter() {
                 let d = format!("{p:?}");
@@ -1864,9 +1848,7 @@ mod stall_tests {
 
         // Dump our cursor's branch entry at 0x5500 and neighbours.
         {
-            use reth_trie::trie_cursor::{
-                TrieCursor as _, TrieCursorFactory as _, TrieStorageCursor as _,
-            };
+            use reth_trie::trie_cursor::{TrieCursor as _, TrieCursorFactory as _};
             let mut c = tf.storage_trie_cursor(acct).unwrap();
             let mut path = reth_trie::Nibbles::default();
             for n in [5u8, 5, 0, 0] {
@@ -1896,9 +1878,7 @@ mod stall_tests {
                 eprintln!("next branch: NONE");
             }
             // leaves under 0x55009
-            use reth_trie::hashed_cursor::{
-                HashedCursor as _, HashedCursorFactory as _, HashedStorageCursor as _,
-            };
+            use reth_trie::hashed_cursor::{HashedCursor as _, HashedCursorFactory as _};
             let mut hc = hf.hashed_storage_cursor(acct).unwrap();
             let mut seek = [0u8; 32];
             seek[0] = 0x55;
@@ -2013,8 +1993,8 @@ mod stall_tests {
         let shadow: &'static RwLock<FlatShadow> = Box::leak(Box::new(RwLock::new(s)));
 
         let mut parent = g;
-        let mut parent_number = 0u64;
         for round in 0..2u64 {
+            let parent_number = round;
             let mut ops: Vec<(Key, StateOp)> = vec![set_acct(200, 2 + round)];
             for s in 0..400u16 {
                 ops.push(set_slot(200, s * 100, 9_000 + round + s as u64)); // updates
@@ -2036,7 +2016,6 @@ mod stall_tests {
                 stats.storage_targets, stats.finish_rounds
             );
             parent = sparse_root;
-            parent_number += 1;
         }
     }
 
@@ -2065,8 +2044,8 @@ mod stall_tests {
         let shadow: &'static RwLock<FlatShadow> = Box::leak(Box::new(RwLock::new(s)));
 
         let mut parent = g;
-        let mut parent_number = 0u64;
         for round in 0..3u64 {
+            let parent_number = round;
             let mut ops: Vec<(Key, StateOp)> = Vec::new();
             for a in 0..250u8 {
                 ops.push(set_acct(a, 2 + round));
@@ -2092,7 +2071,6 @@ mod stall_tests {
                 stats.account_targets, stats.storage_targets, stats.finish_rounds
             );
             parent = sparse_root;
-            parent_number += 1;
         }
     }
 
@@ -2149,7 +2127,7 @@ mod stall_tests {
                 ops.push(set_slot(a, s, 5000 + s as u64));
             }
         }
-        ops.sort_by(|a, b| a.0.cmp(&b.0));
+        ops.sort_by_key(|a| a.0);
 
         let (root, stats) = w.finish(ops.clone()).unwrap();
         let expect = shadow.write().root_for(0, g, ops).unwrap();
@@ -2254,7 +2232,7 @@ mod stall_tests {
 
 #[cfg(test)]
 mod proofbench {
-    use super::{tests::*, *};
+    use super::*;
     use reth_trie::Nibbles;
 
     #[test]
@@ -2454,7 +2432,7 @@ mod overlay_tests {
             let (oracle_root, _) = oracle
                 .apply_block({
                     let mut o = ops.clone();
-                    o.sort_by(|a, b| a.0.cmp(&b.0));
+                    o.sort_by_key(|a| a.0);
                     o
                 })
                 .unwrap();
@@ -2499,7 +2477,7 @@ mod overlay_tests {
         for sl in 0..8u16 {
             ops1.push(set_slot(201, sl, 900 + sl as u64));
         }
-        ops1.sort_by(|a, b| a.0.cmp(&b.0));
+        ops1.sort_by_key(|a| a.0);
         let mut w1 = Worker::new(shadow, g);
         let (root1, _) = w1.finish(ops1.clone()).unwrap();
         let (o1, _) = oracle.apply_block(ops1).unwrap();
@@ -2512,7 +2490,7 @@ mod overlay_tests {
         for sl in 0..4u16 {
             ops2.push(set_slot(201, sl, 7000 + sl as u64));
         }
-        ops2.sort_by(|a, b| a.0.cmp(&b.0));
+        ops2.sort_by_key(|a| a.0);
         let mut w2 = Worker::new(shadow, root1);
         assert!(!w2.stats.pool_hit, "block 2 must be a pool miss");
         let (root2, _) = w2
@@ -2559,7 +2537,7 @@ mod overlay_tests {
         let (o1, _) = oracle
             .apply_block({
                 let mut o = ops1.clone();
-                o.sort_by(|a, b| a.0.cmp(&b.0));
+                o.sort_by_key(|a| a.0);
                 o
             })
             .unwrap();
@@ -2581,7 +2559,7 @@ mod overlay_tests {
         for sl in 0..8u16 {
             ops3.push(set_slot(2, sl * 20, 900_000 + sl as u64));
         }
-        ops3.sort_by(|a, b| a.0.cmp(&b.0));
+        ops3.sort_by_key(|a| a.0);
         let mut w3 = Worker::new(shadow, root1);
         assert!(w3.stats.pool_hit, "block 3 must reuse the young trie");
         let (root3, _) = w3.finish(ops3.clone()).unwrap();
@@ -2648,7 +2626,7 @@ mod finishpath_bench {
         let path = path.to_str().unwrap();
 
         const EOAS: usize = 55_000;
-        const SLOTS: u16 = 55_000u16 as u16;
+        const SLOTS: u16 = 55_000_u16;
         let contract: u8 = 251;
 
         let mut genesis: Vec<(Key, StateOp)> = Vec::new();
@@ -2686,8 +2664,8 @@ mod finishpath_bench {
         let shadow: &'static RwLock<FlatShadow> = Box::leak(Box::new(RwLock::new(s)));
 
         let mut parent = g;
-        let mut parent_number = 0u64;
         for round in 1..=3u64 {
+            let parent_number = round - 1;
             let mut ops: Vec<(Key, StateOp)> = Vec::with_capacity(EOAS + SLOTS as usize);
             for i in 0..EOAS {
                 let a = keccak256(format!("eoa-{i}")).0;
@@ -2711,7 +2689,7 @@ mod finishpath_bench {
                     },
                 ));
             }
-            ops.sort_by(|a, b| a.0.cmp(&b.0));
+            ops.sort_by_key(|a| a.0);
 
             let worker = SparseWorker::begin(shadow, parent);
             let t = Instant::now();
@@ -2736,7 +2714,6 @@ mod finishpath_bench {
             let expect = shadow.write().root_for(parent_number, parent, ops).unwrap();
             assert_eq!(root, expect, "sparse/flat divergence in bench");
             parent = root;
-            parent_number += 1;
         }
     }
 
@@ -2781,7 +2758,7 @@ mod finishpath_bench {
             let build_ms = t.elapsed().as_micros() as f64 / 1000.0;
 
             let t = Instant::now();
-            ops.sort_by(|a, b| a.0.cmp(&b.0));
+            ops.sort_by_key(|a| a.0);
             let sort_ms = t.elapsed().as_micros() as f64 / 1000.0;
 
             let t = Instant::now();

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -509,7 +509,6 @@ where
         // blocks out of the served state.
         if std::env::var("TEMPO_NO_STATE_KV").is_ok_and(|v| v == "1" || v == "all") {
             let provider = ctx.node.provider().clone();
-            let chain_spec = chain_spec.clone();
             // Resolution is cached per tip: pool validation calls this for
             // every incoming transaction's fee-balance read, so the walk must
             // not repeat per read.

--- a/crates/payload/builder/src/flat_reads.rs
+++ b/crates/payload/builder/src/flat_reads.rs
@@ -92,7 +92,7 @@ impl HashedKeyMemo {
 pub(crate) struct RevealFeed {
     pub sink: tempo_flatmpt::RevealSink,
     /// Lock-free probabilistic dedup of keys already handed over this block.
-    /// The previous Mutex<HashSet> stalled all ~30 prewarm workers together
+    /// The previous `Mutex<HashSet>` stalled all ~30 prewarm workers together
     /// whenever the 265k-entry set rehashed under the lock (5-10ms correlated
     /// stalls — the dispatch-latch trigger). A false positive only means the
     /// commitment worker fetches that one path itself.
@@ -329,16 +329,16 @@ impl FlatReadProvider {
     /// Account point-read; when a reveal feed is attached and this is the
     /// first touch of `key`, the read's walk doubles as the reveal.
     fn read_account_rlp(&self, key: &B256) -> ProviderResult<Option<Vec<u8>>> {
-        if let Some(feed) = &self.shared.reveal {
-            if feed.sent_accounts.first(&key.0) {
-                let (value, nodes) = self
-                    .shared
-                    .snap
-                    .get_value_reveal(&key.0)
-                    .map_err(|e| other(anyhow::anyhow!("{e:#}")))?;
-                feed.sink.account(*key, nodes);
-                return Ok(value);
-            }
+        if let Some(feed) = &self.shared.reveal
+            && feed.sent_accounts.first(&key.0)
+        {
+            let (value, nodes) = self
+                .shared
+                .snap
+                .get_value_reveal(&key.0)
+                .map_err(|e| other(anyhow::anyhow!("{e:#}")))?;
+            feed.sink.account(*key, nodes);
+            return Ok(value);
         }
         self.shared
             .snap
@@ -347,23 +347,23 @@ impl FlatReadProvider {
     }
 
     fn read_storage_rlp(&self, acct: &B256, slot: &B256) -> ProviderResult<Option<Vec<u8>>> {
-        if let Some(feed) = &self.shared.reveal {
-            if feed.sent_slots.first(&{
+        if let Some(feed) = &self.shared.reveal
+            && feed.sent_slots.first(&{
                 let mut k = [0u8; 16];
                 k[..8].copy_from_slice(&acct.0[..8]);
                 k[8..].copy_from_slice(&slot.0[..8]);
                 k
-            }) {
-                let (value, nodes) = self
-                    .shared
-                    .snap
-                    .get_storage_reveal(&acct.0, &slot.0)
-                    .map_err(|e| other(anyhow::anyhow!("{e:#}")))?;
-                if let Some(nodes) = nodes {
-                    feed.sink.storage(*acct, *slot, nodes);
-                }
-                return Ok(value);
+            })
+        {
+            let (value, nodes) = self
+                .shared
+                .snap
+                .get_storage_reveal(&acct.0, &slot.0)
+                .map_err(|e| other(anyhow::anyhow!("{e:#}")))?;
+            if let Some(nodes) = nodes {
+                feed.sink.storage(*acct, *slot, nodes);
             }
+            return Ok(value);
         }
         self.shared
             .snap

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -426,92 +426,92 @@ where
             .flatten();
         let t_sparse_begin = state_setup_start.elapsed();
         let mut flat_read_shared: Option<std::sync::Arc<flat_reads::FlatReadShared>> = None;
-        if flat_reads::flat_reads_enabled() {
-            if let Some(shadow) = flat_shadow {
-                // Reads must reflect the exact parent state. Preferred path is
-                // fully lock-free: the follower's last published snapshot plus
-                // the chain of queued-but-unapplied blocks overlaid on top —
-                // the builder never waits on the follower's apply. The direct
-                // bounded lock read covers startup (nothing published yet);
-                // past that, this block reads from MDBX — unless the KV copy
-                // isn't persisted at all, in which case the only correct
-                // option is to wait for the pending chain to become available.
-                let parent_root = parent_header.state_root();
-                let resolve = || {
-                    tempo_flatmpt::published_snapshot().and_then(|(published_root, snap)| {
-                        tempo_flatmpt::pending_chain(published_root, parent_root)
-                            .map(|overlay| (snap, overlay))
-                    })
-                };
-                let mut snap = resolve().or_else(|| {
-                    shadow
-                        .try_read_for(std::time::Duration::from_millis(50))
-                        .and_then(|g| g.at_parent(parent_root).then(|| (g.snapshot(), Vec::new())))
-                });
-                if snap.is_none() && flat_reads::no_state_kv_active() {
-                    warn!(
-                        target: "flatmpt",
-                        parent = %parent_root,
-                        published = ?tempo_flatmpt::published_snapshot().map(|(r, _)| r),
-                        queue = tempo_flatmpt::follower(shadow).depth(),
-                        "no-KV build waiting for a servable parent state"
-                    );
-                    let deadline = Instant::now() + std::time::Duration::from_secs(15);
-                    while snap.is_none() && Instant::now() < deadline {
-                        std::thread::sleep(std::time::Duration::from_millis(5));
-                        snap = resolve().or_else(|| {
-                            shadow
-                                .try_read_for(std::time::Duration::from_millis(5))
-                                .and_then(|g| {
-                                    g.at_parent(parent_root).then(|| (g.snapshot(), Vec::new()))
-                                })
-                        });
-                    }
-                    if snap.is_none() {
-                        return Err(PayloadBuilderError::Other(
-                            anyhow::anyhow!(
-                                "flat store never reached parent and no state KV exists to fall back to"
-                            )
-                            .into(),
-                        ));
-                    }
+        if flat_reads::flat_reads_enabled()
+            && let Some(shadow) = flat_shadow
+        {
+            // Reads must reflect the exact parent state. Preferred path is
+            // fully lock-free: the follower's last published snapshot plus
+            // the chain of queued-but-unapplied blocks overlaid on top —
+            // the builder never waits on the follower's apply. The direct
+            // bounded lock read covers startup (nothing published yet);
+            // past that, this block reads from MDBX — unless the KV copy
+            // isn't persisted at all, in which case the only correct
+            // option is to wait for the pending chain to become available.
+            let parent_root = parent_header.state_root();
+            let resolve = || {
+                tempo_flatmpt::published_snapshot().and_then(|(published_root, snap)| {
+                    tempo_flatmpt::pending_chain(published_root, parent_root)
+                        .map(|overlay| (snap, overlay))
+                })
+            };
+            let mut snap = resolve().or_else(|| {
+                shadow
+                    .try_read_for(std::time::Duration::from_millis(50))
+                    .and_then(|g| g.at_parent(parent_root).then(|| (g.snapshot(), Vec::new())))
+            });
+            if snap.is_none() && flat_reads::no_state_kv_active() {
+                warn!(
+                    target: "flatmpt",
+                    parent = %parent_root,
+                    published = ?tempo_flatmpt::published_snapshot().map(|(r, _)| r),
+                    queue = tempo_flatmpt::follower(shadow).depth(),
+                    "no-KV build waiting for a servable parent state"
+                );
+                let deadline = Instant::now() + std::time::Duration::from_secs(15);
+                while snap.is_none() && Instant::now() < deadline {
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    snap = resolve().or_else(|| {
+                        shadow
+                            .try_read_for(std::time::Duration::from_millis(5))
+                            .and_then(|g| {
+                                g.at_parent(parent_root).then(|| (g.snapshot(), Vec::new()))
+                            })
+                    });
                 }
-                match snap {
-                    Some((snap, overlay)) => {
-                        if !overlay.is_empty() {
-                            debug!(
-                                target: "flatmpt",
-                                pending = overlay.len(),
-                                "flat lags parent; reading through the pending-block overlay"
-                            );
-                        }
-                        let shared = std::sync::Arc::new(flat_reads::FlatReadShared {
-                            snap,
-                            hashed: Default::default(),
-                            // TEMPO_FLATMPT_READ_REVEAL=0 detaches the reveal
-                            // feed (A/B: exec-thread reveal-walk cost vs the
-                            // worker fetching its own reveals). With an active
-                            // overlay the snapshot trie is an ancestor of the
-                            // parent trie — its node hashes are stale — so the
-                            // worker must fetch its own proofs.
-                            reveal: flat_sparse
-                                .as_ref()
-                                .filter(|_| overlay.is_empty())
-                                .filter(|_| {
-                                    std::env::var("TEMPO_FLATMPT_READ_REVEAL").as_deref() != Ok("0")
-                                })
-                                .map(|w| flat_reads::RevealFeed::new(w.reveal_sink())),
-                            overlay,
-                        });
-                        state_provider = Box::new(flat_reads::FlatReadProvider {
-                            inner: state_provider,
-                            shared: shared.clone(),
-                        });
-                        flat_read_shared = Some(shared);
+                if snap.is_none() {
+                    return Err(PayloadBuilderError::Other(
+                        anyhow::anyhow!(
+                            "flat store never reached parent and no state KV exists to fall back to"
+                        )
+                        .into(),
+                    ));
+                }
+            }
+            match snap {
+                Some((snap, overlay)) => {
+                    if !overlay.is_empty() {
+                        debug!(
+                            target: "flatmpt",
+                            pending = overlay.len(),
+                            "flat lags parent; reading through the pending-block overlay"
+                        );
                     }
-                    None => {
-                        debug!(target: "flatmpt", "flat not at parent; MDBX reads this block");
-                    }
+                    let shared = std::sync::Arc::new(flat_reads::FlatReadShared {
+                        snap,
+                        hashed: Default::default(),
+                        // TEMPO_FLATMPT_READ_REVEAL=0 detaches the reveal
+                        // feed (A/B: exec-thread reveal-walk cost vs the
+                        // worker fetching its own reveals). With an active
+                        // overlay the snapshot trie is an ancestor of the
+                        // parent trie — its node hashes are stale — so the
+                        // worker must fetch its own proofs.
+                        reveal: flat_sparse
+                            .as_ref()
+                            .filter(|_| overlay.is_empty())
+                            .filter(|_| {
+                                std::env::var("TEMPO_FLATMPT_READ_REVEAL").as_deref() != Ok("0")
+                            })
+                            .map(|w| flat_reads::RevealFeed::new(w.reveal_sink())),
+                        overlay,
+                    });
+                    state_provider = Box::new(flat_reads::FlatReadProvider {
+                        inner: state_provider,
+                        shared: shared.clone(),
+                    });
+                    flat_read_shared = Some(shared);
+                }
+                None => {
+                    debug!(target: "flatmpt", "flat not at parent; MDBX reads this block");
                 }
             }
         }
@@ -748,7 +748,7 @@ where
             parent_header.hash(),
             executor.evm().evm_env(),
             self.config.enable_parallel,
-            flat_read_shared.clone(),
+            flat_read_shared,
         );
         let mut best_txs = if self.config.enable_prewarming {
             if self.config.enable_parallel {

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -596,6 +596,11 @@ impl<Provider> PrewarmingExecutionContext<Provider> {
 }
 
 /// Command sent by [`BestTransactionsPrewarming`] consumer.
+type PrewarmChannelSwap = (
+    Receiver<Option<PrewarmedTransaction>>,
+    Sender<Option<PrewarmedTransaction>>,
+);
+
 #[derive(Debug)]
 enum BestTransactionsCommand {
     Advance,
@@ -607,10 +612,7 @@ enum BestTransactionsCommand {
         /// conflicting buffered transactions itself, so a gas-capped block's
         /// ~17k tail invalidations cost a set insert instead of a channel
         /// swap + full buffer re-send each.
-        swap: Option<(
-            Receiver<Option<PrewarmedTransaction>>,
-            Sender<Option<PrewarmedTransaction>>,
-        )>,
+        swap: Option<PrewarmChannelSwap>,
     },
     NoUpdates,
     SkipBlobs(bool),


### PR DESCRIPTION
Runs Flat MPT feature phases with commitment and point reads served by the integrated flat store while disabling duplicate state-KV persistence. Adds the same mode to the multi-region bloat workflow for disk-resident comparisons.

Depends on tempoxyz/tempo-multi-region-benchmark#363.

Prompted by: @gakonst