### PR TITLE
fix(consensus): patch Commonware runtime storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3030,8 +3030,7 @@ dependencies = [
 [[package]]
 name = "commonware-actor"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beac6262223b45c6843ab70b245b526b28836a8257b1759a509ba5fab24fa4a6"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3044,8 +3043,7 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a2d7e56dc894ad3f55dbe5726468915492ae8e4650ad2a45c1bcfd138c2037f"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -3061,8 +3059,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8eb7efe071cea13e8b23a0a7f584398870c401d2b2aabfb6b9ab3634ebcba3a"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3079,8 +3076,7 @@ dependencies = [
 [[package]]
 name = "commonware-codec-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a876bec347344381948901d0f5ec2e9443ebc8dbab99a63bc2db78c2fc2efbdd"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3091,8 +3087,7 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "409e9997c1bb3273b9570c26ddef4f252327c9bf18968d4439a83cfd1d3e5661"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3110,8 +3105,7 @@ dependencies = [
 [[package]]
 name = "commonware-conformance"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0840a6116d784b84ec0c64244f310a2f325af79fbe7b093fc812e8ac8efd12"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "commonware-conformance-macros",
  "commonware-formatting",
@@ -3125,8 +3119,7 @@ dependencies = [
 [[package]]
 name = "commonware-conformance-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c8b6096c3820f9e3f01be1954e49509c75a53598a465b8adb6c87ad3f4d308"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3136,8 +3129,7 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf15e3402e26f062695d4dd5e4b5967f601dc7303d06b9fafdb20a6485a3a0a"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3167,8 +3159,7 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b842f31e1aaa1af284a1f9dc4f1234761f72d07e70d53cf3f1521b0870ade094"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3210,8 +3201,7 @@ dependencies = [
 [[package]]
 name = "commonware-formatting"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab01b7f2798e29b0a4f7b47da5b7f3c106881578af3e69e8d2ee9d89d7c1d4fd"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -3220,8 +3210,7 @@ dependencies = [
 [[package]]
 name = "commonware-invariants"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7626b0950e91aad9e954163daa74cbab108825ac6fe5f9967c4ab9e1cedd87a5"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "arbitrary",
  "commonware-formatting",
@@ -3234,8 +3223,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e37a17d5c99ec6711098c6614af1023fd32926aa0414ec0f0613f6bb940278"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3244,8 +3232,7 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d44bceee874226efca172f0e9ec9ec4eb486788ba6be1d98710f3f159b807af"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3257,8 +3244,7 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "593fa0c5aa8bd8d350724b9b1ad4e85072845aa85a06b39ca4598998bbec1e00"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3273,8 +3259,7 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47f974fcd27c0dad7ae73caeaf00c8330fd29c60f5ff1f679ccc1a51c8ed95bc"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -3300,8 +3285,7 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7109817274c671f1fb0ba17cf8aecfbb70672d29379284feeac43fa1b1dc0201"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3313,8 +3297,7 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a497cc9e9a2cd205d96474d0d40c7731f29085cd467adbe9ff0f94719659582"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -3335,8 +3318,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a84bc6cefb099b1ffce3e04705a1e61e91d895b9f09b9e1be14c8ec5823c181"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "ahash",
  "axum",
@@ -3376,8 +3358,7 @@ dependencies = [
 [[package]]
 name = "commonware-runtime-macros"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f7b39ef9fd9f1df4fe4445c9a5ec5ba012d90d1602b12a8b8626a8563ab02c"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3388,8 +3369,7 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac18e2b696ab7bbecf1059bc3b8d39fc0af002180906d65c7df3112fd9385de"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3413,8 +3393,7 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8890b69e3fa209bc9e87d199ff60ca5a21c88322d32914847511887e6dc5364b"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "chacha20poly1305",
  "commonware-codec",
@@ -3433,8 +3412,7 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a484dd46b738d9b5ba892312425e71e6afaf4320e388d74449bd9ca0ea14cd76"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=3ba3af264515e1019340ee353f470da416d5e5f8#3ba3af264515e1019340ee353f470da416d5e5f8"
 dependencies = [
  "ahash",
  "arbitrary",
@@ -4016,7 +3994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4482,7 +4460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6095,7 +6073,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7259,7 +7237,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12222,7 +12200,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12302,7 +12280,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12982,7 +12960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13262,7 +13240,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -15334,7 +15312,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,8 +411,7 @@ vergen-git2 = "10.0.1"
 
 [patch.crates-io]
 
-# Commonware v2026.7.0
-# Storage header truncation fix: https://github.com/commonwarexyz/monorepo/pull/4256
+# Patch right after the storage header truncation fix: https://github.com/commonwarexyz/monorepo/pull/4256
 commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
 commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,6 +412,7 @@ vergen-git2 = "10.0.1"
 [patch.crates-io]
 
 # Commonware v2026.7.0
+# Storage header truncation fix: https://github.com/commonwarexyz/monorepo/pull/4256
 commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
 commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
 commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -412,16 +412,16 @@ vergen-git2 = "10.0.1"
 [patch.crates-io]
 
 # Commonware v2026.7.0
-# commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
+commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "3ba3af264515e1019340ee353f470da416d5e5f8" }

--- a/deny.toml
+++ b/deny.toml
@@ -89,6 +89,7 @@ unknown-registry = "warn"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
+  "https://github.com/commonwarexyz/monorepo",
   "https://github.com/paradigmxyz/reth",
   "https://github.com/sigp/discv5",
 ]


### PR DESCRIPTION
Pins the Commonware v2026.7.0 dependency set to commonwarexyz/monorepo@3ba3af2, which fixes interrupted blob creation leaving a zeroed header and crashing journal reopen.

The full dependency set uses one source revision to avoid duplicate Commonware types from mixed registry and monorepo packages. This can be removed when Tempo upgrades to Commonware v2026.8.0.

Prompted by: @SuperFluffy