### PR TITLE
fix(bench): extend TIP20 transaction validity

### DIFF
--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -25,7 +25,7 @@ templates:
     max_priority_fee_per_gas: 100000000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
-    valid_for_secs: 5
+    valid_for_secs: 10
     call:
       to:
         choice: ${TXGEN_TIP20_TOKENS}

--- a/contrib/bench/txgen/presets/tip20/nonce-expiring.yml
+++ b/contrib/bench/txgen/presets/tip20/nonce-expiring.yml
@@ -2,4 +2,4 @@ merge:
   templates:
     tip20_transfer:
       expiring_nonce: true
-      valid_for_secs: 5
+      valid_for_secs: 10


### PR DESCRIPTION
Raises the public TIP20 benchmark transaction validity from 5 seconds to 10 seconds to reduce expiry evictions under high submission concurrency.

Prompted by: @onbjerg