### PR TITLE
fix(ext): ignore empty TEMPO_HOME

### DIFF
--- a/crates/ext/src/installer/mod.rs
+++ b/crates/ext/src/installer/mod.rs
@@ -350,7 +350,7 @@ impl Installer {
 
 /// The fallback install directory: `TEMPO_HOME/bin` if set, else `~/.local/bin`.
 pub(crate) fn fallback_bin_dir() -> Option<PathBuf> {
-    if let Some(home) = env::var_os("TEMPO_HOME") {
+    if let Some(home) = env::var_os("TEMPO_HOME").filter(|home| !home.is_empty()) {
         Some(PathBuf::from(home).join("bin"))
     } else {
         default_local_bin().ok()
@@ -460,6 +460,24 @@ fn is_newer(manifest_version: &str, installed_version: Option<&str>) -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn empty_tempo_home_does_not_use_relative_bin_dir() {
+        let previous = std::env::var_os("TEMPO_HOME");
+        unsafe { std::env::set_var("TEMPO_HOME", "") };
+
+        let installer = super::Installer::from_env(None).unwrap();
+
+        if let Some(value) = previous {
+            unsafe { std::env::set_var("TEMPO_HOME", value) };
+        } else {
+            unsafe { std::env::remove_var("TEMPO_HOME") };
+        }
+
+        assert_ne!(installer.bin_dir, std::path::PathBuf::from("bin"));
+        assert!(installer.bin_dir.is_absolute());
+    }
+
     use super::file_url_to_path;
     use std::path::Path;
 


### PR DESCRIPTION
Treat an empty `TEMPO_HOME` environment variable as unset when resolving the extension install directory.

Previously, `TEMPO_HOME=""` produced the relative path `bin`, which could cause extension binaries to be installed relative to the current working directory instead of the normal user-local bin directory.

This change filters out an empty `TEMPO_HOME` value and falls back to the existing default local bin resolution.

A regression test covers the empty environment variable case.

Validation:
- `cargo test -p tempo-ext`
- 102 unit tests passed
- 44 lifecycle tests passed
- `git diff --check` passed