### PR TITLE
fix(bench): allow release tags to mint STS tokens

### DIFF
--- a/.github/sts/bench-e2e.sts.yaml
+++ b/.github/sts/bench-e2e.sts.yaml
@@ -1,6 +1,6 @@
-# Allow branch and pull-request e2e benchmark workflows in Tempo to mint a
-# short-lived token for the GitHub API calls and private ValScope checkout.
-subject_pattern: repo:tempoxyz@211589300/tempo@994992847:((ref:refs/heads/.+)|pull_request)
+# Allow branch, pull-request, and semver tag e2e benchmark workflows in Tempo
+# to mint a short-lived token for GitHub API calls and private ValScope checkout.
+subject_pattern: repo:tempoxyz@211589300/tempo@994992847:((ref:refs/heads/.+)|(ref:refs/tags/v[0-9]+\.[0-9]+\.[0-9]+)|pull_request)
 permissions:
   contents: read
   actions: read

--- a/.github/sts/bench-e2e.sts.yaml
+++ b/.github/sts/bench-e2e.sts.yaml
@@ -1,6 +1,9 @@
 # Allow branch, pull-request, and semver tag e2e benchmark workflows in Tempo
 # to mint a short-lived token for GitHub API calls and private ValScope checkout.
-subject_pattern: repo:tempoxyz@211589300/tempo@994992847:((ref:refs/heads/.+)|(ref:refs/tags/v[0-9]+\.[0-9]+\.[0-9]+)|pull_request)
+subject_pattern:
+  - repo:tempoxyz@211589300/tempo@994992847:ref:refs/heads/.+
+  - repo:tempoxyz@211589300/tempo@994992847:ref:refs/tags/v[0-9]+\.[0-9]+\.[0-9]+
+  - repo:tempoxyz@211589300/tempo@994992847:pull_request
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
Allows tag-triggered e2e benchmarks to exchange GitHub STS tokens for stable semver tags. This unblocks release benchmark runs while keeping the trust scope limited.

Prompted by: @emmajam