### PR TITLE
test(node): cover TIP-1061 multisig flows

### DIFF
--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -18,7 +18,7 @@ use alloy::{
     },
     sol_types::SolCall,
 };
-use alloy_eips::Encodable2718;
+use alloy_eips::{Encodable2718, eip2930::AccessListItem};
 use reth_ethereum::network::{NetworkSyncUpdater, SyncState};
 use reth_node_api::BuiltPayload;
 use reth_primitives_traits::transaction::TxHashRef;
@@ -39,14 +39,18 @@ use tempo_precompiles::{
 use tempo_primitives::{
     TempoTransaction, TempoTxEnvelope,
     transaction::{
-        KeyAuthorization, SignedKeyAuthorization,
+        KeyAuthorization, MAX_MULTISIG_OWNERS, MultisigConfig, MultisigOwner,
+        SignedKeyAuthorization, multisig_digest,
         tempo_transaction::Call,
         tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature, WebAuthnSignature},
         tt_signed::AASigned,
     },
 };
+use tempo_revm::{
+    TempoBatchCallEnv, calculate_aa_batch_intrinsic_gas, gas_params::tempo_gas_params,
+};
 
-use super::helpers::*;
+use super::{helpers::*, multisig, types::TestEnv};
 
 fn test_secp256k1_access_key_signature() -> TempoSignature {
     TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()))
@@ -97,11 +101,12 @@ impl Localnet {
     }
 
     pub(crate) async fn with_schedule(schedule: ForkSchedule) -> eyre::Result<Self> {
+        Self::from_builder(TestNodeBuilder::new().with_schedule(schedule)).await
+    }
+
+    async fn from_builder(builder: TestNodeBuilder) -> eyre::Result<Self> {
         reth_tracing::init_test_tracing();
-        let setup = TestNodeBuilder::new()
-            .with_schedule(schedule)
-            .build_with_node_access()
-            .await?;
+        let setup = builder.build_with_node_access().await?;
         let provider = alloy::providers::RootProvider::new_http(setup.node.rpc_url());
         let chain_id = provider.get_chain_id().await?;
         let funder_signer = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
@@ -114,6 +119,301 @@ impl Localnet {
             funder_addr,
         })
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_native_multisig_rejects_code_and_delegation() -> eyre::Result<()> {
+    let signers = multisig::sorted_signers();
+    let (alice, bob) = (&signers[0], &signers[1]);
+    let configs = [
+        multisig::multisig_config(0x81, 2, &[(alice, 1), (bob, 1)]),
+        multisig::multisig_config(0x82, 2, &[(alice, 1), (bob, 1)]),
+    ];
+    let mut delegation = vec![0xef, 0x01, 0x00];
+    delegation.extend_from_slice(Address::repeat_byte(0x55).as_slice());
+
+    let mut genesis: serde_json::Value =
+        serde_json::from_str(&make_genesis_at(TempoHardfork::T12))?;
+    for (config, code) in configs.iter().zip([vec![0x00], delegation]) {
+        let account = multisig::derived_account(config)?;
+        genesis["alloc"][format!("{account:#x}")] = serde_json::json!({
+            "nonce": "0x1",
+            "balance": "0x0",
+            "code": format!("0x{}", alloy::hex::encode(code)),
+        });
+    }
+
+    let mut env = Localnet::from_builder(
+        TestNodeBuilder::new().with_genesis(serde_json::to_string(&genesis)?),
+    )
+    .await?;
+    for (index, config) in configs.iter().enumerate() {
+        let account = multisig::derived_account(config)?;
+        env.fund_account(account).await?;
+        let tx = create_basic_aa_tx(
+            env.chain_id,
+            1,
+            vec![multisig::no_op_call(0x81 + index as u8)],
+            5_000_000,
+        );
+        let signature =
+            multisig::sign_multisig(account, tx.signature_hash(), config, &[alice, bob])?;
+        multisig::reject(
+            &env,
+            tx,
+            signature,
+            "native multisig account cannot have code or EIP-7702 delegation",
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_multisig_rotation_evicts_stale_pool_transaction() -> eyre::Result<()> {
+    let mut env = Localnet::with_schedule(ForkSchedule::DevnetAt(TempoHardfork::T12)).await?;
+    let signers = multisig::sorted_signers();
+    let (alice, bob, carol) = (&signers[0], &signers[1], &signers[2]);
+    let config = multisig::multisig_config(0x83, 2, &[(alice, 1), (bob, 1)]);
+    let account = multisig::derived_account(&config)?;
+    env.fund_account(account).await?;
+
+    let next = MultisigConfig {
+        salt: config.salt,
+        version: 1,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: carol.address(),
+            weight: 1,
+        }],
+    };
+    let valid_after = nonzero_timestamp(env.current_block_timestamp().await? + 60);
+    let chain_id = env.chain_id;
+    let delayed = |config: &MultisigConfig,
+                   owners: &[&PrivateKeySigner]|
+     -> eyre::Result<TempoTxEnvelope> {
+        let mut tx = create_basic_aa_tx(chain_id, 0, vec![multisig::no_op_call(0x83)], 5_000_000);
+        tx.nonce_key = U256::from(1);
+        tx.valid_after = Some(valid_after);
+        let signature = multisig::sign_multisig(account, tx.signature_hash(), config, owners)?;
+        Ok(TempoTxEnvelope::from(tx.into_signed(signature)))
+    };
+
+    let stale = delayed(&config, &[alice, bob])?;
+    let stale_hash = *stale.tx_hash();
+    env.setup
+        .node
+        .rpc
+        .inject_tx(stale.encoded_2718().into())
+        .await?;
+    assert!(env.setup.node.inner.pool.contains(&stale_hash));
+
+    let rotation = create_basic_aa_tx(
+        env.chain_id,
+        0,
+        vec![multisig::update_config_call(&config, &next)],
+        5_000_000,
+    );
+    let signature =
+        multisig::sign_multisig(account, rotation.signature_hash(), &config, &[alice, bob])?;
+    submit_and_mine_aa_tx(&mut env.setup, rotation, signature).await?;
+    wait_until_pool_not_contains(
+        &env.setup.node.inner.pool,
+        &stale_hash,
+        "multisig config rotation",
+    )
+    .await?;
+
+    let replacement = delayed(&next, &[carol])?;
+    let replacement_hash = *replacement.tx_hash();
+    env.setup
+        .node
+        .rpc
+        .inject_tx(replacement.encoded_2718().into())
+        .await?;
+    assert!(env.setup.node.inner.pool.contains(&replacement_hash));
+    Ok(())
+}
+
+struct P256Owner {
+    key: p256::ecdsa::SigningKey,
+    x: B256,
+    y: B256,
+    address: Address,
+}
+
+struct MaximalMultisig {
+    owners: Vec<P256Owner>,
+    child: Address,
+    child_config: MultisigConfig,
+    account: Address,
+    config: MultisigConfig,
+}
+
+impl MaximalMultisig {
+    fn new() -> eyre::Result<Self> {
+        let owners = (0..8)
+            .map(|_| {
+                let (key, x, y, address) = generate_p256_access_key();
+                P256Owner { key, x, y, address }
+            })
+            .collect::<Vec<_>>();
+        let config = |salt, required: Vec<Address>, dummy: u8| {
+            let mut addresses = required;
+            let mut byte = dummy;
+            while addresses.len() < MAX_MULTISIG_OWNERS {
+                let candidate = Address::repeat_byte(byte);
+                byte = byte.wrapping_add(1);
+                if !addresses.contains(&candidate) {
+                    addresses.push(candidate);
+                }
+            }
+            addresses.sort_unstable();
+            MultisigConfig {
+                salt: B256::repeat_byte(salt),
+                version: 0,
+                threshold: 8,
+                owners: addresses
+                    .into_iter()
+                    .map(|owner| MultisigOwner { owner, weight: 1 })
+                    .collect(),
+            }
+        };
+
+        let child_config = config(
+            0x91,
+            owners.iter().map(|owner| owner.address).collect(),
+            0x40,
+        );
+        let child = multisig::derived_account(&child_config)?;
+        let mut outer_owners = owners[..7]
+            .iter()
+            .map(|owner| owner.address)
+            .collect::<Vec<_>>();
+        outer_owners.push(child);
+        let config = config(0x92, outer_owners, 0x80);
+        let account = multisig::derived_account(&config)?;
+        Ok(Self {
+            owners,
+            child,
+            child_config,
+            account,
+            config,
+        })
+    }
+
+    fn approval(&self, index: usize, digest: B256) -> eyre::Result<TempoSignature> {
+        let owner = &self.owners[index];
+        let signature = if index.is_multiple_of(2) {
+            sign_p256_primitive(digest, &owner.key, owner.x, owner.y)?
+        } else {
+            sign_webauthn_primitive(digest, &owner.key, owner.x, owner.y, "https://tempo.xyz")?
+        };
+        Ok(TempoSignature::Primitive(signature))
+    }
+
+    fn approvals(
+        &self,
+        count: usize,
+        digest: B256,
+    ) -> eyre::Result<Vec<(Address, TempoSignature)>> {
+        (0..count)
+            .map(|index| Ok((self.owners[index].address, self.approval(index, digest)?)))
+            .collect()
+    }
+
+    fn node(
+        account: Address,
+        config: &MultisigConfig,
+        mut approvals: Vec<(Address, TempoSignature)>,
+    ) -> eyre::Result<TempoSignature> {
+        approvals.sort_unstable_by_key(|(owner, _)| *owner);
+        multisig::multisig_from_approvals(
+            account,
+            config,
+            approvals
+                .into_iter()
+                .map(|(_, signature)| signature)
+                .collect(),
+        )
+    }
+
+    fn sign(&self, inner_digest: B256) -> eyre::Result<TempoSignature> {
+        let outer_digest = multisig_digest(inner_digest, self.account, 0);
+        let child_digest = multisig_digest(outer_digest, self.child, 0);
+        let child = Self::node(
+            self.child,
+            &self.child_config,
+            self.approvals(8, child_digest)?,
+        )?;
+        let mut approvals = self.approvals(7, outer_digest)?;
+        approvals.push((self.child, child));
+        Self::node(self.account, &self.config, approvals)
+    }
+
+    fn priced(
+        &self,
+        mut tx: TempoTransaction,
+        under: u64,
+    ) -> eyre::Result<(TempoTransaction, TempoSignature)> {
+        let signature = self.sign(tx.signature_hash())?;
+        tx.gas_limit = multisig_intrinsic_gas(&tx, &signature) - under;
+        let signature = self.sign(tx.signature_hash())?;
+        assert_eq!(
+            tx.gas_limit + under,
+            multisig_intrinsic_gas(&tx, &signature),
+        );
+        Ok((tx, signature))
+    }
+}
+
+fn multisig_intrinsic_gas(tx: &TempoTransaction, signature: &TempoSignature) -> u64 {
+    calculate_aa_batch_intrinsic_gas(
+        &TempoBatchCallEnv {
+            signature: signature.clone(),
+            aa_calls: tx.calls.clone(),
+            ..Default::default()
+        },
+        &tempo_gas_params(TempoHardfork::T12),
+        None::<std::iter::Empty<&AccessListItem>>,
+        TempoHardfork::T12,
+    )
+    .expect("valid maximal multisig has computable intrinsic gas")
+    .initial_total_gas()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_maximal_multisig_intrinsic_gas_boundary() -> eyre::Result<()> {
+    let mut env = Localnet::with_schedule(ForkSchedule::DevnetAt(TempoHardfork::T12)).await?;
+    let multisig = MaximalMultisig::new()?;
+    env.fund_account(multisig.account).await?;
+
+    let bootstrap =
+        create_basic_aa_tx(env.chain_id, 0, vec![multisig::no_op_call(0x91)], 5_000_000);
+    let signature = multisig.sign(bootstrap.signature_hash())?;
+    submit_and_mine_aa_tx(&mut env.setup, bootstrap, signature).await?;
+
+    let transaction = |nonce| {
+        create_basic_aa_tx(
+            env.chain_id,
+            nonce,
+            vec![multisig::no_op_call(0x92)],
+            5_000_000,
+        )
+    };
+    let (exact, signature) = multisig.priced(transaction(1), 0)?;
+    let exact: TempoTxEnvelope = exact.into_signed(signature).into();
+    let exact_hash = *exact.tx_hash();
+    env.setup
+        .node
+        .rpc
+        .inject_tx(exact.encoded_2718().into())
+        .await?;
+    assert!(env.setup.node.inner.pool.contains(&exact_hash));
+
+    let (insufficient, signature) = multisig.priced(transaction(2), 1)?;
+    multisig::reject(&env, insufficient, signature, "exceeds the gas limit").await?;
+    Ok(())
 }
 
 impl super::types::TestEnv for Localnet {

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -158,13 +158,9 @@ async fn test_native_multisig_rejects_code_and_delegation() -> eyre::Result<()> 
         );
         let signature =
             multisig::sign_multisig(account, tx.signature_hash(), config, &[alice, bob])?;
-        multisig::reject(
-            &env,
-            tx,
-            signature,
-            "native multisig account cannot have code or EIP-7702 delegation",
-        )
-        .await?;
+        let expected_reason =
+            format!("native multisig account {account} cannot have code or EIP-7702 delegation");
+        multisig::reject(&env, tx, signature, &expected_reason).await?;
     }
     Ok(())
 }

--- a/crates/node/tests/it/tempo_transaction/mod.rs
+++ b/crates/node/tests/it/tempo_transaction/mod.rs
@@ -38,6 +38,7 @@
 //! - Keychain spending limit TOCTOU DoS.
 
 use crate::utils::{ForkSchedule, run_schedule_cases};
+use tempo_chainspec::hardfork::TempoHardfork;
 use test_case::test_case;
 
 pub(crate) mod helpers;
@@ -47,6 +48,7 @@ pub(crate) mod types;
 use types::TestEnv;
 
 mod local;
+mod multisig;
 mod rpc;
 
 /// Run all matrix tests and scenario runners against a single environment.
@@ -78,6 +80,13 @@ async fn test_matrices_local(schedule: ForkSchedule) -> eyre::Result<()> {
         Ok(())
     })
     .await
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip_1061_examples() -> eyre::Result<()> {
+    let mut env =
+        local::Localnet::with_schedule(ForkSchedule::DevnetAt(TempoHardfork::T12)).await?;
+    multisig::run_tip_1061_examples(&mut env).await
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/node/tests/it/tempo_transaction/multisig.rs
+++ b/crates/node/tests/it/tempo_transaction/multisig.rs
@@ -1,0 +1,906 @@
+//! Real-node coverage for the canonical TIP-1061 examples.
+
+use super::{
+    helpers::{
+        assert_fee_payer_spent, create_basic_aa_tx, sign_aa_tx_with_secp256k1_access_key,
+        sign_fee_payer,
+    },
+    types::{ExpectedOutcome, FeePayerContext, TestEnv},
+};
+use alloy::{
+    primitives::{Address, B256, Bytes, U256},
+    signers::{SignerSync, local::PrivateKeySigner},
+    sol_types::SolCall,
+};
+use alloy_eips::Encodable2718;
+use alloy_primitives::TxKind;
+use reth_primitives_traits::transaction::TxHashRef;
+use tempo_contracts::precompiles::{
+    DEFAULT_FEE_TOKEN, NATIVE_MULTISIG_ADDRESS,
+    account_keychain::IAccountKeychain::IAccountKeychainInstance,
+    native_multisig::INativeMultisig::{self, INativeMultisigInstance},
+};
+use tempo_precompiles::{ACCOUNT_KEYCHAIN_ADDRESS, tip20::ITIP20};
+use tempo_primitives::{
+    SignatureType, TempoAddressExt, TempoTransaction, TempoTxEnvelope,
+    transaction::{
+        FEE_PAYER_SIGNATURE_MARKER, KeyAuthorization, MultisigConfig, MultisigOwner,
+        MultisigSignature, SignedKeyAuthorization, multisig_digest,
+        tempo_transaction::Call,
+        tt_signature::{PrimitiveSignature, TempoSignature},
+    },
+};
+
+const EXAMPLE_GAS_LIMIT: u64 = 5_000_000;
+const CONFIG_COMMITMENT_MISMATCH: &str = "multisig configuration commitment mismatch";
+
+pub(super) fn sorted_signers() -> Vec<PrivateKeySigner> {
+    let mut signers = (1..=3)
+        .map(|byte| PrivateKeySigner::from_bytes(&B256::repeat_byte(byte)).unwrap())
+        .collect::<Vec<_>>();
+    signers.sort_by_key(|signer| signer.address());
+    signers
+}
+
+fn signer(byte: u8) -> PrivateKeySigner {
+    PrivateKeySigner::from_bytes(&B256::repeat_byte(byte)).unwrap()
+}
+
+pub(super) fn multisig_config(
+    salt: u8,
+    threshold: u8,
+    owners: &[(&PrivateKeySigner, u8)],
+) -> MultisigConfig {
+    let owners = owners
+        .iter()
+        .map(|(signer, weight)| MultisigOwner {
+            owner: signer.address(),
+            weight: *weight,
+        })
+        .collect::<Vec<_>>();
+    assert!(owners.windows(2).all(|pair| pair[0].owner < pair[1].owner));
+
+    MultisigConfig {
+        salt: B256::repeat_byte(salt),
+        version: 0,
+        threshold,
+        owners,
+    }
+}
+
+pub(super) fn derived_account(config: &MultisigConfig) -> eyre::Result<Address> {
+    config
+        .derive_account()
+        .map_err(|err| eyre::eyre!(err.as_str()))
+}
+
+pub(super) fn no_op_call(byte: u8) -> Call {
+    Call {
+        to: TxKind::Call(Address::repeat_byte(byte)),
+        value: Default::default(),
+        input: Bytes::new(),
+    }
+}
+
+pub(super) fn sign_multisig(
+    account: Address,
+    inner_digest: B256,
+    config: &MultisigConfig,
+    signers: &[&PrivateKeySigner],
+) -> eyre::Result<TempoSignature> {
+    assert!(
+        signers
+            .windows(2)
+            .all(|pair| pair[0].address() < pair[1].address())
+    );
+    let digest = multisig_digest(inner_digest, account, config.version);
+    let approvals = signers
+        .iter()
+        .map(|signer| {
+            signer
+                .sign_hash_sync(&digest)
+                .map(PrimitiveSignature::Secp256k1)
+                .map(TempoSignature::Primitive)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    multisig_from_approvals(account, config, approvals)
+}
+
+pub(super) fn multisig_from_approvals(
+    account: Address,
+    config: &MultisigConfig,
+    approvals: Vec<TempoSignature>,
+) -> eyre::Result<TempoSignature> {
+    Ok(TempoSignature::Multisig(
+        MultisigSignature::try_new(account, config.clone(), approvals)
+            .map_err(|error| eyre::eyre!(error.as_str()))?,
+    ))
+}
+
+/// Funded multisig account with nonce-aware transaction and signing helpers.
+struct MultisigAccountFixture<'a> {
+    account: Address,
+    config: MultisigConfig,
+    owners: Vec<&'a PrivateKeySigner>,
+    nonce: u64,
+}
+
+impl<'a> MultisigAccountFixture<'a> {
+    async fn funded<E: TestEnv>(
+        env: &mut E,
+        salt: u8,
+        threshold: u8,
+        owners: &[(&'a PrivateKeySigner, u8)],
+    ) -> eyre::Result<Self> {
+        let config = multisig_config(salt, threshold, owners);
+        let account = derived_account(&config)?;
+        env.fund_account(account).await?;
+        Ok(Self {
+            account,
+            config,
+            owners: owners.iter().map(|(owner, _)| *owner).collect(),
+            nonce: 0,
+        })
+    }
+
+    fn transaction_with_calls<E: TestEnv>(&self, env: &E, calls: Vec<Call>) -> TempoTransaction {
+        create_basic_aa_tx(env.chain_id(), self.nonce, calls, EXAMPLE_GAS_LIMIT)
+    }
+
+    fn no_op_transaction<E: TestEnv>(&self, env: &E, byte: u8) -> TempoTransaction {
+        self.transaction_with_calls(env, vec![no_op_call(byte)])
+    }
+
+    fn sign(&self, tx: &TempoTransaction) -> eyre::Result<TempoSignature> {
+        self.sign_with_owners(tx, &self.owners)
+    }
+
+    fn sign_with_owners(
+        &self,
+        tx: &TempoTransaction,
+        owners: &[&PrivateKeySigner],
+    ) -> eyre::Result<TempoSignature> {
+        sign_multisig(self.account, tx.signature_hash(), &self.config, owners)
+    }
+
+    fn signed_key_authorization(
+        &self,
+        chain_id: u64,
+        key_id: Address,
+        is_admin: bool,
+    ) -> eyre::Result<SignedKeyAuthorization> {
+        signed_key_authorization(
+            chain_id,
+            self.account,
+            &self.config,
+            key_id,
+            is_admin,
+            KeyAuthorizationSigner::Quorum(&self.owners),
+        )
+    }
+
+    /// Advances the fixture nonce only after a successful submission.
+    async fn submit_signed<E: TestEnv>(
+        &mut self,
+        env: &mut E,
+        tx: TempoTransaction,
+        signature: TempoSignature,
+    ) -> eyre::Result<()> {
+        submit(env, tx, signature).await?;
+        self.nonce += 1;
+        Ok(())
+    }
+
+    async fn submit_no_op<E: TestEnv>(&mut self, env: &mut E, byte: u8) -> eyre::Result<()> {
+        let tx = self.no_op_transaction(env, byte);
+        let signature = self.sign(&tx)?;
+        self.submit_signed(env, tx, signature).await
+    }
+
+    async fn assert_no_stored_config<E: TestEnv>(&self, env: &E) -> eyre::Result<()> {
+        assert_eq!(
+            stored_config_commitment(env, self.account).await?,
+            B256::ZERO
+        );
+        Ok(())
+    }
+}
+
+fn sign_nested_multisig(
+    account: Address,
+    inner_digest: B256,
+    config: &MultisigConfig,
+    nested_account: Address,
+    nested_config: &MultisigConfig,
+    nested_signers: &[&PrivateKeySigner],
+) -> eyre::Result<TempoSignature> {
+    let nested_digest = multisig_digest(inner_digest, account, config.version);
+    let nested_signature =
+        sign_multisig(nested_account, nested_digest, nested_config, nested_signers)?;
+    multisig_from_approvals(account, config, vec![nested_signature])
+}
+
+async fn submit<E: TestEnv>(
+    env: &mut E,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+) -> eyre::Result<serde_json::Value> {
+    let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+    let tx_hash = *envelope.tx_hash();
+    env.submit_tx(envelope.encoded_2718(), tx_hash).await
+}
+
+pub(super) async fn reject<E: TestEnv>(
+    env: &E,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+    expected_reason: &str,
+) -> eyre::Result<()> {
+    let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+    env.submit_tx_expecting_rejection(envelope.encoded_2718(), Some(expected_reason))
+        .await
+}
+
+async fn revert<E: TestEnv>(
+    env: &mut E,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+) -> eyre::Result<()> {
+    let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+    let tx_hash = *envelope.tx_hash();
+    let receipt = env
+        .submit_tx_unchecked(envelope.encoded_2718(), tx_hash)
+        .await?;
+    assert_eq!(receipt["status"].as_str(), Some("0x0"));
+    Ok(())
+}
+
+pub(super) async fn stored_config_commitment<E: TestEnv>(
+    env: &E,
+    account: Address,
+) -> eyre::Result<B256> {
+    Ok(
+        INativeMultisigInstance::new(NATIVE_MULTISIG_ADDRESS, env.provider())
+            .getConfigCommitment(account)
+            .call()
+            .await?,
+    )
+}
+
+async fn assert_active_key<E: TestEnv>(
+    env: &E,
+    account: Address,
+    key_id: Address,
+) -> eyre::Result<()> {
+    let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, env.provider());
+    let key = keychain.getKey(account, key_id).call().await?;
+    assert_eq!(key.keyId, key_id);
+    assert!(!key.isRevoked);
+    Ok(())
+}
+
+async fn assert_inactive_key<E: TestEnv>(
+    env: &E,
+    account: Address,
+    key_id: Address,
+) -> eyre::Result<()> {
+    let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, env.provider());
+    assert_eq!(
+        keychain.getKey(account, key_id).call().await?.keyId,
+        Address::ZERO
+    );
+    Ok(())
+}
+
+async fn assert_admin_key<E: TestEnv>(
+    env: &E,
+    account: Address,
+    key_id: Address,
+) -> eyre::Result<()> {
+    let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, env.provider());
+    assert!(keychain.isAdminKey(account, key_id).call().await?);
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum KeyAuthorizationSigner<'a> {
+    Quorum(&'a [&'a PrivateKeySigner]),
+    Primitive(&'a PrivateKeySigner),
+}
+
+fn signed_key_authorization(
+    chain_id: u64,
+    account: Address,
+    config: &MultisigConfig,
+    key_id: Address,
+    is_admin: bool,
+    signer: KeyAuthorizationSigner<'_>,
+) -> eyre::Result<SignedKeyAuthorization> {
+    let authorization = KeyAuthorization::unrestricted(chain_id, SignatureType::Secp256k1, key_id);
+    let authorization = if is_admin {
+        authorization.into_admin(account)
+    } else {
+        authorization.with_account(account)
+    };
+    let signature = match signer {
+        KeyAuthorizationSigner::Quorum(owners) => {
+            sign_multisig(account, authorization.signature_hash(), config, owners)?
+        }
+        KeyAuthorizationSigner::Primitive(signer) => TempoSignature::Primitive(
+            PrimitiveSignature::Secp256k1(signer.sign_hash_sync(&authorization.signature_hash())?),
+        ),
+    };
+    Ok(authorization.into_signed(signature))
+}
+
+pub(super) fn update_config_call(current: &MultisigConfig, next: &MultisigConfig) -> Call {
+    assert_eq!(next.salt, current.salt);
+    assert_eq!(next.version, current.version + 1);
+    Call {
+        to: NATIVE_MULTISIG_ADDRESS.into(),
+        value: Default::default(),
+        input: INativeMultisig::updateConfigCall {
+            current: current.clone().into(),
+            threshold: next.threshold,
+            owners: next.owners.iter().cloned().map(Into::into).collect(),
+        }
+        .abi_encode()
+        .into(),
+    }
+}
+
+enum SponsorshipOrder {
+    OwnersFirst,
+    FeePayerFirst,
+}
+
+struct MultisigAuthorization {
+    account: Address,
+    config: MultisigConfig,
+}
+
+async fn submit_sponsored<E: TestEnv>(
+    env: &mut E,
+    mut tx: TempoTransaction,
+    authorization: MultisigAuthorization,
+    owners: &[&PrivateKeySigner],
+    fee_payer: &PrivateKeySigner,
+    order: SponsorshipOrder,
+) -> eyre::Result<()> {
+    let balance_before = ITIP20::new(DEFAULT_FEE_TOKEN, env.provider())
+        .balanceOf(fee_payer.address())
+        .call()
+        .await?;
+    let account_balance_before = ITIP20::new(DEFAULT_FEE_TOKEN, env.provider())
+        .balanceOf(authorization.account)
+        .call()
+        .await?;
+    assert_eq!(account_balance_before, U256::ZERO);
+    let owner_signature = match order {
+        SponsorshipOrder::OwnersFirst => {
+            tx.fee_token = None;
+            tx.fee_payer_signature = Some(FEE_PAYER_SIGNATURE_MARKER);
+            let signature = sign_multisig(
+                authorization.account,
+                tx.signature_hash(),
+                &authorization.config,
+                owners,
+            )?;
+            tx.fee_token = Some(DEFAULT_FEE_TOKEN);
+            sign_fee_payer(&mut tx, authorization.account, fee_payer)?;
+            signature
+        }
+        SponsorshipOrder::FeePayerFirst => {
+            sign_fee_payer(&mut tx, authorization.account, fee_payer)?;
+            sign_multisig(
+                authorization.account,
+                tx.signature_hash(),
+                &authorization.config,
+                owners,
+            )?
+        }
+    };
+    let receipt = submit(env, tx, owner_signature).await?;
+    assert_eq!(
+        ITIP20::new(DEFAULT_FEE_TOKEN, env.provider())
+            .balanceOf(authorization.account)
+            .call()
+            .await?,
+        account_balance_before
+    );
+    assert_fee_payer_spent(
+        env.provider(),
+        FeePayerContext {
+            addr: fee_payer.address(),
+            token: DEFAULT_FEE_TOKEN,
+            balance_before,
+        },
+        &receipt,
+    )
+    .await
+}
+
+async fn initial_weighted_quorum<E: TestEnv>(
+    env: &mut E,
+    salt: u8,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+    carol: &PrivateKeySigner,
+    approvals: &[&PrivateKeySigner],
+    rejection_reason: Option<&str>,
+) -> eyre::Result<()> {
+    let mut fixture =
+        MultisigAccountFixture::funded(env, salt, 3, &[(alice, 2), (bob, 1), (carol, 1)]).await?;
+    let tx = fixture.no_op_transaction(env, salt);
+    let signature = fixture.sign_with_owners(&tx, approvals)?;
+    if let Some(reason) = rejection_reason {
+        reject(env, tx, signature, reason).await?;
+        fixture.assert_no_stored_config(env).await?;
+    } else {
+        fixture.submit_signed(env, tx, signature).await?;
+    }
+    Ok(())
+}
+
+async fn repeated_initial_authorization<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let mut fixture = MultisigAccountFixture::funded(env, 0x11, 2, &[(alice, 1), (bob, 1)]).await?;
+
+    fixture.submit_no_op(env, 0x11).await?;
+    fixture.assert_no_stored_config(env).await?;
+
+    fixture.submit_no_op(env, 0x12).await?;
+    fixture.assert_no_stored_config(env).await?;
+    Ok(())
+}
+
+async fn reserved_accounts_are_rejected<E: TestEnv>(
+    env: &E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let mut config = multisig_config(0x12, 2, &[(alice, 1), (bob, 1)]);
+    config.version = 1;
+
+    let mut tip20 = [0u8; 20];
+    tip20[..12].copy_from_slice(&Address::TIP20_PREFIX);
+    tip20[19] = 1;
+    let mut zone_portal = [0u8; 20];
+    zone_portal[..12].copy_from_slice(&Address::ZONE_PORTAL_PREFIX);
+    zone_portal[19] = 1;
+    let mut virtual_account = [0u8; 20];
+    virtual_account[4..14].fill(0xfd);
+
+    for account in [
+        Address::from(tip20),
+        Address::from(zone_portal),
+        Address::from(virtual_account),
+        Address::with_last_byte(1),
+        NATIVE_MULTISIG_ADDRESS,
+    ] {
+        let tx = create_basic_aa_tx(env.chain_id(), 0, vec![no_op_call(0x12)], EXAMPLE_GAS_LIMIT);
+        let signature = sign_multisig(account, tx.signature_hash(), &config, &[alice, bob])?;
+        let expected_reason = format!("invalid multisig account {account}");
+        reject(env, tx, signature, &expected_reason).await?;
+    }
+    Ok(())
+}
+
+async fn nested_ownership<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let mut child_fixture =
+        MultisigAccountFixture::funded(env, 0x21, 2, &[(alice, 1), (bob, 1)]).await?;
+    let child = child_fixture.account;
+
+    child_fixture.submit_no_op(env, 0x21).await?;
+
+    let child_initial_config = child_fixture.config.clone();
+    let mut child_current = child_initial_config.clone();
+    child_current.version = 1;
+    let child_rotation = child_fixture.transaction_with_calls(
+        env,
+        vec![update_config_call(&child_initial_config, &child_current)],
+    );
+    let signature = child_fixture.sign(&child_rotation)?;
+    child_fixture
+        .submit_signed(env, child_rotation, signature)
+        .await?;
+    child_fixture.config = child_current;
+
+    let parent_config = MultisigConfig {
+        salt: B256::repeat_byte(0x22),
+        version: 0,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: child,
+            weight: 1,
+        }],
+    };
+    let parent = derived_account(&parent_config)?;
+    env.fund_account(parent).await?;
+
+    let parent_initial =
+        create_basic_aa_tx(env.chain_id(), 0, vec![no_op_call(0x22)], EXAMPLE_GAS_LIMIT);
+    let signature = sign_nested_multisig(
+        parent,
+        parent_initial.signature_hash(),
+        &parent_config,
+        child,
+        &child_fixture.config,
+        &[alice, bob],
+    )?;
+    submit(env, parent_initial, signature).await?;
+
+    let repeated = create_basic_aa_tx(env.chain_id(), 1, vec![no_op_call(0x23)], EXAMPLE_GAS_LIMIT);
+    let stale_signature = sign_nested_multisig(
+        parent,
+        repeated.signature_hash(),
+        &parent_config,
+        child,
+        &child_initial_config,
+        &[alice, bob],
+    )?;
+    reject(
+        env,
+        repeated.clone(),
+        stale_signature,
+        CONFIG_COMMITMENT_MISMATCH,
+    )
+    .await?;
+    assert_eq!(stored_config_commitment(env, parent).await?, B256::ZERO);
+    assert_eq!(
+        stored_config_commitment(env, child).await?,
+        child_fixture
+            .config
+            .commitment()
+            .map_err(|error| eyre::eyre!(error.as_str()))?
+    );
+    let signature = sign_nested_multisig(
+        parent,
+        repeated.signature_hash(),
+        &parent_config,
+        child,
+        &child_fixture.config,
+        &[alice, bob],
+    )?;
+    submit(env, repeated, signature).await?;
+
+    let access_key = signer(0x24);
+    let authorization = KeyAuthorization::unrestricted(
+        env.chain_id(),
+        SignatureType::Secp256k1,
+        access_key.address(),
+    )
+    .with_account(parent);
+    let authorization_signature = sign_nested_multisig(
+        parent,
+        authorization.signature_hash(),
+        &parent_config,
+        child,
+        &child_fixture.config,
+        &[alice, bob],
+    )?;
+    let mut authorize =
+        create_basic_aa_tx(env.chain_id(), 2, vec![no_op_call(0x24)], EXAMPLE_GAS_LIMIT);
+    authorize.key_authorization = Some(authorization.into_signed(authorization_signature));
+    let signature = sign_nested_multisig(
+        parent,
+        authorize.signature_hash(),
+        &parent_config,
+        child,
+        &child_fixture.config,
+        &[alice, bob],
+    )?;
+    submit(env, authorize, signature).await?;
+    assert_active_key(env, parent, access_key.address()).await?;
+
+    let access_key_tx =
+        create_basic_aa_tx(env.chain_id(), 3, vec![no_op_call(0x25)], EXAMPLE_GAS_LIMIT);
+    let signature = sign_aa_tx_with_secp256k1_access_key(&access_key_tx, &access_key, parent)?;
+    submit(env, access_key_tx, signature).await?;
+    Ok(())
+}
+
+async fn fee_sponsorship<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let chain_id = env.chain_id();
+    let fee_payer = signer(0x31);
+    env.fund_account(fee_payer.address()).await?;
+
+    let config = multisig_config(0x31, 2, &[(alice, 1), (bob, 1)]);
+    let account = derived_account(&config)?;
+    submit_sponsored(
+        env,
+        create_basic_aa_tx(chain_id, 0, vec![no_op_call(0x31)], EXAMPLE_GAS_LIMIT),
+        MultisigAuthorization { account, config },
+        &[alice, bob],
+        &fee_payer,
+        SponsorshipOrder::OwnersFirst,
+    )
+    .await?;
+
+    let config = multisig_config(0x32, 2, &[(alice, 1), (bob, 1)]);
+    let account = derived_account(&config)?;
+    submit_sponsored(
+        env,
+        create_basic_aa_tx(chain_id, 0, vec![no_op_call(0x32)], EXAMPLE_GAS_LIMIT),
+        MultisigAuthorization { account, config },
+        &[alice, bob],
+        &fee_payer,
+        SponsorshipOrder::FeePayerFirst,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn weighted_quorum<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+    carol: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let cases: &[(u8, &[&PrivateKeySigner], Option<&str>)] = &[
+        (0x41, &[alice, bob], None),
+        (0x42, &[alice, carol], None),
+        (
+            0x43,
+            &[bob, carol],
+            Some("multisig signature weight below threshold"),
+        ),
+        (
+            0x44,
+            &[alice, bob, carol],
+            Some("excess multisig owner signatures"),
+        ),
+    ];
+    for &(salt, approvals, rejection_reason) in cases {
+        initial_weighted_quorum(env, salt, alice, bob, carol, approvals, rejection_reason).await?;
+    }
+    Ok(())
+}
+
+async fn initial_and_immediate_access_key_use<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let mut fixture = MultisigAccountFixture::funded(env, 0x51, 2, &[(alice, 1), (bob, 1)]).await?;
+    let access_key = signer(0x51);
+
+    let mut tx = fixture.no_op_transaction(env, 0x51);
+    tx.key_authorization =
+        Some(fixture.signed_key_authorization(env.chain_id(), access_key.address(), false)?);
+    let signature = sign_aa_tx_with_secp256k1_access_key(&tx, &access_key, fixture.account)?;
+    fixture.submit_signed(env, tx, signature).await?;
+
+    fixture.assert_no_stored_config(env).await?;
+    assert_active_key(env, fixture.account, access_key.address()).await?;
+    Ok(())
+}
+
+async fn access_key_authorization_matrix<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let mut fixture = MultisigAccountFixture::funded(env, 0x61, 2, &[(alice, 1), (bob, 1)]).await?;
+    let access_key = signer(0x61);
+
+    let mut initial = fixture.no_op_transaction(env, 0x61);
+    initial.key_authorization =
+        Some(fixture.signed_key_authorization(env.chain_id(), access_key.address(), false)?);
+    let signature = fixture.sign(&initial)?;
+    fixture.submit_signed(env, initial, signature).await?;
+    assert_active_key(env, fixture.account, access_key.address()).await?;
+
+    let access_key_tx = fixture.no_op_transaction(env, 0x62);
+    let signature =
+        sign_aa_tx_with_secp256k1_access_key(&access_key_tx, &access_key, fixture.account)?;
+    fixture.submit_signed(env, access_key_tx, signature).await?;
+
+    struct Case<'a> {
+        outer: &'a PrivateKeySigner,
+        authorizer: KeyAuthorizationSigner<'a>,
+        target: &'a PrivateKeySigner,
+        is_admin: bool,
+        expected: ExpectedOutcome,
+    }
+
+    let admin_key = signer(0x62);
+    let child_key = signer(0x63);
+    let quorum = [alice, bob];
+    let cases = [
+        Case {
+            outer: &access_key,
+            authorizer: KeyAuthorizationSigner::Primitive(&access_key),
+            target: &child_key,
+            is_admin: false,
+            expected: ExpectedOutcome::Rejection,
+        },
+        Case {
+            outer: &access_key,
+            authorizer: KeyAuthorizationSigner::Quorum(&quorum),
+            target: &admin_key,
+            is_admin: true,
+            expected: ExpectedOutcome::Success,
+        },
+        Case {
+            outer: &admin_key,
+            authorizer: KeyAuthorizationSigner::Primitive(&admin_key),
+            target: &child_key,
+            is_admin: false,
+            expected: ExpectedOutcome::Success,
+        },
+    ];
+    for (index, case) in cases.into_iter().enumerate() {
+        let key_authorization = signed_key_authorization(
+            env.chain_id(),
+            fixture.account,
+            &fixture.config,
+            case.target.address(),
+            case.is_admin,
+            case.authorizer,
+        )?;
+        let mut tx = fixture.no_op_transaction(env, 0x63 + index as u8);
+        tx.key_authorization = Some(key_authorization);
+        let signature = sign_aa_tx_with_secp256k1_access_key(&tx, case.outer, fixture.account)?;
+
+        match case.expected {
+            ExpectedOutcome::Success => {
+                fixture.submit_signed(env, tx, signature).await?;
+                assert_active_key(env, fixture.account, case.target.address()).await?;
+                if case.is_admin {
+                    assert_admin_key(env, fixture.account, case.target.address()).await?;
+                }
+            }
+            ExpectedOutcome::Rejection => {
+                reject(
+                    env,
+                    tx,
+                    signature,
+                    "access keys cannot authorize other keys, only the root key can authorize new keys",
+                )
+                .await?;
+                fixture.assert_no_stored_config(env).await?;
+                assert_inactive_key(env, fixture.account, case.target.address()).await?;
+            }
+            ExpectedOutcome::Revert => unreachable!("key authorization is validated pre-call"),
+        }
+    }
+
+    let mut next_config = fixture.config.clone();
+    next_config.version = 1;
+    let update = fixture
+        .transaction_with_calls(env, vec![update_config_call(&fixture.config, &next_config)]);
+    let signature = sign_aa_tx_with_secp256k1_access_key(&update, &admin_key, fixture.account)?;
+    revert(env, update, signature).await?;
+    fixture.assert_no_stored_config(env).await?;
+    Ok(())
+}
+
+async fn configuration_rotation_and_access_keys<E: TestEnv>(
+    env: &mut E,
+    alice: &PrivateKeySigner,
+    bob: &PrivateKeySigner,
+    carol: &PrivateKeySigner,
+) -> eyre::Result<()> {
+    let mut fixture = MultisigAccountFixture::funded(env, 0x71, 2, &[(alice, 1), (bob, 1)]).await?;
+    let account = fixture.account;
+    let initial_config = fixture.config.clone();
+
+    let next_config = MultisigConfig {
+        salt: initial_config.salt,
+        version: 1,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: carol.address(),
+            weight: 1,
+        }],
+    };
+    let rotation = fixture
+        .transaction_with_calls(env, vec![update_config_call(&initial_config, &next_config)]);
+    let signature = fixture.sign(&rotation)?;
+    fixture.submit_signed(env, rotation, signature).await?;
+    fixture.config = next_config;
+    fixture.owners = vec![carol];
+
+    assert_eq!(
+        stored_config_commitment(env, account).await?,
+        fixture
+            .config
+            .commitment()
+            .map_err(|error| eyre::eyre!(error.as_str()))?
+    );
+
+    let stale_tx = fixture.no_op_transaction(env, 0x72);
+    let stale_signature = sign_multisig(
+        account,
+        stale_tx.signature_hash(),
+        &initial_config,
+        &[alice, bob],
+    )?;
+    reject(env, stale_tx, stale_signature, CONFIG_COMMITMENT_MISMATCH).await?;
+    let current_commitment = fixture
+        .config
+        .commitment()
+        .map_err(|error| eyre::eyre!(error.as_str()))?;
+    assert_eq!(
+        stored_config_commitment(env, account).await?,
+        current_commitment
+    );
+
+    let access_key = signer(0x72);
+    let stale_authorization = signed_key_authorization(
+        env.chain_id(),
+        account,
+        &initial_config,
+        access_key.address(),
+        false,
+        KeyAuthorizationSigner::Quorum(&[alice, bob]),
+    )?;
+    let mut stale_sidecar = fixture.no_op_transaction(env, 0x73);
+    stale_sidecar.key_authorization = Some(stale_authorization);
+    let signature = fixture.sign(&stale_sidecar)?;
+    reject(env, stale_sidecar, signature, CONFIG_COMMITMENT_MISMATCH).await?;
+    assert_eq!(
+        stored_config_commitment(env, account).await?,
+        current_commitment
+    );
+    assert_inactive_key(env, account, access_key.address()).await?;
+
+    let current_authorization =
+        fixture.signed_key_authorization(env.chain_id(), access_key.address(), false)?;
+    let mut current = fixture.no_op_transaction(env, 0x74);
+    current.key_authorization = Some(current_authorization);
+    let signature = fixture.sign(&current)?;
+    fixture.submit_signed(env, current, signature).await?;
+    assert_active_key(env, account, access_key.address()).await?;
+
+    let access_key_tx = fixture.no_op_transaction(env, 0x75);
+    let signature = sign_aa_tx_with_secp256k1_access_key(&access_key_tx, &access_key, account)?;
+    fixture.submit_signed(env, access_key_tx, signature).await?;
+
+    let source_fixture =
+        MultisigAccountFixture::funded(env, 0x73, 2, &[(alice, 1), (bob, 1)]).await?;
+    let forbidden_authorization =
+        source_fixture.signed_key_authorization(env.chain_id(), account, false)?;
+    let mut forbidden = source_fixture.no_op_transaction(env, 0x76);
+    forbidden.key_authorization = Some(forbidden_authorization);
+    let signature = source_fixture.sign(&forbidden)?;
+    reject(
+        env,
+        forbidden,
+        signature,
+        &format!("native multisig account {account} cannot be used as an access key"),
+    )
+    .await?;
+    source_fixture.assert_no_stored_config(env).await?;
+    assert_inactive_key(env, source_fixture.account, account).await?;
+    Ok(())
+}
+
+pub(super) async fn run_tip_1061_examples<E: TestEnv>(env: &mut E) -> eyre::Result<()> {
+    let signers = sorted_signers();
+    let (alice, bob, carol) = (&signers[0], &signers[1], &signers[2]);
+
+    repeated_initial_authorization(env, alice, bob).await?;
+    reserved_accounts_are_rejected(env, alice, bob).await?;
+    nested_ownership(env, alice, bob).await?;
+    fee_sponsorship(env, alice, bob).await?;
+    weighted_quorum(env, alice, bob, carol).await?;
+    initial_and_immediate_access_key_use(env, alice, bob).await?;
+    access_key_authorization_matrix(env, alice, bob).await?;
+    configuration_rotation_and_access_keys(env, alice, bob, carol).await?;
+    Ok(())
+}

--- a/crates/node/tests/it/tempo_transaction/rpc.rs
+++ b/crates/node/tests/it/tempo_transaction/rpc.rs
@@ -1,15 +1,16 @@
-//! Remote RPC transaction checks (testnet & devnet).
+//! RPC transaction environments and integration checks.
 //!
-//! These tests target a live RPC endpoint and cover the same core transaction
-//! matrices as the local integration tests, using the faucet for funding.
+//! The remote environment targets live testnet and devnet endpoints using the faucet for funding.
+//! Local RPC tests use an in-process node when they need a specific hardfork or controlled mining.
 //!
 //! Uses alloy's [`RetryBackoffLayer`] to automatically retry transient RPC
 //! errors (429 rate-limits, connection errors) with backoff at the transport
 //! level, so individual call sites don't need manual retry logic.
 use alloy::{
     consensus::BlockHeader,
-    primitives::{Address, B256, Bytes, U256},
+    primitives::{Address, B256, Bytes, TxKind, U256},
     providers::Provider,
+    rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
     transports::{
         RpcError, TransportErrorKind,
@@ -18,13 +19,29 @@ use alloy::{
 };
 use alloy_eips::Encodable2718;
 use reth_primitives_traits::transaction::TxHashRef;
+use tempo_alloy::rpc::{
+    MultisigSimulationApproval, MultisigSimulationPrimitiveApproval, MultisigSimulationSpec,
+};
 use tempo_chainspec::{
     hardfork::{TempoHardfork, TempoHardforks},
     spec::{DEV, MODERATO, PRESTO},
 };
-use tempo_primitives::{TempoTxEnvelope, transaction::tempo_transaction::Call};
+use tempo_contracts::precompiles::DEFAULT_FEE_TOKEN;
+use tempo_node::rpc::TempoTransactionRequest;
+use tempo_primitives::{
+    SignatureType, TempoTransaction, TempoTxEnvelope,
+    transaction::{MultisigConfig, tempo_transaction::Call, tt_signature::TempoSignature},
+};
 
-use super::helpers::*;
+use super::{
+    helpers::*,
+    local::Localnet,
+    multisig::{
+        derived_account, multisig_config, no_op_call, sign_multisig, sorted_signers,
+        stored_config_commitment,
+    },
+    types::TestEnv,
+};
 
 /// Maximum number of 1-second poll iterations when waiting for RPC state to settle.
 const RPC_POLL_RETRIES: usize = 30;
@@ -119,7 +136,7 @@ impl RpcEnv {
     }
 }
 
-impl super::types::TestEnv for RpcEnv {
+impl TestEnv for RpcEnv {
     type P = alloy::providers::RootProvider;
 
     fn provider(&self) -> &Self::P {
@@ -300,4 +317,202 @@ async fn wait_for_receipt(
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
     Err(eyre::eyre!("timed out waiting for receipt {tx_hash}"))
+}
+
+async fn fill_multisig_transaction(
+    env: &Localnet,
+    account: Address,
+    calls: Vec<Call>,
+    config: MultisigConfig,
+    owners: &[Address],
+    expected_nonce: u64,
+) -> eyre::Result<TempoTransaction> {
+    let expected_calls = calls.clone();
+    let request = multisig_fill_request(account, calls, config, owners, None);
+    let request = serde_json::to_value(request)?;
+    let filled: serde_json::Value = env
+        .provider()
+        .raw_request("eth_fillTransaction".into(), [request])
+        .await?;
+    let tx = parse_filled_tx(&filled)?;
+
+    assert_eq!(tx.chain_id, env.chain_id());
+    assert_eq!(tx.nonce, expected_nonce);
+    assert_eq!(tx.nonce_key, U256::ZERO);
+    assert_eq!(tx.calls, expected_calls);
+    assert!(tx.gas_limit > 0);
+    assert!(
+        tx.fee_token.is_none(),
+        "eth_fillTransaction should not select the fee token"
+    );
+    Ok(tx)
+}
+
+fn multisig_fill_request(
+    account: Address,
+    calls: Vec<Call>,
+    config: MultisigConfig,
+    owners: &[Address],
+    gas: Option<u64>,
+) -> TempoTransactionRequest {
+    TempoTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(account),
+            gas,
+            ..Default::default()
+        },
+        calls,
+        multisig_simulation: Some(MultisigSimulationSpec {
+            config,
+            approvals: owners
+                .iter()
+                .map(|owner| {
+                    MultisigSimulationApproval::Primitive(MultisigSimulationPrimitiveApproval {
+                        owner: *owner,
+                        key_type: Some(SignatureType::Secp256k1),
+                        key_data: None,
+                    })
+                })
+                .collect(),
+        }),
+        ..Default::default()
+    }
+}
+
+async fn submit_local_raw_transaction(
+    env: &mut Localnet,
+    tx: TempoTransaction,
+    signature: TempoSignature,
+) -> eyre::Result<serde_json::Value> {
+    let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+    let tx_hash = *envelope.tx_hash();
+    let rpc_hash: B256 = env
+        .provider()
+        .raw_request("eth_sendRawTransaction".into(), [envelope.encoded_2718()])
+        .await?;
+    assert_eq!(rpc_hash, tx_hash);
+
+    for _ in 0..3 {
+        env.setup.node.advance_block().await?;
+        let receipt: Option<serde_json::Value> = env
+            .provider()
+            .raw_request("eth_getTransactionReceipt".into(), [tx_hash])
+            .await?;
+        if let Some(receipt) = receipt {
+            assert_eq!(receipt["status"].as_str(), Some("0x1"));
+            return Ok(receipt);
+        }
+    }
+
+    Err(eyre::eyre!(
+        "Transaction receipt not found for {tx_hash} after 3 blocks"
+    ))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip_1061_fill_sign_send() -> eyre::Result<()> {
+    let mut env =
+        Localnet::with_schedule(crate::utils::ForkSchedule::DevnetAt(TempoHardfork::T12)).await?;
+    let signers = sorted_signers();
+    let (alice, bob) = (&signers[0], &signers[1]);
+    let config = multisig_config(0x81, 2, &[(alice, 1), (bob, 1)]);
+    let account = derived_account(&config)?;
+    env.fund_account(account).await?;
+
+    let owners = [alice.address(), bob.address()];
+    let mut initial = fill_multisig_transaction(
+        &env,
+        account,
+        vec![no_op_call(0x81)],
+        config.clone(),
+        &owners,
+        0,
+    )
+    .await?;
+    initial.fee_token = Some(DEFAULT_FEE_TOKEN);
+    let signature = sign_multisig(account, initial.signature_hash(), &config, &[alice, bob])?;
+    submit_local_raw_transaction(&mut env, initial, signature).await?;
+
+    assert_eq!(stored_config_commitment(&env, account).await?, B256::ZERO);
+
+    let mut repeated = fill_multisig_transaction(
+        &env,
+        account,
+        vec![no_op_call(0x82)],
+        config.clone(),
+        &owners,
+        1,
+    )
+    .await?;
+    repeated.fee_token = Some(DEFAULT_FEE_TOKEN);
+    let signature = sign_multisig(account, repeated.signature_hash(), &config, &[alice, bob])?;
+    submit_local_raw_transaction(&mut env, repeated, signature).await?;
+
+    assert_eq!(env.provider().get_transaction_count(account).await?, 2);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_tip_1061_fill_with_supplied_gas_skips_estimation() -> eyre::Result<()> {
+    let env =
+        Localnet::with_schedule(crate::utils::ForkSchedule::DevnetAt(TempoHardfork::T12)).await?;
+    let signers = sorted_signers();
+    let (alice, bob) = (&signers[0], &signers[1]);
+    let config = multisig_config(0x83, 2, &[(alice, 1), (bob, 1)]);
+    let account = derived_account(&config)?;
+    let gas_limit = 123_456;
+    let request = multisig_fill_request(
+        account,
+        vec![Call {
+            to: TxKind::Call(DEFAULT_FEE_TOKEN),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }],
+        config,
+        &[alice.address(), bob.address()],
+        Some(gas_limit),
+    );
+
+    let filled: serde_json::Value = env
+        .provider()
+        .raw_request(
+            "eth_fillTransaction".into(),
+            [serde_json::to_value(request)?],
+        )
+        .await?;
+
+    assert_eq!(parse_filled_tx(&filled)?.gas_limit, gas_limit);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_fill_transaction_rejects_mismatched_chain_id() -> eyre::Result<()> {
+    let env = Localnet::new().await?;
+    let expected = env.chain_id();
+    let actual = expected + 1;
+    let request = TempoTransactionRequest {
+        inner: TransactionRequest {
+            from: Some(Address::random()),
+            chain_id: Some(actual),
+            gas: Some(21_000),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let result = env
+        .provider()
+        .raw_request::<_, serde_json::Value>(
+            "eth_fillTransaction".into(),
+            [serde_json::to_value(request)?],
+        )
+        .await;
+    let error = result.expect_err("mismatched explicit chain ID must be rejected");
+    assert!(
+        error.to_string().contains(&format!(
+            "chainId mismatch: expected {expected}, actual {actual}"
+        )),
+        "unexpected error: {error}"
+    );
+    Ok(())
 }

--- a/crates/node/tests/it/tempo_transaction/rpc.rs
+++ b/crates/node/tests/it/tempo_transaction/rpc.rs
@@ -420,6 +420,27 @@ async fn test_tip_1061_fill_sign_send() -> eyre::Result<()> {
     env.fund_account(account).await?;
 
     let owners = [alice.address(), bob.address()];
+    let request = serde_json::to_value(multisig_fill_request(
+        account,
+        vec![no_op_call(0x80)],
+        config.clone(),
+        &owners,
+        None,
+    ))?;
+    for (method, params) in [
+        ("eth_estimateGas", vec![request.clone()]),
+        (
+            "eth_call",
+            vec![request.clone(), serde_json::json!("pending")],
+        ),
+        ("eth_createAccessList", vec![request.clone()]),
+    ] {
+        env.provider()
+            .raw_request::<_, serde_json::Value>(method.into(), params)
+            .await
+            .unwrap_or_else(|error| panic!("{method} failed: {error}"));
+    }
+
     let mut initial = fill_multisig_transaction(
         &env,
         account,


### PR DESCRIPTION
Adds end-to-end coverage for initial and current configurations, owner updates, nesting, sponsorship, access keys, and RPC fill/sign/send.

Stacked on #7240; reference implementation: #4069.