### PR TITLE
docs(tip-1097): derive expiring nonce replay protection from history

### DIFF
--- a/tips/tip-1097.md
+++ b/tips/tip-1097.md
@@ -1,0 +1,454 @@
+---
+id: TIP-1097
+title: History-Derived Expiring Nonce Replay Protection
+description: Moves expiring nonce replay protection out of EVM state and derives it from recent canonical block history.
+authors: @emmajam
+status: Draft
+related: TIP-1009, TIP-1093, TIP-0001
+protocolVersion: TBD
+---
+
+# TIP-1097: History-Derived Expiring Nonce Replay Protection
+
+## Abstract
+
+This TIP replaces the EVM-state circular buffer used by expiring nonces with an
+exact replay set derived from recent block history. Expiring nonce transactions
+retain their existing transaction format, validity window, and replay identifier,
+but block validation checks that identifier against transactions included in the
+candidate block's recent ancestors instead of reading and writing the Nonce
+precompile's storage.
+
+The replay set is consensus-critical, but it is not new canonical state. It is a
+pure function of block bodies already committed by ancestor block hashes. Nodes
+may cache the set in memory or in a local database, but MUST be able to discard
+and reconstruct that cache from block history.
+
+## Motivation
+
+TIP-1009 records every expiring nonce transaction in two EVM storage mappings and
+updates a circular-buffer pointer. This creates account changesets, storage trie
+updates, database writes, and later overwrites for data whose useful lifetime is
+at most the expiring nonce validity window.
+
+Increasing the validity window or supported throughput scales this cost directly.
+At 100,000 expiring nonce transactions per second and a five-minute window, the
+network must remember at most 30,000,000 replay identifiers. Storing these values
+in a process-local exact set is materially cheaper than applying tens of millions
+of EVM state transitions, while the canonical block bodies already contain the
+information needed to reconstruct the set.
+
+This TIP makes recent history, rather than the EVM state root alone, an explicit
+input to expiring nonce validation. It does not weaken the account or storage
+commitments represented by the EVM state root.
+
+## Assumptions
+
+1. The expiring nonce replay identifier defined by TIP-1009 is deterministic from
+   the encoded transaction and its recovered sender, and is reconstructible from
+   a block body without reading EVM state.
+2. Block timestamps are consensus-validated and monotonic within a chain branch.
+   Local wall-clock time is never used for block replay validation.
+3. A node validating or building on a block can obtain the recent ancestor bodies
+   required by this TIP. A node missing that history MUST fail closed.
+4. The maximum expiring nonce validity window remains bounded by the active
+   protocol version. A larger or unbounded window requires a separate TIP.
+5. Collision resistance of the full 256-bit replay identifier is sufficient. A
+   truncated or probabilistic identifier is not consensus-safe.
+
+If recent history is unavailable, corrupted, or inconsistent with its ancestor
+headers, the node cannot safely validate expiring nonce transactions on that
+branch and MUST NOT treat the replay set as empty.
+
+## Threat Model
+
+- **Malicious block proposer:** May include the same replay identifier multiple
+  times, replay an identifier included on an ancestor, manipulate transaction
+  ordering, or maximize the number of live identifiers.
+- **Malicious peer:** May offer an incomplete side chain or omit recent bodies.
+  Headers and transaction roots remain authoritative; missing data is not evidence
+  that an identifier is unused.
+- **Local cache corruption or loss:** The replay cache is not trusted. A node MUST
+  rebuild it from canonical bodies before returning to validation or production.
+- **Reorganizations:** Different branches legitimately have different replay
+  sets. Cache entries MUST be scoped to a block hash or otherwise support exact
+  unwind and branch reconstruction.
+- **RPC and transaction-pool attackers:** May submit large numbers of unique,
+  duplicate, or nearly expired transactions. Pending transactions require
+  separate resource limits and are not added to the consensus replay set until
+  included in a valid block.
+
+Out of scope are hash-function compromise and consensus timestamp attacks already
+permitted by the base protocol's timestamp rules.
+
+---
+
+# Specification
+
+## Constants and Existing Semantics
+
+This TIP does not change:
+
+- `TEMPO_EXPIRING_NONCE_KEY`;
+- the requirement that `nonce == 0`;
+- the TIP-1009 replay identifier construction;
+- the active hardfork's maximum validity window; or
+- the validity rule `block.timestamp < validBefore <= block.timestamp + window`.
+
+The active maximum validity window is denoted `MAX_EXPIRY_SECS` below.
+
+## Authoritative Replay Rule
+
+For an expiring nonce transaction `tx`, define:
+
+```text
+replay_id(tx) = TIP-1009 replay identifier
+expiry(tx)    = tx.validBefore
+```
+
+For a candidate block `B`, let `P` be its parent and let `t = B.timestamp`.
+The live ancestor replay set is:
+
+```text
+Live(P, t) = {
+    replay_id(tx) |
+    tx is an expiring nonce transaction included in an ancestor of B,
+    and expiry(tx) > t
+}
+```
+
+An implementation MAY stop walking ancestors once it reaches a block `A` for
+which:
+
+```text
+A.timestamp + MAX_EXPIRY_SECS <= t
+```
+
+because no expiring nonce transaction validly included in `A` or an earlier
+ancestor can remain live at `t`.
+
+Before executing `B`, the implementation MUST:
+
+1. validate each expiring nonce transaction's existing TIP-1009 fields and time
+   bounds;
+2. compute its replay identifier;
+3. reject `B` if the identifier is in `Live(P, t)`; and
+4. reject `B` if the identifier appears more than once among transactions in
+   `B`.
+
+The replay identifier is consumed by inclusion in a valid block regardless of
+whether EVM call execution succeeds, reverts, or exhausts its transaction gas.
+If any transaction makes the block invalid, no replay-cache update for that block
+is committed.
+
+The checks above occur before parallel EVM execution. Expiring nonce transactions
+therefore do not create a shared EVM write dependency after their identifiers
+have been checked for uniqueness.
+
+## Cache Model
+
+`Live(P, t)` is the normative definition. The following cache is a recommended
+implementation, not an additional consensus object:
+
+```text
+seen: exact map replay_id -> validBefore
+expiry_buckets: validBefore bucket -> replay_id[]
+block_deltas: block_hash -> replay_id[]
+```
+
+When extending parent `P` with block `B`, a node SHOULD:
+
+1. obtain the replay snapshot associated with `P`;
+2. expire entries whose `validBefore <= B.timestamp`;
+3. validate all identifiers in `B` against that snapshot and against a
+   block-local exact set;
+4. execute and validate `B`; and
+5. attach `B`'s identifiers as an atomic delta keyed by `B.hash`.
+
+Buckets SHOULD be keyed by expiry time rather than insertion time. Bucket width
+is an implementation choice; expiry MUST still follow the exact `validBefore`
+boundary. Implementations MUST use exact membership for rejection. Bloom,
+Cuckoo, or other probabilistic filters MAY accelerate negative lookups only when
+a positive result is confirmed against exact data.
+
+A persisted replay index is an untrusted performance cache. It MUST be keyed by
+the relevant block hash, checked against canonical headers, and safely
+rebuildable from block bodies.
+
+## Forks and Reorganizations
+
+Replay context is fork-local. A node MUST NOT use a single mutable replay set for
+payloads built or validated on different parents.
+
+When the canonical chain changes, the node MUST derive the set for the new head.
+Identifiers included only on the removed branch cease to be consumed and MAY be
+accepted again if their `validBefore` is still in the future. Identifiers present
+on both branches remain consumed.
+
+Forward expiry is not by itself reversible. An implementation that physically
+removes expired entries MUST either retain sufficient per-block/bucket undo data
+or rebuild from the new branch after a reorganization to an earlier timestamp.
+The implementation MUST remain correct for reorganizations deeper than the
+validity window, even if handling such a reorganization requires fetching or
+rebuilding history.
+
+## Execution and State Transition
+
+After activation, expiring nonce validation MUST NOT read or write:
+
+- `expiringNonceSeen`;
+- `expiringNonceRing`; or
+- `expiringNonceRingPtr`.
+
+The legacy Nonce precompile storage remains part of the EVM state committed before
+activation but is no longer authoritative for post-activation replay validation.
+This TIP does not delete that legacy storage. A separate state-migration or
+pruning proposal may address it.
+
+`ExpiringNonceReplay` and `InvalidExpiringNonceExpiry` remain valid consensus
+errors. `ExpiringNonceSetFull` is unreachable after activation because the replay
+set is bounded by valid chain throughput and the validity window rather than a
+fixed logical ring capacity.
+
+The existing expiring nonce gas charge remains unchanged by this TIP. It prices
+validation work and preserves transaction-capacity assumptions independently of
+the removal of EVM storage operations. Any repricing requires separate benchmark
+evidence and protocol review.
+
+## Transaction Pool
+
+The transaction pool MUST maintain at most one pending logical transaction per
+replay identifier and MUST preserve the existing replacement policy for different
+encodings of that logical transaction, including fee-payer changes that leave the
+replay identifier unchanged.
+
+Pool admission MUST reject a transaction when:
+
+- its validity bounds fail against the current canonical head;
+- its replay identifier is live in the canonical head's replay context; or
+- pool policy rejects a pending transaction with the same replay identifier.
+
+Canonical block notification MUST remove included expiring nonce transactions by
+reading replay identifiers from the block body, not by observing Nonce precompile
+storage changes. After a reorganization, transactions from removed blocks SHOULD
+be reinserted when they remain unexpired, are absent from the new branch's live
+set, and otherwise satisfy pool policy.
+
+Pool expiry timers are policy hints only. Consensus validation always uses the
+candidate block timestamp and fork-local history.
+
+## Payload Building and Validation
+
+Every payload job MUST bind to a specific parent block hash and its replay
+context. A builder MUST reserve identifiers selected for a payload so that it
+cannot select the same identifier twice.
+
+Payload validation on a non-canonical parent, including out-of-order Engine API
+requests, MUST derive the replay context for that parent. If the parent or its
+required recent bodies are unavailable, the node MUST return its existing
+syncing/missing-ancestor outcome rather than validating with an empty set.
+
+Implementations SHOULD share immutable history and finalized replay data between
+branches and represent unfinalized forks as small per-block overlays. They SHOULD
+NOT clone the full live set for every payload branch.
+
+## RPC Behavior
+
+- `eth_sendRawTransaction` MUST check the canonical replay context and return the
+  existing replay error for an already consumed identifier.
+- RPC simulation methods that enforce transaction validity MUST use the replay
+  context of the requested block. Methods explicitly configured to skip nonce
+  validation remain unchanged.
+- Historical transaction tracing or re-execution MUST use the replay context of
+  the transaction's parent block so that pre-execution results match canonical
+  execution.
+- `eth_getTransactionCount` with `TEMPO_EXPIRING_NONCE_KEY` continues to return
+  zero.
+- Account and storage proof RPCs remain unchanged. They do not prove whether a
+  replay identifier is live.
+
+No new public RPC method is required. An implementation MAY expose a debug method
+for replay-cache membership, but MUST identify the block hash against which the
+answer was computed.
+
+## Sync, Restart, and Pruning
+
+Full execution sync naturally reconstructs replay contexts while processing
+blocks. Snapshot or checkpoint sync MUST obtain enough recent bodies to construct
+the target head's live set before validating or producing descendants.
+
+For a target timestamp `t`, the node MUST scan ancestors until reaching a block
+whose timestamp plus `MAX_EXPIRY_SECS` is not greater than `t`. Only identifiers
+with `validBefore > t` need to remain in the target cache.
+
+Nodes MAY load a local replay-cache checkpoint on restart, but MUST associate it
+with an exact block hash and MUST be able to verify or rebuild it. Missing cache
+data is a recoverable synchronization condition, not an empty replay set.
+
+Block-body pruning MUST retain or make retrievable the history needed to validate
+every supported build and validation target. At minimum, a live validator MUST
+retain the maximum validity window behind each unfinalized branch it supports.
+
+## Activation and Migration
+
+At the activation block, the initial history-derived replay context MUST include
+pre-activation expiring nonce transactions from recent canonical ancestors whose
+`validBefore` is greater than the activation block timestamp. This prevents an
+identifier consumed under TIP-1009 from becoming replayable at the transition.
+
+Nodes SHOULD construct and verify this context before activation. The activation
+block and its descendants MUST use only the history-derived rule; implementations
+MUST NOT combine legacy storage membership and history membership in a way that
+produces client-dependent results.
+
+## Commitment and Proof Semantics
+
+This TIP does not remove or weaken the EVM state root. It removes replay
+membership from the data proven by that root.
+
+The replay set is indirectly committed by the chain of ancestor block hashes and
+transaction roots. A verifier with those recent bodies can reconstruct exact
+membership. A verifier with only a parent state root and candidate block cannot.
+Consequently:
+
+- snapshot and stateless validation require recent history as additional input;
+- `eth_getProof` cannot provide a replay-membership or non-membership proof;
+- historical execution, fraud proofs, and zero-knowledge execution must include
+  the relevant recent transactions or an equivalent authenticated witness; and
+- proving non-membership without a separate rolling commitment requires
+  inspecting the complete live history window.
+
+A future TIP MAY add a replay-set commitment to the block header. Such a design
+must specify authenticated insertion, expiry, branch unwind, snapshot witnesses,
+and proof verification. A header commitment is not required by this TIP because
+it would reintroduce substantial hashing and persistence complexity.
+
+# Tooling
+
+Node tooling MUST provide a command or startup mode that rebuilds the replay cache
+for a selected block hash and reports:
+
+- the covered ancestor range and timestamps;
+- number of live replay identifiers;
+- rebuild duration and source; and
+- whether the result came from bodies or a local checkpoint.
+
+Debug and test tooling SHOULD support dumping replay identifiers and expiry
+buckets for a selected block hash. Output containing raw identifiers SHOULD be
+opt-in because it can be large.
+
+SDK transaction construction is unchanged. Documentation MUST state that replay
+status is chain-history-derived and cannot be queried through EVM storage.
+
+# Observability
+
+Implementations MUST expose metrics equivalent to:
+
+| Metric | Purpose |
+|---|---|
+| live replay identifiers | Bound memory use and detect unexpected growth |
+| replay cache resident bytes | Measure implementation overhead |
+| oldest covered block and timestamp | Detect an incomplete validation window |
+| replay rejection count | Detect duplicate submissions and attacks |
+| expiry count and duration | Detect bucket cleanup stalls |
+| rebuild count and duration | Diagnose restart, sync, and corruption recovery |
+| fork overlay count and bytes | Bound competing-branch memory use |
+| missing replay context errors | Detect unsafe body pruning or sync gaps |
+| reorg rollback/reinsertion count | Verify fork handling and pool behavior |
+
+Consensus logs for replay rejection, missing context, rebuild, and reorganization
+MUST include the parent block hash. Replay identifiers SHOULD be sampled or
+redacted in high-volume logs.
+
+# Resource Bounds
+
+The number of live identifiers is bounded by valid expiring nonce throughput
+multiplied by `MAX_EXPIRY_SECS`. At 100,000 transactions per second and 300
+seconds, the bound is 30,000,000 identifiers, or 960 MB of raw 32-byte hashes.
+
+A non-normative Rust prototype using `HashSet<[u8; 32]>` plus one-second expiry
+buckets measured 2.96 GiB resident memory, 11.19 seconds to insert 30,000,000
+identifiers, and 39 milliseconds to expire a 100,000-identifier bucket. Production
+implementations SHOULD reduce duplicate storage between the membership index and
+expiry buckets and MUST benchmark restart reconstruction from real encoded block
+bodies rather than synthetic identifiers.
+
+# Alternatives Considered
+
+## TIP-1009 EVM-State Ring
+
+The existing ring provides state-root commitment and state-only execution, but
+each transaction creates EVM storage, changeset, trie, and database work. Capacity
+must be provisioned in consensus for the maximum throughput and validity window.
+
+## Epoch-Scoped Expiring EVM Storage
+
+Epoch storage can simplify bulk pruning but retains replay identifiers for much
+longer than their five-minute validity window. At high throughput this greatly
+increases live state and pruning volume.
+
+## Header Replay Root
+
+A dedicated header commitment permits succinct membership proofs and validation
+from a committed replay snapshot. It also requires a new authenticated data
+structure with deterministic expiry, witnesses, fork unwind, and snapshot sync.
+This TIP chooses history reconstruction as the smaller initial design.
+
+## Probabilistic Filters
+
+A Bloom or Cuckoo filter is more compact, but false positives would reject valid
+transactions and could split clients with different implementations. Such filters
+are safe only as accelerators backed by exact confirmation.
+
+## Timestamp Check Without Deduplication
+
+Checking only `validBefore` prevents replay after expiry but allows unlimited
+replay before expiry. Temporal validity alone is not replay protection.
+
+# Invariants
+
+1. **No live replay:** A replay identifier included on the candidate branch cannot
+   be included again while its `validBefore` is greater than the candidate block
+   timestamp.
+2. **Same-block uniqueness:** A valid block contains at most one transaction for
+   each expiring nonce replay identifier.
+3. **Revert consumption:** A transaction included with a failed EVM receipt still
+   consumes its replay identifier.
+4. **Fork isolation:** Inclusion on one branch does not consume the identifier on
+   a competing branch.
+5. **Reorg restoration:** Removing the only consuming block makes an unexpired
+   identifier eligible again on the new canonical branch.
+6. **Exact expiry:** An identifier is not live when
+   `validBefore <= candidate_block.timestamp`; the transaction itself is also
+   invalid at that boundary.
+7. **History determinism:** Rebuilding from the same parent history produces the
+   same live set on every conforming implementation.
+8. **Fail closed:** Missing recent history cannot cause a node to accept a block
+   using an empty or partial replay set.
+9. **Activation continuity:** Every identifier live immediately before activation
+   remains protected immediately after activation.
+10. **Payer invariance:** Transactions with the same TIP-1009 replay identifier
+    conflict even when their fee-payer encoding differs.
+11. **State-root independence:** Expiring nonce inclusion creates no Nonce
+    precompile storage change after activation.
+
+The test suite MUST cover same-block duplicates, failed receipts, expiry equality,
+maximum-window boundaries, timestamp jumps, fee-payer replacement, competing
+payload branches, shallow and deep reorganizations across expiry boundaries,
+restart reconstruction, snapshot sync, missing-body failure, activation migration,
+parallel execution, and historical tracing.
+
+# Success Criteria
+
+Before this TIP advances to `Ready for Consideration`:
+
+1. Two independent implementations MUST produce identical replay sets for shared
+   history and adversarial fork test vectors.
+2. End-to-end benchmarks MUST show no Nonce precompile storage changes, account
+   changesets, or trie updates for post-activation expiring nonce transactions.
+3. The implementation MUST sustain the target transaction rate while keeping
+   replay-cache memory within the documented operator budget.
+4. Restart and snapshot reconstruction from real block bodies MUST complete within
+   an agreed readiness threshold.
+5. Transaction-pool, Engine API, reorganization, historical RPC, and activation
+   tests MUST pass under cache loss and forced rebuild.


### PR DESCRIPTION
Defines fork-local, history-derived replay protection for expiring nonce transactions without EVM state mutations. Specifies consensus validation, reorg, Engine API, transaction-pool, RPC, sync, commitment, resource, and activation behavior.

Prompted by: @shekhirin