### PR TITLE
test(primitives): generalize precompile activation checks

### DIFF
--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -222,12 +222,20 @@ mod tests {
 
     #[test]
     fn test_is_precompile_address() {
+        let latest = *TempoHardfork::VARIANTS
+            .last()
+            .expect("hardfork variants should not be empty");
+
         for &(address, activated) in SYSTEM_PRECOMPILES {
             assert!(address.is_precompile(activated));
-            assert!(address.is_precompile(TempoHardfork::T10));
+            assert!(address.is_precompile(latest));
 
-            if activated != TempoHardfork::Genesis {
-                assert!(!address.is_precompile(TempoHardfork::Genesis));
+            if let Some(index) = TempoHardfork::VARIANTS
+                .iter()
+                .position(|hardfork| *hardfork == activated)
+                && index > 0
+            {
+                assert!(!address.is_precompile(TempoHardfork::VARIANTS[index - 1]));
             }
         }
 


### PR DESCRIPTION
Uses the latest `TempoHardfork` variant instead of hardcoding T10 and verifies every system precompile is inactive immediately before its activation. This keeps the test current as new hardforks and precompiles are added.

Tested with:
- `cargo +nightly fmt --all -- --check`
- `cargo test -p tempo-primitives test_is_precompile_address --lib`