### PR TITLE
fix(consensus): read validator state from pending parents

### DIFF
--- a/crates/consensus/src/validators.rs
+++ b/crates/consensus/src/validators.rs
@@ -12,7 +12,7 @@ use commonware_utils::{TryFromIterator, ordered};
 use eyre::{OptionExt as _, WrapErr as _};
 use reth_ethereum::evm::revm::{State, database::StateProviderDatabase};
 use reth_node_builder::ConfigureEvm as _;
-use reth_provider::{HeaderProvider as _, StateProviderBox, StateProviderFactory as _};
+use reth_provider::{BlockReader as _, BlockSource, StateProviderBox, StateProviderFactory as _};
 use tempo_node::{TempoFullNode, evm::evm::TempoEvm};
 use tempo_precompiles::{
     storage::{StorageActions, StorageCtx},
@@ -44,10 +44,12 @@ pub(crate) trait ExecutionNode {
 
 impl ExecutionNode for TempoFullNode {
     fn header(&self, block_hash: B256) -> eyre::Result<TempoHeader> {
+        // DKG may read a proposal parent's validator state before its FCU makes the block canonical.
         self.provider
-            .header(block_hash)
+            .find_sealed_or_recovered_block(block_hash, BlockSource::Any)
             .map_err(eyre::Report::new)
-            .and_then(|maybe| maybe.ok_or_eyre("execution layer returned empty header"))
+            .and_then(|maybe| maybe.ok_or_eyre("execution layer returned empty block"))
+            .map(|block| block.clone_sealed_header().unseal())
     }
 
     fn state_by_block_hash(&self, block_hash: B256) -> eyre::Result<StateProviderBox> {


### PR DESCRIPTION
Prevents DKG validator-state reads from failing when a proposal parent has been executed but is still pending FCU canonicalization. The header lookup now includes pending blocks, matching the existing pending-aware state lookup.

Observed as flaky failures in [main run 31622941971](https://github.com/tempoxyz/tempo/actions/runs/31622941971) and [main run 31712796656](https://github.com/tempoxyz/tempo/actions/runs/31712796656); extracted from #7142.
