### PR TITLE
feat(evm): derive expiring nonce replay protection from history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13631,6 +13631,7 @@ dependencies = [
  "reth-trie",
  "revm",
  "serde_json",
+ "smallvec",
  "tempo-chainspec",
  "tempo-contracts",
  "tempo-dkg-onchain-artifacts",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -307,6 +307,7 @@ serde = { version = "1.0.228", features = ["derive"], default-features = false }
 serde_json = { version = "1.0.149", features = ["alloc", "raw_value"], default-features = false }
 schnellru = "0.2"
 sha2 = { version = "0.10", default-features = false }
+smallvec = "1.15.1"
 tar = "0.4.46"
 tempfile = "3.24.0"
 thiserror = "2.0.18"

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -49,6 +49,7 @@ alloy-rpc-types-eth = { workspace = true, optional = true }
 derive_more.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+smallvec.workspace = true
 
 [dev-dependencies]
 alloy-eips.workspace = true

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -79,6 +79,7 @@ tikv-jemallocator = "0.6.1"
 default = ["rpc", "engine"]
 rpc = ["dep:alloy-rpc-types-eth", "dep:reth-rpc-eth-api", "tempo-revm/rpc", "tempo-primitives/serde", "tempo-primitives/reth-codec"]
 engine = ["dep:tempo-payload-types", "dep:rayon"]
+bench = []
 
 [[bench]]
 name = "tip20_execution"
@@ -87,3 +88,8 @@ harness = false
 [[bench]]
 name = "dex_execution"
 harness = false
+
+[[bench]]
+name = "expiring_nonce_history"
+harness = false
+required-features = ["bench"]

--- a/crates/evm/benches/common/mod.rs
+++ b/crates/evm/benches/common/mod.rs
@@ -399,6 +399,7 @@ where
         validator_set: None,
         consensus_context: None,
         subblock_fee_recipients: Default::default(),
+        block_hash: None,
     };
     let mut executor = config.create_executor(evm, ctx);
     executor

--- a/crates/evm/benches/common/mod.rs
+++ b/crates/evm/benches/common/mod.rs
@@ -400,6 +400,7 @@ where
         consensus_context: None,
         subblock_fee_recipients: Default::default(),
         block_hash: None,
+        expiring_nonce_overlay: Default::default(),
     };
     let mut executor = config.create_executor(evm, ctx);
     executor

--- a/crates/evm/benches/expiring_nonce_history.rs
+++ b/crates/evm/benches/expiring_nonce_history.rs
@@ -1,0 +1,253 @@
+use alloy_consensus::transaction::TxHashRef;
+use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, map::B256HashSet};
+use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
+use std::hint::black_box;
+use tempo_evm::{ExpiringNonceBlock, ExpiringNonceEntry, ExpiringNonceHistory};
+use tempo_primitives::{
+    AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
+    transaction::{Call, PrimitiveSignature},
+};
+
+fn hash(value: u64) -> B256 {
+    B256::left_padding_from(&value.to_be_bytes())
+}
+
+fn entries(start: u64, count: usize, valid_before: u64) -> Vec<ExpiringNonceEntry> {
+    (0..count)
+        .map(|offset| ExpiringNonceEntry {
+            replay_id: hash(start + offset as u64),
+            valid_before,
+        })
+        .collect()
+}
+
+fn block(
+    hash: B256,
+    parent_hash: B256,
+    timestamp: u64,
+    entries: Vec<ExpiringNonceEntry>,
+) -> ExpiringNonceBlock {
+    ExpiringNonceBlock {
+        hash,
+        parent_hash,
+        timestamp,
+        entries,
+    }
+}
+
+fn transactions(count: usize) -> Vec<TempoTxEnvelope> {
+    (0..count)
+        .map(|index| {
+            let tx = TempoTransaction {
+                chain_id: 1,
+                gas_limit: 1_000_000,
+                nonce_key: U256::MAX,
+                nonce: 0,
+                valid_before: core::num::NonZeroU64::new(300),
+                calls: vec![Call {
+                    to: TxKind::Call(Address::from_word(hash(index as u64 + 1))),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                }],
+                ..Default::default()
+            };
+            TempoTxEnvelope::AA(AASigned::new_unhashed(
+                tx,
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                    Signature::test_signature(),
+                )),
+            ))
+        })
+        .collect()
+}
+
+fn bench_record_block(c: &mut Criterion) {
+    let mut group = c.benchmark_group("expiring_nonce_history/record_block");
+    for count in [1_000, 10_000] {
+        group.throughput(Throughput::Elements(count));
+        group.bench_function(count.to_string(), |b| {
+            b.iter_batched(
+                || {
+                    (
+                        ExpiringNonceHistory::new(300),
+                        entries(1, count as usize, 301),
+                    )
+                },
+                |(history, entries)| {
+                    history.record_block(block(hash(1), B256::ZERO, 1, entries));
+                    black_box(history);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
+fn bench_contains(c: &mut Criterion) {
+    let history = ExpiringNonceHistory::new(300);
+    let replay_id = hash(1);
+    let mut parent = B256::ZERO;
+    for number in 1..=300 {
+        let block_hash = hash(number);
+        let entries = if number == 1 {
+            vec![ExpiringNonceEntry {
+                replay_id,
+                valid_before: 600,
+            }]
+        } else {
+            Vec::new()
+        };
+        history.record_block(block(block_hash, parent, number, entries));
+        parent = block_hash;
+    }
+
+    let mut group = c.benchmark_group("expiring_nonce_history/contains");
+    group.bench_function("miss", |b| {
+        b.iter(|| black_box(history.contains(parent, hash(10_000), 300).unwrap()))
+    });
+    group.bench_function("oldest_live_hit", |b| {
+        b.iter(|| black_box(history.contains(parent, replay_id, 300).unwrap()))
+    });
+    group.finish();
+}
+
+fn bench_intra_block_dedup(c: &mut Criterion) {
+    const ENTRY_COUNT: usize = 10_000;
+    let replay_ids = (0..ENTRY_COUNT)
+        .map(|index| hash(index as u64))
+        .collect::<Vec<_>>();
+    let mut group = c.benchmark_group("expiring_nonce_history/intra_block_dedup");
+    group.throughput(Throughput::Elements(ENTRY_COUNT as u64));
+    group.bench_function("10k", |b| {
+        b.iter_batched(
+            B256HashSet::default,
+            |mut seen| {
+                for replay_id in &replay_ids {
+                    black_box(seen.insert(*replay_id));
+                }
+                black_box(seen);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_pending_payload(c: &mut Criterion) {
+    let transactions = transactions(10_000);
+    let pending = transactions
+        .iter()
+        .enumerate()
+        .map(|(index, tx)| {
+            (
+                *tx.tx_hash(),
+                ExpiringNonceEntry {
+                    replay_id: hash(index as u64 + 1),
+                    valid_before: 300,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    let transaction_hashes = pending.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
+    let entries = pending.iter().map(|(_, entry)| *entry).collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("expiring_nonce_history/pending_payload");
+    group.throughput(Throughput::Elements(transactions.len() as u64));
+    group.bench_function("10k", |b| {
+        b.iter_batched(
+            || {
+                let history = ExpiringNonceHistory::new(300);
+                history.bench_cache_pending_block(
+                    B256::ZERO,
+                    1,
+                    transaction_hashes.clone(),
+                    entries.clone(),
+                );
+                history
+            },
+            |history| {
+                black_box(
+                    history
+                        .bench_entries_for_block(B256::ZERO, 1, &transactions)
+                        .unwrap(),
+                );
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_cache_pending_payload(c: &mut Criterion) {
+    const ENTRY_COUNT: usize = 10_000;
+    let (transaction_hashes, entries) = (0..ENTRY_COUNT)
+        .map(|index| {
+            (
+                hash(index as u64),
+                ExpiringNonceEntry {
+                    replay_id: hash(index as u64 + ENTRY_COUNT as u64),
+                    valid_before: 300,
+                },
+            )
+        })
+        .unzip::<_, _, Vec<_>, Vec<_>>();
+
+    let mut group = c.benchmark_group("expiring_nonce_history/cache_pending_payload");
+    group.throughput(Throughput::Elements(ENTRY_COUNT as u64));
+    group.bench_function("10k", |b| {
+        b.iter_batched(
+            || {
+                (
+                    ExpiringNonceHistory::new(300),
+                    transaction_hashes.clone(),
+                    entries.clone(),
+                )
+            },
+            |(history, transaction_hashes, entries)| {
+                history.bench_cache_pending_block(B256::ZERO, 1, transaction_hashes, entries);
+                black_box(history);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_prune(c: &mut Criterion) {
+    const ENTRY_COUNT: usize = 10_000;
+    let mut group = c.benchmark_group("expiring_nonce_history/prune");
+    group.throughput(Throughput::Elements(ENTRY_COUNT as u64));
+    group.bench_function("10k", |b| {
+        b.iter_batched(
+            || {
+                let history = ExpiringNonceHistory::new(10);
+                history.record_block(block(hash(1), B256::ZERO, 1, entries(1, ENTRY_COUNT, 11)));
+                let mut parent = hash(1);
+                for timestamp in 2..=21 {
+                    let block_hash = hash(timestamp);
+                    history.record_block(block(block_hash, parent, timestamp, Vec::new()));
+                    parent = block_hash;
+                }
+                (history, parent)
+            },
+            |(history, parent)| {
+                history.record_block(block(hash(22), parent, 22, Vec::new()));
+                black_box(history);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_record_block,
+    bench_contains,
+    bench_intra_block_dedup,
+    bench_cache_pending_payload,
+    bench_pending_payload,
+    bench_prune
+);
+criterion_main!(benches);

--- a/crates/evm/benches/expiring_nonce_history.rs
+++ b/crates/evm/benches/expiring_nonce_history.rs
@@ -72,6 +72,7 @@ fn bench_contains(c: &mut Criterion) {
         history.record_block(block(block_hash, parent, number, entries));
         parent = block_hash;
     }
+    history.set_canonical_head(parent).unwrap();
 
     let mut group = c.benchmark_group("expiring_nonce_history/contains");
     group.bench_function("miss", |b| {

--- a/crates/evm/benches/expiring_nonce_history.rs
+++ b/crates/evm/benches/expiring_nonce_history.rs
@@ -1,11 +1,8 @@
-use alloy_consensus::transaction::TxHashRef;
-use alloy_primitives::{Address, B256, Bytes, Signature, TxKind, U256, map::B256HashSet};
+use alloy_primitives::{B256, map::B256HashSet};
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
 use std::hint::black_box;
-use tempo_evm::{ExpiringNonceBlock, ExpiringNonceEntry, ExpiringNonceHistory};
-use tempo_primitives::{
-    AASigned, TempoSignature, TempoTransaction, TempoTxEnvelope,
-    transaction::{Call, PrimitiveSignature},
+use tempo_evm::{
+    ExpiringNonceBlock, ExpiringNonceBlockOverlay, ExpiringNonceEntry, ExpiringNonceHistory,
 };
 
 fn hash(value: u64) -> B256 {
@@ -33,32 +30,6 @@ fn block(
         timestamp,
         entries,
     }
-}
-
-fn transactions(count: usize) -> Vec<TempoTxEnvelope> {
-    (0..count)
-        .map(|index| {
-            let tx = TempoTransaction {
-                chain_id: 1,
-                gas_limit: 1_000_000,
-                nonce_key: U256::MAX,
-                nonce: 0,
-                valid_before: core::num::NonZeroU64::new(300),
-                calls: vec![Call {
-                    to: TxKind::Call(Address::from_word(hash(index as u64 + 1))),
-                    value: U256::ZERO,
-                    input: Bytes::new(),
-                }],
-                ..Default::default()
-            };
-            TempoTxEnvelope::AA(AASigned::new_unhashed(
-                tx,
-                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
-                    Signature::test_signature(),
-                )),
-            ))
-        })
-        .collect()
 }
 
 fn bench_record_block(c: &mut Criterion) {
@@ -134,79 +105,18 @@ fn bench_intra_block_dedup(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_pending_payload(c: &mut Criterion) {
-    let transactions = transactions(10_000);
-    let pending = transactions
-        .iter()
-        .enumerate()
-        .map(|(index, tx)| {
-            (
-                *tx.tx_hash(),
-                ExpiringNonceEntry {
-                    replay_id: hash(index as u64 + 1),
-                    valid_before: 300,
-                },
-            )
-        })
-        .collect::<Vec<_>>();
-    let transaction_hashes = pending.iter().map(|(hash, _)| *hash).collect::<Vec<_>>();
-    let entries = pending.iter().map(|(_, entry)| *entry).collect::<Vec<_>>();
-
-    let mut group = c.benchmark_group("expiring_nonce_history/pending_payload");
-    group.throughput(Throughput::Elements(transactions.len() as u64));
-    group.bench_function("10k", |b| {
-        b.iter_batched(
-            || {
-                let history = ExpiringNonceHistory::new(300);
-                history.bench_cache_pending_block(
-                    B256::ZERO,
-                    1,
-                    transaction_hashes.clone(),
-                    entries.clone(),
-                );
-                history
-            },
-            |history| {
-                black_box(
-                    history
-                        .bench_entries_for_block(B256::ZERO, 1, &transactions)
-                        .unwrap(),
-                );
-            },
-            BatchSize::SmallInput,
-        );
-    });
-    group.finish();
-}
-
-fn bench_cache_pending_payload(c: &mut Criterion) {
+fn bench_block_overlay_handoff(c: &mut Criterion) {
     const ENTRY_COUNT: usize = 10_000;
-    let (transaction_hashes, entries) = (0..ENTRY_COUNT)
-        .map(|index| {
-            (
-                hash(index as u64),
-                ExpiringNonceEntry {
-                    replay_id: hash(index as u64 + ENTRY_COUNT as u64),
-                    valid_before: 300,
-                },
-            )
-        })
-        .unzip::<_, _, Vec<_>, Vec<_>>();
+    let entries = entries(1, ENTRY_COUNT, 300);
 
-    let mut group = c.benchmark_group("expiring_nonce_history/cache_pending_payload");
+    let mut group = c.benchmark_group("expiring_nonce_history/block_overlay_handoff");
     group.throughput(Throughput::Elements(ENTRY_COUNT as u64));
     group.bench_function("10k", |b| {
         b.iter_batched(
-            || {
-                (
-                    ExpiringNonceHistory::new(300),
-                    transaction_hashes.clone(),
-                    entries.clone(),
-                )
-            },
-            |(history, transaction_hashes, entries)| {
-                history.bench_cache_pending_block(B256::ZERO, 1, transaction_hashes, entries);
-                black_box(history);
+            || (ExpiringNonceBlockOverlay::default(), entries.clone()),
+            |(overlay, entries)| {
+                overlay.bench_publish(entries);
+                black_box(overlay.bench_take());
             },
             BatchSize::SmallInput,
         );
@@ -246,8 +156,7 @@ criterion_group!(
     bench_record_block,
     bench_contains,
     bench_intra_block_dedup,
-    bench_cache_pending_payload,
-    bench_pending_payload,
+    bench_block_overlay_handoff,
     bench_prune
 );
 criterion_main!(benches);

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -38,7 +38,7 @@ where
         result_closure: impl FnOnce(&TempoTxResult),
         commit_reads: bool,
     ) -> Result<(), BlockExecutionError> {
-        let (tx_env, recovered) = tx.into_parts();
+        let (mut tx_env, recovered) = tx.into_parts();
 
         let StorageActionReplay {
             result,
@@ -46,6 +46,10 @@ where
             expiring_nonce,
             validator_fee,
         } = replay;
+        let expiring_nonce_entry = self.prepare_expiring_nonce(&mut tx_env, recovered.tx())?;
+        let history_protected = self.evm().cfg.spec.is_t11();
+        let skip_expiring_nonce_actions =
+            expiring_nonce.is_some() || (history_protected && expiring_nonce_entry.is_some());
         self.replay_state.reset_tx_changes();
 
         // TODO: handle reverted transactions
@@ -58,7 +62,12 @@ where
                 tx_env.caller(),
                 actions.drain(..),
                 commit_reads,
-                expiring_nonce,
+                if history_protected {
+                    None
+                } else {
+                    expiring_nonce
+                },
+                skip_expiring_nonce_actions,
             )
             .inspect_err(|_| {
                 self.replay_state.reset_tx_changes();
@@ -83,7 +92,8 @@ where
             self.is_payment(recovered.tx()),
             block_gas_used,
             validator_fee,
-        );
+        )
+        .with_expiring_nonce_entry(expiring_nonce_entry);
         result_closure(&result);
 
         self.commit_transaction(result);
@@ -97,9 +107,9 @@ where
         actions: impl IntoIterator<Item = StorageAction>,
         commit_reads: bool,
         expiring_nonce: Option<ExpiringNonceReplay>,
+        skip_expiring_nonce_actions: bool,
     ) -> Result<EvmState, BlockExecutionError> {
         let block_timestamp = self.inner.evm.block().timestamp.to::<u64>();
-        let is_expiring_nonce = expiring_nonce.is_some();
 
         if let Some(expiring_nonce) = expiring_nonce {
             self.apply_expiring_nonce_replay(expiring_nonce, block_timestamp)?;
@@ -108,7 +118,7 @@ where
         let db = self.inner.evm.db_mut();
         for action in actions {
             // Expiring nonces are handled above
-            if is_expiring_nonce && action.address() == NONCE_PRECOMPILE_ADDRESS {
+            if skip_expiring_nonce_actions && action.address() == NONCE_PRECOMPILE_ADDRESS {
                 continue;
             }
 

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -51,6 +51,7 @@ impl TempoBlockAssembler {
                     consensus_context,
                     subblock_fee_recipients: _,
                     block_hash: _,
+                    expiring_nonce_overlay,
                 },
             parent,
             transactions,
@@ -65,10 +66,7 @@ impl TempoBlockAssembler {
         let parent_hash = inner.parent_hash;
         let block_timestamp = evm_env.block_env.inner.timestamp.to::<u64>();
         let entry_resolution_started = Instant::now();
-        let (expiring_nonce_entries, pending_cache_hit) = self
-            .expiring_nonce_history
-            .entries_for_block(parent_hash, block_timestamp, &transactions)
-            .map_err(|err| BlockExecutionError::msg(err.to_string()))?;
+        let expiring_nonce_entries = expiring_nonce_overlay.take();
         let entry_resolution_elapsed = entry_resolution_started.elapsed();
 
         let parent = SealedHeader::new_unhashed(parent.clone().into_header().inner);
@@ -119,7 +117,6 @@ impl TempoBlockAssembler {
             block_timestamp,
             transaction_count = block.body.transactions.len(),
             entry_count,
-            pending_cache_hit,
             ?entry_resolution_elapsed,
             record_elapsed = ?record_started.elapsed(),
             "indexed assembled block into expiring nonce history"
@@ -238,6 +235,7 @@ mod tests {
             consensus_context: None,
             subblock_fee_recipients: HashMap::new(),
             block_hash: None,
+            expiring_nonce_overlay: Default::default(),
         };
 
         let tx = create_legacy_tx();
@@ -356,6 +354,7 @@ mod tests {
             consensus_context: Some(ctx),
             subblock_fee_recipients: HashMap::new(),
             block_hash: None,
+            expiring_nonce_overlay: Default::default(),
         };
 
         let transactions = vec![create_legacy_tx()];
@@ -439,6 +438,7 @@ mod tests {
             consensus_context: None,
             subblock_fee_recipients: HashMap::new(),
             block_hash: None,
+            expiring_nonce_overlay: Default::default(),
         };
 
         let transactions = vec![create_legacy_tx()];

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -40,6 +40,7 @@ impl TempoBlockAssembler {
                     validator_set: _,
                     consensus_context,
                     subblock_fee_recipients: _,
+                    block_hash: _,
                 },
             parent,
             transactions,
@@ -193,6 +194,7 @@ mod tests {
             validator_set: None,
             consensus_context: None,
             subblock_fee_recipients: HashMap::new(),
+            block_hash: None,
         };
 
         let tx = create_legacy_tx();
@@ -304,6 +306,7 @@ mod tests {
             validator_set: None,
             consensus_context: Some(ctx),
             subblock_fee_recipients: HashMap::new(),
+            block_hash: None,
         };
 
         let transactions = vec![create_legacy_tx()];
@@ -386,6 +389,7 @@ mod tests {
             validator_set: None,
             consensus_context: None,
             subblock_fee_recipients: HashMap::new(),
+            block_hash: None,
         };
 
         let transactions = vec![create_legacy_tx()];

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -1,12 +1,14 @@
 use crate::{
-    TempoEvmConfig, TempoEvmFactory, block::TempoReceiptBuilder, context::TempoBlockExecutionCtx,
+    ExpiringNonceBlock, ExpiringNonceHistory, TempoEvmConfig, TempoEvmFactory,
+    block::TempoReceiptBuilder, context::TempoBlockExecutionCtx,
 };
+use alloy_consensus::Sealable as _;
 use alloy_evm::{block::BlockExecutionError, eth::EthBlockExecutorFactory};
 use alloy_primitives::{B256, Bloom};
 use reth_evm::execute::{BlockAssembler, BlockAssemblerInput};
 use reth_evm_ethereum::EthBlockAssembler;
 use reth_primitives_traits::SealedHeader;
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 use tempo_chainspec::TempoChainSpec;
 use tempo_primitives::TempoHeader;
 
@@ -14,13 +16,21 @@ use tempo_primitives::TempoHeader;
 #[derive(Debug, Clone)]
 pub struct TempoBlockAssembler {
     pub(crate) inner: EthBlockAssembler<TempoChainSpec>,
+    expiring_nonce_history: ExpiringNonceHistory,
 }
 
 impl TempoBlockAssembler {
     pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
         Self {
             inner: EthBlockAssembler::new(chain_spec),
+            expiring_nonce_history: ExpiringNonceHistory::default(),
         }
+    }
+
+    /// Uses the provided history-derived expiring nonce cache.
+    pub fn with_expiring_nonce_history(mut self, history: ExpiringNonceHistory) -> Self {
+        self.expiring_nonce_history = history;
+        self
     }
 
     pub fn assemble_block(
@@ -52,6 +62,15 @@ impl TempoBlockAssembler {
             ..
         } = input;
 
+        let parent_hash = inner.parent_hash;
+        let block_timestamp = evm_env.block_env.inner.timestamp.to::<u64>();
+        let entry_resolution_started = Instant::now();
+        let (expiring_nonce_entries, pending_cache_hit) = self
+            .expiring_nonce_history
+            .entries_for_block(parent_hash, block_timestamp, &transactions)
+            .map_err(|err| BlockExecutionError::msg(err.to_string()))?;
+        let entry_resolution_elapsed = entry_resolution_started.elapsed();
+
         let parent = SealedHeader::new_unhashed(parent.clone().into_header().inner);
 
         let timestamp_millis_part = evm_env.block_env.timestamp_millis_part;
@@ -76,13 +95,37 @@ impl TempoBlockAssembler {
             receipts_bloom,
         )?;
 
-        Ok(block.map_header(|inner| TempoHeader {
+        let block = block.map_header(|inner| TempoHeader {
             inner,
             general_gas_limit,
             timestamp_millis_part,
             shared_gas_limit,
             consensus_context,
-        }))
+        });
+        let block_hash = block.header.hash_slow();
+        let entry_count = expiring_nonce_entries.len();
+        let record_started = Instant::now();
+        self.expiring_nonce_history
+            .record_block(ExpiringNonceBlock {
+                hash: block_hash,
+                parent_hash,
+                timestamp: block_timestamp,
+                entries: expiring_nonce_entries,
+            });
+        tracing::info!(
+            target: "tempo::expiring_nonce_history",
+            %block_hash,
+            %parent_hash,
+            block_timestamp,
+            transaction_count = block.body.transactions.len(),
+            entry_count,
+            pending_cache_hit,
+            ?entry_resolution_elapsed,
+            record_elapsed = ?record_started.elapsed(),
+            "indexed assembled block into expiring nonce history"
+        );
+
+        Ok(block)
     }
 }
 
@@ -246,6 +289,12 @@ mod tests {
 
         // Verify consensus context is None when not provided
         assert!(block.header.consensus_context.is_none());
+        assert!(
+            assembler
+                .expiring_nonce_history
+                .contains_block(block.header.hash_slow()),
+            "assembled blocks must be available to child payload execution immediately"
+        );
     }
 
     #[test]

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -108,8 +108,6 @@ pub struct TempoTxResult {
     /// Used by the payload builder to score blocks by actual proposer revenue. The value is the
     /// post-feeAMM amount, regardless of route shape — absorbs any number of pool haircuts.
     validator_fee: U256,
-    /// Hash of the transaction that produced this result.
-    tx_hash: B256,
     /// Expiring nonce consumed by this transaction, if any.
     expiring_nonce_entry: Option<ExpiringNonceEntry>,
 }
@@ -136,7 +134,6 @@ impl TempoTxResult {
             tx: matches!(next_section, BlockSection::SubBlock { .. }).then(|| tx.clone()),
             block_gas_used,
             validator_fee,
-            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         }
     }
@@ -202,8 +199,7 @@ pub struct TempoBlockExecutor<'a, DB: Database, I> {
 
     expiring_nonce_history: ExpiringNonceHistory,
     block_expiring_nonce_entries: Vec<ExpiringNonceEntry>,
-    /// Transaction hashes are only needed to match a locally built payload during assembly.
-    block_expiring_nonce_hashes: Option<Vec<B256>>,
+    expiring_nonce_overlay: crate::ExpiringNonceBlockOverlay,
     block_expiring_nonce_ids: B256HashSet,
     parent_hash: B256,
     block_hash: Option<B256>,
@@ -224,7 +220,7 @@ where
         let parent_hash = ctx.inner.parent_hash;
         let block_hash = ctx.block_hash;
         let block_timestamp = evm.block().timestamp.to::<u64>();
-        let block_expiring_nonce_hashes = block_hash.is_none().then(Vec::new);
+        let expiring_nonce_overlay = ctx.expiring_nonce_overlay.clone();
         Self {
             incentive_gas_used: 0,
             validator_set: ctx.validator_set,
@@ -244,7 +240,7 @@ where
             replay_state: StorageActionReplayState::default(),
             expiring_nonce_history,
             block_expiring_nonce_entries: Vec::new(),
-            block_expiring_nonce_hashes,
+            expiring_nonce_overlay,
             block_expiring_nonce_ids: B256HashSet::default(),
             parent_hash,
             block_hash,
@@ -780,7 +776,6 @@ where
                 .then(|| recovered.tx().clone()),
             block_gas_used,
             validator_fee,
-            tx_hash: *recovered.tx().tx_hash(),
             expiring_nonce_entry,
         })
     }
@@ -793,7 +788,6 @@ where
             tx,
             block_gas_used,
             validator_fee: _,
-            tx_hash,
             expiring_nonce_entry,
         } = output;
 
@@ -838,9 +832,6 @@ where
         self.replay_state.commit_tx_changes();
         if let Some(entry) = expiring_nonce_entry {
             self.block_expiring_nonce_entries.push(entry);
-            if let Some(transaction_hashes) = &mut self.block_expiring_nonce_hashes {
-                transaction_hashes.push(tx_hash);
-            }
         }
 
         gas_output
@@ -877,13 +868,8 @@ where
                     entries: self.block_expiring_nonce_entries,
                 });
         } else {
-            self.expiring_nonce_history.cache_pending_block(
-                self.parent_hash,
-                self.block_timestamp,
-                self.block_expiring_nonce_hashes
-                    .expect("locally built blocks retain expiring transaction hashes"),
-                self.block_expiring_nonce_entries,
-            );
+            self.expiring_nonce_overlay
+                .publish(self.block_expiring_nonce_entries);
         }
 
         // TIP-1016 enabled: block header `gas_used` = block_regular_gas_used.
@@ -1692,7 +1678,6 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
 
@@ -1845,7 +1830,6 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
 
@@ -1887,7 +1871,6 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx1.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output1);
@@ -1913,7 +1896,6 @@ mod tests {
             tx: None,
             block_gas_used: 50000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx2.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output2);
@@ -1978,7 +1960,6 @@ mod tests {
             tx: None,
             block_gas_used: 50000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
@@ -2026,7 +2007,6 @@ mod tests {
             tx: None,
             block_gas_used: 200_000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
@@ -2077,7 +2057,6 @@ mod tests {
             tx: None,
             block_gas_used: 200_000,
             validator_fee: U256::ZERO,
-            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -14,7 +14,7 @@ use alloy_evm::{
         receipt_builder::{ReceiptBuilder, ReceiptBuilderCtx},
     },
 };
-use alloy_primitives::{Address, B256, Bytes, U256};
+use alloy_primitives::{Address, B256, Bytes, U256, map::B256HashSet};
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolCall;
 use commonware_codec::{DecodeExt, ReadExt};
@@ -201,8 +201,10 @@ pub struct TempoBlockExecutor<'a, DB: Database, I> {
     incentive_gas_used: u64,
 
     expiring_nonce_history: ExpiringNonceHistory,
-    block_expiring_nonce_entries: Vec<(B256, ExpiringNonceEntry)>,
-    block_expiring_nonce_ids: HashSet<B256>,
+    block_expiring_nonce_entries: Vec<ExpiringNonceEntry>,
+    /// Transaction hashes are only needed to match a locally built payload during assembly.
+    block_expiring_nonce_hashes: Option<Vec<B256>>,
+    block_expiring_nonce_ids: B256HashSet,
     parent_hash: B256,
     block_hash: Option<B256>,
     block_timestamp: u64,
@@ -222,6 +224,7 @@ where
         let parent_hash = ctx.inner.parent_hash;
         let block_hash = ctx.block_hash;
         let block_timestamp = evm.block().timestamp.to::<u64>();
+        let block_expiring_nonce_hashes = block_hash.is_none().then(Vec::new);
         Self {
             incentive_gas_used: 0,
             validator_set: ctx.validator_set,
@@ -241,7 +244,8 @@ where
             replay_state: StorageActionReplayState::default(),
             expiring_nonce_history,
             block_expiring_nonce_entries: Vec::new(),
-            block_expiring_nonce_ids: HashSet::new(),
+            block_expiring_nonce_hashes,
+            block_expiring_nonce_ids: B256HashSet::default(),
             parent_hash,
             block_hash,
             block_timestamp,
@@ -833,7 +837,10 @@ where
 
         self.replay_state.commit_tx_changes();
         if let Some(entry) = expiring_nonce_entry {
-            self.block_expiring_nonce_entries.push((tx_hash, entry));
+            self.block_expiring_nonce_entries.push(entry);
+            if let Some(transaction_hashes) = &mut self.block_expiring_nonce_hashes {
+                transaction_hashes.push(tx_hash);
+            }
         }
 
         gas_output
@@ -867,16 +874,14 @@ where
                     hash: block_hash,
                     parent_hash: self.parent_hash,
                     timestamp: self.block_timestamp,
-                    entries: self
-                        .block_expiring_nonce_entries
-                        .into_iter()
-                        .map(|(_, entry)| entry)
-                        .collect(),
+                    entries: self.block_expiring_nonce_entries,
                 });
         } else {
             self.expiring_nonce_history.cache_pending_block(
                 self.parent_hash,
                 self.block_timestamp,
+                self.block_expiring_nonce_hashes
+                    .expect("locally built blocks retain expiring transaction hashes"),
                 self.block_expiring_nonce_entries,
             );
         }

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -108,6 +108,8 @@ pub struct TempoTxResult {
     /// Used by the payload builder to score blocks by actual proposer revenue. The value is the
     /// post-feeAMM amount, regardless of route shape — absorbs any number of pool haircuts.
     validator_fee: U256,
+    /// Hash of the transaction that produced this result.
+    tx_hash: B256,
     /// Expiring nonce consumed by this transaction, if any.
     expiring_nonce_entry: Option<ExpiringNonceEntry>,
 }
@@ -134,6 +136,7 @@ impl TempoTxResult {
             tx: matches!(next_section, BlockSection::SubBlock { .. }).then(|| tx.clone()),
             block_gas_used,
             validator_fee,
+            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         }
     }
@@ -198,7 +201,7 @@ pub struct TempoBlockExecutor<'a, DB: Database, I> {
     incentive_gas_used: u64,
 
     expiring_nonce_history: ExpiringNonceHistory,
-    block_expiring_nonce_entries: Vec<ExpiringNonceEntry>,
+    block_expiring_nonce_entries: Vec<(B256, ExpiringNonceEntry)>,
     block_expiring_nonce_ids: HashSet<B256>,
     parent_hash: B256,
     block_hash: Option<B256>,
@@ -773,6 +776,7 @@ where
                 .then(|| recovered.tx().clone()),
             block_gas_used,
             validator_fee,
+            tx_hash: *recovered.tx().tx_hash(),
             expiring_nonce_entry,
         })
     }
@@ -785,6 +789,7 @@ where
             tx,
             block_gas_used,
             validator_fee: _,
+            tx_hash,
             expiring_nonce_entry,
         } = output;
 
@@ -828,7 +833,7 @@ where
 
         self.replay_state.commit_tx_changes();
         if let Some(entry) = expiring_nonce_entry {
-            self.block_expiring_nonce_entries.push(entry);
+            self.block_expiring_nonce_entries.push((tx_hash, entry));
         }
 
         gas_output
@@ -862,8 +867,18 @@ where
                     hash: block_hash,
                     parent_hash: self.parent_hash,
                     timestamp: self.block_timestamp,
-                    entries: self.block_expiring_nonce_entries,
+                    entries: self
+                        .block_expiring_nonce_entries
+                        .into_iter()
+                        .map(|(_, entry)| entry)
+                        .collect(),
                 });
+        } else {
+            self.expiring_nonce_history.cache_pending_block(
+                self.parent_hash,
+                self.block_timestamp,
+                self.block_expiring_nonce_entries,
+            );
         }
 
         // TIP-1016 enabled: block header `gas_used` = block_regular_gas_used.
@@ -1672,6 +1687,7 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
 
@@ -1824,6 +1840,7 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
 
@@ -1865,6 +1882,7 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx1.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output1);
@@ -1890,6 +1908,7 @@ mod tests {
             tx: None,
             block_gas_used: 50000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx2.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output2);
@@ -1954,6 +1973,7 @@ mod tests {
             tx: None,
             block_gas_used: 50000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
@@ -2001,6 +2021,7 @@ mod tests {
             tx: None,
             block_gas_used: 200_000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
@@ -2051,6 +2072,7 @@ mod tests {
             tx: None,
             block_gas_used: 200_000,
             validator_fee: U256::ZERO,
+            tx_hash: *tx.tx_hash(),
             expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -1,4 +1,7 @@
-use crate::{StorageActionReplayState, TempoBlockExecutionCtx, evm::TempoEvm};
+use crate::{
+    ExpiringNonceBlock, ExpiringNonceEntry, ExpiringNonceHistory, StorageActionReplayState,
+    TempoBlockExecutionCtx, evm::TempoEvm,
+};
 use alloy_consensus::{Transaction, transaction::TxHashRef};
 use alloy_evm::{
     Database, Evm, RecoveredTx,
@@ -36,7 +39,7 @@ use tempo_primitives::{
     SubBlock, SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType,
     subblock::PartialValidatorKey,
 };
-use tempo_revm::{TempoHaltReason, evm::TempoContext};
+use tempo_revm::{TempoHaltReason, TempoTxEnv, evm::TempoContext};
 use tracing::trace;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -105,6 +108,8 @@ pub struct TempoTxResult {
     /// Used by the payload builder to score blocks by actual proposer revenue. The value is the
     /// post-feeAMM amount, regardless of route shape — absorbs any number of pool haircuts.
     validator_fee: U256,
+    /// Expiring nonce consumed by this transaction, if any.
+    expiring_nonce_entry: Option<ExpiringNonceEntry>,
 }
 
 impl TempoTxResult {
@@ -129,7 +134,17 @@ impl TempoTxResult {
             tx: matches!(next_section, BlockSection::SubBlock { .. }).then(|| tx.clone()),
             block_gas_used,
             validator_fee,
+            expiring_nonce_entry: None,
         }
+    }
+
+    /// Attaches the expiring nonce entry derived before replay.
+    pub(crate) const fn with_expiring_nonce_entry(
+        mut self,
+        entry: Option<ExpiringNonceEntry>,
+    ) -> Self {
+        self.expiring_nonce_entry = entry;
+        self
     }
 
     /// Returns the block gas consumed by this transaction.
@@ -181,6 +196,13 @@ pub struct TempoBlockExecutor<'a, DB: Database, I> {
     non_shared_gas_left: u64,
     non_payment_gas_left: u64,
     incentive_gas_used: u64,
+
+    expiring_nonce_history: ExpiringNonceHistory,
+    block_expiring_nonce_entries: Vec<ExpiringNonceEntry>,
+    block_expiring_nonce_ids: HashSet<B256>,
+    parent_hash: B256,
+    block_hash: Option<B256>,
+    block_timestamp: u64,
 }
 
 impl<'a, DB, I> TempoBlockExecutor<'a, DB, I>
@@ -192,7 +214,11 @@ where
         evm: TempoEvm<DB, I>,
         ctx: TempoBlockExecutionCtx<'a>,
         chain_spec: &'a TempoChainSpec,
+        expiring_nonce_history: ExpiringNonceHistory,
     ) -> Self {
+        let parent_hash = ctx.inner.parent_hash;
+        let block_hash = ctx.block_hash;
+        let block_timestamp = evm.block().timestamp.to::<u64>();
         Self {
             incentive_gas_used: 0,
             validator_set: ctx.validator_set,
@@ -210,7 +236,61 @@ where
             seen_subblocks: Vec::new(),
             subblock_fee_recipients: ctx.subblock_fee_recipients,
             replay_state: StorageActionReplayState::default(),
+            expiring_nonce_history,
+            block_expiring_nonce_entries: Vec::new(),
+            block_expiring_nonce_ids: HashSet::new(),
+            parent_hash,
+            block_hash,
+            block_timestamp,
         }
+    }
+
+    /// Validates an expiring nonce against recent block history and prepares the EVM to skip the
+    /// legacy Nonce-precompile state transition.
+    pub(crate) fn prepare_expiring_nonce(
+        &mut self,
+        tx_env: &mut TempoTxEnv,
+        tx: &TempoTxEnvelope,
+    ) -> Result<Option<ExpiringNonceEntry>, BlockExecutionError> {
+        if !tx.is_expiring_nonce() {
+            return Ok(None);
+        }
+
+        let valid_before = tx
+            .valid_before()
+            .ok_or_else(|| BlockValidationError::msg("expiring nonce missing validBefore"))?;
+        let replay_id = tx_env
+            .unique_tx_identifier()
+            .ok_or_else(|| BlockValidationError::msg("expiring nonce missing replay identifier"))?;
+        let entry = ExpiringNonceEntry {
+            replay_id,
+            valid_before,
+        };
+
+        if !self.evm().cfg.spec.is_t11() {
+            return Ok(Some(entry));
+        }
+
+        if !self.block_expiring_nonce_ids.insert(replay_id) {
+            return Err(BlockValidationError::msg("duplicate expiring nonce in block").into());
+        }
+        match self.expiring_nonce_history.contains(
+            self.parent_hash,
+            replay_id,
+            self.block_timestamp,
+        ) {
+            Ok(false) => {}
+            Ok(true) => {
+                return Err(BlockValidationError::msg("expiring nonce replay").into());
+            }
+            Err(err) => return Err(BlockValidationError::msg(err.to_string()).into()),
+        }
+
+        if tx_env.tempo_tx_env.is_none() {
+            return Err(BlockValidationError::msg("expiring nonce missing Tempo tx env").into());
+        }
+        tx_env.expiring_nonce_history_verified = true;
+        Ok(Some(entry))
     }
 
     /// Deploys `0xEF` marker bytecode and initializes storage at a precompile address.
@@ -648,6 +728,7 @@ where
         if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
             tempo_tx_env.expiring_nonce_idx = None;
         }
+        let expiring_nonce_entry = self.prepare_expiring_nonce(&mut tx_env, recovered.tx())?;
         let next_section = self.validate_tx_pre_execution(recovered.tx())?;
 
         let beneficiary = self.evm_mut().ctx_mut().block.beneficiary;
@@ -692,6 +773,7 @@ where
                 .then(|| recovered.tx().clone()),
             block_gas_used,
             validator_fee,
+            expiring_nonce_entry,
         })
     }
 
@@ -703,6 +785,7 @@ where
             tx,
             block_gas_used,
             validator_fee: _,
+            expiring_nonce_entry,
         } = output;
 
         let gas_output = self.inner.commit_transaction(inner);
@@ -744,6 +827,9 @@ where
         }
 
         self.replay_state.commit_tx_changes();
+        if let Some(entry) = expiring_nonce_entry {
+            self.block_expiring_nonce_entries.push(entry);
+        }
 
         gas_output
     }
@@ -769,6 +855,16 @@ where
 
         let regular_gas_used = self.inner.block_regular_gas_used;
         let (evm, mut result) = self.inner.finish()?;
+
+        if let Some(block_hash) = self.block_hash {
+            self.expiring_nonce_history
+                .record_block(ExpiringNonceBlock {
+                    hash: block_hash,
+                    parent_hash: self.parent_hash,
+                    timestamp: self.block_timestamp,
+                    entries: self.block_expiring_nonce_entries,
+                });
+        }
 
         // TIP-1016 enabled: block header `gas_used` = block_regular_gas_used.
         // State gas is charged to users (in receipts) but exempted from block
@@ -830,8 +926,8 @@ where
 mod tests {
     use super::*;
     use crate::test_utils::{TestExecutorBuilder, test_chainspec, test_evm};
-    use alloy_consensus::{Signed, TxLegacy};
-    use alloy_evm::{block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
+    use alloy_consensus::{Signed, TxLegacy, transaction::SignerRecoverable};
+    use alloy_evm::{FromRecoveredTx, block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
     use alloy_primitives::{Bytes, Log, Signature, TxKind, address, bytes::BytesMut};
     use alloy_rlp::Encodable;
     use commonware_codec::Encode as _;
@@ -864,7 +960,7 @@ mod tests {
     use tempo_primitives::{
         SubBlockMetadata, TempoSignature, TempoTransaction, TempoTxType,
         subblock::{SubBlockVersion, TEMPO_SUBBLOCK_NONCE_KEY_PREFIX},
-        transaction::{Call, envelope::TEMPO_SYSTEM_TX_SIGNATURE},
+        transaction::{Call, TEMPO_EXPIRING_NONCE_KEY, envelope::TEMPO_SYSTEM_TX_SIGNATURE},
     };
     use tempo_revm::TempoHaltReason;
 
@@ -892,6 +988,52 @@ mod tests {
             input: Bytes::new(),
         };
         TempoTxEnvelope::Legacy(Signed::new_unhashed(tx, Signature::test_signature()))
+    }
+
+    fn create_expiring_nonce_tx(valid_before: u64) -> TempoTxEnvelope {
+        let tx = TempoTransaction {
+            chain_id: 1,
+            calls: vec![Call {
+                to: Address::ZERO.into(),
+                input: Default::default(),
+                value: Default::default(),
+            }],
+            gas_limit: 100_000,
+            nonce_key: TEMPO_EXPIRING_NONCE_KEY,
+            max_fee_per_gas: 1,
+            max_priority_fee_per_gas: 1,
+            valid_before: core::num::NonZeroU64::new(valid_before),
+            ..Default::default()
+        };
+        TempoTxEnvelope::AA(tx.into_signed(TempoSignature::from(Signature::test_signature())))
+    }
+
+    #[test]
+    fn test_t11_rejects_same_block_expiring_nonce_duplicate() {
+        let chainspec = DEV.clone();
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_spec(TempoHardfork::T11)
+            .build(&mut db, &chainspec);
+        let tx = create_expiring_nonce_tx(300);
+        let sender = tx.recover_signer().unwrap();
+        let mut first_env = TempoTxEnv::from_recovered_tx(&tx, sender);
+        let mut duplicate_env = first_env.clone();
+
+        assert!(
+            executor
+                .prepare_expiring_nonce(&mut first_env, &tx)
+                .unwrap()
+                .is_some()
+        );
+        assert!(first_env.expiring_nonce_history_verified);
+        assert_eq!(
+            executor
+                .prepare_expiring_nonce(&mut duplicate_env, &tx)
+                .unwrap_err()
+                .to_string(),
+            "duplicate expiring nonce in block"
+        );
     }
 
     fn create_dkg_outcome(epoch: u64, players: usize) -> OnchainDkgOutcome {
@@ -1530,6 +1672,7 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1681,6 +1824,7 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
 
         let gas_output = executor.commit_transaction(output);
@@ -1721,6 +1865,7 @@ mod tests {
             tx: None,
             block_gas_used: 21000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
         executor.commit_transaction(output1);
 
@@ -1745,6 +1890,7 @@ mod tests {
             tx: None,
             block_gas_used: 50000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
         executor.commit_transaction(output2);
 
@@ -1808,6 +1954,7 @@ mod tests {
             tx: None,
             block_gas_used: 50000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
 
@@ -1854,6 +2001,7 @@ mod tests {
             tx: None,
             block_gas_used: 200_000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
 
@@ -1903,6 +2051,7 @@ mod tests {
             tx: None,
             block_gas_used: 200_000,
             validator_fee: U256::ZERO,
+            expiring_nonce_entry: None,
         };
         executor.commit_transaction(output);
 

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -28,6 +28,11 @@ pub struct TempoBlockExecutionCtx<'a> {
     ///
     /// Used to provide EVM with the fee recipient context when executing subblock transactions.
     pub subblock_fee_recipients: HashMap<PartialValidatorKey, Address>,
+    /// Hash of the block being executed, when it is already sealed.
+    ///
+    /// Payload construction leaves this unset and records replay history when the built block is
+    /// later imported.
+    pub block_hash: Option<B256>,
 }
 
 /// Context required for next block environment.

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -1,9 +1,57 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
 
+use crate::ExpiringNonceEntry;
 use alloy_evm::eth::EthBlockExecutionCtx;
 use alloy_primitives::{Address, B256};
 use reth_evm::NextBlockEnvAttributes;
 use tempo_primitives::{TempoConsensusContext, subblock::PartialValidatorKey};
+
+/// Replay entries committed while constructing one local payload.
+///
+/// The block builder clones the execution context before creating the executor, so this overlay
+/// provides a direct handoff to the assembler without storing unsealed payloads in global replay
+/// history.
+#[derive(Debug, Clone, Default)]
+pub struct ExpiringNonceBlockOverlay {
+    entries: Arc<Mutex<Vec<ExpiringNonceEntry>>>,
+}
+
+impl ExpiringNonceBlockOverlay {
+    /// Publishes the entries committed by the block executor.
+    pub(crate) fn publish(&self, entries: Vec<ExpiringNonceEntry>) {
+        *self
+            .entries
+            .lock()
+            .expect("expiring nonce block overlay lock poisoned") = entries;
+    }
+
+    /// Takes the committed entries when assembling the sealed block.
+    pub(crate) fn take(&self) -> Vec<ExpiringNonceEntry> {
+        std::mem::take(
+            &mut *self
+                .entries
+                .lock()
+                .expect("expiring nonce block overlay lock poisoned"),
+        )
+    }
+
+    /// Benchmark-only access to the block overlay handoff.
+    #[cfg(feature = "bench")]
+    #[doc(hidden)]
+    pub fn bench_publish(&self, entries: Vec<ExpiringNonceEntry>) {
+        self.publish(entries);
+    }
+
+    /// Benchmark-only access to the block overlay handoff.
+    #[cfg(feature = "bench")]
+    #[doc(hidden)]
+    pub fn bench_take(&self) -> Vec<ExpiringNonceEntry> {
+        self.take()
+    }
+}
 
 /// Execution context for Tempo block.
 #[derive(Debug, Clone, derive_more::Deref)]
@@ -33,6 +81,8 @@ pub struct TempoBlockExecutionCtx<'a> {
     /// Payload construction leaves this unset and records replay history when the built block is
     /// later imported.
     pub block_hash: Option<B256>,
+    /// Per-build handoff for expiring nonce entries committed by the executor.
+    pub expiring_nonce_overlay: ExpiringNonceBlockOverlay,
 }
 
 /// Context required for next block environment.
@@ -106,5 +156,19 @@ mod tests {
         assert_eq!(pending_env.shared_gas_limit, shared_gas_limit);
         assert_eq!(pending_env.timestamp_millis_part, timestamp_millis_part);
         assert!(pending_env.subblock_fee_recipients.is_empty());
+    }
+
+    #[test]
+    fn block_overlay_hands_entries_to_assembler_once() {
+        let overlay = ExpiringNonceBlockOverlay::default();
+        let entry = ExpiringNonceEntry {
+            replay_id: B256::repeat_byte(1),
+            valid_before: 300,
+        };
+
+        overlay.publish(vec![entry]);
+
+        assert_eq!(overlay.take(), vec![entry]);
+        assert!(overlay.take().is_empty());
     }
 }

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -1,13 +1,15 @@
-use alloy_consensus::transaction::SignerRecoverable;
-use alloy_primitives::{B256, map::B256Map};
+use alloy_consensus::transaction::{SignerRecoverable, TxHashRef};
+use alloy_primitives::{B256, Keccak256, map::B256Map};
 use smallvec::SmallVec;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     sync::{Arc, RwLock},
     time::Instant,
 };
 use tempo_primitives::TempoTxEnvelope;
 use tracing::info;
+
+const MAX_PENDING_BLOCKS: usize = 256;
 
 /// An expiring nonce identifier and its consensus expiry timestamp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,6 +76,8 @@ struct HistoryInner {
     blocks: B256Map<BlockRecord>,
     inclusions: B256Map<SmallVec<[Inclusion; 1]>>,
     anchors: B256Map<Anchor>,
+    pending_blocks: B256Map<Vec<ExpiringNonceEntry>>,
+    pending_order: VecDeque<B256>,
     highest_timestamp: u64,
 }
 
@@ -85,6 +89,8 @@ impl Default for HistoryInner {
             blocks: B256Map::default(),
             inclusions: B256Map::default(),
             anchors,
+            pending_blocks: B256Map::default(),
+            pending_order: VecDeque::new(),
             highest_timestamp: 0,
         }
     }
@@ -163,6 +169,83 @@ impl ExpiringNonceHistory {
             replay_id: aa.expiring_nonce_hash(sender),
             valid_before,
         }))
+    }
+
+    /// Caches the replay entries collected while building a local payload until its final block
+    /// hash is available to the assembler.
+    pub(crate) fn cache_pending_block(
+        &self,
+        parent_hash: B256,
+        timestamp: u64,
+        entries: Vec<(B256, ExpiringNonceEntry)>,
+    ) {
+        let key = Self::pending_key(
+            parent_hash,
+            timestamp,
+            entries.iter().map(|(hash, _)| *hash),
+        );
+        let entries = entries.into_iter().map(|(_, entry)| entry).collect();
+        let mut inner = self
+            .inner
+            .write()
+            .expect("expiring nonce history lock poisoned");
+        if inner.pending_blocks.insert(key, entries).is_some() {
+            return;
+        }
+        inner.pending_order.push_back(key);
+        while inner.pending_order.len() > MAX_PENDING_BLOCKS {
+            if let Some(oldest) = inner.pending_order.pop_front() {
+                inner.pending_blocks.remove(&oldest);
+            }
+        }
+    }
+
+    /// Resolves replay entries for an assembled payload, reusing the entries collected during
+    /// execution and falling back to sender recovery when the bounded pending cache missed.
+    pub(crate) fn entries_for_block(
+        &self,
+        parent_hash: B256,
+        timestamp: u64,
+        transactions: &[TempoTxEnvelope],
+    ) -> Result<(Vec<ExpiringNonceEntry>, bool), ExpiringNonceHistoryError> {
+        let key = Self::pending_key(
+            parent_hash,
+            timestamp,
+            transactions.iter().filter_map(|tx| {
+                tx.as_aa()
+                    .is_some_and(|aa| aa.tx().is_expiring_nonce_tx())
+                    .then_some(*tx.tx_hash())
+            }),
+        );
+        let mut inner = self
+            .inner
+            .write()
+            .expect("expiring nonce history lock poisoned");
+        if let Some(entries) = inner.pending_blocks.remove(&key) {
+            inner.pending_order.retain(|pending| *pending != key);
+            return Ok((entries, true));
+        }
+        drop(inner);
+
+        let entries = transactions
+            .iter()
+            .filter_map(|tx| Self::entry_from_transaction(tx).transpose())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok((entries, false))
+    }
+
+    fn pending_key(
+        parent_hash: B256,
+        timestamp: u64,
+        transaction_hashes: impl IntoIterator<Item = B256>,
+    ) -> B256 {
+        let mut hasher = Keccak256::new();
+        hasher.update(parent_hash);
+        hasher.update(timestamp.to_be_bytes());
+        for hash in transaction_hashes {
+            hasher.update(hash);
+        }
+        hasher.finalize()
     }
 
     /// Records a block and its replay identifiers.
@@ -572,5 +655,22 @@ mod tests {
             })
         );
         assert!(!history.contains(hash(2), hash(9), 11).unwrap());
+    }
+
+    #[test]
+    fn consumes_pending_local_block_entries() {
+        let history = ExpiringNonceHistory::new(300);
+        history.cache_pending_block(hash(1), 100, Vec::new());
+
+        let (entries, pending_cache_hit) = history
+            .entries_for_block(hash(1), 100, &[])
+            .expect("pending entries should resolve");
+        assert!(pending_cache_hit);
+        assert!(entries.is_empty());
+
+        let (_, pending_cache_hit) = history
+            .entries_for_block(hash(1), 100, &[])
+            .expect("empty blocks can be reconstructed without recovery");
+        assert!(!pending_cache_hit);
     }
 }

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -1,7 +1,7 @@
 use alloy_consensus::transaction::{SignerRecoverable, TxHashRef};
 use alloy_primitives::{
     B256,
-    map::{B256Map, HashMap},
+    map::{B256Map, Entry, HashMap},
 };
 use smallvec::SmallVec;
 use std::{
@@ -64,6 +64,10 @@ struct BlockRecord {
     parent_hash: B256,
     timestamp: u64,
     replay_ids: Vec<B256>,
+    /// Distance from this cache segment's anchor, when the parent lineage is known.
+    height: Option<u64>,
+    /// Ancestors at distances 1, 2, 4, ... for logarithmic branch membership checks.
+    jumps: SmallVec<[B256; 8]>,
     /// Earliest candidate timestamp at which all ancestry missing before this block is expired.
     complete_at: Option<u64>,
 }
@@ -147,6 +151,31 @@ impl ExpiringNonceHistory {
         }
     }
 
+    /// Benchmark-only access to the pending payload cache.
+    #[cfg(feature = "bench")]
+    #[doc(hidden)]
+    pub fn bench_cache_pending_block(
+        &self,
+        parent_hash: B256,
+        timestamp: u64,
+        transaction_hashes: Vec<B256>,
+        entries: Vec<ExpiringNonceEntry>,
+    ) {
+        self.cache_pending_block(parent_hash, timestamp, transaction_hashes, entries);
+    }
+
+    /// Benchmark-only access to pending payload resolution.
+    #[cfg(feature = "bench")]
+    #[doc(hidden)]
+    pub fn bench_entries_for_block(
+        &self,
+        parent_hash: B256,
+        timestamp: u64,
+        transactions: &[TempoTxEnvelope],
+    ) -> Result<(Vec<ExpiringNonceEntry>, bool), ExpiringNonceHistoryError> {
+        self.entries_for_block(parent_hash, timestamp, transactions)
+    }
+
     /// Builds a cache from an oldest-to-newest contiguous block sequence.
     ///
     /// `complete_at` is the earliest timestamp at which history before the first block cannot
@@ -158,8 +187,8 @@ impl ExpiringNonceHistory {
         blocks: impl IntoIterator<Item = ExpiringNonceBlock>,
     ) -> Self {
         let history = Self::new(max_expiry_secs);
-        let blocks = blocks.into_iter().collect::<Vec<_>>();
-        if let Some(first) = blocks.first() {
+        let mut blocks = blocks.into_iter().peekable();
+        if let Some(first) = blocks.peek() {
             history
                 .inner
                 .write()
@@ -203,18 +232,14 @@ impl ExpiringNonceHistory {
         &self,
         parent_hash: B256,
         timestamp: u64,
-        entries: Vec<(B256, ExpiringNonceEntry)>,
+        transaction_hashes: Vec<B256>,
+        entries: Vec<ExpiringNonceEntry>,
     ) {
         let key = PendingKey {
             parent_hash,
             timestamp,
         };
-        let mut transaction_hashes = Vec::with_capacity(entries.len());
-        let mut replay_entries = Vec::with_capacity(entries.len());
-        for (transaction_hash, entry) in entries {
-            transaction_hashes.push(transaction_hash);
-            replay_entries.push(entry);
-        }
+        debug_assert_eq!(transaction_hashes.len(), entries.len());
         let mut inner = self
             .inner
             .write()
@@ -235,7 +260,7 @@ impl ExpiringNonceHistory {
             .push(PendingBlock {
                 sequence,
                 transaction_hashes: transaction_hashes.into(),
-                entries: replay_entries,
+                entries,
             });
         inner.pending_count += 1;
         inner.pending_order.push_back((sequence, key));
@@ -389,12 +414,15 @@ impl ExpiringNonceHistory {
                     .get(&block.parent_hash)
                     .and_then(|parent| parent.complete_at)
             });
+        let (height, jumps) = Self::lineage_for_parent(&inner, block.parent_hash);
         inner.blocks.insert(
             block.hash,
             BlockRecord {
                 parent_hash: block.parent_hash,
                 timestamp: block.timestamp,
                 replay_ids,
+                height,
+                jumps,
                 complete_at,
             },
         );
@@ -510,7 +538,79 @@ impl ExpiringNonceHistory {
         }
     }
 
+    fn lineage_for_parent(
+        inner: &HistoryInner,
+        parent_hash: B256,
+    ) -> (Option<u64>, SmallVec<[B256; 8]>) {
+        let mut jumps = SmallVec::new();
+        jumps.push(parent_hash);
+
+        if inner.anchors.contains_key(&parent_hash) {
+            return (Some(0), jumps);
+        }
+        let Some(parent) = inner.blocks.get(&parent_hash) else {
+            return (None, SmallVec::new());
+        };
+        let Some(height) = parent.height else {
+            return (None, SmallVec::new());
+        };
+
+        let mut level = 1;
+        while let Some(ancestor) = jumps
+            .get(level - 1)
+            .and_then(|ancestor| inner.blocks.get(ancestor))
+            .and_then(|ancestor| ancestor.jumps.get(level - 1))
+            .copied()
+        {
+            jumps.push(ancestor);
+            level += 1;
+        }
+        (Some(height + 1), jumps)
+    }
+
     fn is_ancestor_locked(
+        &self,
+        inner: &HistoryInner,
+        ancestor_hash: B256,
+        descendant_hash: B256,
+        candidate_timestamp: u64,
+    ) -> Result<bool, ExpiringNonceHistoryError> {
+        if let (Some(ancestor), Some(descendant)) = (
+            inner.blocks.get(&ancestor_hash),
+            inner.blocks.get(&descendant_hash),
+        ) && let (Some(ancestor_height), Some(descendant_height)) =
+            (ancestor.height, descendant.height)
+        {
+            if ancestor_height > descendant_height {
+                return Ok(false);
+            }
+
+            let mut cursor = descendant_hash;
+            let mut distance = descendant_height - ancestor_height;
+            while distance != 0 {
+                let level = (u64::BITS - 1 - distance.leading_zeros()) as usize;
+                let Some(next) = inner
+                    .blocks
+                    .get(&cursor)
+                    .and_then(|block| block.jumps.get(level))
+                else {
+                    return self.is_ancestor_linear_locked(
+                        inner,
+                        ancestor_hash,
+                        descendant_hash,
+                        candidate_timestamp,
+                    );
+                };
+                cursor = *next;
+                distance -= 1 << level;
+            }
+            return Ok(cursor == ancestor_hash);
+        }
+
+        self.is_ancestor_linear_locked(inner, ancestor_hash, descendant_hash, candidate_timestamp)
+    }
+
+    fn is_ancestor_linear_locked(
         &self,
         inner: &HistoryInner,
         ancestor_hash: B256,
@@ -571,10 +671,11 @@ impl ExpiringNonceHistory {
                 removed_identifiers += block.replay_ids.len();
                 inner.retained_identifiers -= block.replay_ids.len();
                 for replay_id in &block.replay_ids {
-                    if let Some(inclusions) = inner.inclusions.get_mut(replay_id) {
+                    if let Entry::Occupied(mut entry) = inner.inclusions.entry(*replay_id) {
+                        let inclusions = entry.get_mut();
                         inclusions.retain(|inclusion| inclusion.block_hash != hash);
                         if inclusions.is_empty() {
-                            inner.inclusions.remove(replay_id);
+                            entry.remove();
                         }
                     }
                 }
@@ -633,6 +734,10 @@ impl ExpiringNonceHistory {
         else {
             return;
         };
+
+        if !inner.children.contains_key(&parent_hash) {
+            return;
+        }
 
         let mut pending = VecDeque::from([parent_hash]);
         let children = &inner.children;
@@ -785,9 +890,26 @@ mod tests {
     }
 
     #[test]
+    fn candidate_timestamp_does_not_mutate_parent_history() {
+        let history = ExpiringNonceHistory::new(300);
+        history.record_block(block(
+            1,
+            0,
+            100,
+            vec![ExpiringNonceEntry {
+                replay_id: hash(9),
+                valid_before: 350,
+            }],
+        ));
+
+        assert!(!history.contains(hash(1), hash(9), 350).unwrap());
+        assert!(history.contains(hash(1), hash(9), 200).unwrap());
+    }
+
+    #[test]
     fn consumes_pending_local_block_entries() {
         let history = ExpiringNonceHistory::new(300);
-        history.cache_pending_block(hash(1), 100, Vec::new());
+        history.cache_pending_block(hash(1), 100, Vec::new(), Vec::new());
 
         let (entries, pending_cache_hit) = history
             .entries_for_block(hash(1), 100, &[])

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -1,7 +1,7 @@
-use alloy_consensus::transaction::{SignerRecoverable, TxHashRef};
+use alloy_consensus::transaction::SignerRecoverable;
 use alloy_primitives::{
     B256,
-    map::{B256Map, Entry, HashMap},
+    map::{B256Map, Entry},
 };
 use smallvec::SmallVec;
 use std::{
@@ -11,8 +11,6 @@ use std::{
 };
 use tempo_primitives::TempoTxEnvelope;
 use tracing::info;
-
-const MAX_PENDING_BLOCKS: usize = 256;
 
 /// An expiring nonce identifier and its consensus expiry timestamp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,29 +77,12 @@ struct Anchor {
 }
 
 #[derive(Debug)]
-struct PendingBlock {
-    sequence: u64,
-    transaction_hashes: Arc<[B256]>,
-    entries: Vec<ExpiringNonceEntry>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct PendingKey {
-    parent_hash: B256,
-    timestamp: u64,
-}
-
-#[derive(Debug)]
 struct HistoryInner {
     blocks: B256Map<BlockRecord>,
     blocks_by_timestamp: BTreeMap<u64, SmallVec<[B256; 2]>>,
     children: B256Map<SmallVec<[B256; 2]>>,
     inclusions: B256Map<SmallVec<[Inclusion; 1]>>,
     anchors: B256Map<Anchor>,
-    pending_blocks: HashMap<PendingKey, SmallVec<[PendingBlock; 1]>>,
-    pending_order: VecDeque<(u64, PendingKey)>,
-    next_pending_sequence: u64,
-    pending_count: usize,
     retained_identifiers: usize,
     highest_timestamp: u64,
 }
@@ -116,10 +97,6 @@ impl Default for HistoryInner {
             children: B256Map::default(),
             inclusions: B256Map::default(),
             anchors,
-            pending_blocks: HashMap::default(),
-            pending_order: VecDeque::new(),
-            next_pending_sequence: 0,
-            pending_count: 0,
             retained_identifiers: 0,
             highest_timestamp: 0,
         }
@@ -149,31 +126,6 @@ impl ExpiringNonceHistory {
             inner: Arc::new(RwLock::new(HistoryInner::default())),
             max_expiry_secs,
         }
-    }
-
-    /// Benchmark-only access to the pending payload cache.
-    #[cfg(feature = "bench")]
-    #[doc(hidden)]
-    pub fn bench_cache_pending_block(
-        &self,
-        parent_hash: B256,
-        timestamp: u64,
-        transaction_hashes: Vec<B256>,
-        entries: Vec<ExpiringNonceEntry>,
-    ) {
-        self.cache_pending_block(parent_hash, timestamp, transaction_hashes, entries);
-    }
-
-    /// Benchmark-only access to pending payload resolution.
-    #[cfg(feature = "bench")]
-    #[doc(hidden)]
-    pub fn bench_entries_for_block(
-        &self,
-        parent_hash: B256,
-        timestamp: u64,
-        transactions: &[TempoTxEnvelope],
-    ) -> Result<(Vec<ExpiringNonceEntry>, bool), ExpiringNonceHistoryError> {
-        self.entries_for_block(parent_hash, timestamp, transactions)
     }
 
     /// Builds a cache from an oldest-to-newest contiguous block sequence.
@@ -224,150 +176,6 @@ impl ExpiringNonceHistory {
             replay_id: aa.expiring_nonce_hash(sender),
             valid_before,
         }))
-    }
-
-    /// Caches the replay entries collected while building a local payload until its final block
-    /// hash is available to the assembler.
-    pub(crate) fn cache_pending_block(
-        &self,
-        parent_hash: B256,
-        timestamp: u64,
-        transaction_hashes: Vec<B256>,
-        entries: Vec<ExpiringNonceEntry>,
-    ) {
-        let key = PendingKey {
-            parent_hash,
-            timestamp,
-        };
-        debug_assert_eq!(transaction_hashes.len(), entries.len());
-        let mut inner = self
-            .inner
-            .write()
-            .expect("expiring nonce history lock poisoned");
-        if inner.pending_blocks.get(&key).is_some_and(|pending| {
-            pending
-                .iter()
-                .any(|block| block.transaction_hashes.as_ref() == transaction_hashes)
-        }) {
-            return;
-        }
-        let sequence = inner.next_pending_sequence;
-        inner.next_pending_sequence = inner.next_pending_sequence.wrapping_add(1);
-        inner
-            .pending_blocks
-            .entry(key)
-            .or_default()
-            .push(PendingBlock {
-                sequence,
-                transaction_hashes: transaction_hashes.into(),
-                entries,
-            });
-        inner.pending_count += 1;
-        inner.pending_order.push_back((sequence, key));
-        Self::trim_pending_locked(&mut inner);
-    }
-
-    /// Resolves replay entries for an assembled payload, reusing the entries collected during
-    /// execution and falling back to sender recovery when the bounded pending cache missed.
-    pub(crate) fn entries_for_block(
-        &self,
-        parent_hash: B256,
-        timestamp: u64,
-        transactions: &[TempoTxEnvelope],
-    ) -> Result<(Vec<ExpiringNonceEntry>, bool), ExpiringNonceHistoryError> {
-        let key = PendingKey {
-            parent_hash,
-            timestamp,
-        };
-        let candidates = self
-            .inner
-            .read()
-            .expect("expiring nonce history lock poisoned")
-            .pending_blocks
-            .get(&key)
-            .map(|pending| {
-                pending
-                    .iter()
-                    .map(|block| (block.sequence, Arc::clone(&block.transaction_hashes)))
-                    .collect::<SmallVec<[_; 1]>>()
-            })
-            .unwrap_or_default();
-        let matching_sequence = candidates
-            .iter()
-            .find(|(_, transaction_hashes)| Self::pending_matches(transaction_hashes, transactions))
-            .map(|(sequence, _)| *sequence);
-        if let Some(sequence) = matching_sequence {
-            let mut inner = self
-                .inner
-                .write()
-                .expect("expiring nonce history lock poisoned");
-            if let Some(pending) = Self::remove_pending_locked(&mut inner, key, sequence) {
-                Self::trim_pending_locked(&mut inner);
-                return Ok((pending.entries, true));
-            }
-        }
-
-        let entries = transactions
-            .iter()
-            .filter_map(|tx| Self::entry_from_transaction(tx).transpose())
-            .collect::<Result<Vec<_>, _>>()?;
-        Ok((entries, false))
-    }
-
-    fn pending_matches(transaction_hashes: &[B256], transactions: &[TempoTxEnvelope]) -> bool {
-        transactions
-            .iter()
-            .filter_map(|tx| {
-                tx.as_aa()
-                    .is_some_and(|aa| aa.tx().is_expiring_nonce_tx())
-                    .then_some(*tx.tx_hash())
-            })
-            .eq(transaction_hashes.iter().copied())
-    }
-
-    fn remove_pending_locked(
-        inner: &mut HistoryInner,
-        key: PendingKey,
-        sequence: u64,
-    ) -> Option<PendingBlock> {
-        let (pending, remove_key) = {
-            let blocks = inner.pending_blocks.get_mut(&key)?;
-            let position = blocks.iter().position(|block| block.sequence == sequence)?;
-            let pending = blocks.swap_remove(position);
-            (pending, blocks.is_empty())
-        };
-        if remove_key {
-            inner.pending_blocks.remove(&key);
-        }
-        inner.pending_count -= 1;
-        Some(pending)
-    }
-
-    fn trim_pending_locked(inner: &mut HistoryInner) {
-        while let Some(&(sequence, key)) = inner.pending_order.front() {
-            let is_live = inner
-                .pending_blocks
-                .get(&key)
-                .is_some_and(|pending| pending.iter().any(|block| block.sequence == sequence));
-            if is_live && inner.pending_count <= MAX_PENDING_BLOCKS {
-                break;
-            }
-            inner.pending_order.pop_front();
-            if is_live {
-                Self::remove_pending_locked(inner, key, sequence);
-            }
-        }
-
-        // Out-of-order payload completion can leave tombstones behind a live entry. Compact only
-        // when those tombstones grow large enough, keeping the common in-order path O(1).
-        if inner.pending_order.len() > MAX_PENDING_BLOCKS * 2 {
-            inner.pending_order.retain(|(sequence, key)| {
-                inner
-                    .pending_blocks
-                    .get(key)
-                    .is_some_and(|pending| pending.iter().any(|block| block.sequence == *sequence))
-            });
-        }
     }
 
     /// Records a block and its replay identifiers.
@@ -904,22 +712,5 @@ mod tests {
 
         assert!(!history.contains(hash(1), hash(9), 350).unwrap());
         assert!(history.contains(hash(1), hash(9), 200).unwrap());
-    }
-
-    #[test]
-    fn consumes_pending_local_block_entries() {
-        let history = ExpiringNonceHistory::new(300);
-        history.cache_pending_block(hash(1), 100, Vec::new(), Vec::new());
-
-        let (entries, pending_cache_hit) = history
-            .entries_for_block(hash(1), 100, &[])
-            .expect("pending entries should resolve");
-        assert!(pending_cache_hit);
-        assert!(entries.is_empty());
-
-        let (_, pending_cache_hit) = history
-            .entries_for_block(hash(1), 100, &[])
-            .expect("empty blocks can be reconstructed without recovery");
-        assert!(!pending_cache_hit);
     }
 }

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -4,8 +4,10 @@ use smallvec::SmallVec;
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
+    time::Instant,
 };
 use tempo_primitives::TempoTxEnvelope;
+use tracing::info;
 
 /// An expiring nonce identifier and its consensus expiry timestamp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -168,14 +170,21 @@ impl ExpiringNonceHistory {
     /// Recording is idempotent. Completeness is checked when a descendant performs a lookup, so
     /// sequential sync can record intermediate blocks before their older history is available.
     pub fn record_block(&self, block: ExpiringNonceBlock) {
+        let started = Instant::now();
+        let lock_started = Instant::now();
         let mut inner = self
             .inner
             .write()
             .expect("expiring nonce history lock poisoned");
+        let lock_wait = lock_started.elapsed();
         if inner.blocks.contains_key(&block.hash) {
             return;
         }
 
+        let block_hash = block.hash;
+        let parent_hash = block.parent_hash;
+        let timestamp = block.timestamp;
+        let entry_count = block.entries.len();
         let replay_ids = block
             .entries
             .iter()
@@ -211,7 +220,25 @@ impl ExpiringNonceHistory {
                 complete_at,
             },
         );
-        self.prune_locked(&mut inner);
+        let (pruned_blocks, pruned_identifiers) = self.prune_locked(&mut inner);
+        let retained_blocks = inner.blocks.len();
+        let retained_unique_identifiers = inner.inclusions.len();
+        drop(inner);
+
+        info!(
+            target: "tempo::expiring_nonce_history",
+            %block_hash,
+            %parent_hash,
+            timestamp,
+            entry_count,
+            retained_blocks,
+            retained_unique_identifiers,
+            pruned_blocks,
+            pruned_identifiers,
+            ?lock_wait,
+            elapsed = ?started.elapsed(),
+            "recorded expiring nonce history overlay"
+        );
     }
 
     /// Returns whether `replay_id` was consumed by a live ancestor of `parent_hash`.
@@ -330,13 +357,13 @@ impl ExpiringNonceHistory {
         }
     }
 
-    fn prune_locked(&self, inner: &mut HistoryInner) {
+    fn prune_locked(&self, inner: &mut HistoryInner) -> (usize, usize) {
         // Keep two validity windows so ordinary reorganizations can reuse their existing branch
         // overlays. Older branch requests fail closed and can be rebuilt from persisted bodies.
         let retention = self.max_expiry_secs.saturating_mul(2);
         let cutoff = inner.highest_timestamp.saturating_sub(retention);
         if cutoff == 0 {
-            return;
+            return (0, 0);
         }
 
         let removed = inner
@@ -347,8 +374,10 @@ impl ExpiringNonceHistory {
             })
             .collect::<HashMap<_, _>>();
         if removed.is_empty() {
-            return;
+            return (0, 0);
         }
+        let removed_identifiers = removed.values().map(|block| block.replay_ids.len()).sum();
+        let removed_blocks = removed.len();
 
         for (hash, block) in &removed {
             inner.blocks.remove(hash);
@@ -382,6 +411,7 @@ impl ExpiringNonceHistory {
             }
         }
         self.recompute_completeness_locked(inner);
+        (removed_blocks, removed_identifiers)
     }
 
     fn recompute_completeness_locked(&self, inner: &mut HistoryInner) {

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -1,8 +1,11 @@
 use alloy_consensus::transaction::{SignerRecoverable, TxHashRef};
-use alloy_primitives::{B256, Keccak256, map::B256Map};
+use alloy_primitives::{
+    B256,
+    map::{B256Map, HashMap},
+};
 use smallvec::SmallVec;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     sync::{Arc, RwLock},
     time::Instant,
 };
@@ -72,12 +75,30 @@ struct Anchor {
 }
 
 #[derive(Debug)]
+struct PendingBlock {
+    sequence: u64,
+    transaction_hashes: Arc<[B256]>,
+    entries: Vec<ExpiringNonceEntry>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct PendingKey {
+    parent_hash: B256,
+    timestamp: u64,
+}
+
+#[derive(Debug)]
 struct HistoryInner {
     blocks: B256Map<BlockRecord>,
+    blocks_by_timestamp: BTreeMap<u64, SmallVec<[B256; 2]>>,
+    children: B256Map<SmallVec<[B256; 2]>>,
     inclusions: B256Map<SmallVec<[Inclusion; 1]>>,
     anchors: B256Map<Anchor>,
-    pending_blocks: B256Map<Vec<ExpiringNonceEntry>>,
-    pending_order: VecDeque<B256>,
+    pending_blocks: HashMap<PendingKey, SmallVec<[PendingBlock; 1]>>,
+    pending_order: VecDeque<(u64, PendingKey)>,
+    next_pending_sequence: u64,
+    pending_count: usize,
+    retained_identifiers: usize,
     highest_timestamp: u64,
 }
 
@@ -87,10 +108,15 @@ impl Default for HistoryInner {
         anchors.insert(B256::ZERO, Anchor { complete_at: 0 });
         Self {
             blocks: B256Map::default(),
+            blocks_by_timestamp: BTreeMap::new(),
+            children: B256Map::default(),
             inclusions: B256Map::default(),
             anchors,
-            pending_blocks: B256Map::default(),
+            pending_blocks: HashMap::default(),
             pending_order: VecDeque::new(),
+            next_pending_sequence: 0,
+            pending_count: 0,
+            retained_identifiers: 0,
             highest_timestamp: 0,
         }
     }
@@ -179,25 +205,41 @@ impl ExpiringNonceHistory {
         timestamp: u64,
         entries: Vec<(B256, ExpiringNonceEntry)>,
     ) {
-        let key = Self::pending_key(
+        let key = PendingKey {
             parent_hash,
             timestamp,
-            entries.iter().map(|(hash, _)| *hash),
-        );
-        let entries = entries.into_iter().map(|(_, entry)| entry).collect();
+        };
+        let mut transaction_hashes = Vec::with_capacity(entries.len());
+        let mut replay_entries = Vec::with_capacity(entries.len());
+        for (transaction_hash, entry) in entries {
+            transaction_hashes.push(transaction_hash);
+            replay_entries.push(entry);
+        }
         let mut inner = self
             .inner
             .write()
             .expect("expiring nonce history lock poisoned");
-        if inner.pending_blocks.insert(key, entries).is_some() {
+        if inner.pending_blocks.get(&key).is_some_and(|pending| {
+            pending
+                .iter()
+                .any(|block| block.transaction_hashes.as_ref() == transaction_hashes)
+        }) {
             return;
         }
-        inner.pending_order.push_back(key);
-        while inner.pending_order.len() > MAX_PENDING_BLOCKS {
-            if let Some(oldest) = inner.pending_order.pop_front() {
-                inner.pending_blocks.remove(&oldest);
-            }
-        }
+        let sequence = inner.next_pending_sequence;
+        inner.next_pending_sequence = inner.next_pending_sequence.wrapping_add(1);
+        inner
+            .pending_blocks
+            .entry(key)
+            .or_default()
+            .push(PendingBlock {
+                sequence,
+                transaction_hashes: transaction_hashes.into(),
+                entries: replay_entries,
+            });
+        inner.pending_count += 1;
+        inner.pending_order.push_back((sequence, key));
+        Self::trim_pending_locked(&mut inner);
     }
 
     /// Resolves replay entries for an assembled payload, reusing the entries collected during
@@ -208,24 +250,37 @@ impl ExpiringNonceHistory {
         timestamp: u64,
         transactions: &[TempoTxEnvelope],
     ) -> Result<(Vec<ExpiringNonceEntry>, bool), ExpiringNonceHistoryError> {
-        let key = Self::pending_key(
+        let key = PendingKey {
             parent_hash,
             timestamp,
-            transactions.iter().filter_map(|tx| {
-                tx.as_aa()
-                    .is_some_and(|aa| aa.tx().is_expiring_nonce_tx())
-                    .then_some(*tx.tx_hash())
-            }),
-        );
-        let mut inner = self
+        };
+        let candidates = self
             .inner
-            .write()
-            .expect("expiring nonce history lock poisoned");
-        if let Some(entries) = inner.pending_blocks.remove(&key) {
-            inner.pending_order.retain(|pending| *pending != key);
-            return Ok((entries, true));
+            .read()
+            .expect("expiring nonce history lock poisoned")
+            .pending_blocks
+            .get(&key)
+            .map(|pending| {
+                pending
+                    .iter()
+                    .map(|block| (block.sequence, Arc::clone(&block.transaction_hashes)))
+                    .collect::<SmallVec<[_; 1]>>()
+            })
+            .unwrap_or_default();
+        let matching_sequence = candidates
+            .iter()
+            .find(|(_, transaction_hashes)| Self::pending_matches(transaction_hashes, transactions))
+            .map(|(sequence, _)| *sequence);
+        if let Some(sequence) = matching_sequence {
+            let mut inner = self
+                .inner
+                .write()
+                .expect("expiring nonce history lock poisoned");
+            if let Some(pending) = Self::remove_pending_locked(&mut inner, key, sequence) {
+                Self::trim_pending_locked(&mut inner);
+                return Ok((pending.entries, true));
+            }
         }
-        drop(inner);
 
         let entries = transactions
             .iter()
@@ -234,18 +289,60 @@ impl ExpiringNonceHistory {
         Ok((entries, false))
     }
 
-    fn pending_key(
-        parent_hash: B256,
-        timestamp: u64,
-        transaction_hashes: impl IntoIterator<Item = B256>,
-    ) -> B256 {
-        let mut hasher = Keccak256::new();
-        hasher.update(parent_hash);
-        hasher.update(timestamp.to_be_bytes());
-        for hash in transaction_hashes {
-            hasher.update(hash);
+    fn pending_matches(transaction_hashes: &[B256], transactions: &[TempoTxEnvelope]) -> bool {
+        transactions
+            .iter()
+            .filter_map(|tx| {
+                tx.as_aa()
+                    .is_some_and(|aa| aa.tx().is_expiring_nonce_tx())
+                    .then_some(*tx.tx_hash())
+            })
+            .eq(transaction_hashes.iter().copied())
+    }
+
+    fn remove_pending_locked(
+        inner: &mut HistoryInner,
+        key: PendingKey,
+        sequence: u64,
+    ) -> Option<PendingBlock> {
+        let (pending, remove_key) = {
+            let blocks = inner.pending_blocks.get_mut(&key)?;
+            let position = blocks.iter().position(|block| block.sequence == sequence)?;
+            let pending = blocks.swap_remove(position);
+            (pending, blocks.is_empty())
+        };
+        if remove_key {
+            inner.pending_blocks.remove(&key);
         }
-        hasher.finalize()
+        inner.pending_count -= 1;
+        Some(pending)
+    }
+
+    fn trim_pending_locked(inner: &mut HistoryInner) {
+        while let Some(&(sequence, key)) = inner.pending_order.front() {
+            let is_live = inner
+                .pending_blocks
+                .get(&key)
+                .is_some_and(|pending| pending.iter().any(|block| block.sequence == sequence));
+            if is_live && inner.pending_count <= MAX_PENDING_BLOCKS {
+                break;
+            }
+            inner.pending_order.pop_front();
+            if is_live {
+                Self::remove_pending_locked(inner, key, sequence);
+            }
+        }
+
+        // Out-of-order payload completion can leave tombstones behind a live entry. Compact only
+        // when those tombstones grow large enough, keeping the common in-order path O(1).
+        if inner.pending_order.len() > MAX_PENDING_BLOCKS * 2 {
+            inner.pending_order.retain(|(sequence, key)| {
+                inner
+                    .pending_blocks
+                    .get(key)
+                    .is_some_and(|pending| pending.iter().any(|block| block.sequence == *sequence))
+            });
+        }
     }
 
     /// Records a block and its replay identifiers.
@@ -268,12 +365,9 @@ impl ExpiringNonceHistory {
         let parent_hash = block.parent_hash;
         let timestamp = block.timestamp;
         let entry_count = block.entries.len();
-        let replay_ids = block
-            .entries
-            .iter()
-            .map(|entry| entry.replay_id)
-            .collect::<Vec<_>>();
+        let mut replay_ids = Vec::with_capacity(entry_count);
         for entry in block.entries {
+            replay_ids.push(entry.replay_id);
             inner
                 .inclusions
                 .entry(entry.replay_id)
@@ -283,6 +377,7 @@ impl ExpiringNonceHistory {
                     valid_before: entry.valid_before,
                 });
         }
+        inner.retained_identifiers += entry_count;
         inner.highest_timestamp = inner.highest_timestamp.max(block.timestamp);
         let complete_at = inner
             .anchors
@@ -303,6 +398,17 @@ impl ExpiringNonceHistory {
                 complete_at,
             },
         );
+        inner
+            .blocks_by_timestamp
+            .entry(timestamp)
+            .or_default()
+            .push(block_hash);
+        inner
+            .children
+            .entry(parent_hash)
+            .or_default()
+            .push(block_hash);
+        self.propagate_completeness_locked(&mut inner, block_hash, false);
         let (pruned_blocks, pruned_identifiers) = self.prune_locked(&mut inner);
         let retained_blocks = inner.blocks.len();
         let retained_unique_identifiers = inner.inclusions.len();
@@ -360,10 +466,7 @@ impl ExpiringNonceHistory {
         self.inner
             .read()
             .expect("expiring nonce history lock poisoned")
-            .inclusions
-            .values()
-            .map(SmallVec::len)
-            .sum()
+            .retained_identifiers
     }
 
     /// Returns the number of block overlays retained by the cache.
@@ -449,89 +552,103 @@ impl ExpiringNonceHistory {
             return (0, 0);
         }
 
-        let removed = inner
-            .blocks
-            .iter()
-            .filter_map(|(hash, block)| {
-                (block.timestamp < cutoff).then_some((*hash, block.clone()))
-            })
-            .collect::<HashMap<_, _>>();
-        if removed.is_empty() {
-            return (0, 0);
-        }
-        let removed_identifiers = removed.values().map(|block| block.replay_ids.len()).sum();
-        let removed_blocks = removed.len();
-
-        for (hash, block) in &removed {
-            inner.blocks.remove(hash);
-            for replay_id in &block.replay_ids {
-                if let Some(inclusions) = inner.inclusions.get_mut(replay_id) {
-                    inclusions.retain(|inclusion| inclusion.block_hash != *hash);
-                    if inclusions.is_empty() {
-                        inner.inclusions.remove(replay_id);
+        let mut removed_blocks = 0;
+        let mut removed_identifiers = 0;
+        while inner
+            .blocks_by_timestamp
+            .first_key_value()
+            .is_some_and(|(timestamp, _)| *timestamp < cutoff)
+        {
+            let (_, hashes) = inner
+                .blocks_by_timestamp
+                .pop_first()
+                .expect("an expired timestamp was just observed");
+            for hash in hashes {
+                let Some(block) = inner.blocks.remove(&hash) else {
+                    continue;
+                };
+                removed_blocks += 1;
+                removed_identifiers += block.replay_ids.len();
+                inner.retained_identifiers -= block.replay_ids.len();
+                for replay_id in &block.replay_ids {
+                    if let Some(inclusions) = inner.inclusions.get_mut(replay_id) {
+                        inclusions.retain(|inclusion| inclusion.block_hash != hash);
+                        if inclusions.is_empty() {
+                            inner.inclusions.remove(replay_id);
+                        }
                     }
+                }
+
+                let mut remove_parent_children = false;
+                if let Some(siblings) = inner.children.get_mut(&block.parent_hash) {
+                    siblings.retain(|child| *child != hash);
+                    remove_parent_children = siblings.is_empty();
+                }
+                if remove_parent_children {
+                    inner.children.remove(&block.parent_hash);
+                    if block.parent_hash != B256::ZERO {
+                        inner.anchors.remove(&block.parent_hash);
+                    }
+                }
+
+                let has_retained_child = inner.children.get(&hash).is_some_and(|children| {
+                    children
+                        .iter()
+                        .any(|child| inner.blocks.contains_key(child))
+                });
+                if has_retained_child {
+                    inner.anchors.insert(
+                        hash,
+                        Anchor {
+                            complete_at: block.timestamp.saturating_add(self.max_expiry_secs),
+                        },
+                    );
+                    self.propagate_completeness_locked(inner, hash, true);
+                } else {
+                    inner.children.remove(&hash);
+                    inner.anchors.remove(&hash);
                 }
             }
         }
 
-        let boundary_parents = inner
-            .blocks
-            .values()
-            .filter(|block| !inner.blocks.contains_key(&block.parent_hash))
-            .map(|block| block.parent_hash)
-            .collect::<HashSet<_>>();
-        inner
-            .anchors
-            .retain(|hash, _| *hash == B256::ZERO || boundary_parents.contains(hash));
-        for parent_hash in boundary_parents {
-            if let Some(block) = removed.get(&parent_hash) {
-                inner.anchors.insert(
-                    parent_hash,
-                    Anchor {
-                        complete_at: block.timestamp.saturating_add(self.max_expiry_secs),
-                    },
-                );
-            }
-        }
-        self.recompute_completeness_locked(inner);
         (removed_blocks, removed_identifiers)
     }
 
-    fn recompute_completeness_locked(&self, inner: &mut HistoryInner) {
-        for block in inner.blocks.values_mut() {
-            block.complete_at = None;
-        }
-
-        loop {
-            let updates = inner
-                .blocks
-                .iter()
-                .filter_map(|(hash, block)| {
-                    if block.complete_at.is_some() {
-                        return None;
-                    }
-                    inner
-                        .anchors
-                        .get(&block.parent_hash)
-                        .map(|anchor| anchor.complete_at)
-                        .or_else(|| {
-                            inner
-                                .blocks
-                                .get(&block.parent_hash)
-                                .and_then(|parent| parent.complete_at)
-                        })
-                        .map(|complete_at| (*hash, complete_at))
-                })
-                .collect::<Vec<_>>();
-            if updates.is_empty() {
-                break;
-            }
-            for (hash, complete_at) in updates {
+    fn propagate_completeness_locked(
+        &self,
+        inner: &mut HistoryInner,
+        parent_hash: B256,
+        overwrite: bool,
+    ) {
+        let Some(complete_at) = inner
+            .anchors
+            .get(&parent_hash)
+            .map(|anchor| anchor.complete_at)
+            .or_else(|| {
                 inner
                     .blocks
-                    .get_mut(&hash)
-                    .expect("completeness update references a retained block")
-                    .complete_at = Some(complete_at);
+                    .get(&parent_hash)
+                    .and_then(|block| block.complete_at)
+            })
+        else {
+            return;
+        };
+
+        let mut pending = VecDeque::from([parent_hash]);
+        let children = &inner.children;
+        let blocks = &mut inner.blocks;
+        while let Some(parent_hash) = pending.pop_front() {
+            let Some(children) = children.get(&parent_hash) else {
+                continue;
+            };
+            for child_hash in children {
+                let Some(child) = blocks.get_mut(child_hash) else {
+                    continue;
+                };
+                if overwrite || child.complete_at.is_none() {
+                    child.complete_at = Some(complete_at);
+                    pending.push_back(*child_hash);
+                }
             }
         }
     }
@@ -609,6 +726,15 @@ mod tests {
     }
 
     #[test]
+    fn late_parent_completes_already_recorded_descendants() {
+        let history = ExpiringNonceHistory::new(300);
+        history.record_block(block(2, 1, 101, Vec::new()));
+        history.record_block(block(1, 0, 100, Vec::new()));
+
+        assert!(!history.contains(hash(2), hash(9), 102).unwrap());
+    }
+
+    #[test]
     fn rebuilt_anchor_is_complete_at_head_timestamp() {
         let history = ExpiringNonceHistory::from_blocks(
             300,
@@ -655,6 +781,7 @@ mod tests {
             })
         );
         assert!(!history.contains(hash(2), hash(9), 11).unwrap());
+        assert_eq!(history.retained_identifiers(), 0);
     }
 
     #[test]

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -1,0 +1,546 @@
+use alloy_consensus::transaction::SignerRecoverable;
+use alloy_primitives::{B256, map::B256Map};
+use smallvec::SmallVec;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, RwLock},
+};
+use tempo_primitives::TempoTxEnvelope;
+
+/// An expiring nonce identifier and its consensus expiry timestamp.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExpiringNonceEntry {
+    /// TIP-1009 sender-scoped replay identifier.
+    pub replay_id: B256,
+    /// The transaction's `validBefore` timestamp.
+    pub valid_before: u64,
+}
+
+/// A block and the expiring nonce identifiers it consumed.
+#[derive(Debug, Clone)]
+pub struct ExpiringNonceBlock {
+    /// Block hash.
+    pub hash: B256,
+    /// Parent block hash.
+    pub parent_hash: B256,
+    /// Consensus block timestamp.
+    pub timestamp: u64,
+    /// Expiring nonce identifiers consumed by the block.
+    pub entries: Vec<ExpiringNonceEntry>,
+}
+
+/// Errors returned while resolving history-derived expiring nonce state.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ExpiringNonceHistoryError {
+    /// The cache cannot prove that it covers every live ancestor of the requested parent.
+    #[error("missing expiring nonce history for parent {parent_hash}")]
+    MissingHistory {
+        /// Parent whose history is incomplete.
+        parent_hash: B256,
+    },
+    /// A canonical expiring nonce transaction could not be decoded into a replay entry.
+    #[error("invalid expiring nonce transaction in canonical history: {0}")]
+    InvalidTransaction(&'static str),
+    /// Sender recovery failed for a canonical transaction.
+    #[error("failed recovering expiring nonce transaction sender")]
+    SenderRecovery,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Inclusion {
+    block_hash: B256,
+    valid_before: u64,
+}
+
+#[derive(Debug, Clone)]
+struct BlockRecord {
+    parent_hash: B256,
+    timestamp: u64,
+    replay_ids: Vec<B256>,
+    /// Earliest candidate timestamp at which all ancestry missing before this block is expired.
+    complete_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Anchor {
+    /// The earliest candidate timestamp for which history before this anchor cannot be live.
+    complete_at: u64,
+}
+
+#[derive(Debug)]
+struct HistoryInner {
+    blocks: B256Map<BlockRecord>,
+    inclusions: B256Map<SmallVec<[Inclusion; 1]>>,
+    anchors: B256Map<Anchor>,
+    highest_timestamp: u64,
+}
+
+impl Default for HistoryInner {
+    fn default() -> Self {
+        let mut anchors = B256Map::default();
+        anchors.insert(B256::ZERO, Anchor { complete_at: 0 });
+        Self {
+            blocks: B256Map::default(),
+            inclusions: B256Map::default(),
+            anchors,
+            highest_timestamp: 0,
+        }
+    }
+}
+
+/// Fork-aware cache of expiring nonce replay identifiers derived from block history.
+///
+/// This cache is not consensus state. Every entry is reconstructible from block bodies and the
+/// cache fails closed when it cannot prove that the requested parent has complete recent history.
+#[derive(Debug, Clone)]
+pub struct ExpiringNonceHistory {
+    inner: Arc<RwLock<HistoryInner>>,
+    max_expiry_secs: u64,
+}
+
+impl Default for ExpiringNonceHistory {
+    fn default() -> Self {
+        Self::new(300)
+    }
+}
+
+impl ExpiringNonceHistory {
+    /// Creates an empty history cache rooted at the zero hash.
+    pub fn new(max_expiry_secs: u64) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HistoryInner::default())),
+            max_expiry_secs,
+        }
+    }
+
+    /// Builds a cache from an oldest-to-newest contiguous block sequence.
+    ///
+    /// `complete_at` is the earliest timestamp at which history before the first block cannot
+    /// contain a live replay identifier. A startup rebuild derives it from the excluded
+    /// predecessor after scanning its configured retention horizon.
+    pub fn from_blocks(
+        max_expiry_secs: u64,
+        complete_at: u64,
+        blocks: impl IntoIterator<Item = ExpiringNonceBlock>,
+    ) -> Self {
+        let history = Self::new(max_expiry_secs);
+        let blocks = blocks.into_iter().collect::<Vec<_>>();
+        if let Some(first) = blocks.first() {
+            history
+                .inner
+                .write()
+                .expect("expiring nonce history lock poisoned")
+                .anchors
+                .insert(first.parent_hash, Anchor { complete_at });
+        }
+        for block in blocks {
+            history.record_block(block);
+        }
+        history
+    }
+
+    /// Extracts an expiring nonce entry from a signed transaction.
+    pub fn entry_from_transaction(
+        tx: &TempoTxEnvelope,
+    ) -> Result<Option<ExpiringNonceEntry>, ExpiringNonceHistoryError> {
+        let Some(aa) = tx.as_aa() else {
+            return Ok(None);
+        };
+        if !aa.tx().is_expiring_nonce_tx() {
+            return Ok(None);
+        }
+        let valid_before =
+            tx.valid_before()
+                .ok_or(ExpiringNonceHistoryError::InvalidTransaction(
+                    "missing validBefore",
+                ))?;
+        let sender = tx
+            .recover_signer()
+            .map_err(|_| ExpiringNonceHistoryError::SenderRecovery)?;
+        Ok(Some(ExpiringNonceEntry {
+            replay_id: aa.expiring_nonce_hash(sender),
+            valid_before,
+        }))
+    }
+
+    /// Records a block and its replay identifiers.
+    ///
+    /// Recording is idempotent. Completeness is checked when a descendant performs a lookup, so
+    /// sequential sync can record intermediate blocks before their older history is available.
+    pub fn record_block(&self, block: ExpiringNonceBlock) {
+        let mut inner = self
+            .inner
+            .write()
+            .expect("expiring nonce history lock poisoned");
+        if inner.blocks.contains_key(&block.hash) {
+            return;
+        }
+
+        let replay_ids = block
+            .entries
+            .iter()
+            .map(|entry| entry.replay_id)
+            .collect::<Vec<_>>();
+        for entry in block.entries {
+            inner
+                .inclusions
+                .entry(entry.replay_id)
+                .or_default()
+                .push(Inclusion {
+                    block_hash: block.hash,
+                    valid_before: entry.valid_before,
+                });
+        }
+        inner.highest_timestamp = inner.highest_timestamp.max(block.timestamp);
+        let complete_at = inner
+            .anchors
+            .get(&block.parent_hash)
+            .map(|anchor| anchor.complete_at)
+            .or_else(|| {
+                inner
+                    .blocks
+                    .get(&block.parent_hash)
+                    .and_then(|parent| parent.complete_at)
+            });
+        inner.blocks.insert(
+            block.hash,
+            BlockRecord {
+                parent_hash: block.parent_hash,
+                timestamp: block.timestamp,
+                replay_ids,
+                complete_at,
+            },
+        );
+        self.prune_locked(&mut inner);
+    }
+
+    /// Returns whether `replay_id` was consumed by a live ancestor of `parent_hash`.
+    pub fn contains(
+        &self,
+        parent_hash: B256,
+        replay_id: B256,
+        candidate_timestamp: u64,
+    ) -> Result<bool, ExpiringNonceHistoryError> {
+        let inner = self
+            .inner
+            .read()
+            .expect("expiring nonce history lock poisoned");
+        self.ensure_complete_locked(&inner, parent_hash, candidate_timestamp)?;
+
+        let Some(inclusions) = inner.inclusions.get(&replay_id) else {
+            return Ok(false);
+        };
+        for inclusion in inclusions {
+            if inclusion.valid_before > candidate_timestamp
+                && self.is_ancestor_locked(
+                    &inner,
+                    inclusion.block_hash,
+                    parent_hash,
+                    candidate_timestamp,
+                )?
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns the number of replay identifiers currently retained across all cached branches.
+    pub fn retained_identifiers(&self) -> usize {
+        self.inner
+            .read()
+            .expect("expiring nonce history lock poisoned")
+            .inclusions
+            .values()
+            .map(SmallVec::len)
+            .sum()
+    }
+
+    /// Returns the number of block overlays retained by the cache.
+    pub fn retained_blocks(&self) -> usize {
+        self.inner
+            .read()
+            .expect("expiring nonce history lock poisoned")
+            .blocks
+            .len()
+    }
+
+    /// Returns whether the cache already contains an overlay for `block_hash`.
+    pub fn contains_block(&self, block_hash: B256) -> bool {
+        self.inner
+            .read()
+            .expect("expiring nonce history lock poisoned")
+            .blocks
+            .contains_key(&block_hash)
+    }
+
+    fn ensure_complete_locked(
+        &self,
+        inner: &HistoryInner,
+        parent_hash: B256,
+        candidate_timestamp: u64,
+    ) -> Result<(), ExpiringNonceHistoryError> {
+        let complete_at = if let Some(anchor) = inner.anchors.get(&parent_hash) {
+            Some(anchor.complete_at)
+        } else if let Some(block) = inner.blocks.get(&parent_hash) {
+            if block.timestamp.saturating_add(self.max_expiry_secs) <= candidate_timestamp {
+                return Ok(());
+            }
+            block.complete_at
+        } else {
+            None
+        };
+        if complete_at.is_some_and(|timestamp| candidate_timestamp >= timestamp) {
+            Ok(())
+        } else {
+            Err(ExpiringNonceHistoryError::MissingHistory { parent_hash })
+        }
+    }
+
+    fn is_ancestor_locked(
+        &self,
+        inner: &HistoryInner,
+        ancestor_hash: B256,
+        descendant_hash: B256,
+        candidate_timestamp: u64,
+    ) -> Result<bool, ExpiringNonceHistoryError> {
+        let mut cursor = descendant_hash;
+        loop {
+            if cursor == ancestor_hash {
+                return Ok(true);
+            }
+            if let Some(anchor) = inner.anchors.get(&cursor) {
+                return if candidate_timestamp >= anchor.complete_at {
+                    Ok(false)
+                } else {
+                    Err(ExpiringNonceHistoryError::MissingHistory {
+                        parent_hash: descendant_hash,
+                    })
+                };
+            }
+            let Some(block) = inner.blocks.get(&cursor) else {
+                return Err(ExpiringNonceHistoryError::MissingHistory {
+                    parent_hash: descendant_hash,
+                });
+            };
+            if block.timestamp.saturating_add(self.max_expiry_secs) <= candidate_timestamp {
+                return Ok(false);
+            }
+            cursor = block.parent_hash;
+        }
+    }
+
+    fn prune_locked(&self, inner: &mut HistoryInner) {
+        // Keep two validity windows so ordinary reorganizations can reuse their existing branch
+        // overlays. Older branch requests fail closed and can be rebuilt from persisted bodies.
+        let retention = self.max_expiry_secs.saturating_mul(2);
+        let cutoff = inner.highest_timestamp.saturating_sub(retention);
+        if cutoff == 0 {
+            return;
+        }
+
+        let removed = inner
+            .blocks
+            .iter()
+            .filter_map(|(hash, block)| {
+                (block.timestamp < cutoff).then_some((*hash, block.clone()))
+            })
+            .collect::<HashMap<_, _>>();
+        if removed.is_empty() {
+            return;
+        }
+
+        for (hash, block) in &removed {
+            inner.blocks.remove(hash);
+            for replay_id in &block.replay_ids {
+                if let Some(inclusions) = inner.inclusions.get_mut(replay_id) {
+                    inclusions.retain(|inclusion| inclusion.block_hash != *hash);
+                    if inclusions.is_empty() {
+                        inner.inclusions.remove(replay_id);
+                    }
+                }
+            }
+        }
+
+        let boundary_parents = inner
+            .blocks
+            .values()
+            .filter(|block| !inner.blocks.contains_key(&block.parent_hash))
+            .map(|block| block.parent_hash)
+            .collect::<HashSet<_>>();
+        inner
+            .anchors
+            .retain(|hash, _| *hash == B256::ZERO || boundary_parents.contains(hash));
+        for parent_hash in boundary_parents {
+            if let Some(block) = removed.get(&parent_hash) {
+                inner.anchors.insert(
+                    parent_hash,
+                    Anchor {
+                        complete_at: block.timestamp.saturating_add(self.max_expiry_secs),
+                    },
+                );
+            }
+        }
+        self.recompute_completeness_locked(inner);
+    }
+
+    fn recompute_completeness_locked(&self, inner: &mut HistoryInner) {
+        for block in inner.blocks.values_mut() {
+            block.complete_at = None;
+        }
+
+        loop {
+            let updates = inner
+                .blocks
+                .iter()
+                .filter_map(|(hash, block)| {
+                    if block.complete_at.is_some() {
+                        return None;
+                    }
+                    inner
+                        .anchors
+                        .get(&block.parent_hash)
+                        .map(|anchor| anchor.complete_at)
+                        .or_else(|| {
+                            inner
+                                .blocks
+                                .get(&block.parent_hash)
+                                .and_then(|parent| parent.complete_at)
+                        })
+                        .map(|complete_at| (*hash, complete_at))
+                })
+                .collect::<Vec<_>>();
+            if updates.is_empty() {
+                break;
+            }
+            for (hash, complete_at) in updates {
+                inner
+                    .blocks
+                    .get_mut(&hash)
+                    .expect("completeness update references a retained block")
+                    .complete_at = Some(complete_at);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(value: u8) -> B256 {
+        B256::repeat_byte(value)
+    }
+
+    fn block(
+        hash_value: u8,
+        parent_value: u8,
+        timestamp: u64,
+        entries: Vec<ExpiringNonceEntry>,
+    ) -> ExpiringNonceBlock {
+        ExpiringNonceBlock {
+            hash: hash(hash_value),
+            parent_hash: if parent_value == 0 {
+                B256::ZERO
+            } else {
+                hash(parent_value)
+            },
+            timestamp,
+            entries,
+        }
+    }
+
+    #[test]
+    fn detects_live_replay_on_same_branch() {
+        let history = ExpiringNonceHistory::new(300);
+        let entry = ExpiringNonceEntry {
+            replay_id: hash(9),
+            valid_before: 350,
+        };
+        history.record_block(block(1, 0, 100, vec![entry]));
+
+        assert!(history.contains(hash(1), hash(9), 200).unwrap());
+        assert!(!history.contains(hash(1), hash(9), 350).unwrap());
+    }
+
+    #[test]
+    fn isolates_competing_forks() {
+        let history = ExpiringNonceHistory::new(300);
+        history.record_block(block(1, 0, 100, Vec::new()));
+        history.record_block(block(
+            2,
+            1,
+            101,
+            vec![ExpiringNonceEntry {
+                replay_id: hash(9),
+                valid_before: 350,
+            }],
+        ));
+        history.record_block(block(3, 1, 101, Vec::new()));
+
+        assert!(history.contains(hash(2), hash(9), 200).unwrap());
+        assert!(!history.contains(hash(3), hash(9), 200).unwrap());
+    }
+
+    #[test]
+    fn fails_closed_when_recent_parent_history_is_missing() {
+        let history = ExpiringNonceHistory::new(300);
+        history.record_block(block(2, 1, 100, Vec::new()));
+
+        assert_eq!(
+            history.contains(hash(2), hash(9), 101),
+            Err(ExpiringNonceHistoryError::MissingHistory {
+                parent_hash: hash(2)
+            })
+        );
+    }
+
+    #[test]
+    fn rebuilt_anchor_is_complete_at_head_timestamp() {
+        let history = ExpiringNonceHistory::from_blocks(
+            300,
+            400,
+            [block(
+                2,
+                1,
+                200,
+                vec![ExpiringNonceEntry {
+                    replay_id: hash(9),
+                    valid_before: 450,
+                }],
+            )],
+        );
+
+        assert!(history.contains(hash(2), hash(9), 400).unwrap());
+        assert_eq!(
+            history.contains(hash(2), hash(8), 399),
+            Err(ExpiringNonceHistoryError::MissingHistory {
+                parent_hash: hash(2)
+            })
+        );
+    }
+
+    #[test]
+    fn pruning_preserves_fail_closed_boundary() {
+        let history = ExpiringNonceHistory::new(10);
+        history.record_block(block(
+            1,
+            0,
+            1,
+            vec![ExpiringNonceEntry {
+                replay_id: hash(9),
+                valid_before: 11,
+            }],
+        ));
+        history.record_block(block(2, 1, 2, Vec::new()));
+        history.record_block(block(3, 2, 22, Vec::new()));
+
+        assert_eq!(
+            history.contains(hash(2), hash(9), 10),
+            Err(ExpiringNonceHistoryError::MissingHistory {
+                parent_hash: hash(2)
+            })
+        );
+        assert!(!history.contains(hash(2), hash(9), 11).unwrap());
+    }
+}

--- a/crates/evm/src/expiring_nonce_history.rs
+++ b/crates/evm/src/expiring_nonce_history.rs
@@ -1,8 +1,5 @@
 use alloy_consensus::transaction::SignerRecoverable;
-use alloy_primitives::{
-    B256,
-    map::{B256Map, Entry},
-};
+use alloy_primitives::{B256, map::B256Map};
 use smallvec::SmallVec;
 use std::{
     collections::{BTreeMap, VecDeque},
@@ -51,21 +48,11 @@ pub enum ExpiringNonceHistoryError {
     SenderRecovery,
 }
 
-#[derive(Debug, Clone, Copy)]
-struct Inclusion {
-    block_hash: B256,
-    valid_before: u64,
-}
-
 #[derive(Debug, Clone)]
 struct BlockRecord {
     parent_hash: B256,
     timestamp: u64,
-    replay_ids: Vec<B256>,
-    /// Distance from this cache segment's anchor, when the parent lineage is known.
-    height: Option<u64>,
-    /// Ancestors at distances 1, 2, 4, ... for logarithmic branch membership checks.
-    jumps: SmallVec<[B256; 8]>,
+    entries: Vec<ExpiringNonceEntry>,
     /// Earliest candidate timestamp at which all ancestry missing before this block is expired.
     complete_at: Option<u64>,
 }
@@ -78,13 +65,18 @@ struct Anchor {
 
 #[derive(Debug)]
 struct HistoryInner {
+    /// Live replay identifiers on the canonical branch.
+    live: B256Map<u64>,
+    /// Expiry buckets for canonical entries. Stale bucket entries are ignored during collection.
+    expirations: BTreeMap<u64, Vec<B256>>,
     blocks: B256Map<BlockRecord>,
     blocks_by_timestamp: BTreeMap<u64, SmallVec<[B256; 2]>>,
     children: B256Map<SmallVec<[B256; 2]>>,
-    inclusions: B256Map<SmallVec<[Inclusion; 1]>>,
     anchors: B256Map<Anchor>,
+    canonical_head: B256,
+    canonical_timestamp: u64,
+    canonical_complete_at: u64,
     retained_identifiers: usize,
-    highest_timestamp: u64,
 }
 
 impl Default for HistoryInner {
@@ -92,13 +84,16 @@ impl Default for HistoryInner {
         let mut anchors = B256Map::default();
         anchors.insert(B256::ZERO, Anchor { complete_at: 0 });
         Self {
+            live: B256Map::default(),
+            expirations: BTreeMap::new(),
             blocks: B256Map::default(),
             blocks_by_timestamp: BTreeMap::new(),
             children: B256Map::default(),
-            inclusions: B256Map::default(),
             anchors,
+            canonical_head: B256::ZERO,
+            canonical_timestamp: 0,
+            canonical_complete_at: 0,
             retained_identifiers: 0,
-            highest_timestamp: 0,
         }
     }
 }
@@ -148,8 +143,15 @@ impl ExpiringNonceHistory {
                 .anchors
                 .insert(first.parent_hash, Anchor { complete_at });
         }
+        let mut head = None;
         for block in blocks {
+            head = Some(block.hash);
             history.record_block(block);
+        }
+        if let Some(head) = head {
+            history
+                .set_canonical_head(head)
+                .expect("contiguous rebuilt expiring nonce history");
         }
         history
     }
@@ -197,21 +199,9 @@ impl ExpiringNonceHistory {
         let block_hash = block.hash;
         let parent_hash = block.parent_hash;
         let timestamp = block.timestamp;
-        let entry_count = block.entries.len();
-        let mut replay_ids = Vec::with_capacity(entry_count);
-        for entry in block.entries {
-            replay_ids.push(entry.replay_id);
-            inner
-                .inclusions
-                .entry(entry.replay_id)
-                .or_default()
-                .push(Inclusion {
-                    block_hash: block.hash,
-                    valid_before: entry.valid_before,
-                });
-        }
+        let entries = block.entries;
+        let entry_count = entries.len();
         inner.retained_identifiers += entry_count;
-        inner.highest_timestamp = inner.highest_timestamp.max(block.timestamp);
         let complete_at = inner
             .anchors
             .get(&block.parent_hash)
@@ -222,15 +212,12 @@ impl ExpiringNonceHistory {
                     .get(&block.parent_hash)
                     .and_then(|parent| parent.complete_at)
             });
-        let (height, jumps) = Self::lineage_for_parent(&inner, block.parent_hash);
         inner.blocks.insert(
             block.hash,
             BlockRecord {
                 parent_hash: block.parent_hash,
                 timestamp: block.timestamp,
-                replay_ids,
-                height,
-                jumps,
+                entries,
                 complete_at,
             },
         );
@@ -245,9 +232,8 @@ impl ExpiringNonceHistory {
             .or_default()
             .push(block_hash);
         self.propagate_completeness_locked(&mut inner, block_hash, false);
-        let (pruned_blocks, pruned_identifiers) = self.prune_locked(&mut inner);
         let retained_blocks = inner.blocks.len();
-        let retained_unique_identifiers = inner.inclusions.len();
+        let retained_unique_identifiers = inner.live.len();
         drop(inner);
 
         info!(
@@ -258,15 +244,16 @@ impl ExpiringNonceHistory {
             entry_count,
             retained_blocks,
             retained_unique_identifiers,
-            pruned_blocks,
-            pruned_identifiers,
             ?lock_wait,
             elapsed = ?started.elapsed(),
-            "recorded expiring nonce history overlay"
+            "cached expiring nonce block overlay"
         );
     }
 
     /// Returns whether `replay_id` was consumed by a live ancestor of `parent_hash`.
+    ///
+    /// The canonical-head path is a single lookup in the live replay map. Cached block overlays are
+    /// consulted only when validating a side branch.
     pub fn contains(
         &self,
         parent_hash: B256,
@@ -277,24 +264,64 @@ impl ExpiringNonceHistory {
             .inner
             .read()
             .expect("expiring nonce history lock poisoned");
-        self.ensure_complete_locked(&inner, parent_hash, candidate_timestamp)?;
-
-        let Some(inclusions) = inner.inclusions.get(&replay_id) else {
-            return Ok(false);
-        };
-        for inclusion in inclusions {
-            if inclusion.valid_before > candidate_timestamp
-                && self.is_ancestor_locked(
-                    &inner,
-                    inclusion.block_hash,
-                    parent_hash,
-                    candidate_timestamp,
-                )?
-            {
-                return Ok(true);
+        if parent_hash == inner.canonical_head {
+            if candidate_timestamp < inner.canonical_complete_at {
+                return Err(ExpiringNonceHistoryError::MissingHistory { parent_hash });
             }
+            return Ok(inner
+                .live
+                .get(&replay_id)
+                .is_some_and(|valid_before| *valid_before > candidate_timestamp));
         }
-        Ok(false)
+
+        self.contains_on_side_branch_locked(&inner, parent_hash, replay_id, candidate_timestamp)
+    }
+
+    /// Moves the live replay map to a cached canonical block.
+    ///
+    /// Extending the current head applies only the new block and expired timing-wheel bucket.
+    /// Reorganizations reconcile the small cached suffix outside the transaction lookup path.
+    pub fn set_canonical_head(&self, block_hash: B256) -> Result<(), ExpiringNonceHistoryError> {
+        let mut inner = self
+            .inner
+            .write()
+            .expect("expiring nonce history lock poisoned");
+        if block_hash == inner.canonical_head {
+            return Ok(());
+        }
+
+        let block =
+            inner
+                .blocks
+                .get(&block_hash)
+                .ok_or(ExpiringNonceHistoryError::MissingHistory {
+                    parent_hash: block_hash,
+                })?;
+        let timestamp = block.timestamp;
+        let complete_at = block
+            .complete_at
+            .ok_or(ExpiringNonceHistoryError::MissingHistory {
+                parent_hash: block_hash,
+            })?;
+
+        if block.parent_hash == inner.canonical_head {
+            Self::expire_live_locked(&mut inner, timestamp);
+            Self::apply_block_locked(&mut inner, block_hash, timestamp);
+        } else {
+            let new_suffix = self.live_suffix_locked(&inner, block_hash, timestamp)?;
+            inner.live.clear();
+            inner.expirations.clear();
+            for hash in new_suffix.into_iter().rev() {
+                Self::apply_block_locked(&mut inner, hash, timestamp);
+            }
+            Self::expire_live_locked(&mut inner, timestamp);
+        }
+
+        inner.canonical_head = block_hash;
+        inner.canonical_timestamp = timestamp;
+        inner.canonical_complete_at = complete_at;
+        self.prune_locked(&mut inner);
+        Ok(())
     }
 
     /// Returns the number of replay identifiers currently retained across all cached branches.
@@ -346,108 +373,102 @@ impl ExpiringNonceHistory {
         }
     }
 
-    fn lineage_for_parent(
+    fn contains_on_side_branch_locked(
+        &self,
         inner: &HistoryInner,
         parent_hash: B256,
-    ) -> (Option<u64>, SmallVec<[B256; 8]>) {
-        let mut jumps = SmallVec::new();
-        jumps.push(parent_hash);
-
-        if inner.anchors.contains_key(&parent_hash) {
-            return (Some(0), jumps);
-        }
-        let Some(parent) = inner.blocks.get(&parent_hash) else {
-            return (None, SmallVec::new());
-        };
-        let Some(height) = parent.height else {
-            return (None, SmallVec::new());
-        };
-
-        let mut level = 1;
-        while let Some(ancestor) = jumps
-            .get(level - 1)
-            .and_then(|ancestor| inner.blocks.get(ancestor))
-            .and_then(|ancestor| ancestor.jumps.get(level - 1))
-            .copied()
-        {
-            jumps.push(ancestor);
-            level += 1;
-        }
-        (Some(height + 1), jumps)
-    }
-
-    fn is_ancestor_locked(
-        &self,
-        inner: &HistoryInner,
-        ancestor_hash: B256,
-        descendant_hash: B256,
+        replay_id: B256,
         candidate_timestamp: u64,
     ) -> Result<bool, ExpiringNonceHistoryError> {
-        if let (Some(ancestor), Some(descendant)) = (
-            inner.blocks.get(&ancestor_hash),
-            inner.blocks.get(&descendant_hash),
-        ) && let (Some(ancestor_height), Some(descendant_height)) =
-            (ancestor.height, descendant.height)
-        {
-            if ancestor_height > descendant_height {
-                return Ok(false);
-            }
-
-            let mut cursor = descendant_hash;
-            let mut distance = descendant_height - ancestor_height;
-            while distance != 0 {
-                let level = (u64::BITS - 1 - distance.leading_zeros()) as usize;
-                let Some(next) = inner
-                    .blocks
-                    .get(&cursor)
-                    .and_then(|block| block.jumps.get(level))
-                else {
-                    return self.is_ancestor_linear_locked(
-                        inner,
-                        ancestor_hash,
-                        descendant_hash,
-                        candidate_timestamp,
-                    );
-                };
-                cursor = *next;
-                distance -= 1 << level;
-            }
-            return Ok(cursor == ancestor_hash);
-        }
-
-        self.is_ancestor_linear_locked(inner, ancestor_hash, descendant_hash, candidate_timestamp)
-    }
-
-    fn is_ancestor_linear_locked(
-        &self,
-        inner: &HistoryInner,
-        ancestor_hash: B256,
-        descendant_hash: B256,
-        candidate_timestamp: u64,
-    ) -> Result<bool, ExpiringNonceHistoryError> {
-        let mut cursor = descendant_hash;
+        self.ensure_complete_locked(inner, parent_hash, candidate_timestamp)?;
+        let mut cursor = parent_hash;
         loop {
-            if cursor == ancestor_hash {
-                return Ok(true);
-            }
             if let Some(anchor) = inner.anchors.get(&cursor) {
                 return if candidate_timestamp >= anchor.complete_at {
                     Ok(false)
                 } else {
-                    Err(ExpiringNonceHistoryError::MissingHistory {
-                        parent_hash: descendant_hash,
-                    })
+                    Err(ExpiringNonceHistoryError::MissingHistory { parent_hash })
                 };
             }
             let Some(block) = inner.blocks.get(&cursor) else {
-                return Err(ExpiringNonceHistoryError::MissingHistory {
-                    parent_hash: descendant_hash,
-                });
+                return Err(ExpiringNonceHistoryError::MissingHistory { parent_hash });
             };
             if block.timestamp.saturating_add(self.max_expiry_secs) <= candidate_timestamp {
                 return Ok(false);
             }
+            if block.entries.iter().any(|entry| {
+                entry.replay_id == replay_id && entry.valid_before > candidate_timestamp
+            }) {
+                return Ok(true);
+            }
             cursor = block.parent_hash;
+        }
+    }
+
+    fn live_suffix_locked(
+        &self,
+        inner: &HistoryInner,
+        head: B256,
+        timestamp: u64,
+    ) -> Result<Vec<B256>, ExpiringNonceHistoryError> {
+        let mut suffix = Vec::new();
+        let mut cursor = head;
+        loop {
+            if inner.anchors.contains_key(&cursor) {
+                return Ok(suffix);
+            }
+            let block = inner
+                .blocks
+                .get(&cursor)
+                .ok_or(ExpiringNonceHistoryError::MissingHistory { parent_hash: head })?;
+            if block.timestamp.saturating_add(self.max_expiry_secs) <= timestamp {
+                return Ok(suffix);
+            }
+            suffix.push(cursor);
+            cursor = block.parent_hash;
+        }
+    }
+
+    fn apply_block_locked(inner: &mut HistoryInner, block_hash: B256, timestamp: u64) {
+        let HistoryInner {
+            live,
+            expirations,
+            blocks,
+            ..
+        } = inner;
+        let block = blocks
+            .get(&block_hash)
+            .expect("canonical block is present in replay cache");
+        for entry in &block.entries {
+            if entry.valid_before > timestamp {
+                live.insert(entry.replay_id, entry.valid_before);
+                expirations
+                    .entry(entry.valid_before)
+                    .or_default()
+                    .push(entry.replay_id);
+            }
+        }
+    }
+
+    fn expire_live_locked(inner: &mut HistoryInner, timestamp: u64) {
+        while inner
+            .expirations
+            .first_key_value()
+            .is_some_and(|(valid_before, _)| *valid_before <= timestamp)
+        {
+            let (_, replay_ids) = inner
+                .expirations
+                .pop_first()
+                .expect("an expired replay bucket was just observed");
+            for replay_id in replay_ids {
+                if inner
+                    .live
+                    .get(&replay_id)
+                    .is_some_and(|valid_before| *valid_before <= timestamp)
+                {
+                    inner.live.remove(&replay_id);
+                }
+            }
         }
     }
 
@@ -455,7 +476,7 @@ impl ExpiringNonceHistory {
         // Keep two validity windows so ordinary reorganizations can reuse their existing branch
         // overlays. Older branch requests fail closed and can be rebuilt from persisted bodies.
         let retention = self.max_expiry_secs.saturating_mul(2);
-        let cutoff = inner.highest_timestamp.saturating_sub(retention);
+        let cutoff = inner.canonical_timestamp.saturating_sub(retention);
         if cutoff == 0 {
             return (0, 0);
         }
@@ -476,17 +497,8 @@ impl ExpiringNonceHistory {
                     continue;
                 };
                 removed_blocks += 1;
-                removed_identifiers += block.replay_ids.len();
-                inner.retained_identifiers -= block.replay_ids.len();
-                for replay_id in &block.replay_ids {
-                    if let Entry::Occupied(mut entry) = inner.inclusions.entry(*replay_id) {
-                        let inclusions = entry.get_mut();
-                        inclusions.retain(|inclusion| inclusion.block_hash != hash);
-                        if inclusions.is_empty() {
-                            entry.remove();
-                        }
-                    }
-                }
+                removed_identifiers += block.entries.len();
+                inner.retained_identifiers -= block.entries.len();
 
                 let mut remove_parent_children = false;
                 if let Some(siblings) = inner.children.get_mut(&block.parent_hash) {
@@ -601,6 +613,7 @@ mod tests {
             valid_before: 350,
         };
         history.record_block(block(1, 0, 100, vec![entry]));
+        history.set_canonical_head(hash(1)).unwrap();
 
         assert!(history.contains(hash(1), hash(9), 200).unwrap());
         assert!(!history.contains(hash(1), hash(9), 350).unwrap());
@@ -620,6 +633,7 @@ mod tests {
             }],
         ));
         history.record_block(block(3, 1, 101, Vec::new()));
+        history.set_canonical_head(hash(2)).unwrap();
 
         assert!(history.contains(hash(2), hash(9), 200).unwrap());
         assert!(!history.contains(hash(3), hash(9), 200).unwrap());
@@ -643,6 +657,7 @@ mod tests {
         let history = ExpiringNonceHistory::new(300);
         history.record_block(block(2, 1, 101, Vec::new()));
         history.record_block(block(1, 0, 100, Vec::new()));
+        history.set_canonical_head(hash(2)).unwrap();
 
         assert!(!history.contains(hash(2), hash(9), 102).unwrap());
     }
@@ -684,8 +699,11 @@ mod tests {
                 valid_before: 11,
             }],
         ));
+        history.set_canonical_head(hash(1)).unwrap();
         history.record_block(block(2, 1, 2, Vec::new()));
+        history.set_canonical_head(hash(2)).unwrap();
         history.record_block(block(3, 2, 22, Vec::new()));
+        history.set_canonical_head(hash(3)).unwrap();
 
         assert_eq!(
             history.contains(hash(2), hash(9), 10),
@@ -709,8 +727,54 @@ mod tests {
                 valid_before: 350,
             }],
         ));
+        history.set_canonical_head(hash(1)).unwrap();
 
         assert!(!history.contains(hash(1), hash(9), 350).unwrap());
         assert!(history.contains(hash(1), hash(9), 200).unwrap());
+    }
+
+    #[test]
+    fn reorg_reconciles_live_replay_map() {
+        let history = ExpiringNonceHistory::new(300);
+        history.record_block(block(1, 0, 100, Vec::new()));
+        history.record_block(block(
+            2,
+            1,
+            101,
+            vec![ExpiringNonceEntry {
+                replay_id: hash(9),
+                valid_before: 350,
+            }],
+        ));
+        history.record_block(block(3, 1, 101, Vec::new()));
+
+        history.set_canonical_head(hash(2)).unwrap();
+        assert!(history.contains(hash(2), hash(9), 200).unwrap());
+
+        history.set_canonical_head(hash(3)).unwrap();
+        assert!(!history.contains(hash(3), hash(9), 200).unwrap());
+        assert!(history.contains(hash(2), hash(9), 200).unwrap());
+    }
+
+    #[test]
+    fn reorg_to_earlier_timestamp_restores_live_entry() {
+        let history = ExpiringNonceHistory::new(10);
+        history.record_block(block(
+            1,
+            0,
+            1,
+            vec![ExpiringNonceEntry {
+                replay_id: hash(9),
+                valid_before: 10,
+            }],
+        ));
+        history.record_block(block(2, 1, 10, Vec::new()));
+        history.record_block(block(3, 1, 9, Vec::new()));
+
+        history.set_canonical_head(hash(2)).unwrap();
+        assert!(!history.contains(hash(2), hash(9), 10).unwrap());
+
+        history.set_canonical_head(hash(3)).unwrap();
+        assert!(history.contains(hash(3), hash(9), 9).unwrap());
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -25,6 +25,10 @@ mod engine;
 use rayon as _;
 mod error;
 pub use error::TempoEvmError;
+mod expiring_nonce_history;
+pub use expiring_nonce_history::{
+    ExpiringNonceBlock, ExpiringNonceEntry, ExpiringNonceHistory, ExpiringNonceHistoryError,
+};
 pub mod evm;
 use core::num::NonZeroU64;
 use std::{borrow::Cow, sync::Arc};
@@ -70,6 +74,9 @@ pub struct TempoEvmConfig {
 
     /// Block assembler
     pub block_assembler: TempoBlockAssembler,
+
+    /// Fork-aware replay history for expiring nonce transactions.
+    expiring_nonce_history: ExpiringNonceHistory,
 }
 
 impl FeeTokenResolver for TempoEvmConfig {
@@ -96,6 +103,7 @@ impl TempoEvmConfig {
         Self {
             inner,
             block_assembler: TempoBlockAssembler::new(chain_spec),
+            expiring_nonce_history: ExpiringNonceHistory::default(),
         }
     }
 
@@ -103,6 +111,17 @@ impl TempoEvmConfig {
     pub fn with_sender_recovery_cache(mut self, cache: SenderRecoveryCache) -> Self {
         self.inner = self.inner.with_sender_recovery_cache(cache);
         self
+    }
+
+    /// Uses the provided history-derived expiring nonce cache.
+    pub fn with_expiring_nonce_history(mut self, history: ExpiringNonceHistory) -> Self {
+        self.expiring_nonce_history = history;
+        self
+    }
+
+    /// Returns the shared history-derived expiring nonce cache.
+    pub const fn expiring_nonce_history(&self) -> &ExpiringNonceHistory {
+        &self.expiring_nonce_history
     }
 
     /// Returns the chain spec
@@ -147,7 +166,12 @@ impl BlockExecutorFactory for TempoEvmConfig {
         DB: StateDB,
         I: Inspector<TempoContext<DB>>,
     {
-        TempoBlockExecutor::new(evm, ctx, self.chain_spec())
+        TempoBlockExecutor::new(
+            evm,
+            ctx,
+            self.chain_spec(),
+            self.expiring_nonce_history.clone(),
+        )
     }
 }
 
@@ -308,6 +332,7 @@ impl ConfigureEvm for TempoEvmConfig {
             validator_set: None,
             consensus_context: block.header().consensus_context,
             subblock_fee_recipients,
+            block_hash: Some(block.hash()),
         })
     }
 
@@ -335,6 +360,7 @@ impl ConfigureEvm for TempoEvmConfig {
             validator_set: None,
             consensus_context: attributes.consensus_context,
             subblock_fee_recipients: attributes.subblock_fee_recipients,
+            block_hash: None,
         })
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -17,7 +17,7 @@ pub use pool::{TempoPoolValidationEvm, TempoPoolValidationResult};
 mod block;
 pub use block::{TempoBlockExecutor, TempoReceiptBuilder, TempoTxResult};
 mod context;
-pub use context::{TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
+pub use context::{ExpiringNonceBlockOverlay, TempoBlockExecutionCtx, TempoNextBlockEnvAttributes};
 pub mod consensus;
 #[cfg(feature = "engine")]
 mod engine;
@@ -338,6 +338,7 @@ impl ConfigureEvm for TempoEvmConfig {
             consensus_context: block.header().consensus_context,
             subblock_fee_recipients,
             block_hash: Some(block.hash()),
+            expiring_nonce_overlay: Default::default(),
         })
     }
 
@@ -366,6 +367,7 @@ impl ConfigureEvm for TempoEvmConfig {
             consensus_context: attributes.consensus_context,
             subblock_fee_recipients: attributes.subblock_fee_recipients,
             block_hash: None,
+            expiring_nonce_overlay: Default::default(),
         })
     }
 }

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -100,10 +100,12 @@ impl TempoEvmConfig {
     pub fn new(chain_spec: Arc<TempoChainSpec>) -> Self {
         let inner =
             EthEvmConfig::new_with_evm_factory(chain_spec.clone(), TempoEvmFactory::default());
+        let expiring_nonce_history = ExpiringNonceHistory::default();
         Self {
             inner,
-            block_assembler: TempoBlockAssembler::new(chain_spec),
-            expiring_nonce_history: ExpiringNonceHistory::default(),
+            block_assembler: TempoBlockAssembler::new(chain_spec)
+                .with_expiring_nonce_history(expiring_nonce_history.clone()),
+            expiring_nonce_history,
         }
     }
 
@@ -115,6 +117,9 @@ impl TempoEvmConfig {
 
     /// Uses the provided history-derived expiring nonce cache.
     pub fn with_expiring_nonce_history(mut self, history: ExpiringNonceHistory) -> Self {
+        self.block_assembler = self
+            .block_assembler
+            .with_expiring_nonce_history(history.clone());
         self.expiring_nonce_history = history;
         self
     }

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -196,9 +196,11 @@ impl TestExecutorBuilder {
             validator_set: self.validator_set,
             consensus_context: None,
             subblock_fee_recipients: self.subblock_fee_recipients,
+            block_hash: None,
         };
 
-        let mut executor = TempoBlockExecutor::new(evm, ctx, chainspec);
+        let mut executor =
+            TempoBlockExecutor::new(evm, ctx, chainspec, crate::ExpiringNonceHistory::default());
 
         // Apply test-specific initial state
         if let Some(section) = self.initial_section {

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -197,6 +197,7 @@ impl TestExecutorBuilder {
             consensus_context: None,
             subblock_fee_recipients: self.subblock_fee_recipients,
             block_hash: None,
+            expiring_nonce_overlay: Default::default(),
         };
 
         let mut executor =

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -8,7 +8,7 @@ use crate::{
         TempoToken, TempoTokenApiServer,
     },
 };
-use alloy_primitives::B256;
+use alloy_primitives::{B256, Sealable};
 use reth_chainspec::{ChainKind, EthChainSpec, NamedChain};
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
@@ -26,28 +26,30 @@ use reth_node_builder::{
     },
 };
 use reth_node_ethereum::EthereumNetworkBuilder;
-use reth_primitives_traits::SealedHeader;
-use reth_provider::providers::ProviderFactoryBuilder;
+use reth_primitives_traits::{AlloyBlockHeader, SealedHeader};
+use reth_provider::{BlockReader, providers::ProviderFactoryBuilder};
 use reth_rpc_builder::{Identity, RethRpcModule};
 use reth_rpc_eth_api::{
     RpcNodeCore,
     helpers::config::{EthConfigApiServer, EthConfigHandler},
 };
-use reth_storage_api::{AccountInfoReader, EmptyBodyStorage};
+use reth_storage_api::{AccountInfoReader, BlockNumReader, EmptyBodyStorage};
 use reth_tracing::tracing::{debug, info, warn};
 use reth_transaction_pool::{
     Pool, StatefulValidationFn, StatelessValidationFn, TransactionOrigin,
     TransactionValidationTaskExecutor, blobstore::InMemoryBlobStore,
     error::InvalidPoolTransactionError,
 };
-use std::sync::Arc;
-use tempo_chainspec::spec::TempoChainSpec;
-use tempo_evm::{TempoEvmConfig, consensus::TempoConsensus};
+use std::{sync::Arc, time::Instant};
+use tempo_chainspec::{hardfork::TempoHardfork, spec::TempoChainSpec};
+use tempo_evm::{
+    ExpiringNonceBlock, ExpiringNonceHistory, TempoEvmConfig, consensus::TempoConsensus,
+};
 use tempo_payload_builder::{
     DEFAULT_BUILD_TIME_MULTIPLIER, TempoPayloadBuilder, TempoPayloadBuilderConfig,
 };
 use tempo_payload_types::TempoPayloadAttributes;
-use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
+use tempo_primitives::{Block, TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
 use tempo_transaction_pool::{
     AA2dPool, AA2dPoolConfig, TempoTransactionPool,
     amm::AmmLiquidityCache,
@@ -435,16 +437,80 @@ pub struct TempoExecutorBuilder;
 impl<Node> ExecutorBuilder<Node> for TempoExecutorBuilder
 where
     Node: FullNodeTypes<Types = TempoNode>,
+    Node::Provider: BlockReader<Block = Block> + BlockNumReader,
 {
     type EVM = TempoEvmConfig;
 
     async fn build_evm(self, ctx: &BuilderContext<Node>) -> eyre::Result<Self::EVM> {
-        let mut evm_config = TempoEvmConfig::new(ctx.chain_spec());
+        let rebuild_started = Instant::now();
+        let history = rebuild_expiring_nonce_history(ctx.provider())?;
+        info!(
+            target: "tempo::expiring_nonce_history",
+            blocks = history.retained_blocks(),
+            identifiers = history.retained_identifiers(),
+            elapsed = ?rebuild_started.elapsed(),
+            "rebuilt expiring nonce history from canonical block bodies"
+        );
+        let mut evm_config =
+            TempoEvmConfig::new(ctx.chain_spec()).with_expiring_nonce_history(history);
         if let Some(cache) = ctx.sender_recovery_cache() {
             evm_config = evm_config.with_sender_recovery_cache(cache.clone());
         }
         Ok(evm_config)
     }
+}
+
+fn rebuild_expiring_nonce_history<P>(provider: &P) -> eyre::Result<ExpiringNonceHistory>
+where
+    P: BlockReader<Block = Block> + BlockNumReader,
+{
+    let max_expiry_secs = TempoHardfork::T11.expiring_nonce_max_expiry_secs();
+    let best_number = provider.best_block_number()?;
+    let head = provider
+        .block_by_number(best_number)?
+        .ok_or_else(|| eyre::eyre!("best block {best_number} is unavailable"))?;
+    let head_timestamp = head.header.timestamp();
+
+    let mut blocks = Vec::new();
+    let mut complete_at = 0;
+    let retention_secs = max_expiry_secs.saturating_mul(2);
+    let mut number = best_number;
+    loop {
+        let block = provider
+            .block_by_number(number)?
+            .ok_or_else(|| eyre::eyre!("block {number} is unavailable during replay rebuild"))?;
+        if block.header.timestamp().saturating_add(retention_secs) <= head_timestamp {
+            // This excluded block is the parent of the oldest retained block. Its own entries and
+            // all earlier entries are provably expired from this timestamp onward.
+            complete_at = block.header.timestamp().saturating_add(max_expiry_secs);
+            break;
+        }
+
+        let entries = block
+            .body
+            .transactions
+            .iter()
+            .filter_map(|tx| ExpiringNonceHistory::entry_from_transaction(tx).transpose())
+            .collect::<Result<Vec<_>, _>>()?;
+        blocks.push(ExpiringNonceBlock {
+            hash: block.header.hash_slow(),
+            parent_hash: block.header.parent_hash(),
+            timestamp: block.header.timestamp(),
+            entries,
+        });
+
+        if number == 0 {
+            break;
+        }
+        number -= 1;
+    }
+    blocks.reverse();
+
+    Ok(ExpiringNonceHistory::from_blocks(
+        max_expiry_secs,
+        complete_at,
+        blocks,
+    ))
 }
 
 /// Builder for [`TempoConsensus`].

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -33,7 +33,8 @@ use tempo_contracts::precompiles::{
     },
 };
 use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, NONCE_PRECOMPILE_ADDRESS,
+    nonce::NonceManager,
     tip20::ITIP20::{self},
 };
 use tempo_primitives::{
@@ -1973,6 +1974,11 @@ async fn test_aa_expiring_nonce_replay_protection() -> eyre::Result<()> {
 
     let aa_signature = sign_aa_tx_secp256k1(&tx, &alice_signer)?;
     let envelope: TempoTxEnvelope = tx.into_signed(aa_signature).into();
+    let replay_id = envelope
+        .as_aa()
+        .expect("expiring nonce transaction")
+        .expiring_nonce_hash(alice_signer.address());
+    let legacy_seen_slot = NonceManager::new().expiring_nonce_seen[replay_id].slot();
     let tx_hash = *envelope.tx_hash();
     let encoded = envelope.encoded_2718();
 
@@ -1985,13 +1991,23 @@ async fn test_aa_expiring_nonce_replay_protection() -> eyre::Result<()> {
     assert_receipt_status(&provider, tx_hash, true).await?;
     println!("✓ First submission succeeded");
 
+    if setup.hardfork.is_t11() {
+        assert_eq!(
+            provider
+                .get_storage_at(NONCE_PRECOMPILE_ADDRESS, legacy_seen_slot)
+                .await?,
+            U256::ZERO,
+            "T11 expiring nonce execution must not write legacy Nonce-precompile state"
+        );
+    }
+
     // Second submission with SAME encoded tx (same hash) should fail
     println!("\nSecond submission - attempting replay with same tx hash...");
 
     // Try to inject the same transaction again - should be rejected at pool level
     let replay_result = setup.node.rpc.inject_tx(encoded.clone().into()).await;
 
-    // The replay MUST be rejected at pool validation (we check seen[tx_hash] in validator)
+    // The replay MUST be rejected from the canonical history-derived replay set.
     assert!(
         replay_result.is_err(),
         "Replay should be rejected at transaction pool level"

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1145,42 +1145,62 @@ where
                 .ok_or(TempoInvalidTransaction::ExpiringNonceMissingValidBefore)?;
 
             let block_timestamp = block.timestamp().saturating_to::<u64>();
-            StorageCtx::enter_evm_without_tip1060_accounting(
-                journal,
-                block,
-                cfg,
-                tx,
-                actions.clone(),
-                || {
-                    let mut nonce_manager = NonceManager::new();
+            let max_allowed = block_timestamp.saturating_add(max_expiry_secs);
+            if valid_before <= block_timestamp || valid_before > max_allowed {
+                return Err(TempoInvalidTransaction::NonceManagerError(if valid_before <= block_timestamp {
+                    format!(
+                        "expiring nonce transaction expired: valid_before ({valid_before}) <= block timestamp ({block_timestamp})"
+                    )
+                } else {
+                    format!(
+                        "expiring nonce valid_before ({valid_before}) too far in the future: must be within {max_expiry_secs}s of block timestamp ({block_timestamp}), max allowed is {max_allowed}"
+                    )
+                })
+                .into());
+            }
 
-                    let prev_ptr = if let Some(expiring_nonce_idx) = tempo_tx_env.expiring_nonce_idx
-                    {
-                        let ptr = nonce_manager
-                            .expiring_nonce_ring_ptr
-                            .read()
-                            .map_err(|err| EVMError::Custom(err.to_string()))?;
+            // T11+ block execution checks replay membership against recent block history before
+            // entering the EVM. Simulations with nonce checks disabled intentionally skip replay
+            // validation. Neither path mutates legacy Nonce-precompile storage.
+            let history_verified = spec.is_t11()
+                && (tx.expiring_nonce_history_verified || cfg.is_nonce_check_disabled());
 
-                        let next = (ptr + expiring_nonce_idx as u32) % capacity;
+            if !history_verified {
+                StorageCtx::enter_evm_without_tip1060_accounting(
+                    journal,
+                    block,
+                    cfg,
+                    tx,
+                    actions.clone(),
+                    || {
+                        let mut nonce_manager = NonceManager::new();
+
+                        let prev_ptr =
+                            if let Some(expiring_nonce_idx) = tempo_tx_env.expiring_nonce_idx {
+                                let ptr = nonce_manager
+                                    .expiring_nonce_ring_ptr
+                                    .read()
+                                    .map_err(|err| EVMError::Custom(err.to_string()))?;
+
+                                let next = (ptr + expiring_nonce_idx as u32) % capacity;
+
+                                nonce_manager
+                                    .expiring_nonce_ring_ptr
+                                    .write(next)
+                                    .map_err(|err| EVMError::Custom(err.to_string()))?;
+
+                                Some(ptr)
+                            } else {
+                                None
+                            };
 
                         nonce_manager
-                            .expiring_nonce_ring_ptr
-                            .write(next)
-                            .map_err(|err| EVMError::Custom(err.to_string()))?;
-
-                        Some(ptr)
-                    } else {
-                        None
-                    };
-
-                    nonce_manager
                     .check_and_mark_expiring_nonce(replay_hash, valid_before)
                     .map_err(|err| match err {
                         TempoPrecompileError::Fatal(err) => EVMError::Custom(err),
                         TempoPrecompileError::NonceError(
                             tempo_contracts::precompiles::NonceError::InvalidExpiringNonceExpiry(_),
                         ) => {
-                            let max_allowed = block_timestamp.saturating_add(max_expiry_secs);
                             if valid_before <= block_timestamp {
                                 TempoInvalidTransaction::NonceManagerError(format!(
                                     "expiring nonce transaction expired: valid_before ({valid_before}) <= block timestamp ({block_timestamp})"
@@ -1196,16 +1216,17 @@ where
                         err => TempoInvalidTransaction::NonceManagerError(err.to_string()).into(),
                     })?;
 
-                    if let Some(prev_ptr) = prev_ptr {
-                        nonce_manager
-                            .expiring_nonce_ring_ptr
-                            .write(prev_ptr)
-                            .map_err(|err| EVMError::Custom(err.to_string()))?;
-                    }
+                        if let Some(prev_ptr) = prev_ptr {
+                            nonce_manager
+                                .expiring_nonce_ring_ptr
+                                .write(prev_ptr)
+                                .map_err(|err| EVMError::Custom(err.to_string()))?;
+                        }
 
-                    Ok::<_, EVMError<DB::Error, TempoInvalidTransaction>>(())
-                },
-            )?;
+                        Ok::<_, EVMError<DB::Error, TempoInvalidTransaction>>(())
+                    },
+                )?;
+            }
         } else if !nonce_key.is_zero() {
             // 2D nonce transaction
             StorageCtx::enter_evm_without_tip1060_accounting(

--- a/crates/revm/src/tx.rs
+++ b/crates/revm/src/tx.rs
@@ -103,6 +103,12 @@ pub struct TempoTxEnv {
     /// Synthetic transaction environments used by tests and simulations may leave this unset.
     pub unique_tx_identifier: Option<B256>,
 
+    /// Whether this transaction was verified against recent expiring nonce history.
+    ///
+    /// T11+ block execution sets this flag before entering the EVM. RPC simulations that disable
+    /// nonce checks may leave it unset.
+    pub expiring_nonce_history_verified: bool,
+
     /// Optional fee payer specified for the transaction.
     ///
     /// - Some(Some(address)) corresponds to a successfully recovered fee payer
@@ -372,6 +378,7 @@ impl FromRecoveredTx<AASigned> for TempoTxEnv {
                 tx_hash: *aa_signed.hash(),
             },
             unique_tx_identifier: Some(aa_signed.expiring_nonce_hash(caller)),
+            expiring_nonce_history_verified: false,
             fee_payer: fee_payer_signature.map(|sig| {
                 secp256k1::recover_signer(&sig, tx.fee_payer_signature_hash(caller)).ok()
             }),
@@ -411,6 +418,7 @@ impl FromRecoveredTx<TempoTxEnvelope> for TempoTxEnv {
                     tx_hash: *tx.tx_hash(),
                 },
                 unique_tx_identifier: Some(tx.unique_tx_identifier(sender)),
+                expiring_nonce_history_verified: false,
                 fee_payer: None,
                 tempo_tx_env: None, // Non-AA transaction
             },

--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -649,6 +649,10 @@ where
                 // unblocked transactions before later pool scans.
                 let nonce_pool_start = Instant::now();
                 removed_txs.push(pool.notify_aa_pool_on_state_updates(bundle_state));
+                removed_txs.push(pool.notify_aa_pool_on_mined_expiring(
+                    tip.blocks_iter()
+                        .flat_map(|block| block.body().transactions.iter()),
+                ));
                 metrics.nonce_pool_update_duration_seconds.record(nonce_pool_start.elapsed());
 
                 // 2. Update AMM liquidity cache before revalidation/invalidation scans.

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -10,7 +10,7 @@ use crate::{
     tt_2d_pool::AA2dPool,
     validator::{ConfigureTempoPoolEvm, TempoTransactionValidator},
 };
-use alloy_consensus::Transaction;
+use alloy_consensus::{Transaction, transaction::TxHashRef};
 use alloy_primitives::{
     Address, B256, TxHash, U256,
     map::{AddressMap, AddressSet, Entry, HashMap},
@@ -42,7 +42,7 @@ use tempo_precompiles::{
     tip20::TIP20Token,
     tip403_registry::{REJECT_ALL_POLICY_ID, TIP403Registry},
 };
-use tempo_primitives::{Block, TempoHeader};
+use tempo_primitives::{Block, TempoHeader, TempoTxEnvelope};
 use tempo_revm::TempoStateAccess;
 
 /// Tempo transaction pool that routes based on nonce_key
@@ -112,6 +112,23 @@ where
             .inner()
             .notify_on_transaction_updates(promoted, discarded);
         mined
+    }
+
+    /// Removes expiring nonce transactions included in canonical block bodies.
+    ///
+    /// T11+ replay protection no longer writes Nonce-precompile storage, so mined expiring nonce
+    /// transactions must be detected from block contents instead of state updates.
+    pub(crate) fn notify_aa_pool_on_mined_expiring<'a>(
+        &self,
+        transactions: impl Iterator<Item = &'a TempoTxEnvelope>,
+    ) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
+        let hashes = transactions
+            .filter(|tx| tx.is_expiring_nonce())
+            .map(|tx| *tx.tx_hash())
+            .collect::<Vec<_>>();
+        self.aa_2d_pool
+            .write()
+            .remove_transactions_and_descendants(hashes.iter())
     }
 
     /// Evicts transactions that are no longer valid due to on-chain events.

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -27,9 +27,12 @@ use revm::{
     DatabaseRef,
     context::result::{EVMError, InvalidTransaction},
 };
-use std::sync::{
-    Arc,
-    atomic::{AtomicU8, Ordering},
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU8, Ordering},
+    },
+    time::Instant,
 };
 use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
 use tempo_evm::{ExpiringNonceBlock, ExpiringNonceHistory, TempoEvmConfig, TempoPoolValidationEvm};
@@ -772,6 +775,8 @@ where
             .expiring_nonce_history
             .contains_block(new_tip_block.hash())
         {
+            let indexing_started = Instant::now();
+            let recovery_started = Instant::now();
             let entries = new_tip_block
                 .body()
                 .transactions
@@ -779,6 +784,9 @@ where
                 .filter_map(|tx| ExpiringNonceHistory::entry_from_transaction(tx).transpose())
                 .collect::<Result<Vec<_>, _>>()
                 .expect("canonical expiring nonce transactions must have recoverable senders");
+            let recovery_elapsed = recovery_started.elapsed();
+            let entry_count = entries.len();
+            let record_started = Instant::now();
             self.expiring_nonce_history
                 .record_block(ExpiringNonceBlock {
                     hash: new_tip_block.hash(),
@@ -786,6 +794,18 @@ where
                     timestamp: new_tip_block.timestamp(),
                     entries,
                 });
+            let record_elapsed = record_started.elapsed();
+            tracing::info!(
+                target: "tempo::expiring_nonce_history",
+                block_hash = %new_tip_block.hash(),
+                block_number = new_tip_block.number(),
+                transaction_count = new_tip_block.body().transactions.len(),
+                entry_count,
+                ?recovery_elapsed,
+                ?record_elapsed,
+                elapsed = ?indexing_started.elapsed(),
+                "indexed canonical block into expiring nonce history"
+            );
         }
 
         // Cache the EVM environment for the new tip block.

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -11,7 +11,7 @@ use parking_lot::RwLock;
 use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_evm::{ConfigureEvm, EvmEnvFor, EvmFactory, EvmFor, block::BlockExecutorFactory};
 use reth_primitives_traits::{
-    Account, Bytecode, SealedBlock, transaction::error::InvalidTransactionError,
+    Account, AlloyBlockHeader, Bytecode, SealedBlock, transaction::error::InvalidTransactionError,
 };
 use reth_provider::BlockReaderIdExt;
 use reth_revm::database::StateProviderDatabase;
@@ -32,7 +32,7 @@ use std::sync::{
     atomic::{AtomicU8, Ordering},
 };
 use tempo_chainspec::hardfork::{TempoHardfork, TempoHardforks};
-use tempo_evm::{TempoEvmConfig, TempoPoolValidationEvm};
+use tempo_evm::{ExpiringNonceBlock, ExpiringNonceHistory, TempoEvmConfig, TempoPoolValidationEvm};
 use tempo_precompiles::{
     nonce::{INonce, NonceManager},
     storage::StorageActions,
@@ -108,6 +108,8 @@ pub struct TempoTransactionValidator<Client, EvmConfig = TempoEvmConfig> {
     /// Cached here so hot paths can resolve the active hardfork with a single atomic load
     /// instead of walking the chain spec's fork schedule.
     active_hardfork: AtomicU8,
+    /// Shared history-derived replay cache used by block execution.
+    expiring_nonce_history: ExpiringNonceHistory,
 }
 
 impl<Client, EvmConfig> TempoTransactionValidator<Client, EvmConfig>
@@ -135,6 +137,7 @@ where
             .evm_env(latest_header.header())
             .expect("failed constructing EvmEnv from latest header");
         let active_hardfork = AtomicU8::new(evm_env.cfg_env.spec.variant_index());
+        let expiring_nonce_history = inner.evm_config().expiring_nonce_history().clone();
         Self {
             inner,
             aa_valid_after_max_secs,
@@ -144,6 +147,7 @@ where
             cached_evm_env: parking_lot::RwLock::new(evm_env),
             cached_state: RwLock::new((latest_header.hash(), Arc::new(StateCache::default()))),
             active_hardfork,
+            expiring_nonce_history,
         }
     }
 
@@ -445,11 +449,42 @@ where
         // authorization, and balance checks.
         //
         // Returns resolved fee token and key expiry for pool caching.
-        let result = if let Some(tx_env) = transaction.cached_tx_env() {
-            let (result, _) = evm.validate_pool_transaction(tx_env.clone());
+        let mut tx_env = transaction
+            .cached_tx_env()
+            .cloned()
+            .unwrap_or_else(|| transaction.tx_env_slow());
+        if spec.is_t11() && transaction.is_expiring_nonce() {
+            let replay_id = transaction.precomputed_expiring_nonce_hash();
+            let (tip_hash, _) = &*self.cached_state.read();
+            let tip_timestamp = self.cached_evm_env.read().block_env.timestamp.to::<u64>();
+            match self
+                .expiring_nonce_history
+                .contains(*tip_hash, replay_id, tip_timestamp)
+            {
+                Ok(false) => {}
+                Ok(true) => {
+                    return TransactionValidationOutcome::Invalid(
+                        transaction,
+                        InvalidPoolTransactionError::other(TempoPoolTransactionError::Evm(
+                            TempoInvalidTransaction::NonceManagerError(
+                                "expiring nonce replay".to_string(),
+                            ),
+                        )),
+                    );
+                }
+                Err(err) => {
+                    return TransactionValidationOutcome::Error(*transaction.hash(), Box::new(err));
+                }
+            }
+            tx_env.expiring_nonce_history_verified = true;
+        }
+
+        let was_cached = transaction.cached_tx_env().is_some();
+        let result = if was_cached {
+            let (result, _) = evm.validate_pool_transaction(tx_env);
             result
         } else {
-            let (result, tx_env) = evm.validate_pool_transaction(transaction.tx_env_slow());
+            let (result, tx_env) = evm.validate_pool_transaction(tx_env);
             transaction.cache_tx_env(tx_env);
             result
         };
@@ -730,6 +765,29 @@ where
     fn on_new_head_block(&self, new_tip_block: &SealedBlock<Self::Block>) {
         self.inner.on_new_head_block(new_tip_block);
 
+        // Locally built blocks reuse their payload execution result and are not executed again on
+        // import, so canonical notification is the authoritative fallback for attaching their
+        // history overlay. Remotely imported blocks are already present and this path is a no-op.
+        if !self
+            .expiring_nonce_history
+            .contains_block(new_tip_block.hash())
+        {
+            let entries = new_tip_block
+                .body()
+                .transactions
+                .iter()
+                .filter_map(|tx| ExpiringNonceHistory::entry_from_transaction(tx).transpose())
+                .collect::<Result<Vec<_>, _>>()
+                .expect("canonical expiring nonce transactions must have recoverable senders");
+            self.expiring_nonce_history
+                .record_block(ExpiringNonceBlock {
+                    hash: new_tip_block.hash(),
+                    parent_hash: new_tip_block.parent_hash(),
+                    timestamp: new_tip_block.timestamp(),
+                    entries,
+                });
+        }
+
         // Cache the EVM environment for the new tip block.
         let evm_env = self
             .inner
@@ -791,6 +849,9 @@ pub trait ConfigureTempoPoolEvm:
         >,
     > + 'static
 {
+    /// Returns the shared history-derived expiring nonce cache.
+    fn expiring_nonce_history(&self) -> &ExpiringNonceHistory;
+
     fn pool_evm<'a>(
         &self,
         db: StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
@@ -808,9 +869,14 @@ where
                 EvmFactory: EvmFactory<Spec = TempoHardfork, BlockEnv = TempoBlockEnv>,
             >,
         > + 'static,
+    T: ExpiringNonceHistoryProvider,
     for<'a> EvmFor<T, StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>>:
         TempoPoolValidationEvm,
 {
+    fn expiring_nonce_history(&self) -> &ExpiringNonceHistory {
+        ExpiringNonceHistoryProvider::expiring_nonce_history(self)
+    }
+
     fn pool_evm<'a>(
         &self,
         db: StateCacheDb<'a, StateProviderDatabase<&'a dyn StateProvider>>,
@@ -821,6 +887,18 @@ where
         let mut evm = self.evm_with_env(db, evm_env);
         evm.configure_for_pool();
         evm
+    }
+}
+
+/// EVM configurations that carry the node's history-derived expiring nonce cache.
+pub trait ExpiringNonceHistoryProvider {
+    /// Returns the shared cache.
+    fn expiring_nonce_history(&self) -> &ExpiringNonceHistory;
+}
+
+impl ExpiringNonceHistoryProvider for TempoEvmConfig {
+    fn expiring_nonce_history(&self) -> &ExpiringNonceHistory {
+        Self::expiring_nonce_history(self)
     }
 }
 

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -807,6 +807,9 @@ where
                 "indexed canonical block into expiring nonce history"
             );
         }
+        self.expiring_nonce_history
+            .set_canonical_head(new_tip_block.hash())
+            .expect("canonical expiring nonce history must connect to the cached head");
 
         // Cache the EVM environment for the new tip block.
         let evm_env = self


### PR DESCRIPTION
## Summary

- Derives T11 expiring nonce replay protection from recent block history instead of mutating Nonce-precompile state.
- Uses a canonical `replay_id -> valid_before` map so the normal replay check is one O(1) hash lookup; expiry buckets and cached block overlays handle collection and reorgs outside the transaction hot path.
- Keeps same-block replay rejection executor-local and hands committed entries directly from execution to assembly.

## Profile

- Canonical live-hit lookup: ~97.8 ns -> ~15.6 ns (-84%).
- Canonical miss lookup: ~18.8 ns -> ~14.1 ns (-25%).
- A 10k-entry block-cache record measures ~13.4 us; executor-to-assembler handoff measures ~15.2 us.

## Benchmark

- Latest paired e2e run: [No Difference](https://github.com/tempoxyz/tempo/actions/runs/32256869372) (`run-pairs=1`, Samply, 2000 concurrent requests).
- Informational only because one pair has no confidence interval: TPS +17.41%, builder throughput +19.09%, validator throughput +15.34%, block-time mean -2.48%; block-time P50 +8.68%, P90 +9.38%, P99 -8.34%.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo test -q -p tempo-evm` (109 passed)
- `cargo test -q -p tempo-transaction-pool expiring_nonce` (17 passed)
- `cargo +nightly clippy -p tempo-evm --all-targets --features bench -- -D warnings`
- `cargo +nightly clippy -p tempo-transaction-pool --all-targets -- -D warnings`
- `cargo test -q -p tempo-node --test it test_aa_expiring_nonce_replay_protection`

Prompted by: @shekhirin

Prompted by: @onbjerg
