### PR TITLE
docs(tip-1096): allow only full block batches and specify events

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -139,7 +139,7 @@ Tempo leader. No historical or current Tempo leader is designated for a
 header-only block, and leadership changes within or after its imported range do
 not affect its validity.
 
-A header-only chain is authorized only as part of a batch ending in a full block.
+A header-only chain is authorized only as part of a batch that ends with a block that calls `advanceTempo()` to process incoming queues and does not contain any further `advanceTempoHeaders()` calls that aren't followed by an `advanceTempo()` call.
 The existing threshold settlement certificate commits to the Zone height and
 `BlockTransition`, whose `nextBlockHash` transitively commits to every
 header-only block in that batch, including their beneficiaries. Quorum members

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -397,6 +397,64 @@ verifier checks that the value matches the proven batch shape, and successful
 settlement assigns the portal index to that value instead of unconditionally
 incrementing it.
 
+### Events
+
+Z1 extends `ZoneInbox.TempoAdvanced` with the cumulative token-enablement cursor
+after the full import:
+
+```solidity
+event TempoAdvanced(
+    bytes32 indexed tempoBlockHash,
+    uint64 indexed tempoBlockNumber,
+    uint256 depositsProcessed,
+    bytes32 newProcessedDepositQueueHash,
+    uint64 lastProcessedDepositNumber,
+    uint64 lastProcessedEnabledTokenCount
+);
+```
+
+`lastProcessedEnabledTokenCount` MUST equal the post-execution value of
+`ZoneInbox.processedEnabledTokenCount`. It is cumulative. After activation has
+initialized the cursor, the number of token enablements processed by a call is
+the difference from the preceding full block's value. The first post-activation
+value also incorporates the authenticated migration prefix `N` described above.
+A full import emits `TempoAdvanced` even when neither deposits nor token
+enablements were processed.
+
+T11 likewise extends `ZonePortal.BatchSubmitted` with the cumulative cursor
+accepted by settlement:
+
+```solidity
+event BatchSubmitted(
+    uint64 indexed withdrawalBatchIndex,
+    uint256 indexed withdrawalQueueIndex,
+    bytes32 nextProcessedDepositQueueHash,
+    bytes32 nextBlockHash,
+    bytes32 withdrawalQueueHash,
+    uint64 lastProcessedDepositNumber,
+    uint64 lastProcessedEnabledTokenCount
+);
+```
+
+`lastProcessedEnabledTokenCount` MUST equal the portal's post-settlement value
+and the accepted `TokenEnablementTransition.nextProcessedTokenCount`. A
+header-only settlement emits `BatchSubmitted` with an unchanged token count,
+the current `withdrawalBatchIndex`, `withdrawalQueueHash = bytes32(0)`, and the
+sentinel no-queue index defined by the portal ABI.
+
+Before the coordinated T11/Z1 activation, `TempoAdvanced` and `BatchSubmitted`
+retain their legacy signatures without `lastProcessedEnabledTokenCount`.
+Because appending a field changes an event's signature hash, indexers and
+settlement tooling that span the activation boundary MUST recognize both the
+legacy and post-activation signatures and select the decoder by topic.
+
+No other event signature changes. `advanceTempoHeaders` emits no
+`TempoAdvanced`; its only checkpoint event is the existing single
+`TempoBlockFinalized` for the final imported header. A header-only block emits
+no `BatchFinalized`, while settlement of a header-only batch still emits the
+post-activation `BatchSubmitted` described above. Deposit, withdrawal, and
+token-enablement lifecycle event signatures remain unchanged.
+
 ## Activation and Compatibility
 
 This TIP activates through the coordinated T11 Tempo upgrade and Z1 Zone

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -323,9 +323,10 @@ When T11 replaces the T10 portal runtime, the new
 `tokenEnablementCursorInitialized` storage slot is false. This flag serves as the
 in-contract T11 activation gate for the new token cursor; it does not disable
 unrelated T11 functionality. While it is false, the portal MUST reject new token
-enablements and MUST reject settlement of a header-only batch. The first
-post-activation batch MUST use operational settlement, though it MAY contain
-header-only recovery blocks before its final full block.
+enablements. Header-only Zone blocks MAY advance the local checkpoint during
+recovery, but they MUST NOT be settled as a standalone batch while the cursor is
+uninitialized. They may only form a prefix of the first post-activation batch,
+which MUST end in a full block and use operational settlement.
 
 The first post-activation proof supplies a count `N` and authenticates the Tempo
 header stored in the parent Zone state. Against that header's state root, it MUST
@@ -352,9 +353,16 @@ ZonePortal.depositCount
     <= MAX_UNPROCESSED_DEPOSITS
 
 ZonePortal.enabledTokenCount
-    - TokenEnablementTransition.prevProcessedTokenCount
+    - N
     <= MAX_UNPROCESSED_TOKEN_ENABLEMENTS
 ```
+
+For this activation batch, `N` is the effective previous processed-token count
+for the outstanding-work bound even though
+`TokenEnablementTransition.prevProcessedTokenCount` remains the physical Zone
+pre-state value `0`. Subsequent batches use the transition's ordinary previous
+count. The activation batch's next count includes `N` and the complete suffix
+processed by its final full block.
 
 Only after accepting a proof that satisfies these checks does `submitBatch` set
 `lastProcessedEnabledTokenCount` to the transition's next count and set

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -437,10 +437,18 @@ event BatchSubmitted(
 ```
 
 `lastProcessedEnabledTokenCount` MUST equal the portal's post-settlement value
-and the accepted `TokenEnablementTransition.nextProcessedTokenCount`. A
-header-only settlement emits `BatchSubmitted` with an unchanged token count,
-the current `withdrawalBatchIndex`, `withdrawalQueueHash = bytes32(0)`, and the
-sentinel no-queue index defined by the portal ABI.
+and the accepted `TokenEnablementTransition.nextProcessedTokenCount`. For a
+header-only settlement, `BatchSubmitted` MUST emit the current unchanged
+`withdrawalBatchIndex`, `withdrawalQueueIndex = NO_QUEUE_INDEX`
+(`type(uint256).max`), the unchanged `nextProcessedDepositQueueHash`, the newly
+settled `nextBlockHash`, `withdrawalQueueHash = bytes32(0)`, and the unchanged
+`lastProcessedDepositNumber` and `lastProcessedEnabledTokenCount`.
+
+`NO_QUEUE_INDEX` means that the settlement created no withdrawal queue entry.
+Consumers MUST NOT create or overwrite a withdrawal queue record for such an
+event. `withdrawalBatchIndex` is a withdrawal-batch cursor and MAY repeat across
+header-only events; consumers MUST NOT use it as a unique event identifier or
+withdrawal queue key.
 
 Before the coordinated T11/Z1 activation, `TempoAdvanced` and `BatchSubmitted`
 retain their legacy signatures without `lastProcessedEnabledTokenCount`.

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -352,16 +352,9 @@ ZonePortal.depositCount
     <= MAX_UNPROCESSED_DEPOSITS
 
 ZonePortal.enabledTokenCount
-    - N
+    - TokenEnablementTransition.prevProcessedTokenCount
     <= MAX_UNPROCESSED_TOKEN_ENABLEMENTS
 ```
-
-For this activation batch, `N` is the effective previous processed-token count
-for the outstanding-work bound even though
-`TokenEnablementTransition.prevProcessedTokenCount` remains the physical Zone
-pre-state value `0`. Subsequent batches use the transition's ordinary previous
-count. The activation batch's next count includes `N` and the complete suffix
-processed by its final full block.
 
 Only after accepting a proof that satisfies these checks does `submitBatch` set
 `lastProcessedEnabledTokenCount` to the transition's next count and set

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -352,9 +352,16 @@ ZonePortal.depositCount
     <= MAX_UNPROCESSED_DEPOSITS
 
 ZonePortal.enabledTokenCount
-    - TokenEnablementTransition.prevProcessedTokenCount
+    - N
     <= MAX_UNPROCESSED_TOKEN_ENABLEMENTS
 ```
+
+For this activation batch, `N` is the effective previous processed-token count
+for the outstanding-work bound even though
+`TokenEnablementTransition.prevProcessedTokenCount` remains the physical Zone
+pre-state value `0`. Subsequent batches use the transition's ordinary previous
+count. The activation batch's next count includes `N` and the complete suffix
+processed by its final full block.
 
 Only after accepting a proof that satisfies these checks does `submitBatch` set
 `lastProcessedEnabledTokenCount` to the transition's next count and set

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -139,7 +139,17 @@ Tempo leader. No historical or current Tempo leader is designated for a
 header-only block, and leadership changes within or after its imported range do
 not affect its validity.
 
-A header-only chain is authorized only as part of a batch that ends with a block that calls `advanceTempo()` to process incoming queues and does not contain any further `advanceTempoHeaders()` calls that aren't followed by an `advanceTempo()` call.
+Leader authority resumes at the final full block. That block MUST be produced by
+the leader effective for the Tempo header imported by its `advanceTempo` call.
+Therefore, if a header-only prefix crosses from leader A to leader B and the
+final full block imports a header governed by B, B MUST produce the final full
+block. The batch certificate commits transitively to all preceding leader-neutral
+header-only blocks.
+
+A header-only chain is authorized only as part of a batch that ends with a block
+that calls `advanceTempo()` to process incoming queues and does not contain any
+further `advanceTempoHeaders()` calls that aren't followed by an `advanceTempo()` call.
+
 The existing threshold settlement certificate commits to the Zone height and
 `BlockTransition`, whose `nextBlockHash` transitively commits to every
 header-only block in that batch, including their beneficiaries. Quorum members

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -139,19 +139,21 @@ Tempo leader. No historical or current Tempo leader is designated for a
 header-only block, and leadership changes within or after its imported range do
 not affect its validity.
 
-A header-only chain is authorized through the existing threshold settlement
-certificate. The certificate commits to the Zone height and `BlockTransition`,
-whose `nextBlockHash` transitively commits to every header-only block, including
-its beneficiary. Quorum members MUST validate the complete header-only block
-sequence before signing, but they do not verify a Tempo-derived producer for
-those blocks. The certificate therefore selects an exact transition rather than
-attesting that a particular Tempo leader produced it.
+A header-only chain is authorized only as part of a batch ending in a full block.
+The existing threshold settlement certificate commits to the Zone height and
+`BlockTransition`, whose `nextBlockHash` transitively commits to every
+header-only block in that batch, including their beneficiaries. Quorum members
+MUST validate the complete block sequence before signing, but they do not verify
+a Tempo-derived producer for the header-only blocks. The certificate therefore
+selects an exact transition rather than attesting that a particular Tempo leader
+produced those blocks.
 
-Any active sequencer may construct, propose, relay, or submit the certified
-transition. A candidate header-only chain is not canonical merely because of its
-sender. It becomes canonical when `submitBatch` accepts its threshold certificate
-and its `prevBlockHash` matches the portal's settled tip. Once accepted, portal
-tip continuity rejects every conflicting transition from that tip.
+Any active sequencer may construct, propose, or relay a candidate header-only
+chain. It is not independently settlement-canonical and MUST NOT be submitted as
+a standalone batch. It becomes settlement-canonical only when `submitBatch`
+accepts the batch ending in its full block and the batch's `prevBlockHash`
+matches the portal's settled tip. Once accepted, portal tip continuity rejects
+every conflicting transition from that tip.
 
 This rule deliberately makes header-only coordination depend on the configured
 settlement threshold. In a one-of-one configuration, the sole sequencer chooses
@@ -177,27 +179,16 @@ user transaction execution and withdrawal finalization are unchanged.
 
 ## Batch Settlement
 
-Settlement behavior is derived from the proven block sequence. A settleable batch
-either contains only header-only blocks or ends in a full block. A batch that
-contains a full block but does not end in one is invalid.
+Every settleable batch MUST end in a full block. A batch containing only
+header-only blocks is invalid, as is any mixed batch whose final block is
+header-only.
 
-A header-only batch exposes identity deposit and `TokenEnablementTransition`
-values. Its public withdrawal queue hash is zero, and the verifier checks that
-`ZoneOutbox.lastBatch` is unchanged instead of copying that storage value into
-the public withdrawal output. The portal MUST NOT increment
-`withdrawalBatchIndex`; it updates only its settled Zone block hash,
-`lastSyncedTempoBlockNumber`, and Zone height.
-
-Its settlement certificate authorizes the exact header-only block transition as
-specified above; neither the proof nor `submitBatch` performs a separate leader
-or beneficiary check for that transition.
-
-A batch ending in a full block follows the existing operational settlement rules,
-including `finalizeWithdrawalBatch` in its final block. The proof exposes the
-resulting withdrawal batch index: it equals the portal's current index for a
-header-only batch and exactly the next index for an operational batch. The
-settlement attestation binds this index with the existing batch outputs; any
-other index or block shape is invalid.
+The final full block follows the existing operational settlement rules,
+including `finalizeWithdrawalBatch`. The proof exposes exactly the next
+withdrawal batch index, and the settlement attestation binds that index with the
+existing batch outputs. The certificate's block transition commits transitively
+to every preceding header-only block in the batch; neither the proof nor
+`submitBatch` performs a separate leader or beneficiary check for those blocks.
 
 ## Bootstrap
 
@@ -312,8 +303,8 @@ The proof requires the Zone pre-state `processedEnabledTokenCount` to equal
 `prevProcessedTokenCount`, verifies every newly processed array entry in order,
 and requires the Zone post-state count to equal `nextProcessedTokenCount`. For
 each full block, the resulting Zone count MUST equal `enabledTokenCount` at that
-block's final imported Tempo root. A header-only block advances neither count,
-and a header-only batch therefore exposes an identity transition.
+block's final imported Tempo root. A header-only block advances neither count
+and contributes an identity step to its containing batch transition.
 
 After accepting the proof, `submitBatch` sets
 `lastProcessedEnabledTokenCount` to `nextProcessedTokenCount`. Skipping,
@@ -324,9 +315,9 @@ When T11 replaces the T10 portal runtime, the new
 in-contract T11 activation gate for the new token cursor; it does not disable
 unrelated T11 functionality. While it is false, the portal MUST reject new token
 enablements. Header-only Zone blocks MAY advance the local checkpoint during
-recovery, but they MUST NOT be settled as a standalone batch while the cursor is
-uninitialized. They may only form a prefix of the first post-activation batch,
-which MUST end in a full block and use operational settlement.
+recovery, but they are not settlement boundaries. They may only form a prefix of
+the first post-activation batch, which MUST end in a full block and use
+operational settlement.
 
 The first post-activation proof supplies a count `N` and authenticates the Tempo
 header stored in the parent Zone state. Against that header's state root, it MUST
@@ -398,13 +389,6 @@ a public output. The settlement attestation commits to
 deposit-transition commitment, so a certificate cannot be reused with different
 token counts.
 
-`ZonePortal.submitBatch` adds a `resultingWithdrawalBatchIndex` parameter and
-passes it to the verifier. The existing settlement-attestation field binds that
-value. The portal accepts only its current index or exactly the next index, the
-verifier checks that the value matches the proven batch shape, and successful
-settlement assigns the portal index to that value instead of unconditionally
-incrementing it.
-
 ### Events
 
 Z1 extends `ZoneInbox.TempoAdvanced` with the cumulative token-enablement cursor
@@ -445,18 +429,12 @@ event BatchSubmitted(
 ```
 
 `lastProcessedEnabledTokenCount` MUST equal the portal's post-settlement value
-and the accepted `TokenEnablementTransition.nextProcessedTokenCount`. For a
-header-only settlement, `BatchSubmitted` MUST emit the current unchanged
-`withdrawalBatchIndex`, `withdrawalQueueIndex = NO_QUEUE_INDEX`
-(`type(uint256).max`), the unchanged `nextProcessedDepositQueueHash`, the newly
-settled `nextBlockHash`, `withdrawalQueueHash = bytes32(0)`, and the unchanged
-`lastProcessedDepositNumber` and `lastProcessedEnabledTokenCount`.
+and the accepted `TokenEnablementTransition.nextProcessedTokenCount`.
 
 `NO_QUEUE_INDEX` means that the settlement created no withdrawal queue entry.
 Consumers MUST NOT create or overwrite a withdrawal queue record for such an
-event. `withdrawalBatchIndex` is a withdrawal-batch cursor and MAY repeat across
-header-only events; consumers MUST NOT use it as a unique event identifier or
-withdrawal queue key.
+event. This occurs when the final full block finalizes an empty withdrawal batch;
+the `withdrawalBatchIndex` still advances exactly once.
 
 Before the coordinated T11/Z1 activation, `TempoAdvanced` and `BatchSubmitted`
 retain their legacy signatures without `lastProcessedEnabledTokenCount`.
@@ -467,7 +445,8 @@ legacy and post-activation signatures and select the decoder by topic.
 No other event signature changes. `advanceTempoHeaders` emits no
 `TempoAdvanced`; its only checkpoint event is the existing single
 `TempoBlockFinalized` for the final imported header. A header-only block emits
-no `BatchFinalized`, while settlement of a header-only batch still emits the
+no `BatchFinalized` and is not a settlement boundary. The final full block emits
+`BatchFinalized`, and settlement of the batch ending in that block emits the
 post-activation `BatchSubmitted` described above. Deposit, withdrawal, and
 token-enablement lifecycle event signatures remain unchanged.
 
@@ -510,8 +489,9 @@ During recovery, the sequencer MUST:
 
 1. reserve one finalized Tempo header for the next full block;
 2. split every earlier consecutive header into bounded header-only blocks;
-3. optionally prove and submit one or more checkpoint batches;
+3. retain those header-only blocks as an unsettled prefix of the next batch;
 4. collect the complete deposit and token-enablement suffix since the last full
    block; and
 5. decrypt deposits and obtain Tempo state proofs only for the single header
-   imported by the full block.
+   imported by the full block, then prove and submit the batch ending in that
+   full block.


### PR DESCRIPTION
- Clarifies TIP-1096 so header-only recovery blocks are never settlement boundaries and are committed only as part of a batch ending in a full block. The final certificate commits to the complete block sequence, while the withdrawal batch index advances normally.
- Defines T11/Z1 event compatibility by adding the cumulative processed-token count to `TempoAdvanced` and `BatchSubmitted` after activation while retaining legacy signatures for historical blocks. Also specifies cursor initialization and checks outstanding token-enablement work against the authenticated migration count `N`.