### PR TITLE
feat(pool): revalidate native multisig transactions

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -1,8 +1,11 @@
 //! Transaction pool maintenance tasks.
 
 use crate::{
-    RevokedKeys, SpendingLimitUpdates, TempoTransactionPool, metrics::TempoPoolMaintenanceMetrics,
-    transaction::TempoPooledTransaction, validator::ConfigureTempoPoolEvm,
+    RevokedKeys, SpendingLimitUpdates, TempoTransactionPool,
+    metrics::TempoPoolMaintenanceMetrics,
+    tempo_pool::{InvalidationScanOutcome, MultisigUpdateAction},
+    transaction::TempoPooledTransaction,
+    validator::ConfigureTempoPoolEvm,
 };
 use alloy_primitives::{
     Address, B256, Log, TxHash,
@@ -18,9 +21,12 @@ use reth_storage_api::StateProviderFactory;
 use reth_transaction_pool::{AllPoolTransactions, TransactionPool};
 use std::time::Instant;
 use tempo_chainspec::hardfork::TempoHardforks;
-use tempo_contracts::precompiles::{IAccountKeychain, IFeeManager, ITIP20, ITIP403Registry};
+use tempo_contracts::precompiles::{
+    IAccountKeychain, IFeeManager, INativeMultisig, ITIP20, ITIP403Registry,
+};
 use tempo_precompiles::{
-    ACCOUNT_KEYCHAIN_ADDRESS, TIP_FEE_MANAGER_ADDRESS, TIP403_REGISTRY_ADDRESS,
+    ACCOUNT_KEYCHAIN_ADDRESS, NATIVE_MULTISIG_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
+    TIP403_REGISTRY_ADDRESS,
 };
 use tempo_primitives::{TempoAddressExt, TempoHeader, TempoPrimitives};
 use tracing::{debug, error};
@@ -91,6 +97,11 @@ pub struct TempoPoolUpdates {
     /// Pending AA transactions carrying the same `(account, witness)` key authorization are no
     /// longer executable once the account explicitly burns that witness.
     pub key_authorization_witness_burns: AddressMap<B256Set>,
+    /// Native multisig accounts whose configuration commitment changed.
+    ///
+    /// Transactions carrying the account's configuration or newly authorizing it as an access key
+    /// must be revalidated against the new commitment. Indexed by account.
+    pub multisig_config_changes: AddressSet,
 }
 
 impl TempoPoolUpdates {
@@ -114,6 +125,7 @@ impl TempoPoolUpdates {
             && self.fee_balance_changes.is_empty()
             && self.spending_limit_spends.is_empty()
             && self.key_authorization_witness_burns.is_empty()
+            && self.multisig_config_changes.is_empty()
     }
 
     /// Extracts pool updates from a committed chain segment.
@@ -233,9 +245,33 @@ impl TempoPoolUpdates {
                     Some(_) | None => {}
                 }
             }
+            // Native multisig configuration updates.
+            else if log.address == NATIVE_MULTISIG_ADDRESS {
+                updates.record_native_multisig_config_change(log);
+            }
         }
 
         updates
+    }
+
+    fn record_native_multisig_config_change(&mut self, log: &Log) {
+        if let Some(event) = decode_native_multisig_event(log) {
+            self.multisig_config_changes.insert(event.account);
+        }
+    }
+
+    /// Adds multisig configurations changed by a reverted chain segment.
+    fn extend_reverted_multisig_config_changes(&mut self, chain: &Chain<TempoPrimitives>) {
+        for log in chain
+            .execution_outcome()
+            .receipts()
+            .iter()
+            .flatten()
+            .flat_map(|receipt| &receipt.logs)
+            .filter(|log| log.address == NATIVE_MULTISIG_ADDRESS)
+        {
+            self.record_native_multisig_config_change(log);
+        }
     }
 
     /// Returns true if there are any invalidation events that require scanning the pool.
@@ -249,6 +285,22 @@ impl TempoPoolUpdates {
             || !self.paused_tokens.is_empty()
             || !self.fee_balance_changes.is_empty()
             || !self.key_authorization_witness_burns.is_empty()
+    }
+
+    /// Returns true if these updates require inspecting pooled transactions.
+    pub fn requires_pool_scan(&self) -> bool {
+        self.has_invalidation_events() || self.has_multisig_updates()
+    }
+
+    pub(crate) fn affects_multisig_transaction(
+        &self,
+        transaction: &TempoPooledTransaction,
+    ) -> bool {
+        transaction.depends_on_multisig_config(&self.multisig_config_changes)
+    }
+
+    pub(crate) fn has_multisig_updates(&self) -> bool {
+        !self.multisig_config_changes.is_empty()
     }
 
     /// Returns true if updates may invalidate keychain-signature transactions.
@@ -297,6 +349,14 @@ impl AccountKeychainPoolEvent {
             }
             _ => None,
         }
+    }
+}
+
+/// Decodes the native-multisig event used by transaction-pool maintenance.
+fn decode_native_multisig_event(log: &Log) -> Option<INativeMultisig::MultisigConfigUpdated> {
+    match first_topic(log)? {
+        INativeMultisig::MultisigConfigUpdated::SIGNATURE_HASH => decode_event(log),
+        _ => None,
     }
 }
 
@@ -492,17 +552,17 @@ where
 
     // Process all maintenance operations on new block commit or reorg.
     while let Some(event) = chain_events.next().await {
-        let new = match event {
-            CanonStateNotification::Reorg { old: _, new } => {
+        let (new, reverted) = match event {
+            CanonStateNotification::Reorg { old, new } => {
                 // Repopulate AMM liquidity cache from the new canonical chain
                 // to invalidate stale entries from orphaned blocks.
                 if let Err(err) = amm_cache.repopulate(pool.client()) {
                     error!(target: "txpool", ?err, "AMM liquidity cache repopulate after reorg failed");
                 }
 
-                new
+                (new, Some(old))
             }
-            CanonStateNotification::Commit { new } => new,
+            CanonStateNotification::Commit { new } => (new, None),
         };
 
         let block_update_start = Instant::now();
@@ -539,7 +599,10 @@ where
             .record(amm_start.elapsed());
 
         // 3. Collect all block-level invalidation events
-        let updates = TempoPoolUpdates::from_chain(tip);
+        let mut updates = TempoPoolUpdates::from_chain(tip);
+        if let Some(reverted) = reverted {
+            updates.extend_reverted_multisig_config_changes(&reverted);
+        }
 
         let mut all_txs: Option<AllPoolTransactions<TempoPooledTransaction>> = None;
         // Reth's canonical-update handling may not have pruned mined transactions yet.
@@ -623,22 +686,49 @@ where
             user_token_changes = updates.user_token_changes.len(),
             blacklist_additions = updates.blacklist_additions.len(),
             whitelist_removals = updates.whitelist_removals.len(),
+            multisig_config_changes = updates.multisig_config_changes.len(),
             "Processing transaction invalidation events"
         );
-        let evicted = {
+        let InvalidationScanOutcome {
+            evicted,
+            multisig_to_revalidate,
+        } = {
             let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
-            pool.evict_invalidated_transactions_from(
+            pool.scan_and_remove_invalidated_transactions(
                 &updates,
                 all_txs
                     .iter()
                     .filter(|tx| !removed_this_iteration.contains(tx.hash())),
                 Some(tip_timestamp.saturating_add(EVICTION_BUFFER_SECS)),
+                MultisigUpdateAction::Revalidate,
             )
         };
         metrics
             .transactions_invalidated
             .increment(evicted.len() as u64);
         removed_txs.push(evicted);
+
+        if !multisig_to_revalidate.is_empty() {
+            let count = multisig_to_revalidate.len();
+            metrics.multisig_revalidated.increment(count as u64);
+
+            let pool_clone = pool.clone();
+            tokio::spawn(async move {
+                let txs = multisig_to_revalidate
+                    .into_iter()
+                    .map(|tx| (tx.origin, tx.transaction.with_discarded_caches()))
+                    .collect();
+                let results = pool_clone.add_transactions_with_origins(txs).await;
+                let success = results.iter().filter(|result| result.is_ok()).count();
+                debug!(
+                    target: "txpool",
+                    total = count,
+                    success,
+                    reason = "native multisig state update",
+                    "Re-validated transactions"
+                );
+            });
+        }
         metrics
             .invalidation_eviction_duration_seconds
             .record(invalidation_start.elapsed());
@@ -895,6 +985,29 @@ mod tests {
         }
 
         #[test]
+        fn native_multisig_decode_matches_generated_event_decoders() {
+            let log = event_log(
+                NATIVE_MULTISIG_ADDRESS,
+                INativeMultisig::MultisigConfigUpdated {
+                    account: Address::random(),
+                    salt: B256::random(),
+                    version: 1,
+                    threshold: 2,
+                    owners: vec![INativeMultisig::MultisigOwner {
+                        owner: Address::random(),
+                        weight: 1,
+                    }],
+                },
+            );
+            assert_eq!(
+                decode_native_multisig_event(&log),
+                Some(generated_decode::<INativeMultisig::MultisigConfigUpdated>(
+                    &log
+                ))
+            );
+        }
+
+        #[test]
         fn fee_manager_decode_matches_generated_event_decoders() {
             let log = event_log(
                 TIP_FEE_MANAGER_ADDRESS,
@@ -1045,6 +1158,34 @@ mod tests {
         ))
     }
 
+    fn create_native_multisig_update_chain(account: Address) -> Arc<Chain<TempoPrimitives>> {
+        let log = Log::new_from_event_unchecked(
+            NATIVE_MULTISIG_ADDRESS,
+            INativeMultisig::MultisigConfigUpdated {
+                account,
+                salt: B256::random(),
+                version: 1,
+                threshold: 1,
+                owners: vec![INativeMultisig::MultisigOwner {
+                    owner: Address::random(),
+                    weight: 1,
+                }],
+            },
+        )
+        .reserialize();
+        let receipt = tempo_primitives::TempoReceipt {
+            tx_type: tempo_primitives::TempoTxType::AA,
+            success: true,
+            cumulative_gas_used: 1,
+            logs: vec![log],
+        };
+
+        create_test_chain_with_receipts(
+            vec![create_block_with_txs(1, vec![], vec![])],
+            vec![vec![receipt]],
+        )
+    }
+
     /// Helper to create a recovered block containing the given transactions.
     fn create_block_with_txs(
         block_number: u64,
@@ -1064,6 +1205,38 @@ mod tests {
         };
         let block = Block::new(header, body);
         RecoveredBlock::new_unhashed(block, senders)
+    }
+
+    #[test]
+    fn reorg_updates_include_reverted_multisig_config_changes() {
+        let account = Address::random();
+        let reverted = create_native_multisig_update_chain(account);
+        let replacement = create_test_chain(vec![create_block_with_txs(1, vec![], vec![])]);
+
+        let mut updates = TempoPoolUpdates::from_chain(&replacement);
+        assert!(updates.multisig_config_changes.is_empty());
+        assert!(!updates.requires_pool_scan());
+
+        updates.extend_reverted_multisig_config_changes(&reverted);
+
+        assert!(updates.requires_pool_scan());
+        assert_eq!(
+            updates.multisig_config_changes,
+            AddressSet::from_iter([account])
+        );
+    }
+
+    #[test]
+    fn committed_multisig_update_tracks_config_changes() {
+        let account = Address::random();
+        let chain = create_native_multisig_update_chain(account);
+
+        let updates = TempoPoolUpdates::from_chain(&chain);
+        assert!(updates.requires_pool_scan());
+        assert_eq!(
+            updates.multisig_config_changes,
+            AddressSet::from_iter([account])
+        );
     }
 
     /// Helper to extract a TempoTxEnvelope from a TempoPooledTransaction.

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -101,4 +101,7 @@ pub struct TempoPoolMaintenanceMetrics {
 
     /// Number of transactions re-validated due to quote token updates.
     pub quote_token_revalidated: Counter,
+
+    /// Number of transactions re-validated due to native multisig state changes.
+    pub multisig_revalidated: Counter,
 }

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -79,6 +79,7 @@ where
         }
     }
 }
+
 impl<Client, EvmConfig> TempoTransactionPool<Client, EvmConfig>
 where
     Client: StateProviderFactory
@@ -129,6 +130,8 @@ where
     /// 4. **Fee payer balance changes**: Transactions whose fee payer no longer has enough
     ///    balance in the resolved fee token after a TIP20 transfer
     /// 5. **Fee token pauses**: Transactions using a token paused in the committed block
+    /// 6. **Native multisig updates**: Transactions whose authorization depends on a changed
+    ///    multisig configuration
     ///
     /// All checks are combined into one scan to avoid iterating the pool multiple times
     /// per block.
@@ -136,24 +139,31 @@ where
         &self,
         updates: &crate::maintain::TempoPoolUpdates,
     ) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
-        if !updates.has_invalidation_events() {
+        if !updates.requires_pool_scan() {
             return Vec::new();
         }
 
         let all_txs = self.all_transactions();
-        self.evict_invalidated_transactions_from(updates, all_txs.iter(), None)
+        self.scan_and_remove_invalidated_transactions(
+            updates,
+            all_txs.iter(),
+            None,
+            MultisigUpdateAction::Evict,
+        )
+        .evicted
     }
 
-    /// See [`Self::evict_invalidated_transactions`]; returns the removed transactions so
-    /// the caller controls when they are dropped.
-    pub(crate) fn evict_invalidated_transactions_from<'a>(
+    /// Scans one transaction snapshot and partitions removals by their next action.
+    pub(crate) fn scan_and_remove_invalidated_transactions<'a>(
         &self,
         updates: &crate::maintain::TempoPoolUpdates,
         transactions: impl IntoIterator<Item = &'a Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
         expiry_cutoff: Option<u64>,
-    ) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
-        if !updates.has_invalidation_events() && expiry_cutoff.is_none() {
-            return Vec::new();
+        multisig_action: MultisigUpdateAction,
+    ) -> InvalidationScanOutcome {
+        let has_multisig_updates = updates.has_multisig_updates();
+        if !updates.requires_pool_scan() && expiry_cutoff.is_none() {
+            return InvalidationScanOutcome::default();
         }
 
         // Fetch state provider if any check needs on-chain reads:
@@ -227,6 +237,7 @@ where
         };
 
         let mut to_remove = Vec::new();
+        let mut to_revalidate = Vec::new();
         let mut revoked_count = 0;
         let mut key_authorization_target_count = 0;
         let mut spending_limit_count = 0;
@@ -244,6 +255,14 @@ where
         let mut fee_balance_cache: HashMap<(Address, Address), U256> = HashMap::default();
 
         for tx in transactions {
+            if has_multisig_updates && updates.affects_multisig_transaction(&tx.transaction) {
+                match multisig_action {
+                    MultisigUpdateAction::Evict => to_remove.push(*tx.hash()),
+                    MultisigUpdateAction::Revalidate => to_revalidate.push(*tx.hash()),
+                }
+                continue;
+            }
+
             if expiry_cutoff.is_some_and(|cutoff| tx.transaction.is_expired_by(cutoff)) {
                 to_remove.push(*tx.hash());
                 continue;
@@ -506,8 +525,17 @@ where
             }
         }
 
+        let multisig_to_revalidate = if to_revalidate.is_empty() {
+            Vec::new()
+        } else {
+            self.remove_transactions(to_revalidate)
+        };
+
         if to_remove.is_empty() {
-            return Vec::new();
+            return InvalidationScanOutcome {
+                evicted: Vec::new(),
+                multisig_to_revalidate,
+            };
         }
 
         tracing::debug!(
@@ -526,7 +554,10 @@ where
             paused_token_count,
             "Evicting invalidated or expired transactions"
         );
-        self.remove_transactions(to_remove)
+        InvalidationScanOutcome {
+            evicted: self.remove_transactions(to_remove),
+            multisig_to_revalidate,
+        }
     }
 
     /// Adds a validated transaction to the subpool derived from its type and nonce key.
@@ -619,6 +650,20 @@ where
             }
         }
     }
+}
+
+/// How the shared invalidation scan handles transactions affected by multisig updates.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum MultisigUpdateAction {
+    Evict,
+    Revalidate,
+}
+
+/// Transactions removed by one invalidation scan, partitioned by their next action.
+#[derive(Default)]
+pub(crate) struct InvalidationScanOutcome {
+    pub(crate) evicted: Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+    pub(crate) multisig_to_revalidate: Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
 }
 
 // Manual Clone implementation
@@ -1648,6 +1693,52 @@ mod tests {
         assert_eq!(size.queued, 0);
         assert_eq!(size.queued_size, 0);
         assert_eq!(size.total, 1);
+    }
+
+    #[test]
+    fn classifies_multisig_revalidation_during_invalidation_scan() {
+        let multisig_account = Address::random();
+        let multisig =
+            crate::test_utils::TxBuilder::aa(multisig_account).build_multisig(multisig_account);
+        let expired = crate::test_utils::TxBuilder::aa(Address::random())
+            .valid_before(10)
+            .build();
+        let pool = create_test_pool(create_provider_with_tip());
+        add_validated(&pool, multisig.clone());
+        add_validated(&pool, expired.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.multisig_config_changes.insert(multisig_account);
+        let all_txs = pool.all_transactions();
+        let InvalidationScanOutcome {
+            evicted,
+            multisig_to_revalidate,
+        } = pool.scan_and_remove_invalidated_transactions(
+            &updates,
+            all_txs.iter(),
+            Some(10),
+            MultisigUpdateAction::Revalidate,
+        );
+
+        assert_eq!(tx_hashes(&multisig_to_revalidate), vec![*multisig.hash()]);
+        assert_eq!(tx_hashes(&evicted), vec![*expired.hash()]);
+        assert!(pool.get(multisig.hash()).is_none());
+        assert!(pool.get(expired.hash()).is_none());
+    }
+
+    #[test]
+    fn public_invalidation_evicts_affected_multisig_transactions() {
+        let account = Address::random();
+        let multisig = crate::test_utils::TxBuilder::aa(account).build_multisig(account);
+        let pool = create_test_pool(create_provider_with_tip());
+        add_validated(&pool, multisig.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.multisig_config_changes.insert(account);
+
+        let evicted = pool.evict_invalidated_transactions(&updates);
+        assert_eq!(tx_hashes(&evicted), vec![*multisig.hash()]);
+        assert!(pool.get(multisig.hash()).is_none());
     }
 
     fn sponsored_keychain_transaction(

--- a/crates/transaction-pool/src/test_utils.rs
+++ b/crates/transaction-pool/src/test_utils.rs
@@ -17,12 +17,22 @@ use tempo_precompiles::storage::{StorageCtx, hashmap::HashMapStorageProvider};
 use tempo_primitives::{
     TempoPrimitives, TempoTxEnvelope,
     transaction::{
-        SignedKeyAuthorization, TempoSignedAuthorization, TempoTransaction,
+        MultisigConfig, MultisigOwner, MultisigSignature, SignedKeyAuthorization,
+        TempoSignedAuthorization, TempoTransaction,
         tempo_transaction::Call,
         tt_signature::{KeychainVersion, PrimitiveSignature, TempoSignature},
         tt_signed::AASigned,
     },
 };
+
+fn test_multisig_config(owner: Address) -> MultisigConfig {
+    MultisigConfig {
+        salt: B256::ZERO,
+        version: 1,
+        threshold: 1,
+        owners: vec![MultisigOwner { owner, weight: 1 }],
+    }
+}
 
 /// Builder for creating test transactions.
 ///
@@ -189,8 +199,7 @@ impl TxBuilder {
         self
     }
 
-    /// Build an AA transaction.
-    pub(crate) fn build(self) -> TempoPooledTransaction {
+    fn into_aa_transaction(self) -> TempoTransaction {
         let calls = self.calls.unwrap_or_else(|| {
             vec![Call {
                 to: self.kind,
@@ -199,7 +208,7 @@ impl TxBuilder {
             }]
         });
 
-        let tx = TempoTransaction {
+        TempoTransaction {
             chain_id: self.chain_id,
             max_priority_fee_per_gas: self.max_priority_fee_per_gas,
             max_fee_per_gas: self.max_fee_per_gas,
@@ -214,15 +223,44 @@ impl TxBuilder {
             access_list: self.access_list,
             tempo_authorization_list: self.authorization_list.unwrap_or_default(),
             key_authorization: self.key_authorization,
-        };
+        }
+    }
 
+    fn build_aa_with_signature(
+        tx: TempoTransaction,
+        signature: TempoSignature,
+        sender: Address,
+    ) -> TempoPooledTransaction {
+        let envelope: TempoTxEnvelope = AASigned::new_unhashed(tx, signature).into();
+        TempoPooledTransaction::new(Recovered::new_unchecked(envelope, sender))
+    }
+
+    /// Build an AA transaction.
+    pub(crate) fn build(self) -> TempoPooledTransaction {
+        let sender = self.sender;
+        let tx = self.into_aa_transaction();
         let signature =
             TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
-        let aa_signed = AASigned::new_unhashed(tx, signature);
-        let envelope: TempoTxEnvelope = aa_signed.into();
+        Self::build_aa_with_signature(tx, signature, sender)
+    }
 
-        let recovered = Recovered::new_unchecked(envelope, self.sender);
-        TempoPooledTransaction::new(recovered)
+    /// Build an AA transaction with a native multisig outer signature for `account`.
+    ///
+    /// The sender equals `account`, matching how native multisig transactions execute.
+    pub(crate) fn build_multisig(self, account: Address) -> TempoPooledTransaction {
+        let tx = self.into_aa_transaction();
+        let owner = Address::repeat_byte(0x11);
+        let signature = TempoSignature::Multisig(
+            MultisigSignature::try_new(
+                account,
+                test_multisig_config(owner),
+                vec![TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                    Signature::test_signature(),
+                ))],
+            )
+            .unwrap(),
+        );
+        Self::build_aa_with_signature(tx, signature, account)
     }
 
     /// Build an AA transaction with a V2 keychain signature.
@@ -247,30 +285,7 @@ impl TxBuilder {
         use alloy_signer::SignerSync;
         use tempo_primitives::transaction::tt_signature::KeychainSignature;
 
-        let calls = self.calls.unwrap_or_else(|| {
-            vec![Call {
-                to: self.kind,
-                value: self.value,
-                input: Default::default(),
-            }]
-        });
-
-        let tx = TempoTransaction {
-            chain_id: self.chain_id,
-            max_priority_fee_per_gas: self.max_priority_fee_per_gas,
-            max_fee_per_gas: self.max_fee_per_gas,
-            gas_limit: self.gas_limit,
-            calls,
-            nonce_key: self.nonce_key,
-            nonce: self.nonce,
-            fee_token: self.fee_token,
-            fee_payer_signature: None,
-            valid_after: self.valid_after,
-            valid_before: self.valid_before,
-            access_list: self.access_list,
-            tempo_authorization_list: self.authorization_list.unwrap_or_default(),
-            key_authorization: self.key_authorization,
-        };
+        let tx = self.into_aa_transaction();
 
         // Create a temp AASigned to get the signature hash
         let temp_sig =
@@ -278,19 +293,16 @@ impl TxBuilder {
         let unsigned = AASigned::new_unhashed(tx.clone(), temp_sig);
         let sig_hash = unsigned.signature_hash();
 
-        let (effective_hash, keychain_sig) = match version {
+        let keychain_sig = match version {
             KeychainVersion::V1 => {
                 // V1: sign raw sig_hash directly
                 let signature = access_key_signer
                     .sign_hash_sync(&sig_hash)
                     .expect("signing failed");
-                (
-                    sig_hash,
-                    TempoSignature::Keychain(KeychainSignature::new_v1(
-                        user_address,
-                        PrimitiveSignature::Secp256k1(signature),
-                    )),
-                )
+                TempoSignature::Keychain(KeychainSignature::new_v1(
+                    user_address,
+                    PrimitiveSignature::Secp256k1(signature),
+                ))
             }
             KeychainVersion::V2 => {
                 // V2: sign keccak256(0x04 || sig_hash || user_address)
@@ -298,16 +310,12 @@ impl TxBuilder {
                 let signature = access_key_signer
                     .sign_hash_sync(&hash)
                     .expect("signing failed");
-                (
-                    hash,
-                    TempoSignature::Keychain(KeychainSignature::new(
-                        user_address,
-                        PrimitiveSignature::Secp256k1(signature),
-                    )),
-                )
+                TempoSignature::Keychain(KeychainSignature::new(
+                    user_address,
+                    PrimitiveSignature::Secp256k1(signature),
+                ))
             }
         };
-        let _ = effective_hash;
 
         let signed_tx = AASigned::new_unhashed(tx, keychain_sig);
         let envelope: TempoTxEnvelope = signed_tx.into();

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -11,7 +11,8 @@ use alloy_eips::{
 };
 use alloy_evm::FromRecoveredTx;
 use alloy_primitives::{
-    Address, B256, Bytes, TxHash, TxKind, U256, bytes, keccak256, map::AddressMap,
+    Address, B256, Bytes, TxHash, TxKind, U256, bytes, keccak256,
+    map::{AddressMap, AddressSet},
 };
 use alloy_sol_types::SolInterface;
 use reth_evm::execute::WithTxEnv;
@@ -35,7 +36,9 @@ use tempo_precompiles::{
 };
 use tempo_primitives::{
     TempoTxEnvelope,
-    transaction::{InvalidValidAfter, InvalidValidBefore, calc_gas_balance_spending},
+    transaction::{
+        InvalidValidAfter, InvalidValidBefore, MultisigSignature, calc_gas_balance_spending,
+    },
 };
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
 use thiserror::Error;
@@ -211,6 +214,36 @@ impl TempoPooledTransaction {
             account: keychain_sig.user_address,
             key_id,
             fee_token,
+        })
+    }
+
+    /// Returns whether this transaction's authorization depends on one of the changed multisig
+    /// configs, including nested owner accounts.
+    pub(crate) fn depends_on_multisig_config(&self, changed_accounts: &AddressSet) -> bool {
+        fn contains_changed_account(
+            signature: &MultisigSignature,
+            changed_accounts: &AddressSet,
+        ) -> bool {
+            changed_accounts.contains(&signature.account())
+                || signature.signatures().iter().any(|approval| {
+                    approval
+                        .as_multisig()
+                        .is_some_and(|nested| contains_changed_account(nested, changed_accounts))
+                })
+        }
+
+        self.inner().as_aa().is_some_and(|aa_tx| {
+            let key_authorization = aa_tx.tx().key_authorization.as_ref();
+            aa_tx
+                .signature()
+                .as_multisig()
+                .is_some_and(|signature| contains_changed_account(signature, changed_accounts))
+                || key_authorization
+                    .and_then(|authorization| authorization.signature.as_multisig())
+                    .is_some_and(|signature| contains_changed_account(signature, changed_accounts))
+                || key_authorization.is_some_and(|authorization| {
+                    changed_accounts.contains(&authorization.authorization.key_id)
+                })
         })
     }
 
@@ -955,6 +988,7 @@ mod tests {
     use super::*;
     use crate::test_utils::TxBuilder;
     use alloy_consensus::TxEip1559;
+    use alloy_eips::eip7702::Authorization;
     use alloy_primitives::{Address, Signature, TxKind, address};
     use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
@@ -964,9 +998,10 @@ mod tests {
     use tempo_contracts::precompiles::ITIP20;
     use tempo_precompiles::{PATH_USD_ADDRESS, nonce::NonceManager};
     use tempo_primitives::transaction::{
-        TEMPO_EXPIRING_NONCE_KEY, TempoTransaction,
+        KeyAuthorization, MultisigConfig, MultisigOwner, MultisigSignature, SignatureType,
+        TEMPO_EXPIRING_NONCE_KEY, TempoSignedAuthorization, TempoTransaction,
         tempo_transaction::Call,
-        tt_signature::{PrimitiveSignature, TempoSignature},
+        tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
         tt_signed::AASigned,
     };
 
@@ -1118,6 +1153,102 @@ mod tests {
         assert!(
             tx.aa_transaction_id().is_none(),
             "Non-AA tx should have no AA transaction ID"
+        );
+    }
+
+    #[test]
+    fn test_multisig_accounts_includes_key_authorization_tree() {
+        let account = Address::random();
+        let nested_account = Address::random();
+        let access_key = PrivateKeySigner::random();
+        let key_authorization = |nested: Option<Address>| {
+            let primitive_owner = Address::repeat_byte(0x11);
+            let owner_approval = TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                Signature::test_signature(),
+            ));
+            let owner_approval = match nested {
+                None => owner_approval,
+                Some(nested_account) => TempoSignature::Multisig(
+                    MultisigSignature::try_new(
+                        nested_account,
+                        MultisigConfig {
+                            salt: B256::ZERO,
+                            version: 1,
+                            threshold: 1,
+                            owners: vec![MultisigOwner {
+                                owner: primitive_owner,
+                                weight: 1,
+                            }],
+                        },
+                        vec![owner_approval],
+                    )
+                    .unwrap(),
+                ),
+            };
+            KeyAuthorization::unrestricted(42431, SignatureType::Secp256k1, access_key.address())
+                .with_account(account)
+                .into_signed(TempoSignature::Multisig(
+                    MultisigSignature::try_new(
+                        account,
+                        MultisigConfig {
+                            salt: B256::ZERO,
+                            version: 1,
+                            threshold: 1,
+                            owners: vec![MultisigOwner {
+                                owner: nested.unwrap_or(primitive_owner),
+                                weight: 1,
+                            }],
+                        },
+                        vec![owner_approval],
+                    )
+                    .unwrap(),
+                ))
+        };
+
+        let direct = TxBuilder::aa(account)
+            .key_authorization(key_authorization(None))
+            .build_keychain(account, &access_key);
+        assert!(direct.depends_on_multisig_config(&AddressSet::from_iter([account])));
+        assert!(!direct.depends_on_multisig_config(&AddressSet::from_iter([nested_account])));
+
+        let nested = TxBuilder::aa(account)
+            .key_authorization(key_authorization(Some(nested_account)))
+            .build_keychain(account, &access_key);
+        assert!(nested.depends_on_multisig_config(&AddressSet::from_iter([account])));
+        assert!(nested.depends_on_multisig_config(&AddressSet::from_iter([nested_account])));
+    }
+
+    #[test]
+    fn multisig_config_dependencies_include_access_key_targets() {
+        let account = Address::random();
+        let key_id = Address::random();
+        let key_authorization =
+            KeyAuthorization::unrestricted(42431, SignatureType::Secp256k1, key_id)
+                .with_account(account)
+                .into_signed(TempoSignature::Primitive(PrimitiveSignature::default()));
+        let key_transaction = TxBuilder::aa(account)
+            .key_authorization(key_authorization)
+            .build();
+        assert!(key_transaction.depends_on_multisig_config(&AddressSet::from_iter([key_id])));
+
+        let authority = Address::random();
+        let authorization = TempoSignedAuthorization::new_unchecked(
+            Authorization {
+                chain_id: U256::from(42431),
+                address: Address::random(),
+                nonce: 0,
+            },
+            TempoSignature::Keychain(KeychainSignature::new(
+                authority,
+                PrimitiveSignature::default(),
+            )),
+        );
+        let authorization_transaction = TxBuilder::aa(account)
+            .authorization_list(vec![authorization])
+            .build();
+        assert!(
+            !authorization_transaction
+                .depends_on_multisig_config(&AddressSet::from_iter([authority]))
         );
     }
 


### PR DESCRIPTION
Revalidates pooled transactions after applied or reverted multisig commitment updates affect their outer, nested, or key-authorization dependencies. Classification reuses the existing pool invalidation scan.

Stacked on #7239; reference implementation: #4069.