### PR TITLE
refactor(revm): isolate signature gas accounting

### DIFF
--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -28,10 +28,7 @@ use revm::{
     inspector::{Inspector, InspectorHandler},
     interpreter::{
         CallOutcome, CreateOutcome, FrameInput, Gas, InitialAndFloorGas,
-        gas::{
-            COLD_SLOAD_COST, STANDARD_TOKEN_COST, WARM_SSTORE_RESET,
-            get_tokens_in_calldata_istanbul,
-        },
+        gas::{COLD_SLOAD_COST, WARM_SSTORE_RESET, get_tokens_in_calldata_istanbul},
         interpreter::EthInterpreter,
     },
     precompile::PrecompileError,
@@ -58,8 +55,7 @@ use tempo_precompiles::{
 use tempo_primitives::{
     TempoAddressExt,
     transaction::{
-        PrimitiveSignature, SignatureType, TEMPO_EXPIRING_NONCE_KEY, TempoSignature,
-        calc_gas_balance_spending, validate_calls,
+        SignatureType, TEMPO_EXPIRING_NONCE_KEY, calc_gas_balance_spending, validate_calls,
     },
 };
 
@@ -68,14 +64,8 @@ use crate::{
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
     gas_credits,
+    signature_gas::{primitive_signature_verification_gas, tempo_signature_verification_gas},
 };
-
-/// Additional gas for P256 signature verification
-/// P256 precompile cost (6900 from EIP-7951) + 1100 for 129 bytes extra signature size - ecrecover savings (3000)
-const P256_VERIFY_GAS: u64 = 5_000;
-
-/// Additional gas for Keychain signatures (key validation overhead: COLD_SLOAD_COST + 900 processing)
-const KEYCHAIN_VALIDATION_GAS: u64 = COLD_SLOAD_COST + 900;
 
 /// Base gas for KeyAuthorization (22k storage + 5k buffer), signature gas added at runtime
 const KEY_AUTH_BASE_GAS: u64 = 27_000;
@@ -108,39 +98,6 @@ const KEY_AUTH_EXTRA_EVENT_BUFFER: u64 = 1_500;
 ///
 /// Total: 2*2100 + 100 + 3*2900 = 13,000 gas
 pub const EXPIRING_NONCE_GAS: u64 = 2 * COLD_SLOAD_COST + 100 + 3 * WARM_SSTORE_RESET;
-
-/// Calculates the gas cost for verifying a primitive signature.
-///
-/// Returns the additional gas required beyond the base transaction cost:
-/// - Secp256k1: 0 (already included in base 21k)
-/// - P256: 5000 gas
-/// - WebAuthn: 5000 gas + calldata cost for webauthn_data
-#[inline]
-fn primitive_signature_verification_gas(signature: &PrimitiveSignature) -> u64 {
-    match signature {
-        PrimitiveSignature::Secp256k1(_) => 0,
-        PrimitiveSignature::P256(_) => P256_VERIFY_GAS,
-        PrimitiveSignature::WebAuthn(webauthn_sig) => {
-            let tokens = get_tokens_in_calldata_istanbul(&webauthn_sig.webauthn_data);
-            P256_VERIFY_GAS + tokens * STANDARD_TOKEN_COST
-        }
-    }
-}
-
-/// Calculates the gas cost for verifying an AA signature.
-///
-/// For Keychain signatures, adds key validation overhead to the inner signature cost
-/// Returns the additional gas required beyond the base transaction cost.
-#[inline]
-fn tempo_signature_verification_gas(signature: &TempoSignature) -> u64 {
-    match signature {
-        TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
-        TempoSignature::Keychain(keychain_sig) => {
-            // Keychain = inner signature + key validation overhead (SLOAD + processing)
-            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
-        }
-    }
-}
 
 #[derive(Debug, Clone)]
 struct LoadedTxAccessKey {

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::{
     FeeTokenResolver, ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoTxEnv,
-    evm::TempoEvm, gas_params::tempo_gas_params, tx::TempoBatchCallEnv,
+    evm::TempoEvm, gas_params::tempo_gas_params, signature_gas::P256_VERIFY_GAS,
+    tx::TempoBatchCallEnv,
 };
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
 use proptest::prelude::*;
@@ -23,7 +24,8 @@ use tempo_precompiles::{
     tip_fee_manager::TipFeeManager,
 };
 use tempo_primitives::transaction::{
-    Call, RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
+    Call, PrimitiveSignature, RecoveredTempoAuthorization, TempoSignature,
+    TempoSignedAuthorization,
     tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
 };
 

--- a/crates/revm/src/lib.rs
+++ b/crates/revm/src/lib.rs
@@ -17,6 +17,7 @@ pub mod gas_credits;
 pub mod gas_params;
 pub mod handler;
 mod instructions;
+mod signature_gas;
 mod tx;
 
 pub use error::{TempoHaltReason, TempoInvalidTransaction};

--- a/crates/revm/src/signature_gas.rs
+++ b/crates/revm/src/signature_gas.rs
@@ -1,0 +1,45 @@
+use revm::interpreter::gas::{
+    COLD_SLOAD_COST, STANDARD_TOKEN_COST, get_tokens_in_calldata_istanbul,
+};
+use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
+
+/// Additional gas for P256 signature verification.
+///
+/// This includes the P256 precompile cost, the extra signature calldata, and the ecrecover savings
+/// already included in the base transaction cost.
+pub(crate) const P256_VERIFY_GAS: u64 = 5_000;
+
+/// Additional gas for keychain signatures (key validation overhead: cold SLOAD + processing).
+const KEYCHAIN_VALIDATION_GAS: u64 = COLD_SLOAD_COST + 900;
+
+/// Calculates the gas cost for verifying a primitive signature.
+///
+/// Returns the additional gas required beyond the base transaction cost:
+/// - Secp256k1: 0 (already included in base 21k)
+/// - P256: 5000 gas
+/// - WebAuthn: 5000 gas + calldata cost for `webauthn_data`
+#[inline]
+pub(crate) fn primitive_signature_verification_gas(signature: &PrimitiveSignature) -> u64 {
+    match signature {
+        PrimitiveSignature::Secp256k1(_) => 0,
+        PrimitiveSignature::P256(_) => P256_VERIFY_GAS,
+        PrimitiveSignature::WebAuthn(webauthn_sig) => {
+            let tokens = get_tokens_in_calldata_istanbul(&webauthn_sig.webauthn_data);
+            P256_VERIFY_GAS + tokens * STANDARD_TOKEN_COST
+        }
+    }
+}
+
+/// Calculates the gas cost for verifying an AA signature.
+///
+/// For keychain signatures, adds key validation overhead to the inner signature cost. Returns the
+/// additional gas required beyond the base transaction cost.
+#[inline]
+pub(crate) fn tempo_signature_verification_gas(signature: &TempoSignature) -> u64 {
+    match signature {
+        TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
+        TempoSignature::Keychain(keychain_sig) => {
+            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
+        }
+    }
+}


### PR DESCRIPTION
Moves existing primitive and keychain signature gas calculations out of `handler.rs` into a dedicated internal module without changing gas values or public behavior. This leaves the handler focused on orchestration and makes additional signature schemes easier to add. Extracted while reviewing #4069.