### PR TITLE
fix(docker): make Tempo binary read-only

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /data
 # tempo
 FROM base AS tempo
 ARG RUST_PROFILE=profiling
-COPY --from=builder /app/target/${RUST_PROFILE}/tempo /usr/local/bin/tempo
+COPY --from=builder --chown=0:0 --chmod=0555 /app/target/${RUST_PROFILE}/tempo /usr/local/bin/tempo
 ENTRYPOINT ["/usr/local/bin/tempo"]
 
 # tempo-sidecar


### PR DESCRIPTION
Installs the Tempo runtime binary as root-owned mode 0555 so the non-root runtime user cannot modify it, even if a deployment omits a read-only root filesystem.

Prompted by: @0xalpharush