### PR TITLE
fix(ci): update renamed S3 upload action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,7 @@ jobs:
             echo "dir=binaries/${VERSION}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: shallwefootball/s3-upload-action@4350529f410221787ccf424e50133cbc1b52704e # v1.3.3
+      - uses: shallwefootball/upload-s3-action@4350529f410221787ccf424e50133cbc1b52704e # v1.3.3
         with:
           aws_key_id: ${{ secrets.R2_BINARIES_KEY_ID }}
           aws_secret_access_key: ${{ secrets.R2_BINARIES_SECRET_KEY }}


### PR DESCRIPTION
Updates the release workflow to use the renamed `shallwefootball/upload-s3-action` repository while preserving the pinned commit. The old repository name no longer resolves in GitHub Actions.

Prompted by: @sds
