### PR TITLE
refactor(consensus): simplify DKG share send handling

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -941,13 +941,8 @@ where
             } else {
                 // Send to remote player
                 let payload = Message::Dealer(pub_msg, priv_msg).encode();
-                let success = round_channel.send(Recipients::One(player.clone()), payload, true);
-                if success.is_empty() {
-                    // TODO(janis): figure out what it means if the response
-                    // is empty. Does it just mean the other party failed
-                    // to respond?
-                    info!(%player, "failed to send share");
-                } else {
+                let sent_to = round_channel.send(Recipients::One(player.clone()), payload, true);
+                if !sent_to.is_empty() {
                     self.metrics.shares_distributed.metric().inc();
                     info!(%player, "share sent");
                 }


### PR DESCRIPTION
Treat Commonware’s returned recipient set as send-attempt acceptance and only record successful submissions. Empty sends are left for the existing per-block retry path without emitting misleading failure logs.

Prompted by: @pepyakin