### PR TITLE
feat(accounts): support multisig key authorizations

### DIFF
--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -3685,6 +3685,18 @@ mod tests {
         let authorization =
             || KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address());
 
+        let other_account = Address::repeat_byte(0x45);
+        let wrong_account = authorization()
+            .with_account(other_account)
+            .into_signed(PrimitiveSignature::default());
+        assert!(matches!(
+            validate_stored_authorization(account, &signer, &wrong_account),
+            Err(TempoAccountsError::InvalidAuthorizationForAccount(reason))
+                if reason == format!(
+                    "authorization account mismatch: expected {account}, actual {other_account}"
+                )
+        ));
+
         let keychain = authorization().into_signed(TempoSignature::Keychain(
             KeychainSignature::new(account, PrimitiveSignature::default()),
         ));

--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -28,11 +28,14 @@ use serde::{
 };
 use serde_json::value::RawValue;
 use tempo_contracts::precompiles::ITIP20;
+#[cfg(test)]
+use tempo_primitives::transaction::{MultisigConfig, MultisigOwner};
 use tempo_primitives::{
     SignatureType, TempoAddressExt, TempoTxEnvelope,
     transaction::{
-        Call, CallScope, KeyAuthorization, KeychainSignature, PrimitiveSignature, SelectorRule,
-        SignedKeyAuthorization, TempoSignature, TempoTypedTransaction, TokenLimit,
+        Call, CallScope, KeyAuthorization, KeychainSignature, MultisigSignature,
+        PrimitiveSignature, SelectorRule, SignedKeyAuthorization, TempoSignature,
+        TempoTypedTransaction, TokenLimit,
         tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
     },
 };
@@ -325,14 +328,8 @@ impl TempoAccessKey {
                 "chain ID does not match the selected key",
             ));
         }
-        if authorization
-            .account
-            .is_some_and(|account| account != self.account)
-        {
-            return Err(TempoAccessKeyError::InvalidAuthorization(
-                "account does not match the selected key",
-            ));
-        }
+        validate_authorization_for_account(self.account, authorization)
+            .map_err(TempoAccessKeyError::InvalidAuthorizationForAccount)?;
         if authorization.account.is_none()
             && authorization.recover_signer().ok() != Some(self.account)
         {
@@ -675,6 +672,8 @@ enum TempoAccessKeyError {
     AuthorizationMismatch,
     #[error("invalid pending Tempo key authorization: {0}")]
     InvalidAuthorization(&'static str),
+    #[error("invalid pending Tempo key authorization: {0}")]
+    InvalidAuthorizationForAccount(String),
     #[error(
         "Tempo key authorization for {key_id} on account {account} and chain {chain_id} is already in flight"
     )]
@@ -747,6 +746,9 @@ pub enum TempoAccountsError {
     /// A supplied authorization did not describe the access key being stored.
     #[error("invalid Tempo Accounts access-key authorization: {0}")]
     InvalidAuthorization(&'static str),
+    /// A supplied authorization is incompatible with its account.
+    #[error("invalid Tempo Accounts access-key authorization: {0}")]
+    InvalidAuthorizationForAccount(String),
     /// The active account selector was missing or invalid.
     #[error("Tempo Accounts active account is missing or invalid")]
     ActiveAccount,
@@ -1798,7 +1800,14 @@ struct PersistedSignedKeyAuthorization {
     account: Option<Address>,
     #[serde(rename = "type")]
     key_type: PersistedKeyType,
-    signature: PersistedPrimitiveSignature,
+    signature: PersistedAuthorizationSignature,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(untagged)]
+enum PersistedAuthorizationSignature {
+    Primitive(PersistedPrimitiveSignature),
+    Multisig(MultisigSignature),
 }
 
 #[derive(Clone, Deserialize)]
@@ -1847,7 +1856,8 @@ impl TryFrom<AccountsRpcKeyAuthorization> for SignedKeyAuthorization {
             is_admin: false,
             account: None,
         };
-        Ok(Self::new(authorization, value.signature.try_into()?))
+        let signature: PrimitiveSignature = value.signature.try_into()?;
+        Ok(Self::new(authorization, signature))
     }
 }
 
@@ -1993,7 +2003,15 @@ impl TryFrom<PersistedSignedKeyAuthorization> for SignedKeyAuthorization {
             is_admin,
             account,
         };
-        Ok(Self::new(authorization, signature.try_into()?))
+        let signature = match signature {
+            PersistedAuthorizationSignature::Primitive(signature) => {
+                TempoSignature::Primitive(signature.try_into()?)
+            }
+            PersistedAuthorizationSignature::Multisig(signature) => {
+                TempoSignature::Multisig(signature)
+            }
+        };
+        Ok(Self::new(authorization, signature))
     }
 }
 
@@ -2272,14 +2290,19 @@ fn stored_access_key(key: &PersistedAccessKey) -> Result<TempoStoredAccessKey, T
         authorization.key_id != key.address
             || authorization.chain_id != key.chain_id
             || authorization.key_type != key_type
-            || authorization
-                .account
-                .is_some_and(|account| account != key.access)
     }) {
         return Err(TempoAccountsError::InvalidAccessKey {
             address: key.address,
             reason: "authorization metadata does not match the stored key".into(),
         });
+    }
+    if let Some(authorization) = key_authorization.as_ref() {
+        validate_authorization_for_account(key.access, authorization).map_err(|reason| {
+            TempoAccountsError::InvalidAccessKey {
+                address: key.address,
+                reason: reason.into(),
+            }
+        })?;
     }
 
     let allowed_calls =
@@ -2335,14 +2358,47 @@ fn validate_stored_authorization(
             "the authorization key ID does not match the local signer",
         ));
     }
-    if authorization
-        .account
-        .is_some_and(|authorized| authorized != account)
+    validate_authorization_for_account(account, authorization)
+        .map_err(TempoAccountsError::InvalidAuthorizationForAccount)?;
+    Ok(())
+}
+
+/// Checks that an authorization uses a supported signature kind and does not target another
+/// account.
+///
+/// This does not verify the signature or multisig quorum.
+fn validate_authorization_for_account(
+    account: Address,
+    authorization: &SignedKeyAuthorization,
+) -> Result<(), String> {
+    if let Some(actual) = authorization.account
+        && actual != account
     {
-        return Err(TempoAccountsError::InvalidAuthorization(
-            "the authorization targets a different account",
+        return Err(format!(
+            "authorization account mismatch: expected {account}, actual {actual}"
         ));
     }
+
+    match &authorization.signature {
+        TempoSignature::Primitive(_) => {}
+        TempoSignature::Multisig(signature) => {
+            if authorization.account != Some(account) {
+                return Err(format!(
+                    "multisig authorization account mismatch: expected {account}, actual none"
+                ));
+            }
+            let actual = signature.account();
+            if actual != account {
+                return Err(format!(
+                    "multisig signature account mismatch: expected {account}, actual {actual}"
+                ));
+            }
+        }
+        TempoSignature::Keychain(_) => {
+            return Err("key authorization signatures cannot use keychain encoding".into());
+        }
+    }
+
     Ok(())
 }
 
@@ -2376,7 +2432,7 @@ struct WritableAccount {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct WritableAccessKey {
+struct WritableAccessKey<'a> {
     address: Address,
     access: Address,
     chain_id: u64,
@@ -2388,7 +2444,7 @@ struct WritableAccessKey {
     limits: Option<Vec<WritableTokenLimit>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<Vec<WritableScope>>,
-    key_authorization: WritableSignedKeyAuthorization,
+    key_authorization: WritableSignedKeyAuthorization<'a>,
 }
 
 #[derive(Clone, Serialize)]
@@ -2399,7 +2455,7 @@ struct WritableTokenLimit {
     period: Option<u64>,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 struct WritableScope {
     address: Address,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2410,7 +2466,7 @@ struct WritableScope {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct WritableSignedKeyAuthorization {
+struct WritableSignedKeyAuthorization<'a> {
     address: Address,
     chain_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2427,7 +2483,7 @@ struct WritableSignedKeyAuthorization {
     account: Option<Address>,
     #[serde(rename = "type")]
     key_type: &'static str,
-    signature: WritablePrimitiveSignature,
+    signature: WritableAuthorizationSignature<'a>,
 }
 
 #[derive(Serialize)]
@@ -2449,6 +2505,13 @@ enum WritablePrimitiveSignature {
         public_key: WritablePublicKey,
         metadata: WritableWebAuthnMetadata,
     },
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum WritableAuthorizationSignature<'a> {
+    Primitive(WritablePrimitiveSignature),
+    Multisig(&'a MultisigSignature),
 }
 
 #[derive(Serialize)]
@@ -2577,11 +2640,11 @@ fn writable_scopes(authorization: &SignedKeyAuthorization) -> Option<Vec<Writabl
     })
 }
 
-fn writable_access_key(
+fn writable_access_key<'a>(
     account: Address,
     signer: &PrivateKeySigner,
-    authorization: &SignedKeyAuthorization,
-) -> Result<WritableAccessKey, TempoAccountsError> {
+    authorization: &'a SignedKeyAuthorization,
+) -> Result<WritableAccessKey<'a>, TempoAccountsError> {
     let limits = authorization.limits.as_ref().map(|limits| {
         limits
             .iter()
@@ -2592,6 +2655,31 @@ fn writable_access_key(
             })
             .collect()
     });
+    let scopes = writable_scopes(authorization);
+    let signature = match &authorization.signature {
+        TempoSignature::Primitive(signature) => {
+            WritableAuthorizationSignature::Primitive(writable_signature(signature)?)
+        }
+        TempoSignature::Multisig(signature) => WritableAuthorizationSignature::Multisig(signature),
+        TempoSignature::Keychain(_) => {
+            return Err(TempoAccountsError::InvalidAuthorization(
+                "key authorization signatures cannot use keychain encoding",
+            ));
+        }
+    };
+    let key_authorization = WritableSignedKeyAuthorization {
+        address: authorization.key_id,
+        chain_id: writable_bigint(U256::from(authorization.chain_id)),
+        expiry: authorization.expiry.map(NonZeroU64::get),
+        limits: limits.clone(),
+        scopes: scopes.clone(),
+        witness: authorization.witness,
+        is_admin: authorization.is_admin,
+        account: authorization.account,
+        key_type: "secp256k1",
+        signature,
+    };
+
     Ok(WritableAccessKey {
         address: signer.address(),
         access: account,
@@ -2599,20 +2687,9 @@ fn writable_access_key(
         key_type: "secp256k1",
         private_key: alloy_primitives::hex::encode_prefixed(signer.to_bytes()),
         expiry: authorization.expiry.map(NonZeroU64::get),
-        limits: limits.clone(),
-        scopes: writable_scopes(authorization),
-        key_authorization: WritableSignedKeyAuthorization {
-            address: authorization.key_id,
-            chain_id: writable_bigint(U256::from(authorization.chain_id)),
-            expiry: authorization.expiry.map(NonZeroU64::get),
-            limits,
-            scopes: writable_scopes(authorization),
-            witness: authorization.witness,
-            is_admin: authorization.is_admin,
-            account: authorization.account,
-            key_type: "secp256k1",
-            signature: writable_signature(&authorization.signature)?,
-        },
+        limits,
+        scopes,
+        key_authorization,
     })
 }
 
@@ -2999,14 +3076,13 @@ fn select_access_key(
                 || authorization
                     .expiry
                     .is_some_and(|expiry| expiry.get() <= now)
-                || authorization
-                    .account
-                    .is_some_and(|authorized_account| authorized_account != account)
         }) {
             continue;
         }
         if key_authorization.as_ref().is_some_and(|authorization| {
-            authorization.account.is_none() && authorization.recover_signer().ok() != Some(account)
+            validate_authorization_for_account(account, authorization).is_err()
+                || (authorization.account.is_none()
+                    && authorization.recover_signer().ok() != Some(account))
         }) {
             continue;
         }
@@ -3255,7 +3331,10 @@ mod tests {
     use alloy_network::{NetworkWallet, TransactionBuilder};
     use alloy_provider::{ProviderBuilder, SendableTx, fillers::TxFiller, mock::Asserter};
     use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
-    use tempo_primitives::{TempoTxEnvelope, transaction::TempoSignature};
+    use tempo_primitives::{
+        TempoTxEnvelope,
+        transaction::{MultisigSignature, TempoSignature},
+    };
 
     use super::*;
 
@@ -3556,6 +3635,108 @@ mod tests {
     }
 
     #[test]
+    fn multisig_key_authorization_roundtrips_through_store() {
+        let directory = unique_test_directory();
+        let path = directory.join("wallet/store.json");
+        let account = Address::repeat_byte(0x44);
+        let signer = PrivateKeySigner::random();
+        let config = MultisigConfig {
+            salt: B256::ZERO,
+            version: 1,
+            threshold: 1,
+            owners: vec![MultisigOwner {
+                owner: Address::repeat_byte(0x55),
+                weight: 1,
+            }],
+        };
+        let authorization =
+            KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address())
+                .with_account(account)
+                .into_signed(TempoSignature::Multisig(
+                    MultisigSignature::try_new(
+                        account,
+                        config,
+                        vec![TempoSignature::Primitive(PrimitiveSignature::default())],
+                    )
+                    .unwrap(),
+                ));
+
+        TempoAccountsStore::at(&path)
+            .upsert_secp256k1_access_key(account, &signer, &authorization)
+            .unwrap();
+
+        let written: serde_json::Value = serde_json::from_slice(&fs::read(&path).unwrap()).unwrap();
+        let persisted = &written["tempo-cli.store"]["state"]["accessKeys"][0]["keyAuthorization"];
+        assert!(persisted["signature"].is_string());
+        let stored = TempoAccountsStore::open(&path)
+            .unwrap()
+            .access_keys()
+            .unwrap()
+            .remove(0);
+        assert_eq!(stored.key_authorization(), Some(&authorization));
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejects_unusable_key_authorization_signatures() {
+        let account = Address::repeat_byte(0x44);
+        let signer = PrivateKeySigner::random();
+        let authorization =
+            || KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address());
+
+        let keychain = authorization().into_signed(TempoSignature::Keychain(
+            KeychainSignature::new(account, PrimitiveSignature::default()),
+        ));
+        assert!(matches!(
+            validate_stored_authorization(account, &signer, &keychain),
+            Err(TempoAccountsError::InvalidAuthorizationForAccount(reason))
+                if reason == "key authorization signatures cannot use keychain encoding"
+        ));
+
+        let config = MultisigConfig {
+            salt: B256::ZERO,
+            version: 1,
+            threshold: 1,
+            owners: vec![MultisigOwner {
+                owner: Address::repeat_byte(0x55),
+                weight: 1,
+            }],
+        };
+        let signature_account = Address::repeat_byte(0x66);
+        let multisig = MultisigSignature::try_new(
+            signature_account,
+            config,
+            vec![TempoSignature::Primitive(PrimitiveSignature::default())],
+        )
+        .unwrap();
+
+        let missing_account =
+            authorization().into_signed(TempoSignature::Multisig(multisig.clone()));
+        assert!(matches!(
+            validate_stored_authorization(account, &signer, &missing_account),
+            Err(TempoAccountsError::InvalidAuthorizationForAccount(reason))
+                if reason == format!(
+                    "multisig authorization account mismatch: expected {account}, actual none"
+                )
+        ));
+
+        let wrong_account = authorization()
+            .with_account(account)
+            .into_signed(TempoSignature::Multisig(multisig));
+        let reason = match validate_stored_authorization(account, &signer, &wrong_account) {
+            Err(TempoAccountsError::InvalidAuthorizationForAccount(reason)) => reason,
+            result => panic!("unexpected result: {result:?}"),
+        };
+        assert_eq!(
+            reason,
+            format!(
+                "multisig signature account mismatch: expected {account}, actual {signature_account}"
+            )
+        );
+    }
+
+    #[test]
     fn persisted_boundary_deserializes_to_strict_types() {
         let state: PersistedAccountsState = serde_json::from_value(serde_json::json!({
             "activeAccount": ROOT,
@@ -3634,7 +3815,9 @@ mod tests {
                 .as_slice()
             )
         );
-        let PrimitiveSignature::WebAuthn(signature) = &authorization.signature else {
+        let TempoSignature::Primitive(PrimitiveSignature::WebAuthn(signature)) =
+            &authorization.signature
+        else {
             panic!("expected WebAuthn root signature")
         };
         assert_eq!(signature.webauthn_data.as_ref(), webauthn_data);

--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -2300,7 +2300,7 @@ fn stored_access_key(key: &PersistedAccessKey) -> Result<TempoStoredAccessKey, T
         validate_authorization_for_account(key.access, authorization).map_err(|reason| {
             TempoAccountsError::InvalidAccessKey {
                 address: key.address,
-                reason: reason.into(),
+                reason,
             }
         })?;
     }

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -608,11 +608,11 @@ pub(super) async fn run_estimate_gas_matrix<E: TestEnv>(
                 auth.authorization = auth
                     .authorization
                     .with_witness(B256::with_last_byte((i + 1) as u8));
-                auth.signature = PrimitiveSignature::Secp256k1(
+                auth.signature = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
                     signer
                         .sign_hash_sync(&auth.authorization.signature_hash())
                         .expect("signing should succeed"),
-                );
+                ));
                 request.key_authorization = Some(auth);
             }
         }

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -1,5 +1,5 @@
 use super::SignatureType;
-use crate::transaction::PrimitiveSignature;
+use crate::transaction::TempoSignature;
 use alloc::vec::Vec;
 use alloy_consensus::crypto::RecoveryError;
 use alloy_primitives::{Address, B256, U256, keccak256};
@@ -356,7 +356,7 @@ impl KeyAuthorization {
     }
 
     /// Convert the key authorization into a [`SignedKeyAuthorization`] with a signature.
-    pub fn into_signed(self, signature: PrimitiveSignature) -> SignedKeyAuthorization {
+    pub fn into_signed(self, signature: impl Into<TempoSignature>) -> SignedKeyAuthorization {
         SignedKeyAuthorization::new(self, signature)
     }
 
@@ -420,8 +420,8 @@ pub struct SignedKeyAuthorization {
     #[deref]
     pub authorization: KeyAuthorization,
 
-    /// Signature authorizing this key (signed by root key)
-    pub signature: PrimitiveSignature,
+    /// Signature authorizing this key.
+    pub signature: TempoSignature,
 
     /// Cached signer recovered from `signature`.
     ///
@@ -434,26 +434,40 @@ pub struct SignedKeyAuthorization {
 
 impl SignedKeyAuthorization {
     /// Create a signed key authorization with an empty signer cache.
-    pub fn new(authorization: KeyAuthorization, signature: PrimitiveSignature) -> Self {
+    pub fn new(authorization: KeyAuthorization, signature: impl Into<TempoSignature>) -> Self {
         Self {
             authorization,
-            signature,
+            signature: signature.into(),
             signer: OnceLock::new(),
         }
     }
 
-    /// Recover the signer of the [`KeyAuthorization`].
+    /// Recovers and cryptographically verifies a primitive signer.
     pub fn recover_signer(&self) -> Result<Address, RecoveryError> {
+        let TempoSignature::Primitive(signature) = &self.signature else {
+            return Err(RecoveryError::new());
+        };
+
         if let Some(signer) = self.signer.get() {
             return Ok(*signer);
         }
 
-        let signer = self
-            .signature
-            .recover_signer(&self.authorization.signature_hash())?;
+        let signer = signature.recover_signer(&self.authorization.signature_hash())?;
         self.cache_signer(signer);
 
         Ok(signer)
+    }
+
+    /// Returns the account that claims to authorize this key.
+    ///
+    /// Primitive signatures are verified here. A multisig account is only shape-checked; callers
+    /// must verify its owner quorum against native multisig state before granting authority.
+    pub fn recover_authorizing_account(&self) -> Result<Address, RecoveryError> {
+        match &self.signature {
+            TempoSignature::Primitive(_) => self.recover_signer(),
+            TempoSignature::Multisig(signature) => Ok(signature.account()),
+            TempoSignature::Keychain(_) => Err(RecoveryError::new()),
+        }
     }
 
     #[cfg(feature = "std")]
@@ -707,7 +721,7 @@ mod selector_hex_serde {
 mod tests {
     use super::*;
     use crate::transaction::{
-        TempoSignature,
+        PrimitiveSignature, TempoSignature,
         tt_authorization::tests::{generate_secp256k1_keypair, sign_hash},
     };
     use alloy_rlp::{Decodable, Encodable};
@@ -727,6 +741,18 @@ mod tests {
             witness: None,
             is_admin: false,
             account: None,
+        }
+    }
+
+    fn multisig_config() -> crate::transaction::MultisigConfig {
+        crate::transaction::MultisigConfig {
+            salt: B256::ZERO,
+            version: 1,
+            threshold: 1,
+            owners: vec![crate::transaction::MultisigOwner {
+                owner: Address::repeat_byte(0x55),
+                weight: 1,
+            }],
         }
     }
 
@@ -926,6 +952,80 @@ mod tests {
         let bad_recovered = bad_signed.recover_signer();
         assert!(bad_recovered.is_ok());
         assert_ne!(bad_recovered.unwrap(), expected_address);
+    }
+
+    #[test]
+    fn primitive_signed_authorization_encoding_is_unchanged() {
+        #[derive(alloy_rlp::RlpEncodable)]
+        struct LegacySignedKeyAuthorization {
+            authorization: KeyAuthorization,
+            signature: PrimitiveSignature,
+        }
+
+        let auth = make_auth(Some(1000), None);
+        let signature = PrimitiveSignature::default();
+        let signed = auth.clone().into_signed(signature.clone());
+        let legacy = LegacySignedKeyAuthorization {
+            authorization: auth,
+            signature,
+        };
+
+        let mut encoded = Vec::new();
+        signed.encode(&mut encoded);
+        let mut legacy_encoded = Vec::new();
+        legacy.encode(&mut legacy_encoded);
+        assert_eq!(encoded, legacy_encoded);
+    }
+
+    #[test]
+    fn multisig_signed_authorization_roundtrip() {
+        let auth = make_auth(None, None).with_account(Address::repeat_byte(0x44));
+        let signature = TempoSignature::Multisig(
+            crate::transaction::MultisigSignature::try_new(
+                Address::repeat_byte(0x44),
+                multisig_config(),
+                vec![TempoSignature::Primitive(PrimitiveSignature::default())],
+            )
+            .unwrap(),
+        );
+        let signed = auth.into_signed(signature);
+
+        let mut encoded = Vec::new();
+        signed.encode(&mut encoded);
+        let decoded = SignedKeyAuthorization::decode(&mut encoded.as_slice())
+            .expect("decode multisig-signed key authorization");
+
+        assert_eq!(decoded, signed);
+        assert!(decoded.signature.is_multisig());
+        assert!(decoded.recover_signer().is_err());
+        assert_eq!(
+            decoded.recover_authorizing_account().unwrap(),
+            Address::repeat_byte(0x44)
+        );
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn signed_key_authorization_json_roundtrips_multisig_rlp_bytes() {
+        let account = Address::repeat_byte(0x44);
+        let signature = TempoSignature::Multisig(
+            crate::transaction::MultisigSignature::try_new(
+                account,
+                multisig_config(),
+                vec![TempoSignature::Primitive(PrimitiveSignature::default())],
+            )
+            .unwrap(),
+        );
+        let signed = make_auth(None, None)
+            .with_account(account)
+            .into_signed(signature);
+
+        let json = serde_json::to_value(&signed).unwrap();
+        assert!(json["signature"].is_string());
+        assert_eq!(
+            serde_json::from_value::<SignedKeyAuthorization>(json).unwrap(),
+            signed
+        );
     }
 
     #[test]

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -151,6 +151,10 @@ pub enum TempoInvalidTransaction {
     #[error("failed to recover signer from KeyAuthorization signature")]
     KeyAuthorizationSignatureRecoveryFailed,
 
+    /// Keychain encoding is not valid for a key authorization signature.
+    #[error("key authorization signatures cannot use keychain encoding")]
+    InvalidKeyAuthorizationSignature,
+
     /// KeyAuthorization not signed by root account.
     ///
     /// The KeyAuthorization must be signed by the root account (transaction caller),
@@ -307,6 +311,7 @@ impl TempoInvalidTransaction {
             | Self::AccessKeyRecoveryFailed
             | Self::AccessKeyCannotAuthorizeOtherKeys
             | Self::KeyAuthorizationSignatureRecoveryFailed
+            | Self::InvalidKeyAuthorizationSignature
             | Self::KeyAuthorizationNotSignedByRoot { .. }
             | Self::KeychainUserAddressMismatch { .. }
             | Self::KeyAuthorizationChainIdMismatch { .. }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -64,7 +64,7 @@ use crate::{
     error::{FeePaymentError, TempoHaltReason},
     evm::TempoContext,
     gas_credits,
-    signature_gas::{primitive_signature_verification_gas, tempo_signature_verification_gas},
+    signature_gas::tempo_signature_verification_gas,
 };
 
 /// Base gas for KeyAuthorization (22k storage + 5k buffer), signature gas added at runtime
@@ -298,9 +298,9 @@ fn calculate_key_authorization_gas(
     spec: tempo_chainspec::hardfork::TempoHardfork,
 ) -> (u64, u64) {
     // All signature types pay ECRECOVER_GAS (3k) as the baseline since
-    // primitive_signature_verification_gas assumes ecrecover is already in base 21k.
+    // tempo_signature_verification_gas assumes ecrecover is already in base 21k.
     // For KeyAuthorization, we're doing an additional signature verification.
-    let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+    let sig_gas = ECRECOVER_GAS + tempo_signature_verification_gas(&key_auth.signature);
 
     let num_limits = key_auth
         .authorization
@@ -1371,7 +1371,11 @@ where
                 .map_err(|_| TempoInvalidTransaction::KeyAuthorizationSignatureRecoveryFailed)?;
 
             if auth_signer != tx.caller {
-                let key_auth_sig_type: u8 = key_auth.signature.signature_type().into();
+                let key_auth_sig_type: u8 = key_auth
+                    .signature
+                    .signature_type()
+                    .expect("non-primitive key authorization rejected in validate_env")
+                    .into();
                 let signer_is_admin = match loaded_tx_access_key {
                     Some(loaded_key)
                         if loaded_key.key_id == auth_signer
@@ -1802,6 +1806,10 @@ where
 
             if aa_env.signature.is_multisig()
                 || aa_env
+                    .key_authorization
+                    .as_ref()
+                    .is_some_and(|authorization| authorization.signature.is_multisig())
+                || aa_env
                     .tempo_authorization_list
                     .iter()
                     .any(|authorization| authorization.signature().is_multisig())
@@ -1835,6 +1843,11 @@ where
                 auth.signature()
                     .validate_version(cfg.spec().is_t1c())
                     .map_err(TempoInvalidTransaction::from)?;
+            }
+            if let Some(key_auth) = &aa_env.key_authorization
+                && key_auth.signature.is_keychain()
+            {
+                return Err(TempoInvalidTransaction::InvalidKeyAuthorizationSignature.into());
             }
 
             let has_keychain_fields =
@@ -2014,7 +2027,7 @@ where
                         }
 
                         if key_auth.signature.signature_type()
-                            != keychain_sig.signature.signature_type()
+                            != Some(keychain_sig.signature.signature_type())
                         {
                             return Err(TempoInvalidTransaction::KeychainValidationFailed {
                                 reason:

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -1,7 +1,11 @@
 use super::*;
 use crate::{
     FeeTokenResolver, ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoTxEnv,
-    evm::TempoEvm, gas_params::tempo_gas_params, signature_gas::P256_VERIFY_GAS,
+    evm::TempoEvm,
+    gas_params::tempo_gas_params,
+    signature_gas::{
+        P256_VERIFY_GAS, primitive_signature_verification_gas, tempo_signature_verification_gas,
+    },
     tx::TempoBatchCallEnv,
 };
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
@@ -24,8 +28,9 @@ use tempo_precompiles::{
     tip_fee_manager::TipFeeManager,
 };
 use tempo_primitives::transaction::{
-    Call, MultisigConfig, MultisigOwner, MultisigSignature, PrimitiveSignature,
-    RecoveredTempoAuthorization, TempoSignature, TempoSignedAuthorization,
+    Call, KeyAuthorization, KeychainSignature, MultisigConfig, MultisigOwner, MultisigSignature,
+    PrimitiveSignature, RecoveredTempoAuthorization, SignatureType, TempoSignature,
+    TempoSignedAuthorization,
     tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
 };
 
@@ -1269,7 +1274,7 @@ fn test_t4_key_authorization_matches_tip1016_sstore_regular_cost() {
     // TIP-1016 is opt-in via amsterdam_eip8037; manually enable for this test.
     let gas_params = crate::gas_params::tempo_gas_params_with_amsterdam(TempoHardfork::T4, true);
 
-    let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+    let sig_gas = ECRECOVER_GAS + tempo_signature_verification_gas(&key_auth.signature);
     let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
     let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
     let (regular_gas, state_gas) =
@@ -1291,7 +1296,7 @@ fn test_t7_key_authorization_intrinsic_includes_storage_credit_value() {
         ));
 
     let gas_params = crate::gas_params::tempo_gas_params(TempoHardfork::T7);
-    let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+    let sig_gas = ECRECOVER_GAS + tempo_signature_verification_gas(&key_auth.signature);
     let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
     let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
     let (regular_gas, state_gas) =
@@ -4492,8 +4497,12 @@ fn native_multisig_execution_remains_inactive() {
     let account = config.derive_account().unwrap();
     let aa_env = TempoBatchCallEnv {
         signature: TempoSignature::Multisig(
-            MultisigSignature::try_new(account, config, vec![TempoSignature::default()])
-                .expect("valid multisig test fixture"),
+            MultisigSignature::try_new(
+                account,
+                config,
+                vec![TempoSignature::Primitive(PrimitiveSignature::default())],
+            )
+            .expect("valid multisig test fixture"),
         ),
         aa_calls: vec![Call {
             to: TxKind::Call(Address::random()),
@@ -4512,4 +4521,81 @@ fn native_multisig_execution_remains_inactive() {
             TempoInvalidTransaction::NativeMultisigNotActive
         ))
     ));
+}
+
+#[test]
+fn native_multisig_key_authorization_remains_inactive() {
+    let config = MultisigConfig {
+        salt: B256::ZERO,
+        version: 0,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: Address::repeat_byte(0x11),
+            weight: 1,
+        }],
+    };
+    let account = config.derive_account().unwrap();
+    let key_authorization =
+        KeyAuthorization::unrestricted(1, SignatureType::Secp256k1, Address::repeat_byte(0x55))
+            .with_account(account)
+            .into_signed(TempoSignature::Multisig(
+                MultisigSignature::try_new(
+                    account,
+                    config,
+                    vec![TempoSignature::Primitive(PrimitiveSignature::default())],
+                )
+                .unwrap(),
+            ));
+    let aa_env = TempoBatchCallEnv {
+        key_authorization: Some(key_authorization),
+        aa_calls: vec![Call {
+            to: TxKind::Call(Address::random()),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }],
+        ..Default::default()
+    };
+    let mut test = TestHandlerEvm::aa(TempoHardfork::T11, aa_env, |tx_env| {
+        tx_env.inner.caller = account;
+    });
+
+    assert!(matches!(
+        test.validate_env(),
+        Err(EVMError::Transaction(
+            TempoInvalidTransaction::NativeMultisigNotActive
+        ))
+    ));
+}
+
+#[test]
+fn test_t12_rejects_keychain_key_authorization_signature() {
+    let caller = Address::repeat_byte(0x11);
+    let key_authorization =
+        KeyAuthorization::unrestricted(1, SignatureType::Secp256k1, Address::repeat_byte(0x33))
+            .into_signed(TempoSignature::Keychain(KeychainSignature::new(
+                caller,
+                PrimitiveSignature::default(),
+            )));
+    let aa_env = TempoBatchCallEnv {
+        signature: TempoSignature::Primitive(PrimitiveSignature::default()),
+        key_authorization: Some(key_authorization),
+        aa_calls: vec![Call {
+            to: TxKind::Call(Address::random()),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }],
+        ..Default::default()
+    };
+    let mut test = TestHandlerEvm::aa(TempoHardfork::T12, aa_env, |tx_env| {
+        tx_env.inner.caller = caller;
+    });
+
+    let Err(EVMError::Transaction(error)) = test.validate_env() else {
+        panic!("keychain key authorization must be rejected");
+    };
+    assert_eq!(
+        error,
+        TempoInvalidTransaction::InvalidKeyAuthorizationSignature
+    );
+    assert!(error.is_bad_transaction());
 }


### PR DESCRIPTION
Expands signed key authorizations to `TempoSignature` while preserving primitive wire encoding, and persists multisig authorizations as typed wallet JSON.

Stacked on #7234; reference implementation: #4069.