### PR TITLE
chore(deps): pin partial persistence fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8d8a7d7e896331d13d94cd50779a843d3fb3d8b0389826e43638f6276bc4b3"
+checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9eb70841f76b69b1205bb57b551b7d7afd8407ad57cbda02e833877507c16"
+checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89486e1bd2c5c56522cf18e73460c3fe7b54d50f5e80131466e62b7632edfcb"
+checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c0dadb2468adc8aaaaad4c9a6cfa6bd055fe6596c40017067b37671f2c45f5"
+checksum = "b86722084d6d07822a6c67e39ae794d437fb9de12fa4127d4f9fd93f89651121"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -257,7 +257,9 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -338,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -353,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddc9c1868d6331b56926de8ab4c4a80d8dcb7bc4f8f7bebc6a89d0548f79af2"
+checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -379,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe3f812d024acd2a612aea20629130cd59595064f1420953e6e20c84165def9"
+checksum = "be9aa797694e7c55b007aa8f172daef76a83272cbedb8800bdc7038eed3bdb1a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -413,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921b3dccecc4e9dd571c9f9a728d913c2fc7a8ecdfce6005ed99751817523d0d"
+checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -428,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-hardforks"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ba208044232d14d4adbfa77e57d6329f51bc1acc21f5667bb7db72d88a0831"
+checksum = "865371fb677c005f7cb0ea9c2847a1ba4fdb042caf6428b1769fee20368bbfc7"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
@@ -454,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989d701ece9bccec3294991ce4b4a39dd1cecd0979ea58e86b9878679591b4f5"
+checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -469,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfca49fbbe3b30de8114b9cfd89029f87cb33ca7e8a5f5f48a809caaf085126"
+checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -495,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af7b76520abc91b9e0f1aa987d42df55a66494f94a1881cdadd9b8f67e0b924"
+checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -540,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3fb53b31526b0f97cdbfaf9d8bb72b3e4a9ac7965148d79ecec4c733c8558e"
+checksum = "386124639a5c386329b9f2ef2b42969badbf7bba40422b513e3e5739c516dc34"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -571,7 +573,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
- "lru",
+ "lru 0.18.2",
  "parking_lot",
  "pin-project",
  "reqwest 0.13.3",
@@ -586,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197325ef17fcdf5dfa21999a2a33877b82bb5009d5cc9b5c7f5ddb840fa3b6bb"
+checksum = "ca2c32b323d8001b6e883444b7433804be0e6d55e4dbfd64e3bd2ba025282b77"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -630,9 +632,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5274f9ada7f558d2feaba16fadcb96022512566cf424147f9cfa2000bc2e458"
+checksum = "3dfd3ebc1756426a6a9e17979d4467632aff01f359136c50e5320ac6e32d6b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -656,9 +658,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a456d697d4f639d20ac242981de13b94f911c99199e4175e85eaf52b8f785c"
+checksum = "417dc664965e36fc43a4f9c8eb8b2d14067a29c430e23470d2c923c1c977bac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -673,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f36ee47a0f4e901b95180fbe86c92fec3ea73f12c88c5ec70d1cb41abb8d911"
+checksum = "8bfdc2a2cde178ad3a79594b4fabbc0f2f11be5a98a3363083e91575fc95335c"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -685,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7e911c628067c406effef5137d0e253d98e117cdb81d47aacfe2816199297e"
+checksum = "5a07bb602ee07767e393b5862f719a1d061deca15e617fbb1f7af49cd49576e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -697,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c88bfdd02271de47f28d69481191a2af6b2907901a3a8c7aff79a6b574eb"
+checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -712,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573342cde98a4d40120b7bc0063fbda42cfd87fb305ab834704177b60d8691"
+checksum = "905e705ef91d2ed6cf08afbec0f9d79318175785eb146656441e8c644786ee5f"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -732,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bddf06191e2b12eaaeb3a50ef29a8f3416fb74c61421b80f9d7554c4c1d59a56"
+checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -745,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "866fa880cfd95681c979bf3f8385964c2317ef7423c31c0de53159f01112fedf"
+checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -765,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d3b805bb9cafaf1362c28b377e2035e49fc5ae0a5ee3ea61bafd9a5d33959e1"
+checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -787,9 +789,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b973745b97a364c0215f681b2fb3cb6f0bbeda4dcdba5f56c50f999719ec96f"
+checksum = "e97bfdac1ec57f53ab2a0dacfedf382aeba1245ecb4ad7ecd8aeb4438a6c3b9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -802,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6fae28f1bda2586b117a5754b49366160770e63e09ac93fc3d872015a5a993"
+checksum = "7d45ae3eadb97bf7933086205b4be0fef82c208bfc3007759e9afdcb6efa74c5"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -816,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4962825b8819e54028cbdaadeba128a613afa55c91b9a88e0b0dc257772a14d7"
+checksum = "ce0d7a9ab748d011daac12902ab9aedf8232d9b070bec6344cadd8509d8a6798"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -828,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad7efdd5e8fe92f5bab87956d6d3f717d1614c4ab6ad0d1f869b16e83b0dff9"
+checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -840,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa150cd076471ef21aa7b181d8186cb86c3239518859a2e5d80fbec74f0ec38"
+checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -855,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c621822c9971a3d895bbd5620dca425ca78ce3345b60ae8268a89f1faa35cd8a"
+checksum = "495d56d8b67d1d656d50053cf6263e4191bd626952f0401197eeb755b390924e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -874,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e774bb2e422fb7a1d07618273fe62ea3665c6cba800979cffa7a5a162f2cd69e"
+checksum = "85c81d27fc6d869e0a1c1bd2c69d072d56c3b4f4aae0670ad85f4b6d373df064"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -892,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61301531ee6aacbb242b9f7daca4bc6cf6529f21498e9f6aeecae7ea15afca4b"
+checksum = "29eedbaa8de81b8c204572a783ac90eeaf7ae6e67fe2f8c2cc3c13c53eb1f1e0"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -910,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f125bb730d4772538835d4a31e8e5ed5068e2a991619ba32711fd53ad8c93032"
+checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -929,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c5f7e7e14e6d22ba836739c0dd2573d1aea1512275e0caf597ba03e8d62e43"
+checksum = "4ef14606034a850914aa4d2b641b2d89d47e62b5eec6087c4f645bc834aec6d5"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1019,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cd5dbd32cae5d1bc3afaf455064ebd9bcce70b57de220468908717c225225dd"
+checksum = "06f4ca8484d6295d5165f67de8fdb00ae630ba585efb606f003171286b56441c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1042,9 +1044,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b7b1f0e528ae788d05937f5b351afae3b4c1e08f17a061d868bd28e56aa9e3"
+checksum = "8342aa5a7f8dee6d606307eebbc847d9799a823c7e4f37b9c1e32b08715f73c8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1058,9 +1060,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b964b4c048eea647a701a6af07307c64995c4abd42d46ba0b3be9593ae3c333c"
+checksum = "184e03e1845edd5534f309d3169d93969a819ad1609108d9378fd33059de7547"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1078,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efecf9efc5d56276e115b13b36ff27311b8cd6f72affc9788a10ff46b55b2616"
+checksum = "ee146fb5859e612e95570642a29def87c060c7ce47d14a0caa5ab7ee8570ec2c"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1117,9 +1119,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e2386593cef5b12c7d439dbcf62d7d51c3a50dc943909b42ae34b48f1b69dc"
+checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -5260,6 +5262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -6783,6 +6786,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -8719,7 +8731,7 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.4",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -8971,8 +8983,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8998,8 +9010,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9029,8 +9041,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9049,8 +9061,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9062,11 +9074,12 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
@@ -9146,8 +9159,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9156,8 +9169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9209,11 +9222,12 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "eyre",
  "humantime-serde",
+ "reth-network-peers",
  "reth-network-types",
  "reth-prune-types",
  "reth-stages-types",
@@ -9225,12 +9239,13 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
+ "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -9239,8 +9254,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9252,8 +9267,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9277,8 +9292,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9306,8 +9321,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9332,8 +9347,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9362,8 +9377,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9377,8 +9392,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9402,8 +9417,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9426,8 +9441,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9450,8 +9465,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9485,8 +9500,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9542,8 +9557,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9569,8 +9584,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9592,8 +9607,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9619,8 +9634,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9676,8 +9691,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9706,8 +9721,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9724,8 +9739,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9740,8 +9755,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9764,8 +9779,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9775,8 +9790,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9803,8 +9818,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9813,6 +9828,7 @@ dependencies = [
  "alloy-hardforks",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-trie",
  "bytes",
  "derive_more",
  "reth-chainspec",
@@ -9825,8 +9841,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9866,8 +9882,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "clap",
  "eyre",
@@ -9889,8 +9905,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9905,8 +9921,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9921,8 +9937,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9934,8 +9950,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9964,8 +9980,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9978,8 +9994,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9988,8 +10004,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10014,8 +10030,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10034,8 +10050,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10052,8 +10068,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10065,8 +10081,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10084,8 +10100,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10122,8 +10138,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10136,8 +10152,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "serde",
  "serde_json",
@@ -10146,8 +10162,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10172,8 +10188,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "bytes",
  "futures",
@@ -10192,8 +10208,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10209,8 +10225,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "bindgen",
  "cc",
@@ -10218,8 +10234,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "futures",
  "libc",
@@ -10232,8 +10248,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10241,8 +10257,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10255,8 +10271,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10314,8 +10330,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10339,8 +10355,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10363,8 +10379,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10378,8 +10394,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10392,8 +10408,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10409,8 +10425,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10433,8 +10449,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10501,8 +10517,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10556,8 +10572,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10605,8 +10621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10629,8 +10645,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10653,8 +10669,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "bytes",
  "eyre",
@@ -10682,8 +10698,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10694,8 +10710,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10718,8 +10734,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10730,8 +10746,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10753,8 +10769,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10796,8 +10812,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10845,8 +10861,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10872,8 +10888,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10888,8 +10904,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10903,8 +10919,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10944,7 +10960,6 @@ dependencies = [
  "reth-engine-primitives",
  "reth-errors",
  "reth-ethereum-engine-primitives",
- "reth-ethereum-primitives",
  "reth-evm",
  "reth-evm-ethereum",
  "reth-execution-types",
@@ -10980,8 +10995,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11010,8 +11025,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11053,8 +11068,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11073,8 +11088,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11104,8 +11119,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11151,8 +11166,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11202,13 +11217,15 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
+ "http-body-util",
  "jsonrpsee-http-client",
  "pin-project",
+ "tokio",
  "tower",
  "tower-http",
  "tracing",
@@ -11216,8 +11233,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11247,10 +11264,11 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "eyre",
@@ -11298,8 +11316,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11326,8 +11344,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11340,8 +11358,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11360,8 +11378,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11375,8 +11393,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11401,8 +11419,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11418,8 +11436,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11427,6 +11445,7 @@ dependencies = [
  "parking_lot",
  "rayon",
  "reth-chain-state",
+ "reth-db-api",
  "reth-errors",
  "reth-ethereum-primitives",
  "reth-metrics",
@@ -11444,8 +11463,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11465,8 +11484,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11481,8 +11500,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11491,8 +11510,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "clap",
  "eyre",
@@ -11511,8 +11530,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11530,8 +11549,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11573,8 +11592,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11599,8 +11618,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11626,8 +11645,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11642,8 +11661,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11667,8 +11686,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+version = "2.5.0"
+source = "git+https://github.com/paradigmxyz/reth?rev=affcf4ed0dfbf4d82ced9707b937e8b199243c8e#affcf4ed0dfbf4d82ced9707b937e8b199243c8e"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11829,9 +11848,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3958b5de5c2c08c6a49b8d94f6ead3e9cd7980c43d6ed240aa3d6485d53269b5"
+checksum = "90c136a072540987ee442e9824631835520b13e5756f20780a637ba2e11f9c28"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,103 +146,103 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "affcf4ed0dfbf4d82ced9707b937e8b199243c8e", features = [
   "std",
   "optional-checks",
 ] }
 revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "0.42.0"
+revm-inspectors = "0.42.2"
 
 alloy-json-abi = { version = "1.6.1", default-features = false }
 alloy-primitives = { version = "1.6.1", default-features = false }
 alloy-sol-types = { version = "1.6.1", default-features = false }
 
-alloy = { version = "2.3.0", default-features = false }
-alloy-consensus = { version = "2.3.0", default-features = false }
-alloy-contract = { version = "2.3.0", default-features = false }
+alloy = { version = "2.4.1", default-features = false }
+alloy-consensus = { version = "2.4.1", default-features = false }
+alloy-contract = { version = "2.4.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
-alloy-eips = { version = "2.3.0", default-features = false }
+alloy-eips = { version = "2.4.1", default-features = false }
 alloy-evm = { version = "0.38.0", default-features = false }
-alloy-genesis = { version = "2.3.0", default-features = false }
+alloy-genesis = { version = "2.4.1", default-features = false }
 alloy-hardforks = "0.4.7"
-alloy-json-rpc = "2.3.0"
-alloy-network = { version = "2.3.0", default-features = false }
-alloy-provider = { version = "2.3.0", default-features = false }
+alloy-json-rpc = "2.4.1"
+alloy-network = { version = "2.4.1", default-features = false }
+alloy-provider = { version = "2.4.1", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-client = { version = "2.3.0", default-features = false }
-alloy-rpc-types-admin = "2.3.0"
-alloy-rpc-types-engine = "2.3.0"
-alloy-rpc-types-eth = { version = "2.3.0" }
-alloy-serde = { version = "2.3.0", default-features = false }
-alloy-signer = "2.3.0"
-alloy-signer-aws = "2.3.0"
-alloy-signer-gcp = "2.3.0"
-alloy-signer-ledger = "2.3.0"
-alloy-signer-local = "2.3.0"
-alloy-signer-trezor = "2.3.0"
-alloy-transport = "2.3.0"
+alloy-rpc-client = { version = "2.4.1", default-features = false }
+alloy-rpc-types-admin = "2.4.1"
+alloy-rpc-types-engine = "2.4.1"
+alloy-rpc-types-eth = { version = "2.4.1" }
+alloy-serde = { version = "2.4.1", default-features = false }
+alloy-signer = "2.4.1"
+alloy-signer-aws = "2.4.1"
+alloy-signer-gcp = "2.4.1"
+alloy-signer-ledger = "2.4.1"
+alloy-signer-local = "2.4.1"
+alloy-signer-trezor = "2.4.1"
+alloy-transport = "2.4.1"
 
 commonware-actor = "2026.7.0"
 commonware-broadcast = "2026.7.0"

--- a/bin/tempo/src/regenesis.rs
+++ b/bin/tempo/src/regenesis.rs
@@ -371,13 +371,14 @@ fn replacement_hashed_post_state(replacements: &[GenesisAccountReplacement]) -> 
                 .map(|replacement| (replacement.hashed_address, Some(replacement.account))),
         )
         .with_storages(replacements.iter().map(|replacement| {
-            let storage = HashedStorage::from_iter(
-                true,
-                replacement
+            let storage = HashedStorage {
+                wiped: true,
+                storage: replacement
                     .hashed_storage
                     .iter()
-                    .map(|entry| (entry.key, entry.value)),
-            );
+                    .map(|entry| (entry.key, entry.value))
+                    .collect(),
+            };
             (replacement.hashed_address, storage)
         }))
 }

--- a/crates/consensus/src/validators.rs
+++ b/crates/consensus/src/validators.rs
@@ -12,7 +12,7 @@ use commonware_utils::{TryFromIterator, ordered};
 use eyre::{OptionExt as _, WrapErr as _};
 use reth_ethereum::evm::revm::{State, database::StateProviderDatabase};
 use reth_node_builder::ConfigureEvm as _;
-use reth_provider::{BlockReader as _, BlockSource, StateProviderBox, StateProviderFactory as _};
+use reth_provider::{HeaderProvider as _, StateProviderBox, StateProviderFactory as _};
 use tempo_node::{TempoFullNode, evm::evm::TempoEvm};
 use tempo_precompiles::{
     storage::{StorageActions, StorageCtx},
@@ -46,10 +46,9 @@ impl ExecutionNode for TempoFullNode {
     fn header(&self, block_hash: B256) -> eyre::Result<TempoHeader> {
         // DKG may read a proposal parent's validator state before its FCU makes the block canonical.
         self.provider
-            .find_sealed_or_recovered_block(block_hash, BlockSource::Any)
+            .header(block_hash)
             .map_err(eyre::Report::new)
-            .and_then(|maybe| maybe.ok_or_eyre("execution layer returned empty block"))
-            .map(|block| block.clone_sealed_header().unseal())
+            .and_then(|maybe| maybe.ok_or_eyre("execution layer returned empty header"))
     }
 
     fn state_by_block_hash(&self, block_hash: B256) -> eyre::Result<StateProviderBox> {

--- a/crates/evm/benches/common/mod.rs
+++ b/crates/evm/benches/common/mod.rs
@@ -203,8 +203,11 @@ impl StateProofProvider for InMemoryStateProvider {
     }
 }
 impl HashedPostStateProvider for InMemoryStateProvider {
-    fn hashed_post_state(&self, _bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
-        HashedPostState::default()
+    fn hashed_post_state(
+        &self,
+        _bundle_state: &reth_revm::db::BundleState,
+    ) -> ProviderResult<HashedPostState> {
+        Ok(HashedPostState::default())
     }
 }
 

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -16,7 +16,7 @@ pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
 use futures::{TryFutureExt, future::Either};
 pub use operator::{TempoOperatorApiServer, TempoOperatorRpc};
 use reth_errors::RethError;
-use reth_primitives_traits::{HeaderTy, Recovered, TransactionMeta, WithEncoded};
+use reth_primitives_traits::{HeaderTy, Recovered, SealedHeaderFor, TransactionMeta, WithEncoded};
 use reth_rpc_eth_api::{FromEthApiError, IntoEthApiError, RpcTxReq};
 use reth_transaction_pool::{PoolTransaction, PoolTx, TransactionOrigin, TransactionPool};
 pub use simulate::{TempoSimulate, TempoSimulateApiServer, TempoSimulateV1Response};
@@ -568,7 +568,17 @@ where
     ChainSpec: EthChainSpec + 'static,
 {
     type RpcReceipt = TempoTransactionReceipt;
+    type RpcLog = Log;
     type Error = EthApiError;
+
+    fn convert_log(
+        &self,
+        log: Log,
+        _receipt: &TempoReceipt,
+        _header: &SealedHeaderFor<TempoPrimitives>,
+    ) -> Result<Self::RpcLog, Self::Error> {
+        Ok(log)
+    }
 
     fn convert_receipts(
         &self,

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1029,7 +1029,11 @@ where
         {
             hashed_state
         } else {
-            Arc::new(finish_provider.hashed_post_state(&db.bundle_state))
+            Arc::new(
+                finish_provider
+                    .hashed_post_state(&db.bundle_state)
+                    .map_err(PayloadBuilderError::other)?,
+            )
         };
 
         let (state_root_outcome, sparse_trie_state_root_wait_elapsed) =

--- a/crates/payload/builder/src/metrics.rs
+++ b/crates/payload/builder/src/metrics.rs
@@ -211,7 +211,10 @@ reth_storage_api::delegate_impls_to_as_ref!(
 );
 
 impl HashedPostStateProvider for InstrumentedFinishProvider<'_> {
-    fn hashed_post_state(&self, bundle_state: &reth_revm::db::BundleState) -> HashedPostState {
+    fn hashed_post_state(
+        &self,
+        bundle_state: &reth_revm::db::BundleState,
+    ) -> ProviderResult<HashedPostState> {
         let start = Instant::now();
         let _span = debug_span!(target: "payload_builder", "hashed_post_state").entered();
         let result = self.inner.hashed_post_state(bundle_state);

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -111,10 +111,11 @@ impl TempoPooledTransaction {
         let fee_token_cost = cost - value;
         Self {
             inner: EthPooledTransaction {
+                transaction,
                 cost,
                 encoded_length,
                 blob_sidecar: EthBlobTransactionSidecar::None,
-                transaction,
+                blob_cell_availability: None,
             },
             fee_token_cost,
             is_payment,


### PR DESCRIPTION
Pins Reth to [`affcf4ed`](https://github.com/paradigmxyz/reth/commit/affcf4ed0dfbf4d82ced9707b937e8b199243c8e), which is based on `aa90fb1` and contains [#26559](https://github.com/paradigmxyz/reth/pull/26559), [#26580](https://github.com/paradigmxyz/reth/pull/26580), [#26612](https://github.com/paradigmxyz/reth/pull/26612), and the execution-cache validation lock fix. The deployed dev-eu partial-persistence digest `sha256:0d0c92bf89b345517a8ecb1a58a2b47859a41bed3580519b2f74489176f52d49` came from the [scheduled `main` build at `2ea901d1`](https://github.com/tempoxyz/tempo/actions/runs/32014653781) and still pins Reth `10aa6a5`; this supersedes #7142 while retaining its compatibility updates.

Validated with `cargo +nightly fmt --all -- --check`, `cargo check --locked -p tempo --features "asm-keccak,jemalloc,otlp,partial-persistence"`, and `cargo +nightly clippy --locked -p tempo --features "asm-keccak,jemalloc,otlp,partial-persistence"`.

Prompted by: @laibe