### PR TITLE
fix(evm): classify invalid subblock transactions as validation errors

### DIFF
--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -656,7 +656,7 @@ where
             let fee_recipient = *self
                 .subblock_fee_recipients
                 .get(&validator)
-                .ok_or(BlockExecutionError::msg("invalid subblock transaction"))?;
+                .ok_or_else(|| BlockValidationError::msg("invalid subblock transaction"))?;
 
             self.evm_mut().ctx_mut().block.beneficiary = fee_recipient;
         }
@@ -830,7 +830,7 @@ where
 mod tests {
     use super::*;
     use crate::test_utils::{TestExecutorBuilder, test_chainspec, test_evm};
-    use alloy_consensus::{Signed, TxLegacy};
+    use alloy_consensus::{Signed, TxLegacy, transaction::Recovered};
     use alloy_evm::{block::BlockExecutor, eth::receipt_builder::ReceiptBuilder};
     use alloy_primitives::{Bytes, Log, Signature, TxKind, address, bytes::BytesMut};
     use alloy_rlp::Encodable;
@@ -1407,6 +1407,26 @@ mod tests {
 
         let signature = TempoSignature::from(Signature::test_signature());
         TempoTxEnvelope::AA(tx.into_signed(signature))
+    }
+
+    #[test]
+    fn test_execute_transaction_t4_subblock_nonce_returns_validation_error() {
+        let chainspec = DEV.clone();
+        let mut db = State::builder().with_bundle_update().build();
+        let mut executor = TestExecutorBuilder::default()
+            .with_spec(TempoHardfork::T11)
+            .build(&mut db, &chainspec);
+
+        let proposer = PartialValidatorKey::from_slice(&[0xff; 15]);
+        let subblock_tx = create_subblock_tx(&proposer);
+        let recovered = Recovered::new_unchecked(subblock_tx, Address::ZERO);
+
+        let err = executor.execute_transaction(&recovered).unwrap_err();
+        assert!(
+            matches!(&err, BlockExecutionError::Validation(_)),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(err.to_string(), "invalid subblock transaction");
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

AA transactions with the reserved subblock nonce prefix can reach a missing fee-recipient lookup. This was classified as an internal execution error, causing malformed block input to be handled as a fatal node error instead of an invalid block.

## Solution

Return a block validation error when the subblock fee recipient is missing. Add regression coverage for the error classification.

Codex was used to help understand the existing code and assist with the implementation. I fully understand and manually reviewed the resulting changes.

## PR Checklist

- [x] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes
