### PR TITLE
docs(evm): document EthBlockExecutor reuse in TempoBlockExecutor

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -168,34 +168,19 @@ impl TxResult for TempoTxResult {
 ///
 /// # Reuse of the inner [`EthBlockExecutor`]
 ///
-/// Every [`BlockExecutor`] method delegates to the inner executor and wraps it with
-/// Tempo-specific logic:
+/// Transaction execution, gas accounting, receipt building and state commits are delegated to
+/// the inner executor, as are the Ethereum system calls:
 ///
-/// - [`apply_pre_execution_changes`](BlockExecutor::apply_pre_execution_changes): after
-///   rejecting non-empty withdrawals, delegates to the inner executor, which transacts the
-///   Ethereum pre-block system calls: the [EIP-2935] blockhashes and [EIP-4788] beacon root
-///   contract calls (Cancun and Prague are active at genesis on all Tempo networks, and Tempo
-///   headers set a zero `parent_beacon_block_root`). Whether these calls have any effect
-///   depends on the respective system contract being deployed in the network's genesis state.
-///   Afterwards, Tempo deploys the `0xEF` marker bytecode for precompiles at their activation
-///   hardforks.
-/// - [`execute_transaction_without_commit`](BlockExecutor::execute_transaction_without_commit):
-///   reuses the inner executor for the block gas limit check and EVM execution, wrapped with
-///   section validation and the subblock fee recipient override.
-/// - [`commit_transaction`](BlockExecutor::commit_transaction): reuses the inner executor for
-///   block gas accounting, receipt building via [`TempoReceiptBuilder`], and committing the
-///   state changes, then updates the section-specific gas counters.
-/// - [`finish`](BlockExecutor::finish): applies Tempo end-of-block logic first (shared gas
-///   validation and the `CurrentCommittee` epoch rotation system call), then delegates to the
-///   inner executor, thereby also reusing the Ethereum post-block logic: [EIP-6110] deposit
-///   request parsing and the [EIP-7002] withdrawal requests and [EIP-7251] consolidation
-///   requests system calls (effective no-ops on Tempo because the corresponding system
-///   contracts are not deployed, so the resulting requests are empty), as well as post-block
-///   balance increments (also a no-op: withdrawals are rejected and there are no ommers or
-///   block rewards). When TIP-1016 (EIP-8037) is enabled, the returned `gas_used` is
-///   overridden with the accumulated regular gas.
-/// - [`receipts`](BlockExecutor::receipts), [`evm`](BlockExecutor::evm) and
-///   [`evm_mut`](BlockExecutor::evm_mut) are plain passthroughs to the inner executor.
+/// - Pre-block ([`apply_pre_execution_changes`](BlockExecutor::apply_pre_execution_changes)):
+///   the inner executor transacts the [EIP-2935] blockhashes and [EIP-4788] beacon root calls
+///   (Cancun and Prague are active at genesis, and Tempo headers set a zero
+///   `parent_beacon_block_root`); they only have an effect if the respective system contract
+///   is deployed in the network's genesis state.
+/// - Post-block ([`finish`](BlockExecutor::finish)): the inner executor transacts the
+///   [EIP-7002] withdrawal requests and [EIP-7251] consolidation requests calls and parses
+///   [EIP-6110] deposits — effective no-ops on Tempo because these system contracts are not
+///   deployed, so the resulting requests are empty. Tempo's own post-block system call, the
+///   `CurrentCommittee` epoch rotation, runs before this delegation.
 ///
 /// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
 /// [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -174,19 +174,23 @@ impl TxResult for TempoTxResult {
 /// - Pre-block ([`apply_pre_execution_changes`](BlockExecutor::apply_pre_execution_changes)):
 ///   the inner executor transacts the [EIP-2935] blockhashes and [EIP-4788] beacon root calls
 ///   (Cancun and Prague are active at genesis, and Tempo headers set a zero
-///   `parent_beacon_block_root`); they only have an effect if the respective system contract
-///   is deployed in the network's genesis state.
+///   `parent_beacon_block_root`). Only the EIP-2935 call is currently effective: the history
+///   contract is deployed on Tempo networks (at genesis on dev, post-genesis on live
+///   networks), while the EIP-4788 contract has no code, making that call a no-op.
 /// - Post-block ([`finish`](BlockExecutor::finish)): the inner executor transacts the
 ///   [EIP-7002] withdrawal requests and [EIP-7251] consolidation requests calls and parses
-///   [EIP-6110] deposits — effective no-ops on Tempo because these system contracts are not
-///   deployed, so the resulting requests are empty. Tempo's own post-block system call, the
-///   `CurrentCommittee` epoch rotation, runs before this delegation.
+///   [EIP-6110] deposits — all no-ops on Tempo because these system contracts are not
+///   deployed, so the resulting requests are empty. The same applies to the [EIP-8282]
+///   builder request calls if Amsterdam is ever activated, unless its predeploys are deployed
+///   first. Tempo's own post-block system call, the `CurrentCommittee` epoch rotation, runs
+///   before this delegation.
 ///
 /// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
 /// [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788
 /// [EIP-6110]: https://eips.ethereum.org/EIPS/eip-6110
 /// [EIP-7002]: https://eips.ethereum.org/EIPS/eip-7002
 /// [EIP-7251]: https://eips.ethereum.org/EIPS/eip-7251
+/// [EIP-8282]: https://eips.ethereum.org/EIPS/eip-8282
 pub struct TempoBlockExecutor<'a, DB: Database, I> {
     pub(crate) inner:
         EthBlockExecutor<'a, TempoEvm<DB, I>, &'a TempoChainSpec, TempoReceiptBuilder>,

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -165,6 +165,43 @@ impl TxResult for TempoTxResult {
 /// Wraps an inner [`EthBlockExecutor`] and layers Tempo-specific block execution
 /// logic on top: section-based transaction ordering (`BlockSection`), subblock
 /// validation, shared/non-shared gas accounting, and gas incentive tracking.
+///
+/// # Reuse of the inner [`EthBlockExecutor`]
+///
+/// Every [`BlockExecutor`] method delegates to the inner executor and wraps it with
+/// Tempo-specific logic:
+///
+/// - [`apply_pre_execution_changes`](BlockExecutor::apply_pre_execution_changes): after
+///   rejecting non-empty withdrawals, delegates to the inner executor, which transacts the
+///   Ethereum pre-block system calls: the [EIP-2935] blockhashes and [EIP-4788] beacon root
+///   contract calls (Cancun and Prague are active at genesis on all Tempo networks, and Tempo
+///   headers set a zero `parent_beacon_block_root`). Whether these calls have any effect
+///   depends on the respective system contract being deployed in the network's genesis state.
+///   Afterwards, Tempo deploys the `0xEF` marker bytecode for precompiles at their activation
+///   hardforks.
+/// - [`execute_transaction_without_commit`](BlockExecutor::execute_transaction_without_commit):
+///   reuses the inner executor for the block gas limit check and EVM execution, wrapped with
+///   section validation and the subblock fee recipient override.
+/// - [`commit_transaction`](BlockExecutor::commit_transaction): reuses the inner executor for
+///   block gas accounting, receipt building via [`TempoReceiptBuilder`], and committing the
+///   state changes, then updates the section-specific gas counters.
+/// - [`finish`](BlockExecutor::finish): applies Tempo end-of-block logic first (shared gas
+///   validation and the `CurrentCommittee` epoch rotation system call), then delegates to the
+///   inner executor, thereby also reusing the Ethereum post-block logic: [EIP-6110] deposit
+///   request parsing and the [EIP-7002] withdrawal requests and [EIP-7251] consolidation
+///   requests system calls (effective no-ops on Tempo because the corresponding system
+///   contracts are not deployed, so the resulting requests are empty), as well as post-block
+///   balance increments (also a no-op: withdrawals are rejected and there are no ommers or
+///   block rewards). When TIP-1016 (EIP-8037) is enabled, the returned `gas_used` is
+///   overridden with the accumulated regular gas.
+/// - [`receipts`](BlockExecutor::receipts), [`evm`](BlockExecutor::evm) and
+///   [`evm_mut`](BlockExecutor::evm_mut) are plain passthroughs to the inner executor.
+///
+/// [EIP-2935]: https://eips.ethereum.org/EIPS/eip-2935
+/// [EIP-4788]: https://eips.ethereum.org/EIPS/eip-4788
+/// [EIP-6110]: https://eips.ethereum.org/EIPS/eip-6110
+/// [EIP-7002]: https://eips.ethereum.org/EIPS/eip-7002
+/// [EIP-7251]: https://eips.ethereum.org/EIPS/eip-7251
 pub struct TempoBlockExecutor<'a, DB: Database, I> {
     pub(crate) inner:
         EthBlockExecutor<'a, TempoEvm<DB, I>, &'a TempoChainSpec, TempoReceiptBuilder>,


### PR DESCRIPTION
TempoBlockExecutor wraps EthBlockExecutor, but it was not obvious from the docs which Ethereum system calls are reused through the inner executor. This documents the delegation on the struct.

Pre-block, `inner.apply_pre_execution_changes` transacts the EIP-2935 blockhashes and EIP-4788 beacon root calls. Only EIP-2935 is currently effective: the history contract is deployed on mainnet and Moderato (post-genesis) and in the dev genesis, while the EIP-4788 contract has no code on any network. Post-block, `inner.finish` transacts the EIP-7002/EIP-7251 request calls and parses EIP-6110 deposits — all no-ops since those contracts are not deployed, so requests come back empty; the same would hold for the EIP-8282 builder request calls if Amsterdam were activated without deploying its predeploys. Tempo's own post-block system call (CurrentCommittee epoch rotation) runs before that delegation.

Docs only, no functional changes.