### PR TITLE
feat(precompiles): add native multisig storage

### DIFF
--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -20,11 +20,11 @@ use revm::{
     precompile::{PrecompileError, PrecompileHalt, PrecompileOutput, PrecompileResult},
 };
 use tempo_contracts::precompiles::{
-    AccountKeychainError, AddrRegistryError, CurrentCommitteeError, FeeManagerError, NonceError,
-    ReceivePolicyGuardError, RolesAuthError, SignatureVerifierError, StablecoinDEXError,
-    StorageCreditsError, TIP20ChannelReserveError, TIP20FactoryError, TIP403RegistryError,
-    TIPFeeAMMError, UnknownFunctionSelector, ValidatorConfigError, ValidatorConfigV2Error,
-    ZoneFactoryError,
+    AccountKeychainError, AddrRegistryError, CurrentCommitteeError, FeeManagerError,
+    NativeMultisigError, NonceError, ReceivePolicyGuardError, RolesAuthError,
+    SignatureVerifierError, StablecoinDEXError, StorageCreditsError, TIP20ChannelReserveError,
+    TIP20FactoryError, TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector,
+    ValidatorConfigError, ValidatorConfigV2Error, ZoneFactoryError,
 };
 
 /// Top-level error type for all Tempo precompile operations
@@ -91,6 +91,10 @@ pub enum TempoPrecompileError {
     /// Error from account keychain precompile
     #[error("Account keychain error: {0:?}")]
     AccountKeychainError(AccountKeychainError),
+
+    /// Error from native multisig precompile
+    #[error("Native multisig error: {0:?}")]
+    NativeMultisigError(NativeMultisigError),
 
     /// Error from signature verifier precompile
     #[error("Signature verifier error: {0:?}")]
@@ -172,6 +176,7 @@ impl TempoPrecompileError {
             Self::ValidatorConfigError(e) => e.selector(),
             Self::ValidatorConfigV2Error(e) => e.selector(),
             Self::AccountKeychainError(e) => e.selector(),
+            Self::NativeMultisigError(e) => e.selector(),
             Self::SignatureVerifierError(e) => e.selector(),
             Self::ReceivePolicyGuardError(e) => e.selector(),
             Self::StorageCreditsError(e) => e.selector(),
@@ -204,6 +209,7 @@ impl TempoPrecompileError {
             | Self::ValidatorConfigError(_)
             | Self::ValidatorConfigV2Error(_)
             | Self::AccountKeychainError(_)
+            | Self::NativeMultisigError(_)
             | Self::SignatureVerifierError(_)
             | Self::ReceivePolicyGuardError(_)
             | Self::StorageCreditsError(_)
@@ -267,6 +273,7 @@ impl TempoPrecompileError {
             Self::ValidatorConfigError(e) => e.abi_encode().into(),
             Self::ValidatorConfigV2Error(e) => e.abi_encode().into(),
             Self::AccountKeychainError(e) => e.abi_encode().into(),
+            Self::NativeMultisigError(e) => e.abi_encode().into(),
             Self::SignatureVerifierError(e) => e.abi_encode().into(),
             Self::ReceivePolicyGuardError(e) => e.abi_encode().into(),
             Self::StorageCreditsError(e) => e.abi_encode().into(),
@@ -342,6 +349,7 @@ pub fn error_decoder_registry() -> TempoPrecompileErrorRegistry {
     add_errors_to_registry(&mut registry, TempoPrecompileError::ValidatorConfigError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::ValidatorConfigV2Error);
     add_errors_to_registry(&mut registry, TempoPrecompileError::AccountKeychainError);
+    add_errors_to_registry(&mut registry, TempoPrecompileError::NativeMultisigError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::SignatureVerifierError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::ReceivePolicyGuardError);
     add_errors_to_registry(&mut registry, TempoPrecompileError::StorageCreditsError);
@@ -543,5 +551,16 @@ mod tests {
             TempoPrecompileError::TIP20(_) => {}
             other => panic!("Expected TIP20 error, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_decode_native_multisig_error() {
+        let encoded = NativeMultisigError::invalid_multisig_owner().abi_encode();
+        assert!(matches!(
+            decode_error(&encoded).map(|decoded| decoded.error),
+            Some(TempoPrecompileError::NativeMultisigError(
+                NativeMultisigError::InvalidMultisigOwner(_)
+            ))
+        ));
     }
 }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -15,6 +15,7 @@ pub(crate) mod ip_validation;
 pub mod account_keychain;
 pub mod address_registry;
 pub mod current_committee;
+pub mod native_multisig;
 pub mod nonce;
 pub mod receive_policy_guard;
 pub mod signature_verifier;
@@ -36,6 +37,7 @@ use crate::{
     account_keychain::AccountKeychain,
     address_registry::AddressRegistry,
     current_committee::CurrentCommittee,
+    native_multisig::NativeMultisig,
     nonce::NonceManager,
     receive_policy_guard::ReceivePolicyGuard,
     signature_verifier::SignatureVerifier,
@@ -68,12 +70,12 @@ use revm::{
 
 pub use tempo_contracts::precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS, ADDRESS_REGISTRY_ADDRESS, CURRENT_COMMITTEE_ADDRESS,
-    DEFAULT_FEE_TOKEN, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS, RECEIVE_POLICY_GUARD_ADDRESS,
-    SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS, STORAGE_CREDITS_ADDRESS,
-    SYSTEM_PRECOMPILES, TIP_FEE_MANAGER_ADDRESS, TIP20_CHANNEL_RESERVE_ADDRESS,
-    TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS, VALIDATOR_CONFIG_ADDRESS,
-    VALIDATOR_CONFIG_V2_ADDRESS, ZONE_FACTORY_ADDRESS, ZONE_MESSENGER_ADDRESS,
-    ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
+    DEFAULT_FEE_TOKEN, NATIVE_MULTISIG_ADDRESS, NONCE_PRECOMPILE_ADDRESS, PATH_USD_ADDRESS,
+    RECEIVE_POLICY_GUARD_ADDRESS, SIGNATURE_VERIFIER_ADDRESS, STABLECOIN_DEX_ADDRESS,
+    STORAGE_CREDITS_ADDRESS, SYSTEM_PRECOMPILES, TIP_FEE_MANAGER_ADDRESS,
+    TIP20_CHANNEL_RESERVE_ADDRESS, TIP20_FACTORY_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    VALIDATOR_CONFIG_ADDRESS, VALIDATOR_CONFIG_V2_ADDRESS, ZONE_FACTORY_ADDRESS,
+    ZONE_MESSENGER_ADDRESS, ZONE_PORTAL_IMPL_ADDRESS, ZONE_VERIFIER_ADDRESS,
 };
 
 // Re-export storage layout helpers for read-only contexts (e.g., pool validation)
@@ -166,14 +168,28 @@ pub fn tempo_precompiles(
     actions: StorageActions,
     non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
 ) -> PrecompilesMap {
-    let spec = if cfg.spec.is_t1c() {
-        cfg.spec.into()
-    } else {
-        SpecId::PRAGUE
-    };
-    let mut precompiles = PrecompilesMap::from_static(EthPrecompiles::new(spec).precompiles);
+    let mut precompiles = PrecompilesMap::from_static(
+        EthPrecompiles::new(ethereum_precompile_spec(cfg.spec)).precompiles,
+    );
     extend_tempo_precompiles(&mut precompiles, cfg, actions, non_creditable_slots);
     precompiles
+}
+
+fn ethereum_precompile_spec(spec: TempoHardfork) -> SpecId {
+    if spec.is_t1c() {
+        spec.into()
+    } else {
+        SpecId::PRAGUE
+    }
+}
+
+/// Returns whether an address can represent a native multisig account at `spec`.
+pub fn is_valid_multisig_account(account: Address, spec: TempoHardfork) -> bool {
+    !account.is_zero()
+        && !account.is_virtual()
+        && !account.as_slice().starts_with(&Address::ZONE_PORTAL_PREFIX)
+        && !account.is_precompile(spec)
+        && !EthPrecompiles::new(ethereum_precompile_spec(spec)).contains(&account)
 }
 
 /// Registers Tempo-specific precompiles into an existing [`PrecompilesMap`] by installing a
@@ -345,6 +361,13 @@ impl AccountKeychain {
     }
 }
 
+impl NativeMultisig {
+    /// Creates the EVM precompile for this type.
+    pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
+        tempo_precompile!("NativeMultisig", env: env, |input| { Self::new() })
+    }
+}
+
 impl ValidatorConfig {
     /// Creates the EVM precompile for this type.
     pub fn create_precompile(env: &PrecompileEnv) -> DynPrecompile {
@@ -442,6 +465,10 @@ mod tests {
             StorageActions::disabled(),
             Rc::new(RefCell::new(NonCreditableSlots::empty())),
         )
+    }
+
+    fn p256verify_address() -> Address {
+        Address::from_word(U256::from(revm::precompile::secp256r1::P256VERIFY_ADDRESS).into())
     }
 
     #[test]
@@ -1211,13 +1238,13 @@ mod tests {
 
     #[test]
     fn test_p256verify_availability_across_t1c_boundary() {
+        let p256verify_address = p256verify_address();
         let has_p256 = |spec: TempoHardfork| -> bool {
-            // P256VERIFY lives at address 0x100 (256), added in Osaka
-            let p256_addr = Address::from_word(U256::from(256).into());
-
             let mut cfg = CfgEnv::<TempoHardfork>::default();
             cfg.set_spec_and_mainnet_gas_params(spec);
-            test_tempo_precompiles(&cfg).get(&p256_addr).is_some()
+            test_tempo_precompiles(&cfg)
+                .get(&p256verify_address)
+                .is_some()
         };
 
         // Pre-T1C hardforks should use Prague precompiles (no P256VERIFY)
@@ -1241,5 +1268,33 @@ mod tests {
                 "P256VERIFY should be available at {spec:?} (T1C+)"
             );
         }
+    }
+
+    #[test]
+    fn multisig_account_eligibility_uses_registered_precompiles() {
+        let spec = TempoHardfork::T12;
+        let p256verify_address = p256verify_address();
+        for address in EthPrecompiles::new(ethereum_precompile_spec(spec)).warm_addresses() {
+            assert!(!is_valid_multisig_account(*address, spec));
+        }
+        for &(address, activated) in SYSTEM_PRECOMPILES {
+            if activated <= spec {
+                assert!(!is_valid_multisig_account(address, spec));
+            }
+        }
+
+        assert!(is_valid_multisig_account(
+            p256verify_address,
+            TempoHardfork::T1B
+        ));
+        assert!(!is_valid_multisig_account(
+            p256verify_address,
+            TempoHardfork::T1C
+        ));
+
+        let mut zone_portal = [0u8; 20];
+        zone_portal[..12].copy_from_slice(&Address::ZONE_PORTAL_PREFIX);
+        zone_portal[19] = 1;
+        assert!(!is_valid_multisig_account(Address::from(zone_portal), spec));
     }
 }

--- a/crates/precompiles/src/native_multisig/dispatch.rs
+++ b/crates/precompiles/src/native_multisig/dispatch.rs
@@ -1,0 +1,76 @@
+//! ABI dispatch for the [`NativeMultisig`] precompile.
+
+use super::NativeMultisig;
+use crate::{Precompile, charge_input_cost, dispatch, mutate_void, view};
+use alloy::primitives::Address;
+use revm::precompile::PrecompileResult;
+use tempo_contracts::precompiles::INativeMultisig;
+
+impl Precompile for NativeMultisig {
+    fn call(&mut self, calldata: &[u8], msg_sender: Address) -> PrecompileResult {
+        if let Some(err) = charge_input_cost(&mut self.storage, calldata) {
+            return err;
+        }
+
+        dispatch!(
+            calldata,
+            |call| match call {
+                INativeMultisig::INativeMultisigCalls {
+                    deriveAccount(call) => view(call, |c| {
+                        self.derive_account(c.salt, c.threshold, c.owners)
+                    }),
+                    getConfigCommitment(call) => {
+                        view(call, |c| self.get_config_commitment(c.account))
+                    },
+                    updateConfig(call) => mutate_void(call, msg_sender, |sender, c| {
+                        self.update_multisig_config(sender, c.current, c.threshold, c.owners)
+                    })
+                }
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        test_util::{assert_full_coverage, check_selector_coverage},
+    };
+    use alloy::sol_types::SolCall;
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_contracts::precompiles::INativeMultisig::INativeMultisigCalls;
+
+    #[test]
+    fn selectors_match_tip_1061() {
+        assert_eq!(
+            INativeMultisig::deriveAccountCall::SELECTOR,
+            [0xce, 0x8e, 0x07, 0x1c]
+        );
+        assert_eq!(
+            INativeMultisig::getConfigCommitmentCall::SELECTOR,
+            [0x5b, 0xd9, 0x33, 0x59]
+        );
+        assert_eq!(
+            INativeMultisig::updateConfigCall::SELECTOR,
+            [0x64, 0x20, 0x36, 0x45]
+        );
+    }
+
+    #[test]
+    fn selector_coverage() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+        StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            let unsupported = check_selector_coverage(
+                &mut multisig,
+                INativeMultisigCalls::SELECTORS,
+                "INativeMultisig",
+                INativeMultisigCalls::name_by_selector,
+            );
+            assert_full_coverage([unsupported]);
+            Ok(())
+        })
+    }
+}

--- a/crates/precompiles/src/native_multisig/error.rs
+++ b/crates/precompiles/src/native_multisig/error.rs
@@ -1,0 +1,53 @@
+use alloy::primitives::{Address, B256};
+use tempo_primitives::transaction::MultisigQuorumError;
+
+use crate::error::TempoPrecompileError;
+
+/// Failure while validating a native multisig authorization.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NativeMultisigAuthError {
+    /// Deterministic authorization validation failed.
+    #[error(transparent)]
+    Invalid(#[from] NativeMultisigAuthorizationError),
+    /// Validation against current native multisig state failed.
+    #[error(transparent)]
+    State(#[from] NativeMultisigStateError),
+    /// An unrecoverable precompile operation failed.
+    #[error("Fatal precompile error: {0:?}")]
+    Fatal(String),
+}
+
+impl NativeMultisigAuthError {
+    /// Converts a native multisig state-access failure into an unrecoverable error.
+    pub fn from_state_access_error(error: TempoPrecompileError) -> Self {
+        match error {
+            TempoPrecompileError::Fatal(reason) => Self::Fatal(reason),
+            error => Self::Fatal(error.to_string()),
+        }
+    }
+}
+
+/// Deterministic native multisig authorization failure.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum NativeMultisigAuthorizationError {
+    /// The signature names an account outside the native multisig address space.
+    #[error("invalid multisig account {account}")]
+    InvalidAccount { account: Address },
+    /// A primitive owner approval could not be recovered.
+    #[error("invalid multisig owner signature at approval {approval_index}")]
+    OwnerSignatureRecoveryFailed { approval_index: usize },
+    /// A keychain signature was supplied as an owner approval.
+    #[error("keychain signature cannot authorize multisig owner at approval {approval_index}")]
+    KeychainOwnerSignature { approval_index: usize },
+    /// Owner membership, ordering, or weight validation failed.
+    #[error("{0}")]
+    Quorum(MultisigQuorumError),
+}
+
+/// Native multisig failure that depends on current precompile state.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum NativeMultisigStateError {
+    /// The supplied configuration does not match the account's stored commitment.
+    #[error("multisig configuration commitment mismatch: expected {expected}, actual {actual}")]
+    ConfigurationCommitmentMismatch { expected: B256, actual: B256 },
+}

--- a/crates/precompiles/src/native_multisig/mod.rs
+++ b/crates/precompiles/src/native_multisig/mod.rs
@@ -1,0 +1,310 @@
+//! Native multisig account precompile.
+
+pub mod dispatch;
+mod error;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::{
+    NativeMultisigAuthError, NativeMultisigAuthorizationError, NativeMultisigStateError,
+};
+pub use tempo_contracts::precompiles::INativeMultisig;
+
+use crate::{
+    account_keychain::{AccountKeychain, getTransactionKeyCall},
+    error::{Result, TempoPrecompileError},
+    storage::{Handler, Mapping, StorageCtx},
+};
+use alloy::primitives::{Address, B256, TxKind, U256};
+use revm::interpreter::gas::{KECCAK256, KECCAK256WORD};
+use tempo_contracts::precompiles::{
+    NATIVE_MULTISIG_ADDRESS, NativeMultisigError, NativeMultisigEvent,
+};
+use tempo_precompiles_macros::contract;
+use tempo_primitives::transaction::{
+    MULTISIG_ACCOUNT_CREATE2_PREIMAGE_LEN, MultisigConfig, MultisigConfigError,
+    MultisigQuorumError, MultisigSignature, MultisigWeightAccumulator, TempoSignature,
+    multisig_account_address,
+};
+
+use crate::is_valid_multisig_account;
+
+/// Gas for hashing the fixed-length native multisig CREATE2 preimage.
+pub const MULTISIG_ACCOUNT_CREATE2_GAS: u64 =
+    KECCAK256 + KECCAK256WORD * MULTISIG_ACCOUNT_CREATE2_PREIMAGE_LEN.div_ceil(32) as u64;
+
+/// Native multisig account storage.
+#[contract(addr = NATIVE_MULTISIG_ADDRESS)]
+pub struct NativeMultisig {
+    /// Latest nonzero configuration commitment. Zero means no update has occurred.
+    config_commitments: Mapping<Address, B256>,
+
+    // WARNING: transient storage slots must remain after persistent storage fields until the
+    // `contract` macro supports independent persistent/transient layouts.
+    tx_origin: Address,
+    directly_authorized_account: Address,
+}
+
+impl NativeMultisig {
+    /// Returns the persistent commitment slot for `account`.
+    pub fn config_commitment_storage_slot(account: Address) -> U256 {
+        Self::new().config_commitments[account].slot()
+    }
+
+    /// Seeds the enclosing transaction origin.
+    pub fn set_tx_origin(&mut self, origin: Address) -> Result<()> {
+        self.tx_origin.t_write(origin)
+    }
+
+    /// Records the account directly authorized by the outer multisig signature.
+    pub fn set_directly_authorized_account(&mut self, account: Address) -> Result<()> {
+        self.directly_authorized_account.t_write(account)
+    }
+
+    /// Derives an account from an initial configuration without reading persistent state.
+    pub fn derive_account(
+        &self,
+        salt: B256,
+        threshold: u8,
+        owners: Vec<INativeMultisig::MultisigOwner>,
+    ) -> Result<Address> {
+        self.derive_account_from_config(&MultisigConfig {
+            salt,
+            version: 0,
+            threshold,
+            owners: owners.into_iter().map(Into::into).collect(),
+        })
+    }
+
+    /// Returns the persisted configuration commitment, including zero before the first update.
+    pub fn get_config_commitment(&self, account: Address) -> Result<B256> {
+        self.config_commitments[account].read()
+    }
+
+    /// Commits to the caller's next owner configuration.
+    pub fn update_multisig_config(
+        &mut self,
+        msg_sender: Address,
+        current: INativeMultisig::MultisigConfig,
+        threshold: u8,
+        owners: Vec<INativeMultisig::MultisigOwner>,
+    ) -> Result<()> {
+        self.ensure_update_authorized(msg_sender)?;
+
+        let current = MultisigConfig::from(current);
+        current
+            .validate_for_account(msg_sender)
+            .map_err(map_multisig_config_error)?;
+        let stored = self.get_config_commitment(msg_sender)?;
+        if current.version == 0 {
+            if !stored.is_zero()
+                || self.derive_account_from_validated_config(&current)? != msg_sender
+            {
+                return Err(NativeMultisigError::invalid_config().into());
+            }
+        } else if stored.is_zero() || self.hash_validated_config_commitment(&current)? != stored {
+            return Err(NativeMultisigError::invalid_config().into());
+        }
+
+        let version = current
+            .version
+            .checked_add(1)
+            .ok_or_else(NativeMultisigError::invalid_config)?;
+        let event_owners = owners.clone();
+        let next = MultisigConfig {
+            salt: current.salt,
+            version,
+            threshold,
+            owners: owners.into_iter().map(Into::into).collect(),
+        };
+        next.validate_for_account(msg_sender)
+            .map_err(map_multisig_config_error)?;
+        let commitment = self.hash_validated_config_commitment(&next)?;
+        if commitment.is_zero() {
+            return Err(NativeMultisigError::invalid_config().into());
+        }
+
+        self.config_commitments[msg_sender].write(commitment)?;
+        self.emit_event(NativeMultisigEvent::multisig_config_updated(
+            msg_sender,
+            next.salt,
+            next.version,
+            next.threshold,
+            event_owners,
+        ))
+    }
+
+    /// Validates every configuration witness against its account's current commitment.
+    pub fn validate_authorization_state(
+        &self,
+        signature: &MultisigSignature,
+    ) -> std::result::Result<(), NativeMultisigAuthError> {
+        self.validate_authorization_state_inner(signature)
+    }
+
+    fn validate_authorization_state_inner(
+        &self,
+        signature: &MultisigSignature,
+    ) -> std::result::Result<(), NativeMultisigAuthError> {
+        if !is_valid_multisig_account(signature.account(), self.storage.spec()) {
+            return Err(NativeMultisigAuthorizationError::InvalidAccount {
+                account: signature.account(),
+            }
+            .into());
+        }
+
+        let stored = self
+            .get_config_commitment(signature.account())
+            .map_err(NativeMultisigAuthError::from_state_access_error)?;
+        let config = signature.config();
+        let (valid, expected, actual) = if config.version == 0 {
+            (stored.is_zero(), B256::ZERO, stored)
+        } else {
+            let actual = signature.config_commitment();
+            (!stored.is_zero() && actual == stored, stored, actual)
+        };
+        if !valid {
+            return Err(NativeMultisigStateError::ConfigurationCommitmentMismatch {
+                expected,
+                actual,
+            }
+            .into());
+        }
+
+        for approval in signature.signatures() {
+            let TempoSignature::Multisig(nested) = approval else {
+                continue;
+            };
+            self.validate_authorization_state_inner(nested)?;
+        }
+        Ok(())
+    }
+
+    /// Verifies owner membership, ordering, signatures, and quorum for a validated witness tree.
+    pub fn verify_authorization_quorum(
+        inner_digest: B256,
+        signature: &MultisigSignature,
+    ) -> std::result::Result<(), NativeMultisigAuthError> {
+        let digest = signature.digest(inner_digest);
+        let config = signature.config();
+        let mut weight = MultisigWeightAccumulator::new(config.threshold)
+            .map_err(NativeMultisigAuthorizationError::Quorum)?;
+
+        for (index, approval) in signature.signatures().iter().enumerate() {
+            let owner = match approval {
+                TempoSignature::Primitive(primitive) => {
+                    primitive.recover_signer(&digest).map_err(|_| {
+                        NativeMultisigAuthorizationError::OwnerSignatureRecoveryFailed {
+                            approval_index: index,
+                        }
+                    })?
+                }
+                TempoSignature::Multisig(nested) => {
+                    Self::verify_authorization_quorum(digest, nested)?;
+                    nested.account()
+                }
+                TempoSignature::Keychain(_) => {
+                    return Err(NativeMultisigAuthorizationError::KeychainOwnerSignature {
+                        approval_index: index,
+                    }
+                    .into());
+                }
+            };
+
+            let owner_weight =
+                config
+                    .owner_weight(owner)
+                    .ok_or(NativeMultisigAuthorizationError::Quorum(
+                        MultisigQuorumError::SignerNotOwner,
+                    ))?;
+            weight
+                .record_owner(owner, owner_weight)
+                .map_err(NativeMultisigAuthorizationError::Quorum)?;
+            if weight.has_quorum() {
+                if index + 1 != signature.signatures().len() {
+                    return Err(NativeMultisigAuthorizationError::Quorum(
+                        MultisigQuorumError::ExcessSignatures,
+                    )
+                    .into());
+                }
+                return weight
+                    .finish()
+                    .map_err(NativeMultisigAuthorizationError::Quorum)
+                    .map_err(Into::into);
+            }
+        }
+
+        weight
+            .finish()
+            .map_err(NativeMultisigAuthorizationError::Quorum)
+            .map_err(Into::into)
+    }
+
+    fn ensure_update_authorized(&self, msg_sender: Address) -> Result<()> {
+        if msg_sender.is_zero()
+            || StorageCtx.tx_kind() != Some(TxKind::Call(NATIVE_MULTISIG_ADDRESS))
+            || self.tx_origin.t_read()? != msg_sender
+            || self.directly_authorized_account.t_read()? != msg_sender
+        {
+            return Err(NativeMultisigError::unauthorized_multisig_caller().into());
+        }
+
+        let transaction_key =
+            AccountKeychain::new().get_transaction_key(getTransactionKeyCall {}, msg_sender)?;
+        if !transaction_key.is_zero() {
+            return Err(NativeMultisigError::unauthorized_multisig_caller().into());
+        }
+        Ok(())
+    }
+
+    fn derive_account_from_config(&self, config: &MultisigConfig) -> Result<Address> {
+        config.validate().map_err(map_multisig_config_error)?;
+        self.derive_account_from_validated_config(config)
+    }
+
+    fn derive_account_from_validated_config(&self, config: &MultisigConfig) -> Result<Address> {
+        let preimage = config
+            .account_salt_preimage()
+            .expect("validated multisig config has an encodable owner count");
+        let account_salt = self.storage.keccak256(&preimage)?;
+        self.storage.deduct_gas(MULTISIG_ACCOUNT_CREATE2_GAS)?;
+        let account = multisig_account_address(account_salt);
+        if config.owner_weight(account).is_some() {
+            return Err(NativeMultisigError::invalid_multisig_owner().into());
+        }
+        if !is_valid_multisig_account(account, self.storage.spec()) {
+            return Err(NativeMultisigError::invalid_account().into());
+        }
+        Ok(account)
+    }
+
+    fn hash_validated_config_commitment(&self, config: &MultisigConfig) -> Result<B256> {
+        let preimage = config
+            .commitment_preimage()
+            .expect("validated multisig config has an encodable owner count");
+        self.storage.keccak256(&preimage)
+    }
+}
+
+fn map_multisig_config_error(err: MultisigConfigError) -> TempoPrecompileError {
+    match err {
+        MultisigConfigError::EmptyOwners
+        | MultisigConfigError::ZeroOwner
+        | MultisigConfigError::AccountIsOwner => {
+            NativeMultisigError::invalid_multisig_owner().into()
+        }
+        MultisigConfigError::TooManyOwners => NativeMultisigError::too_many_owners().into(),
+        MultisigConfigError::ZeroThreshold | MultisigConfigError::ThresholdExceedsWeight => {
+            NativeMultisigError::invalid_threshold().into()
+        }
+        MultisigConfigError::ZeroWeight | MultisigConfigError::TotalWeightExceedsMax => {
+            NativeMultisigError::invalid_weight().into()
+        }
+        MultisigConfigError::DuplicateOwner => NativeMultisigError::duplicate_owner().into(),
+        MultisigConfigError::OwnersNotAscending => {
+            NativeMultisigError::invalid_owner_order().into()
+        }
+        MultisigConfigError::DerivedAccountZero => NativeMultisigError::invalid_account().into(),
+    }
+}

--- a/crates/precompiles/src/native_multisig/tests.rs
+++ b/crates/precompiles/src/native_multisig/tests.rs
@@ -277,6 +277,8 @@ fn update_requires_root_authorized_direct_outer_call() -> eyre::Result<()> {
 fn update_rejects_invalid_state_and_version() {
     let initial = initial_config();
     let account = initial.derive_account().unwrap();
+    let mut other_initial = initial.clone();
+    other_initial.salt = B256::repeat_byte(0x42);
     let mut current = initial.clone();
     current.version = 1;
     let mut overflow = current.clone();
@@ -289,6 +291,7 @@ fn update_rejects_invalid_state_and_version() {
             &initial,
             B256::repeat_byte(1),
         ),
+        ("initial for another account", &other_initial, B256::ZERO),
         ("current against zero state", &current, B256::ZERO),
         (
             "current against mismatching state",

--- a/crates/precompiles/src/native_multisig/tests.rs
+++ b/crates/precompiles/src/native_multisig/tests.rs
@@ -583,21 +583,26 @@ mod auth {
         let nested_account = nested_config.derive_account().unwrap();
         let outer_config = initial_config(&[(nested_account, 1)], 1);
         let outer_account = outer_config.derive_account().unwrap();
-        let nested = signed_initial(
-            nested_config,
+        let outer = |nested| {
+            MultisigSignature::try_new(
+                outer_account,
+                outer_config.clone(),
+                vec![TempoSignature::Multisig(nested)],
+            )
+            .unwrap()
+        };
+
+        let valid = outer(signed_initial(
+            nested_config.clone(),
             multisig_digest(inner_digest, outer_account, 0),
             &[&owner],
-        );
-        let outer = MultisigSignature::try_new(
-            outer_account,
-            outer_config,
-            vec![TempoSignature::Multisig(nested)],
-        )
-        .unwrap();
-
+        ));
         assert_eq!(
-            NativeMultisig::verify_authorization_quorum(inner_digest, &outer),
+            NativeMultisig::verify_authorization_quorum(inner_digest, &valid),
             Ok(())
         );
+
+        let invalid = outer(signed_initial(nested_config, inner_digest, &[&owner]));
+        assert_quorum_error(&invalid, MultisigQuorumError::SignerNotOwner);
     }
 }

--- a/crates/precompiles/src/native_multisig/tests.rs
+++ b/crates/precompiles/src/native_multisig/tests.rs
@@ -1,0 +1,600 @@
+use super::*;
+use crate::{
+    error::TempoPrecompileError,
+    storage::{StorageCtx, hashmap::HashMapStorageProvider},
+};
+use alloy::primitives::{IntoLogData, address, keccak256};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::transaction::MultisigOwner;
+
+fn initial_config() -> MultisigConfig {
+    MultisigConfig {
+        salt: B256::ZERO,
+        version: 0,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: address!("0000000000000000000000000000000000000011"),
+            weight: 1,
+        }],
+    }
+}
+
+fn abi_config(config: &MultisigConfig) -> INativeMultisig::MultisigConfig {
+    config.clone().into()
+}
+
+fn abi_owners(owner: Address) -> Vec<INativeMultisig::MultisigOwner> {
+    vec![INativeMultisig::MultisigOwner { owner, weight: 1 }]
+}
+
+fn update_error(
+    account: Address,
+    current: &MultisigConfig,
+    stored: B256,
+    threshold: u8,
+    owners: Vec<INativeMultisig::MultisigOwner>,
+) -> NativeMultisigError {
+    let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12)
+        .with_tx_kind(TxKind::Call(NATIVE_MULTISIG_ADDRESS));
+    StorageCtx::enter(&mut storage, || {
+        let mut multisig = NativeMultisig::new();
+        multisig.set_tx_origin(account)?;
+        multisig.set_directly_authorized_account(account)?;
+        if !stored.is_zero() {
+            multisig.config_commitments[account].write(stored)?;
+        }
+        match multisig.update_multisig_config(account, abi_config(current), threshold, owners) {
+            Err(TempoPrecompileError::NativeMultisigError(error)) => {
+                Ok::<_, TempoPrecompileError>(error)
+            }
+            result => panic!("expected native multisig error, got {result:?}"),
+        }
+    })
+    .unwrap()
+}
+
+#[test]
+fn commitment_slot_matches_tip_layout() {
+    let account = Address::repeat_byte(0x11);
+    let mut preimage = [0u8; 64];
+    preimage[12..32].copy_from_slice(account.as_slice());
+
+    assert_eq!(
+        NativeMultisig::config_commitment_storage_slot(account),
+        U256::from_be_bytes(keccak256(preimage).0)
+    );
+}
+
+#[test]
+fn derive_account_is_stateless() -> eyre::Result<()> {
+    let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+    let config = initial_config();
+    let expected = config.derive_account().unwrap();
+
+    StorageCtx::enter(&mut storage, || {
+        assert_eq!(
+            NativeMultisig::new().derive_account(
+                config.salt,
+                config.threshold,
+                config.owners.clone().into_iter().map(Into::into).collect(),
+            )?,
+            expected
+        );
+        Ok::<_, TempoPrecompileError>(())
+    })?;
+
+    assert_eq!(storage.counter_sload(), 0);
+    assert_eq!(storage.counter_sstore(), 0);
+    Ok(())
+}
+
+#[test]
+fn updates_replace_one_commitment_and_emit_config() -> eyre::Result<()> {
+    let config = initial_config();
+    let account = config.derive_account().unwrap();
+    let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12)
+        .with_tx_kind(TxKind::Call(NATIVE_MULTISIG_ADDRESS));
+
+    let first_owner = address!("0000000000000000000000000000000000000022");
+    StorageCtx::enter(&mut storage, || {
+        let mut multisig = NativeMultisig::new();
+        multisig.set_tx_origin(account)?;
+        multisig.set_directly_authorized_account(account)?;
+        multisig.update_multisig_config(
+            account,
+            abi_config(&config),
+            1,
+            abi_owners(first_owner),
+        )?;
+        Ok::<_, TempoPrecompileError>(())
+    })?;
+
+    assert_eq!(storage.counter_sstore(), 1);
+    let first_event = NativeMultisigEvent::multisig_config_updated(
+        account,
+        config.salt,
+        1,
+        1,
+        abi_owners(first_owner),
+    )
+    .into_log_data();
+    assert_eq!(
+        storage.get_events(NATIVE_MULTISIG_ADDRESS).as_slice(),
+        std::slice::from_ref(&first_event)
+    );
+    let current = MultisigConfig {
+        salt: config.salt,
+        version: 1,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: first_owner,
+            weight: 1,
+        }],
+    };
+    StorageCtx::enter(&mut storage, || {
+        assert_eq!(
+            NativeMultisig::new().get_config_commitment(account)?,
+            current.commitment().unwrap()
+        );
+        Ok::<_, TempoPrecompileError>(())
+    })?;
+
+    storage.clear_transient();
+    storage.reset_counters();
+    let second_owner = address!("0000000000000000000000000000000000000033");
+    StorageCtx::enter(&mut storage, || {
+        let mut multisig = NativeMultisig::new();
+        multisig.set_tx_origin(account)?;
+        multisig.set_directly_authorized_account(account)?;
+        multisig.update_multisig_config(account, abi_config(&current), 1, abi_owners(second_owner))
+    })?;
+    assert_eq!(storage.counter_sstore(), 1);
+
+    let next = MultisigConfig {
+        owners: vec![MultisigOwner {
+            owner: second_owner,
+            weight: 1,
+        }],
+        version: 2,
+        ..current
+    };
+    StorageCtx::enter(&mut storage, || {
+        assert_eq!(
+            NativeMultisig::new().get_config_commitment(account)?,
+            next.commitment().unwrap()
+        );
+        Ok::<_, TempoPrecompileError>(())
+    })?;
+    let second_event = NativeMultisigEvent::multisig_config_updated(
+        account,
+        next.salt,
+        next.version,
+        next.threshold,
+        abi_owners(second_owner),
+    )
+    .into_log_data();
+    assert_eq!(
+        storage.get_events(NATIVE_MULTISIG_ADDRESS).as_slice(),
+        &[first_event, second_event]
+    );
+    Ok(())
+}
+
+#[test]
+fn update_requires_root_authorized_direct_outer_call() -> eyre::Result<()> {
+    let config = initial_config();
+    let account = config.derive_account().unwrap();
+    let other = Address::repeat_byte(0x44);
+    let valid_target = Some(TxKind::Call(NATIVE_MULTISIG_ADDRESS));
+
+    assert_eq!(
+        update_error(
+            Address::ZERO,
+            &config,
+            B256::ZERO,
+            1,
+            abi_owners(Address::repeat_byte(0x22)),
+        ),
+        NativeMultisigError::unauthorized_multisig_caller(),
+    );
+
+    let cases = [
+        (
+            "missing transaction target",
+            None,
+            account,
+            account,
+            Address::ZERO,
+        ),
+        (
+            "wrong transaction target",
+            Some(TxKind::Call(other)),
+            account,
+            account,
+            Address::ZERO,
+        ),
+        (
+            "contract-creation transaction",
+            Some(TxKind::Create),
+            account,
+            account,
+            Address::ZERO,
+        ),
+        (
+            "different transaction origin",
+            valid_target,
+            other,
+            account,
+            Address::ZERO,
+        ),
+        (
+            "different outer authority",
+            valid_target,
+            account,
+            other,
+            Address::ZERO,
+        ),
+        (
+            "access-key transaction",
+            valid_target,
+            account,
+            account,
+            other,
+        ),
+    ];
+
+    for (case, tx_kind, origin, directly_authorized, transaction_key) in cases {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+        if let Some(tx_kind) = tx_kind {
+            storage = storage.with_tx_kind(tx_kind);
+        }
+        StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            multisig.set_tx_origin(origin)?;
+            multisig.set_directly_authorized_account(directly_authorized)?;
+            AccountKeychain::new().set_transaction_key(transaction_key)?;
+            assert!(
+                matches!(
+                    multisig.update_multisig_config(
+                        account,
+                        abi_config(&config),
+                        1,
+                        abi_owners(Address::repeat_byte(0x22)),
+                    ),
+                    Err(TempoPrecompileError::NativeMultisigError(
+                        NativeMultisigError::UnauthorizedMultisigCaller(_)
+                    ))
+                ),
+                "{case}"
+            );
+            Ok::<_, TempoPrecompileError>(())
+        })?;
+    }
+    Ok(())
+}
+
+#[test]
+fn update_rejects_invalid_state_and_version() {
+    let initial = initial_config();
+    let account = initial.derive_account().unwrap();
+    let mut current = initial.clone();
+    current.version = 1;
+    let mut overflow = current.clone();
+    overflow.version = u64::MAX;
+    let next = abi_owners(Address::repeat_byte(0x22));
+
+    for (case, config, stored) in [
+        (
+            "initial against nonzero state",
+            &initial,
+            B256::repeat_byte(1),
+        ),
+        ("current against zero state", &current, B256::ZERO),
+        (
+            "current against mismatching state",
+            &current,
+            B256::repeat_byte(2),
+        ),
+        (
+            "version overflow",
+            &overflow,
+            overflow.commitment().unwrap(),
+        ),
+    ] {
+        assert_eq!(
+            update_error(account, config, stored, 1, next.clone()),
+            NativeMultisigError::invalid_config(),
+            "{case}",
+        );
+    }
+}
+
+#[test]
+fn update_config_errors_follow_tip_order() {
+    let current = initial_config();
+    let account = current.derive_account().unwrap();
+    let owner = |byte, weight| INativeMultisig::MultisigOwner {
+        owner: Address::repeat_byte(byte),
+        weight,
+    };
+    let too_many = (1..=49).map(|byte| owner(byte, 1)).collect::<Vec<_>>();
+
+    let cases = [
+        (
+            "empty owners precede zero threshold",
+            0,
+            vec![],
+            NativeMultisigError::invalid_multisig_owner(),
+        ),
+        (
+            "owner limit precedes zero threshold",
+            0,
+            too_many,
+            NativeMultisigError::too_many_owners(),
+        ),
+        (
+            "zero owner precedes zero weight",
+            1,
+            vec![INativeMultisig::MultisigOwner {
+                owner: Address::ZERO,
+                weight: 0,
+            }],
+            NativeMultisigError::invalid_multisig_owner(),
+        ),
+        (
+            "self owner precedes zero weight",
+            1,
+            vec![INativeMultisig::MultisigOwner {
+                owner: account,
+                weight: 0,
+            }],
+            NativeMultisigError::invalid_multisig_owner(),
+        ),
+        (
+            "zero weight precedes duplicate owner",
+            1,
+            vec![owner(0x22, 1), owner(0x22, 0)],
+            NativeMultisigError::invalid_weight(),
+        ),
+        (
+            "duplicate owner",
+            1,
+            vec![owner(0x22, 1), owner(0x22, 1)],
+            NativeMultisigError::duplicate_owner(),
+        ),
+        (
+            "owner order",
+            1,
+            vec![owner(0x33, 1), owner(0x22, 1)],
+            NativeMultisigError::invalid_owner_order(),
+        ),
+        (
+            "weight overflow precedes reachability",
+            u8::MAX,
+            vec![owner(0x22, 128), owner(0x33, 128)],
+            NativeMultisigError::invalid_weight(),
+        ),
+        (
+            "unreachable threshold",
+            2,
+            vec![owner(0x22, 1)],
+            NativeMultisigError::invalid_threshold(),
+        ),
+    ];
+
+    for (case, threshold, owners, expected) in cases {
+        assert_eq!(
+            update_error(account, &current, B256::ZERO, threshold, owners),
+            expected,
+            "{case}",
+        );
+    }
+}
+
+mod auth {
+    use crate::{
+        native_multisig::{
+            NativeMultisig, NativeMultisigAuthError, NativeMultisigAuthorizationError,
+            NativeMultisigStateError,
+        },
+        storage::{Handler, StorageCtx, hashmap::HashMapStorageProvider},
+    };
+    use alloy::primitives::{Address, B256, Signature};
+    use alloy_signer::SignerSync;
+    use alloy_signer_local::PrivateKeySigner;
+    use tempo_chainspec::hardfork::TempoHardfork;
+    use tempo_primitives::transaction::{
+        MultisigConfig, MultisigOwner, MultisigQuorumError, MultisigSignature, PrimitiveSignature,
+        TempoSignature, multisig_digest,
+    };
+    fn signer(seed: u8) -> PrivateKeySigner {
+        PrivateKeySigner::from_bytes(&B256::with_last_byte(seed)).unwrap()
+    }
+
+    fn initial_config(owners: &[(Address, u8)], threshold: u8) -> MultisigConfig {
+        let mut owners = owners
+            .iter()
+            .map(|&(owner, weight)| MultisigOwner { owner, weight })
+            .collect::<Vec<_>>();
+        owners.sort_by_key(|owner| owner.owner);
+        MultisigConfig {
+            salt: B256::ZERO,
+            version: 0,
+            threshold,
+            owners,
+        }
+    }
+
+    fn signed_initial(
+        config: MultisigConfig,
+        inner_digest: B256,
+        signers: &[&PrivateKeySigner],
+    ) -> MultisigSignature {
+        let account = config.derive_account().unwrap();
+        let digest = multisig_digest(inner_digest, account, 0);
+        let approvals = signers
+            .iter()
+            .map(|signer| {
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                    signer.sign_hash_sync(&digest).unwrap(),
+                ))
+            })
+            .collect();
+        MultisigSignature::try_new(account, config, approvals).unwrap()
+    }
+
+    fn assert_quorum_error(signature: &MultisigSignature, expected: MultisigQuorumError) {
+        assert_eq!(
+            NativeMultisig::verify_authorization_quorum(B256::repeat_byte(0x42), signature),
+            Err(NativeMultisigAuthError::Invalid(
+                NativeMultisigAuthorizationError::Quorum(expected)
+            ))
+        );
+    }
+
+    fn signature(version: u64) -> MultisigSignature {
+        let config = MultisigConfig {
+            salt: B256::ZERO,
+            version,
+            threshold: 1,
+            owners: vec![MultisigOwner {
+                owner: Address::repeat_byte(0x11),
+                weight: 1,
+            }],
+        };
+        let account = if version == 0 {
+            config.derive_account().unwrap()
+        } else {
+            Address::repeat_byte(0x22)
+        };
+        MultisigSignature::try_new(
+            account,
+            config,
+            vec![TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                Signature::test_signature(),
+            ))],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn initial_witness_requires_zero_commitment() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+        StorageCtx::enter(&mut storage, || {
+            NativeMultisig::new().validate_authorization_state(&signature(0))
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn current_witness_requires_matching_commitment() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+        let signature = signature(1);
+        StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            multisig.config_commitments[signature.account()]
+                .write(signature.config().commitment().unwrap())
+                .map_err(NativeMultisigAuthError::from_state_access_error)?;
+            multisig.validate_authorization_state(&signature)
+        })?;
+        Ok(())
+    }
+
+    #[test]
+    fn commitment_mismatch_reports_expected_and_actual() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+        let signature = signature(1);
+        let expected = B256::repeat_byte(0x11);
+        let actual = signature.config_commitment();
+        let error = StorageCtx::enter(&mut storage, || {
+            let mut multisig = NativeMultisig::new();
+            multisig.config_commitments[signature.account()]
+                .write(expected)
+                .map_err(NativeMultisigAuthError::from_state_access_error)?;
+            multisig.validate_authorization_state(&signature)
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            NativeMultisigAuthError::State(
+                NativeMultisigStateError::ConfigurationCommitmentMismatch { expected, actual }
+            )
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn primitive_quorum_enforces_membership_order_weight_and_minimality() {
+        let signer_a = signer(1);
+        let signer_b = signer(2);
+        let outsider = signer(3);
+        let mut owners = [&signer_a, &signer_b];
+        owners.sort_by_key(|signer| signer.address());
+        let config = initial_config(
+            &owners
+                .iter()
+                .map(|signer| (signer.address(), 1))
+                .collect::<Vec<_>>(),
+            2,
+        );
+        let inner_digest = B256::repeat_byte(0x42);
+
+        let valid = signed_initial(config.clone(), inner_digest, &owners);
+        assert_eq!(
+            NativeMultisig::verify_authorization_quorum(inner_digest, &valid),
+            Ok(())
+        );
+
+        let insufficient = signed_initial(config.clone(), inner_digest, &owners[..1]);
+        assert_quorum_error(&insufficient, MultisigQuorumError::WeightBelowThreshold);
+
+        owners.reverse();
+        let unordered = signed_initial(config.clone(), inner_digest, &owners);
+        assert_quorum_error(&unordered, MultisigQuorumError::SignersNotAscending);
+        owners.reverse();
+
+        let excess = signed_initial(
+            MultisigConfig {
+                threshold: 1,
+                ..config
+            },
+            inner_digest,
+            &owners,
+        );
+        assert_quorum_error(&excess, MultisigQuorumError::ExcessSignatures);
+
+        let non_owner = signed_initial(
+            initial_config(&[(owners[0].address(), 1)], 1),
+            inner_digest,
+            &[&outsider],
+        );
+        assert_quorum_error(&non_owner, MultisigQuorumError::SignerNotOwner);
+    }
+
+    #[test]
+    fn nested_multisig_quorum_is_verified_recursively() {
+        let owner = signer(4);
+        let inner_digest = B256::repeat_byte(0x42);
+        let nested_config = initial_config(&[(owner.address(), 1)], 1);
+        let nested_account = nested_config.derive_account().unwrap();
+        let outer_config = initial_config(&[(nested_account, 1)], 1);
+        let outer_account = outer_config.derive_account().unwrap();
+        let nested = signed_initial(
+            nested_config,
+            multisig_digest(inner_digest, outer_account, 0),
+            &[&owner],
+        );
+        let outer = MultisigSignature::try_new(
+            outer_account,
+            outer_config,
+            vec![TempoSignature::Multisig(nested)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            NativeMultisig::verify_authorization_quorum(inner_digest, &outer),
+            Ok(())
+        );
+    }
+}

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -3,7 +3,7 @@ use crate::{
     storage::{PrecompileStorageProvider, StorageActions, actions::StorageAction},
     storage_credits::{NonCreditableSlots, sstore_storage_credits},
 };
-use alloy::primitives::{Address, B256, Log, LogData, U256};
+use alloy::primitives::{Address, B256, Log, LogData, TxKind, U256};
 use alloy_evm::EvmInternals;
 use bitflags::bitflags;
 use revm::{
@@ -348,6 +348,10 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         self.internals
             .block_env_downcast_ref::<TempoBlockEnv>()
             .expect("EvmPrecompileStorageProvider requires TempoBlockEnv")
+    }
+
+    fn tx_kind(&self) -> Option<TxKind> {
+        Some(self.internals.tx_env().kind())
     }
 
     #[inline]

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256, LogData, U256};
+use alloy::primitives::{Address, B256, LogData, TxKind, U256};
 use revm::{
     context::{BlockEnv, journaled_state::JournalCheckpoint},
     context_interface::cfg::GasParams,
@@ -25,6 +25,7 @@ pub struct HashMapStorageProvider {
     fail_on_sload: Option<(Address, U256)>,
     chain_id: u64,
     block_env: TempoBlockEnv,
+    tx_kind: Option<TxKind>,
     spec: TempoHardfork,
     amsterdam_eip8037_enabled: bool,
     is_static: bool,
@@ -78,6 +79,7 @@ impl HashMapStorageProvider {
                 },
                 ..Default::default()
             },
+            tx_kind: None,
             spec,
             amsterdam_eip8037_enabled: false,
             is_static: false,
@@ -104,6 +106,12 @@ impl HashMapStorageProvider {
         self.gas_params = GasParams::new_spec(self.spec.into());
         self
     }
+
+    /// Returns self with the top-level transaction target overridden.
+    pub fn with_tx_kind(mut self, tx_kind: TxKind) -> Self {
+        self.tx_kind = Some(tx_kind);
+        self
+    }
 }
 
 impl PrecompileStorageProvider for HashMapStorageProvider {
@@ -113,6 +121,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn block_env(&self) -> &TempoBlockEnv {
         &self.block_env
+    }
+
+    fn tx_kind(&self) -> Option<TxKind> {
+        self.tx_kind
     }
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -21,7 +21,7 @@ pub mod packing;
 pub use packing::FieldLocation;
 pub use types::mapping as slots;
 
-use alloy::primitives::{Address, B256, LogData, Signature, U256};
+use alloy::primitives::{Address, B256, LogData, Signature, TxKind, U256};
 use revm::{
     context::journaled_state::JournalCheckpoint,
     interpreter::gas::{KECCAK256, KECCAK256WORD},
@@ -49,6 +49,9 @@ pub trait PrecompileStorageProvider {
 
     /// Returns the full Tempo block environment.
     fn block_env(&self) -> &TempoBlockEnv;
+
+    /// Returns the current top-level transaction call target when the provider models one.
+    fn tx_kind(&self) -> Option<TxKind>;
 
     /// Sets the bytecode at the given address.
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<()>;

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -1,5 +1,5 @@
 use alloy::{
-    primitives::{Address, B256, Bytes, LogData, U256},
+    primitives::{Address, B256, Bytes, LogData, TxKind, U256},
     sol_types::SolInterface,
 };
 use alloy_evm::{Database, EvmInternals};
@@ -153,6 +153,11 @@ impl StorageCtx {
         Self::with_storage(|s| f(s.block_env()))
     }
 
+    /// Returns the current top-level transaction call target.
+    pub fn tx_kind(&self) -> Option<TxKind> {
+        Self::with_storage(|s| s.tx_kind())
+    }
+
     /// Returns the epoch containing `height`.
     pub fn epoch(&self, height: u64) -> u64 {
         self.with_block_env(|block_env| block_env.epoch(height))
@@ -288,7 +293,7 @@ impl StorageCtx {
     }
 
     /// Deducts gas from the remaining gas and returns an error if insufficient.
-    pub fn deduct_gas(&mut self, gas: u64) -> Result<()> {
+    pub fn deduct_gas(&self, gas: u64) -> Result<()> {
         Self::try_with_storage(|s| s.deduct_gas(gas))
     }
 

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -303,6 +303,10 @@ impl<S, M> PrecompileStorageProvider for ReadOnlyStorageProvider<'_, S, M>
 where
     S: TempoStateAccess<M>,
 {
+    fn tx_kind(&self) -> Option<TxKind> {
+        None
+    }
+
     fn spec(&self) -> TempoHardfork {
         self.spec
     }

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use alloy_consensus::Sealable as _;
-use alloy_primitives::{Address, B256, Bytes, LogData, U256, keccak256};
+use alloy_primitives::{Address, B256, Bytes, LogData, TxKind, U256, keccak256};
 use commonware_codec::{Encode as _, EncodeSize, RangeCfg, Read, ReadExt, Write};
 use commonware_consensus::types::Epoch;
 use commonware_cryptography::{
@@ -488,6 +488,10 @@ where
 
     fn block_env(&self) -> &TempoBlockEnv {
         &self.block_env
+    }
+
+    fn tx_kind(&self) -> Option<TxKind> {
+        None
     }
 
     fn set_code(&mut self, _address: Address, _code: Bytecode) -> Result<(), TempoPrecompileError> {


### PR DESCRIPTION
Adds the unregistered native multisig precompile with one-slot commitment storage, ABI dispatch, state validation, and quorum verification.

Stacked on #7236; reference implementation: #4069.