### PR TITLE
docs(tip-1096): clarify activation transition

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -336,11 +336,12 @@ ZoneInbox.processedTokenEnablementHash == ZonePortal.tokenEnablementHash
 ZonePortal.enabledTokenCount            == N
 ```
 
-The activation state transition initializes the Zone's
-`processedEnabledTokenCount` to `N` before executing the first block. For this
-one batch, `TokenEnablementTransition.prevProcessedTokenCount` MUST equal `N`,
-and the verifier treats it as the previous settled count instead of requiring an
-initialized portal cursor.
+The activation state transition internally derives `N` and initializes the
+Zone's `processedEnabledTokenCount` to `N` before executing the first block. For
+this one batch, `TokenEnablementTransition.prevProcessedTokenCount` MUST remain
+the physical pre-state value `0`; the proof authenticates `N` internally before
+processing the outstanding suffix. The verifier treats an uninitialized portal
+cursor as the activation case instead of requiring ordinary count continuity.
 
 The proof MUST additionally verify against the full block's final imported Tempo
 root that both outstanding-work bounds hold:


### PR DESCRIPTION
Clarify the TIP-1096 token-enablement cursor initialization semantics. The activation transition derives `N` internally while `TokenEnablementTransition.prevProcessedTokenCount` retains its physical pre-state value of zero, and the verifier recognizes an uninitialized portal cursor as the activation case.

Without this clarification, the pre-state `prevProcessedTokenCount` would have been equal to `N`, which is not correct, because in the transition batch it can't be anything but zero.