### PR TITLE
fix(txpool): revalidate transactions in place

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -18,8 +18,10 @@ use reth_chainspec::{ChainSpecProvider, EthChainSpec};
 use reth_primitives_traits::AlloyBlockHeader;
 use reth_provider::{CanonStateNotification, CanonStateSubscriptions, Chain, HeaderProvider};
 use reth_storage_api::StateProviderFactory;
-use reth_transaction_pool::{AllPoolTransactions, TransactionPool};
-use std::time::Instant;
+use reth_transaction_pool::{
+    AllPoolTransactions, TransactionPool, TransactionValidationOutcome, ValidPoolTransaction,
+};
+use std::{sync::Arc, time::Instant};
 use tempo_chainspec::hardfork::TempoHardforks;
 use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
 use tempo_precompiles::{
@@ -31,6 +33,110 @@ use tracing::{debug, error};
 /// Evict transactions this many seconds before they expire to reduce propagation
 /// of near-expiry transactions that are likely to fail validation on peers.
 const EVICTION_BUFFER_SECS: u64 = 3;
+
+/// Revalidates the selected entries without making them temporarily invisible to pool maintenance.
+///
+/// A validation result is only applied if it was produced while the canonical head stayed fixed
+/// and the exact pool entry is still current. Head changes retry against the new state; entry
+/// changes mean another pool operation already superseded this work.
+async fn revalidate_current_entries<Client, EvmConfig>(
+    pool: TempoTransactionPool<Client, EvmConfig>,
+    mut entries: Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+    reason: &'static str,
+) where
+    EvmConfig: ConfigureTempoPoolEvm,
+    Client: StateProviderFactory
+        + HeaderProvider<Header = TempoHeader>
+        + ChainSpecProvider<ChainSpec: EthChainSpec<Header = TempoHeader> + TempoHardforks>
+        + 'static,
+{
+    loop {
+        entries.retain(|expected| {
+            pool.get(expected.hash())
+                .is_some_and(|current| Arc::ptr_eq(&current, expected))
+        });
+        if entries.is_empty() {
+            return;
+        }
+
+        let validation_head = match pool.client().chain_info() {
+            Ok(info) => info.best_hash,
+            Err(err) => {
+                error!(target: "txpool", ?err, reason, "Failed to read revalidation head");
+                return;
+            }
+        };
+        let transactions = entries
+            .iter()
+            .map(|tx| (tx.origin, tx.transaction.with_discarded_caches()))
+            .collect();
+        let outcomes = pool.validate_transactions(transactions).await;
+
+        let current_head = match pool.client().chain_info() {
+            Ok(info) => info.best_hash,
+            Err(err) => {
+                error!(target: "txpool", ?err, reason, "Failed to verify revalidation head");
+                return;
+            }
+        };
+        if current_head != validation_head {
+            debug!(
+                target: "txpool",
+                ?validation_head,
+                ?current_head,
+                reason,
+                "Canonical head changed during revalidation; retrying"
+            );
+            continue;
+        }
+
+        let mut valid = 0usize;
+        let mut invalid = 0usize;
+        let mut errors = 0usize;
+        for (expected, outcome) in entries.into_iter().zip(outcomes) {
+            let is_current = || {
+                pool.get(expected.hash())
+                    .is_some_and(|current| Arc::ptr_eq(&current, &expected))
+            };
+            if !is_current() {
+                continue;
+            }
+
+            match outcome {
+                TransactionValidationOutcome::Valid { transaction, .. } => {
+                    expected
+                        .transaction
+                        .refresh_validation_caches_from(transaction.transaction());
+                    valid += 1;
+                }
+                TransactionValidationOutcome::Invalid(_, _) => {
+                    if is_current()
+                        && pool
+                            .remove_transactions(vec![*expected.hash()])
+                            .iter()
+                            .any(|removed| Arc::ptr_eq(removed, &expected))
+                    {
+                        invalid += 1;
+                    }
+                }
+                TransactionValidationOutcome::Error(_, err) => {
+                    errors += 1;
+                    debug!(target: "txpool", ?err, tx_hash = %expected.hash(), reason, "Transaction revalidation failed");
+                }
+            }
+        }
+
+        debug!(
+            target: "txpool",
+            valid,
+            invalid,
+            errors,
+            reason,
+            "Revalidated transactions in place"
+        );
+        return;
+    }
+}
 
 /// Aggregated block-level invalidation events for the transaction pool.
 ///
@@ -646,7 +752,7 @@ where
                 tokio::spawn(async move {
                     let txs: Vec<_> = paused_entries
                         .into_iter()
-                        .map(|e| e.tx.transaction.clone())
+                        .map(|e| e.tx.transaction.with_discarded_caches())
                         .collect();
 
                     let results = pool_clone.add_external_transactions(txs).await;
@@ -695,9 +801,9 @@ where
             .record(pause_start.elapsed());
 
         // 7. Handle potentially invalidating updates
-        // When a cached value changes of a token (transfer policy, or quote token) changes,
-        // pending transactions using that token may become invalid. We need to remove them
-        // and re-add so they go through full validation against the updated state.
+        // When a cached value of a token (transfer policy or quote token) changes, pending
+        // transactions using that token may become invalid. Revalidate copies while keeping the
+        // current entries visible so later maintenance events cannot miss them.
         for (updated, counter, reason) in [
             (
                 &updates.transfer_policy_updates,
@@ -714,7 +820,7 @@ where
                 continue;
             }
 
-            let hashes: Vec<TxHash> = {
+            let transactions: Vec<_> = {
                 let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
                 all_txs
                     .iter()
@@ -724,36 +830,15 @@ where
                             .resolved_fee_token()
                             .is_some_and(|t| updated.contains(&t))
                     })
-                    .map(|tx| *tx.hash())
+                    .cloned()
                     .collect()
             };
-            if !hashes.is_empty() {
-                let removed_txs = pool.remove_transactions(hashes);
-                let count = removed_txs.len();
-
-                for tx in &removed_txs {
-                    removed_this_iteration.insert(*tx.hash());
-                }
-
+            if !transactions.is_empty() {
+                let count = transactions.len();
                 counter.increment(count as u64);
 
                 let pool_clone = pool.clone();
-                tokio::spawn(async move {
-                    let txs: Vec<_> = removed_txs
-                        .into_iter()
-                        .map(|tx| (tx.origin, tx.transaction.clone()))
-                        .collect();
-
-                    let results = pool_clone.add_transactions_with_origins(txs).await;
-                    let success = results.iter().filter(|r| r.is_ok()).count();
-                    debug!(
-                        target: "txpool",
-                        total = count,
-                        success,
-                        reason,
-                        "Re-validated transactions"
-                    );
-                });
+                tokio::spawn(revalidate_current_entries(pool_clone, transactions, reason));
             }
         }
 

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -99,6 +99,17 @@ where
         self.protocol_pool.validator().validator().client()
     }
 
+    /// Validates transactions without inserting them into either subpool.
+    pub(crate) async fn validate_transactions(
+        &self,
+        transactions: Vec<(TransactionOrigin, TempoPooledTransaction)>,
+    ) -> Vec<TransactionValidationOutcome<TempoPooledTransaction>> {
+        self.protocol_pool
+            .validator()
+            .validate_transactions(transactions)
+            .await
+    }
+
     /// Updates the 2d nonce pool with the given state changes.
     ///
     /// Returns mined AA transactions.

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -14,6 +14,7 @@ use alloy_primitives::{
     Address, B256, Bytes, TxHash, TxKind, U256, bytes, keccak256, map::AddressMap,
 };
 use alloy_sol_types::SolInterface;
+use parking_lot::RwLock;
 use reth_evm::execute::WithTxEnv;
 use reth_primitives_traits::{InMemorySize, Recovered, SignerRecoverable};
 use reth_transaction_pool::{
@@ -43,7 +44,7 @@ use thiserror::Error;
 /// Tempo pooled transaction representation.
 ///
 /// This is a wrapper around the regular ethereum [`EthPooledTransaction`], but with tempo specific implementations.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TempoPooledTransaction {
     inner: EthPooledTransaction<TempoTxEnvelope>,
     /// Cached cost of the transaction in the fee token.
@@ -58,25 +59,39 @@ pub struct TempoPooledTransaction {
     expiring_nonce_slot: OnceLock<Option<U256>>,
     /// Cached prepared [`TempoTxEnv`] for payload building.
     tx_env: OnceLock<TempoTxEnv>,
-    /// Keychain key expiry timestamp (set during validation for keychain-signed txs).
-    ///
-    /// `Some(expiry)` for keychain transactions where expiry < u64::MAX (finite expiry).
-    /// `None` for non-keychain transactions or keys that never expire.
-    key_expiry: OnceLock<Option<u64>>,
-    /// Resolved fee token cached at validation time.
-    ///
-    /// Used by `keychain_subject()` so pool maintenance matches against the same token
-    /// that was validated without requiring state access.
-    resolved_fee_token: OnceLock<Address>,
-    /// Cached keychain subject for the signer of an inline `KeyAuthorization`.
-    key_authorization_signer_subject: OnceLock<Option<KeychainSubject>>,
+    /// State-derived values populated during pool validation.
+    validation_caches: RwLock<ValidationCaches>,
     /// Cached target key of an inline `KeyAuthorization`.
     key_authorization_target_subject: OnceLock<Option<KeyAuthorizationTargetSubject>>,
+}
+
+impl Clone for TempoPooledTransaction {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            fee_token_cost: self.fee_token_cost,
+            is_payment: self.is_payment,
+            expiring_nonce_hash: self.expiring_nonce_hash,
+            nonce_key_slot: self.nonce_key_slot.clone(),
+            expiring_nonce_slot: self.expiring_nonce_slot.clone(),
+            tx_env: self.tx_env.clone(),
+            validation_caches: RwLock::new(self.validation_caches.read().clone()),
+            key_authorization_target_subject: self.key_authorization_target_subject.clone(),
+        }
+    }
+}
+
+/// State-derived transaction metadata that must be refreshed together after revalidation.
+#[derive(Debug, Clone, Default)]
+struct ValidationCaches {
+    /// Keychain key expiry timestamp. The outer option distinguishes uncached from no expiry.
+    key_expiry: Option<Option<u64>>,
+    /// Resolved fee token cached at validation time.
+    resolved_fee_token: Option<Address>,
+    /// Cached keychain subject for the signer of an inline `KeyAuthorization`.
+    key_authorization_signer_subject: Option<Option<KeychainSubject>>,
     /// Cached TIP20 balance storage slot for the fee payer.
-    ///
-    /// Stores `(fee_token, balance_slot)` so the payload builder's state-aware iterator
-    /// can check if the fee payer's balance was modified without recomputing the keccak.
-    fee_balance_slot: OnceLock<Option<(Address, U256)>>,
+    fee_balance_slot: Option<Option<(Address, U256)>>,
 }
 
 impl TempoPooledTransaction {
@@ -122,11 +137,8 @@ impl TempoPooledTransaction {
             nonce_key_slot: OnceLock::new(),
             expiring_nonce_slot: OnceLock::new(),
             tx_env: OnceLock::new(),
-            key_expiry: OnceLock::new(),
-            resolved_fee_token: OnceLock::new(),
-            key_authorization_signer_subject: OnceLock::new(),
+            validation_caches: RwLock::new(ValidationCaches::default()),
             key_authorization_target_subject: OnceLock::new(),
-            fee_balance_slot: OnceLock::new(),
         }
     }
 
@@ -218,7 +230,15 @@ impl TempoPooledTransaction {
     /// Used for revocation matching: if the access key that signed an inline authorization is
     /// revoked while the transaction is still in the pool, the transaction must be revalidated.
     pub fn key_authorization_signer_subject(&self) -> Option<KeychainSubject> {
-        *self.key_authorization_signer_subject.get_or_init(|| {
+        if let Some(subject) = self
+            .validation_caches
+            .read()
+            .key_authorization_signer_subject
+        {
+            return subject;
+        }
+
+        let subject = (|| {
             let aa_tx = self.inner().as_aa()?;
             let key_authorization = aa_tx.tx().key_authorization.as_ref()?;
             let key_id = key_authorization.recover_signer().ok()?;
@@ -232,7 +252,12 @@ impl TempoPooledTransaction {
                 key_id,
                 fee_token,
             })
-        })
+        })();
+
+        let mut caches = self.validation_caches.write();
+        *caches
+            .key_authorization_signer_subject
+            .get_or_insert(subject)
     }
 
     /// Extracts the target key of an inline `KeyAuthorization`.
@@ -348,7 +373,10 @@ impl TempoPooledTransaction {
     /// Pass `Some(expiry)` for keys with finite expiry, `None` for non-keychain txs
     /// or keys that never expire.
     pub fn set_key_expiry(&self, expiry: Option<u64>) {
-        let _ = self.key_expiry.set(expiry);
+        self.validation_caches
+            .write()
+            .key_expiry
+            .get_or_insert(expiry);
     }
 
     /// Returns the keychain key expiry timestamp, if set during validation.
@@ -356,7 +384,7 @@ impl TempoPooledTransaction {
     /// Returns `Some(expiry)` for keychain transactions with finite expiry.
     /// Returns `None` if not a keychain tx, key never expires, or not yet validated.
     pub fn key_expiry(&self) -> Option<u64> {
-        self.key_expiry.get().copied().flatten()
+        self.validation_caches.read().key_expiry.flatten()
     }
 
     /// Returns whether the transaction or its signing key expires by `cutoff`.
@@ -374,7 +402,23 @@ impl TempoPooledTransaction {
     /// transaction's explicit `fee_token` field or from fee-manager state. Pool
     /// maintenance code should not call this directly.
     pub fn set_resolved_fee_token(&self, fee_token: Address) {
-        let _ = self.resolved_fee_token.set(fee_token);
+        self.validation_caches
+            .write()
+            .resolved_fee_token
+            .get_or_insert(fee_token);
+    }
+
+    /// Clones this transaction without state derived by an earlier validation.
+    pub(crate) fn with_discarded_caches(&self) -> Self {
+        let mut transaction = self.clone();
+        transaction.validation_caches = RwLock::new(ValidationCaches::default());
+        transaction
+    }
+
+    /// Atomically replaces state-derived caches with values from a fresh validation.
+    pub(crate) fn refresh_validation_caches_from(&self, fresh: &Self) {
+        let fresh = fresh.validation_caches.read().clone();
+        *self.validation_caches.write() = fresh;
     }
 
     /// Returns the fee token cached during transaction validation, if available.
@@ -383,7 +427,7 @@ impl TempoPooledTransaction {
     /// the pool validator. Prefer [`Self::effective_fee_token`] in maintenance code
     /// that needs the token a transaction will actually use to pay fees.
     pub fn resolved_fee_token(&self) -> Option<Address> {
-        self.resolved_fee_token.get().copied()
+        self.validation_caches.read().resolved_fee_token
     }
 
     /// Returns the effective fee token for pool maintenance and accounting.
@@ -402,14 +446,21 @@ impl TempoPooledTransaction {
     /// Returns the `(fee_token, balance_slot)` pair for this transaction's fee payer,
     /// lazily computed and cached on first access.
     pub fn fee_balance_slot(&self) -> Option<(Address, U256)> {
-        *self.fee_balance_slot.get_or_init(|| {
+        if let Some(slot) = self.validation_caches.read().fee_balance_slot {
+            return slot;
+        }
+
+        let slot = (|| {
             let fee_token = self
                 .resolved_fee_token()
                 .unwrap_or_else(|| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN));
             let fee_payer = self.fee_payer().ok()?;
             let slot = TIP20Token::from_address_unchecked(fee_token).balances[fee_payer].slot();
             Some((fee_token, slot))
-        })
+        })();
+
+        let mut caches = self.validation_caches.write();
+        *caches.fee_balance_slot.get_or_insert(slot)
     }
 
     /// Returns true when the transaction fee is paid by the transaction sender.
@@ -960,6 +1011,37 @@ mod tests {
         let pooled = <TempoPooledTransaction as PoolTransaction>::recover_raw_transaction(&raw)
             .expect("raw transaction recovery failed");
         (pooled, envelope, sender, encoded_length)
+    }
+
+    #[test]
+    fn revalidation_caches_are_discarded_and_refreshed_atomically() {
+        let original = TxBuilder::aa(Address::random())
+            .nonce_key(U256::from(42))
+            .build();
+        let old_fee_token = address!("20C0000000000000000000000000000000000002");
+        let new_fee_token = address!("20C0000000000000000000000000000000000003");
+
+        let nonce_key_slot = original.nonce_key_slot();
+        let _ = original.tx_env();
+        original.set_key_expiry(Some(100));
+        original.set_resolved_fee_token(old_fee_token);
+        let old_balance_slot = original.fee_balance_slot();
+
+        let fresh = original.with_discarded_caches();
+        assert_eq!(fresh.nonce_key_slot(), nonce_key_slot);
+        assert!(fresh.cached_tx_env().is_some());
+        assert_eq!(fresh.key_expiry(), None);
+        assert_eq!(fresh.resolved_fee_token(), None);
+
+        fresh.set_key_expiry(Some(200));
+        fresh.set_resolved_fee_token(new_fee_token);
+        let new_balance_slot = fresh.fee_balance_slot();
+        assert_ne!(new_balance_slot, old_balance_slot);
+
+        original.refresh_validation_caches_from(&fresh);
+        assert_eq!(original.key_expiry(), Some(200));
+        assert_eq!(original.resolved_fee_token(), Some(new_fee_token));
+        assert_eq!(original.fee_balance_slot(), new_balance_slot);
     }
 
     #[test]


### PR DESCRIPTION
Keeps transfer-policy and quote-token revalidation candidates visible in the pool so later pause maintenance cannot miss them. Revalidation retries when the canonical head changes, applies results only to the same `Arc` entry, atomically refreshes grouped validation caches on success, and removes the entry only when validation rejects it.

Validated with `cargo test -p tempo-transaction-pool --lib` and strict Clippy for all transaction-pool targets.
