### PR TITLE
fix(consensus): ignore revealed players in DKG outcome equality

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/ignore_revealed.rs
+++ b/crates/consensus/src/dkg/manager/actor/ignore_revealed.rs
@@ -1,0 +1,117 @@
+use std::num::NonZeroU32;
+
+use bytes::{Buf, BufMut};
+use commonware_codec::{Encode as _, EncodeSize, Read, Write};
+use commonware_cryptography::{
+    bls12381::{
+        dkg::feldman_desmedt::Output,
+        primitives::{
+            sharing::{ModeVersion, Sharing},
+            variant::MinSig,
+        },
+    },
+    ed25519::PublicKey,
+};
+use commonware_utils::ordered;
+
+/// A DKG outcome whose equality ignores the set of revealed players.
+#[derive(Clone, Debug)]
+pub(super) struct IgnoreRevealed(Output<MinSig, PublicKey>);
+
+impl IgnoreRevealed {
+    pub(super) fn public(&self) -> &Sharing<MinSig> {
+        self.0.public()
+    }
+
+    pub(super) fn players(&self) -> &ordered::Set<PublicKey> {
+        self.0.players()
+    }
+
+    pub(super) fn into_inner(self) -> Output<MinSig, PublicKey> {
+        self.0
+    }
+}
+
+impl From<Output<MinSig, PublicKey>> for IgnoreRevealed {
+    fn from(outcome: Output<MinSig, PublicKey>) -> Self {
+        Self(outcome)
+    }
+}
+
+impl PartialEq for IgnoreRevealed {
+    fn eq(&self, other: &Self) -> bool {
+        output_without_revealed(&self.0) == output_without_revealed(&other.0)
+    }
+}
+
+impl Eq for IgnoreRevealed {}
+
+impl Write for IgnoreRevealed {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.0.write(buf);
+    }
+}
+
+impl Read for IgnoreRevealed {
+    type Cfg = (NonZeroU32, ModeVersion);
+
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
+        Output::read_cfg(buf, cfg).map(Self)
+    }
+}
+
+impl EncodeSize for IgnoreRevealed {
+    fn encode_size(&self) -> usize {
+        self.0.encode_size()
+    }
+}
+
+fn output_without_revealed(outcome: &Output<MinSig, PublicKey>) -> Vec<u8> {
+    // `revealed` is the final field in `Output`'s canonical encoding, so this
+    // retains every other field, including the private transcript summary.
+    let mut encoded = outcome.encode().to_vec();
+    encoded.truncate(encoded.len() - outcome.revealed().encode_size());
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use commonware_codec::{Encode as _, EncodeSize as _, Read as _, Write as _};
+    use commonware_cryptography::{
+        Signer as _,
+        bls12381::{
+            dkg::feldman_desmedt::{self as dkg, Output},
+            primitives::{sharing::ModeVersion, variant::MinSig},
+        },
+        ed25519::PrivateKey,
+    };
+    use commonware_math::algebra::Random as _;
+    use commonware_utils::{N3f1, NZU32, TryFromIterator as _, ordered};
+    use rand::SeedableRng as _;
+
+    use super::IgnoreRevealed;
+
+    #[test]
+    fn equality_ignores_revealed_players() {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
+        let keys = (0..4)
+            .map(|_| PrivateKey::random(&mut rng))
+            .collect::<Vec<_>>();
+        let players = ordered::Set::try_from_iter(keys.iter().map(|key| key.public_key())).unwrap();
+        let (output, _) =
+            dkg::deal::<MinSig, _, N3f1>(&mut rng, Default::default(), players).unwrap();
+
+        let mut encoded = output.encode().to_vec();
+        encoded.truncate(encoded.len() - output.revealed().encode_size());
+        ordered::Set::try_from_iter([keys[0].public_key()])
+            .unwrap()
+            .write(&mut encoded);
+        let output_with_reveal =
+            Output::read_cfg(&mut encoded.as_slice(), &(NZU32!(4), ModeVersion::v0())).unwrap();
+
+        assert_eq!(
+            IgnoreRevealed::from(output),
+            IgnoreRevealed::from(output_with_reveal)
+        );
+    }
+}

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -57,7 +57,9 @@ use crate::{
     validators::{read_active_and_known_peers_at_block_hash, read_validator_config_at_block_hash},
 };
 
+mod ignore_revealed;
 mod state;
+use ignore_revealed::IgnoreRevealed;
 use state::State;
 
 use super::{
@@ -804,6 +806,7 @@ where
         let onchain_outcome =
             tempo_dkg_onchain_artifacts::OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
                 .expect("the last block of an epoch must contain the DKG outcome");
+        let onchain_output = IgnoreRevealed::from(onchain_outcome.output);
 
         info!("reading validator from contract");
 
@@ -854,7 +857,7 @@ where
                 match observe::<_, _, N3f1, ed25519::Batch>(ctx_mut, logs, &Sequential) {
                     Ok(output) => {
                         info!("local DKG ceremony was a success");
-                        (output, state::ShareState::Plaintext(None))
+                        (output.into(), state::ShareState::Plaintext(None))
                     }
                     Err(error) => {
                         warn!(
@@ -867,7 +870,7 @@ where
             }
         };
 
-        if local_output != onchain_outcome.output {
+        if local_output != onchain_output {
             let am_player = onchain_outcome
                 .next_players
                 .position(&self.config.me.public_key())
@@ -886,7 +889,7 @@ where
         // Because we use cached data, we need to check for DKG success here:
         // if the on-chain output is the same as the input into the loop (which
         // is just state.output), then we know the DKG failed.
-        if onchain_outcome.output == state.output {
+        if onchain_output == state.output {
             self.metrics.failures.metric().inc();
         } else {
             self.metrics.successes.metric().inc();
@@ -895,7 +898,7 @@ where
         Ok(Some(state::State {
             epoch: onchain_outcome.epoch,
             seed: Summary::random(self.context.as_present_mut()),
-            output: onchain_outcome.output.clone(),
+            output: onchain_output,
             share,
             players: onchain_outcome.next_players,
             is_full_dkg: onchain_outcome.is_next_full_dkg,
@@ -1190,7 +1193,7 @@ where
                     ) {
                         Ok(output) => {
                             info!("local DKG ceremony was a success");
-                            (output, state::ShareState::Plaintext(None))
+                            (output.into(), state::ShareState::Plaintext(None))
                         }
                         Err(error) => {
                             warn!(
@@ -1226,7 +1229,7 @@ where
             .response
             .send(OnchainDkgOutcome {
                 epoch: next_epoch,
-                output,
+                output: output.into_inner(),
                 next_players,
                 is_next_full_dkg: will_be_re_dkg,
             })
@@ -1305,7 +1308,7 @@ where
     Ok(State {
         epoch: onchain_outcome.epoch,
         seed: Summary::random(context),
-        output: onchain_outcome.output.clone(),
+        output: onchain_outcome.output.into(),
         share,
         players: onchain_outcome.next_players,
         is_full_dkg: onchain_outcome.is_next_full_dkg,

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
     Signer as _,
     bls12381::{
         dkg::feldman_desmedt::{
-            self as dkg, DealerPrivMsg, DealerPubMsg, Info, Output, PlayerAck, SignedDealerLog,
+            self as dkg, DealerPrivMsg, DealerPubMsg, Info, PlayerAck, SignedDealerLog,
         },
         primitives::{
             group::Share,
@@ -34,6 +34,8 @@ use tempo_primitives::TempoHeader;
 use tracing::{debug, info, instrument, warn};
 
 use crate::consensus::{Digest, block::Block};
+
+use super::IgnoreRevealed;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(1 << 12);
 const POOL_CAPACITY: NonZeroUsize = NZUsize!(1 << 13);
@@ -313,7 +315,7 @@ where
         &mut self,
         epoch: Epoch,
         digest: Digest,
-        output: Output<MinSig, PublicKey>,
+        output: IgnoreRevealed,
         share: ShareState,
     ) {
         self.cache
@@ -327,7 +329,7 @@ where
         &self,
         epoch: &Epoch,
         digest: &Digest,
-    ) -> Option<&(Output<MinSig, PublicKey>, ShareState)> {
+    ) -> Option<&(IgnoreRevealed, ShareState)> {
         self.cache
             .get(epoch)
             .and_then(|events| events.dkg_outcomes.get(digest))
@@ -648,7 +650,7 @@ impl Read for ShareState {
 pub(super) struct State {
     pub(super) epoch: Epoch,
     pub(super) seed: Summary,
-    pub(super) output: Output<MinSig, PublicKey>,
+    pub(super) output: IgnoreRevealed,
     pub(super) share: ShareState,
     pub(super) players: ordered::Set<PublicKey>,
     pub(super) is_full_dkg: bool,
@@ -708,7 +710,7 @@ impl Read for State {
     ) -> Result<Self, commonware_codec::Error> {
         let epoch = ReadExt::read(buf)?;
         let seed = ReadExt::read(buf)?;
-        let output = Read::read_cfg(buf, &(*cfg, ModeVersion::v0()))?;
+        let output: IgnoreRevealed = Read::read_cfg(buf, &(*cfg, ModeVersion::v0()))?;
         let share = ReadExt::read(buf)?;
         let players = Read::read_cfg(buf, &(RangeCfg::from(1..=(u16::MAX as usize)), ()))?;
 
@@ -748,7 +750,7 @@ struct Events {
     finalized: BTreeMap<Height, FinalizedBlockInfo>,
 
     notarized_blocks: HashMap<Digest, ReducedBlock>,
-    dkg_outcomes: HashMap<Digest, (Output<MinSig, PublicKey>, ShareState)>,
+    dkg_outcomes: HashMap<Digest, (IgnoreRevealed, ShareState)>,
 }
 
 impl Events {
@@ -1028,7 +1030,7 @@ impl Round {
         let previous_output = if state.is_full_dkg {
             None
         } else {
-            Some(state.output.clone())
+            Some(state.output.clone().into_inner())
         };
 
         let dealers = state.dealers().clone();
@@ -1146,9 +1148,10 @@ impl Player {
         rng: &mut impl rand_core::CryptoRng,
         logs: dkg::Logs<MinSig, PublicKey, N3f1>,
         strategy: &impl Strategy,
-    ) -> Result<(Output<MinSig, PublicKey>, Share), dkg::Error> {
+    ) -> Result<(IgnoreRevealed, Share), dkg::Error> {
         self.player
             .finalize::<N3f1, commonware_cryptography::ed25519::Batch>(rng, logs, strategy)
+            .map(|(outcome, share)| (outcome.into(), share))
     }
 }
 
@@ -1238,7 +1241,7 @@ mod tests {
         State {
             epoch: Epoch::new(epoch),
             seed: Summary::random(rng),
-            output,
+            output: output.into(),
             share: ShareState::Plaintext(None),
             players: pubkeys,
             is_full_dkg: false,


### PR DESCRIPTION
Wraps every Commonware DKG `Output` stored or compared by the DKG actor in `IgnoreRevealed`, so local/onchain equality ignores only the observer-dependent revealed-player set. Preserves codec behavior, delegates field access through getters, and adds a regression test.

Prompted by: @SuperFluffy