### PR TITLE
fix(consensus): startup uses all available header sources, not just execution layer

### DIFF
--- a/crates/alloy/tests/relay_transport.rs
+++ b/crates/alloy/tests/relay_transport.rs
@@ -38,6 +38,7 @@ fn non_empty_env_var(name: &str) -> Option<String> {
 /// Test that the RelayTransport correctly routes reads to the default transport
 /// and sendRawTransaction through the sponsor relay.
 #[tokio::test]
+#[ignore]
 async fn relay_transport_sponsors_tx_on_testnet() -> eyre::Result<()> {
     let (rpc_url, sponsor_url) = match rpc_and_sponsor_urls() {
         Some(urls) => urls,

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -135,16 +135,6 @@ pub(crate) mod marshal {
         .await
         .wrap_err("failed to initialize finalizations by height archive")?;
 
-        let finalized_blocks = storage::init_finalized_blocks(
-            &context,
-            &config.partition_prefix,
-            page_cache.clone(),
-            execution_node.provider.clone(),
-            config.finalized_blocks_retention,
-        )
-        .await
-        .wrap_err("failed to initialize hybrid finalized blocks store")?;
-
         let FinalizationRange {
             floor: finalized_floor,
             tip: finalized_tip,
@@ -161,6 +151,16 @@ pub(crate) mod marshal {
         let start =
             start_from_finalized_floor(&finalizations_by_height, &execution_node, finalized_floor)
                 .await?;
+
+        let finalized_blocks = storage::init_finalized_blocks(
+            &context,
+            &config.partition_prefix,
+            page_cache.clone(),
+            execution_node.provider.clone(),
+            config.finalized_blocks_retention,
+        )
+        .await
+        .wrap_err("failed to initialize hybrid finalized blocks store")?;
 
         if let marshal::Start::Floor(finalization) = &start {
             register_scheme(

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -8,7 +8,7 @@ pub(crate) mod marshal {
     use commonware_codec::ReadExt as _;
     use commonware_consensus::{
         Epochable as _,
-        marshal::{self, core, standard::Standard},
+        marshal::{self, core, standard::Standard, store::Blocks as _},
         simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
         types::{Epoch, Epocher as _, FixedEpocher, Height, Round, ViewDelta},
     };
@@ -135,6 +135,16 @@ pub(crate) mod marshal {
         .await
         .wrap_err("failed to initialize finalizations by height archive")?;
 
+        let finalized_blocks = storage::init_finalized_blocks(
+            &context,
+            &config.partition_prefix,
+            page_cache.clone(),
+            execution_node.provider.clone(),
+            config.finalized_blocks_retention,
+        )
+        .await
+        .wrap_err("failed to initialize hybrid finalized blocks store")?;
+
         let FinalizationRange {
             floor: finalized_floor,
             tip: finalized_tip,
@@ -157,20 +167,12 @@ pub(crate) mod marshal {
                 &mut context,
                 &config.epoch_strategy,
                 &config.scheme_provider,
+                &finalized_blocks,
                 &execution_node,
                 (finalized_floor.0, finalization),
-            )?;
+            )
+            .await?;
         }
-
-        let finalized_blocks = storage::init_finalized_blocks(
-            &context,
-            &config.partition_prefix,
-            page_cache.clone(),
-            execution_node.provider.clone(),
-            config.finalized_blocks_retention,
-        )
-        .await
-        .wrap_err("failed to initialize hybrid finalized blocks store")?;
 
         let (actor, mailbox, marshal_stored_height) = core::Actor::init(
             context,
@@ -333,35 +335,61 @@ pub(crate) mod marshal {
         ))
     }
 
-    fn register_scheme<R: CryptoRng>(
+    async fn register_scheme<TContext, R>(
         rng: &mut R,
         epoch_strategy: &FixedEpocher,
         scheme_provider: &SchemeProvider,
+        finalized_blocks: &Hybrid<
+            TContext,
+            BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>,
+        >,
         execution_node: &TempoFullNode,
         (height, finalization): (Height, &Finalization<Scheme<PublicKey, MinSig>, Digest>),
-    ) -> eyre::Result<()> {
-        let digest = execution_node
+    ) -> eyre::Result<()>
+    where
+        TContext: Clock + Metrics + Storage + BufferPooler + Send + Sync + 'static,
+        R: CryptoRng,
+    {
+        let digest = match execution_node
             .provider
             .block_hash(height.get())
             .map_err(eyre::Report::new)
             .wrap_err("failed reading finalized floor block hash")?
-            .ok_or_eyre("missing finalized floor block hash")?;
+        {
+            Some(digest) => Digest(digest),
+            None => finalized_blocks
+                .get(Identifier::Index(height.get()))
+                .await
+                .wrap_err("failed reading finalized floor block from archive")?
+                .map(|block| block.digest())
+                .ok_or_eyre("missing finalized floor block")?,
+        };
 
         ensure!(
-            digest == finalization.proposal.payload.0,
+            digest == finalization.proposal.payload,
             "finalization digest does not match execution state"
         );
 
         let epoch = finalization.epoch();
         let boundary = boundary_for_epoch(epoch_strategy, epoch)?;
-        let header = execution_node
+        let header = match execution_node
             .provider
             .header_by_number(boundary.get())
             .map_err(eyre::Report::new)
-            .wrap_err("failed reading block header")?
-            .ok_or_eyre("missing boundary header")?;
+            .wrap_err("failed reading boundary header")?
+        {
+            Some(header) => header,
+            None => finalized_blocks
+                .get(Identifier::Index(boundary.get()))
+                .await
+                .wrap_err("failed reading boundary block from archive")?
+                .map(|block| block.block().header().clone())
+                .ok_or_eyre("missing boundary block")?,
+        };
+
         let onchain_outcome = OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
             .wrap_err("failed to read DKG outcome from boundary header")?;
+
         let scheme = Scheme::verifier(
             crate::config::NAMESPACE,
             onchain_outcome.players().clone(),

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -335,8 +335,8 @@ pub(crate) mod marshal {
         ))
     }
 
-    async fn register_scheme<TContext, R>(
-        rng: &mut R,
+    async fn register_scheme<TContext>(
+        context: &mut TContext,
         epoch_strategy: &FixedEpocher,
         scheme_provider: &SchemeProvider,
         finalized_blocks: &Hybrid<
@@ -347,8 +347,7 @@ pub(crate) mod marshal {
         (height, finalization): (Height, &Finalization<Scheme<PublicKey, MinSig>, Digest>),
     ) -> eyre::Result<()>
     where
-        TContext: Clock + Metrics + Storage + BufferPooler + Send + Sync + 'static,
-        R: CryptoRng,
+        TContext: Clock + Metrics + Storage + BufferPooler + CryptoRng + Send + Sync + 'static,
     {
         let digest = match execution_node
             .provider
@@ -397,7 +396,7 @@ pub(crate) mod marshal {
         );
 
         ensure!(
-            finalization.verify(rng, &scheme, &Sequential),
+            finalization.verify(context, &scheme, &Sequential),
             "finalized floor failed verification"
         );
 

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -388,6 +388,11 @@ pub(crate) mod marshal {
 
         let onchain_outcome = OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
             .wrap_err("failed to read DKG outcome from boundary header")?;
+        ensure!(
+            onchain_outcome.epoch == epoch,
+            "boundary outcome is for epoch `{}`, expected finalization epoch `{epoch}`",
+            onchain_outcome.epoch,
+        );
 
         let scheme = Scheme::verifier(
             crate::config::NAMESPACE,

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -334,6 +334,7 @@ pub(crate) mod marshal {
         ))
     }
 
+    #[instrument(skip_all, fields(%height), err)]
     async fn register_scheme<TContext>(
         context: &mut TContext,
         epoch_strategy: &FixedEpocher,

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -383,6 +383,9 @@ pub(crate) mod marshal {
         Ok(())
     }
 
+    /// Reads the header at `height` from the execution layer, falling back to
+    /// the hybrid store (and therefore its finalized-block archive cache) when
+    /// unavailable.
     #[instrument(skip_all, fields(%height), err)]
     async fn read_header<TContext>(
         execution_node: &TempoFullNode,

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -4,7 +4,7 @@
 pub(crate) mod marshal {
     use std::{num::NonZeroUsize, sync::Arc};
 
-    use alloy_consensus::BlockHeader as _;
+    use alloy_consensus::{BlockHeader as _, Sealable as _};
     use commonware_codec::ReadExt as _;
     use commonware_consensus::{
         Epochable as _,
@@ -23,12 +23,11 @@ pub(crate) mod marshal {
     use rand_core::{CryptoRng, Rng};
     use reth_ethereum::{chainspec::EthChainSpec, provider::db::DatabaseEnv};
     use reth_node_builder::NodeTypesWithDBAdapter;
-    use reth_provider::{
-        BlockHashReader as _, BlockReader as _, HeaderProvider as _, providers::BlockchainProvider,
-    };
+    use reth_provider::{BlockReader as _, HeaderProvider as _, providers::BlockchainProvider};
     use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
     use tempo_node::{TempoFullNode, node::TempoNode};
-    use tracing::{info, instrument};
+    use tempo_primitives::TempoHeader;
+    use tracing::{info, instrument, warn};
 
     use crate::{
         consensus::{Digest, block::Block},
@@ -349,42 +348,16 @@ pub(crate) mod marshal {
     where
         TContext: Clock + Metrics + Storage + BufferPooler + CryptoRng + Send + Sync + 'static,
     {
-        let digest = match execution_node
-            .provider
-            .block_hash(height.get())
-            .map_err(eyre::Report::new)
-            .wrap_err("failed reading finalized floor block hash")?
-        {
-            Some(digest) => Digest(digest),
-            None => finalized_blocks
-                .get(Identifier::Index(height.get()))
-                .await
-                .wrap_err("failed reading finalized floor block from archive")?
-                .map(|block| block.digest())
-                .ok_or_eyre("missing finalized floor block")?,
-        };
+        let finalized_header = read_header(execution_node, finalized_blocks, height).await?;
 
         ensure!(
-            digest == finalization.proposal.payload,
+            Digest(finalized_header.hash_slow()) == finalization.proposal.payload,
             "finalization digest does not match execution state"
         );
 
         let epoch = finalization.epoch();
         let boundary = boundary_for_epoch(epoch_strategy, epoch)?;
-        let header = match execution_node
-            .provider
-            .header_by_number(boundary.get())
-            .map_err(eyre::Report::new)
-            .wrap_err("failed reading boundary header")?
-        {
-            Some(header) => header,
-            None => finalized_blocks
-                .get(Identifier::Index(boundary.get()))
-                .await
-                .wrap_err("failed reading boundary block from archive")?
-                .map(|block| block.block().header().clone())
-                .ok_or_eyre("missing boundary block")?,
-        };
+        let header = read_header(execution_node, finalized_blocks, boundary).await?;
 
         let onchain_outcome = OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
             .wrap_err("failed to read DKG outcome from boundary header")?;
@@ -407,6 +380,45 @@ pub(crate) mod marshal {
 
         scheme_provider.register(epoch, scheme);
         Ok(())
+    }
+
+    async fn read_header<TContext>(
+        execution_node: &TempoFullNode,
+        finalized_blocks: &Hybrid<
+            TContext,
+            BlockchainProvider<NodeTypesWithDBAdapter<TempoNode, DatabaseEnv>>,
+        >,
+        height: Height,
+    ) -> eyre::Result<TempoHeader>
+    where
+        TContext: Clock + Metrics + Storage + BufferPooler + Send + Sync + 'static,
+    {
+        match execution_node.provider.header_by_number(height.get()) {
+            Ok(Some(header)) => return Ok(header),
+            Ok(None) => {
+                warn!(%height, "execution layer did not contain finalized header; falling back to hybrid store");
+            }
+            Err(error) => {
+                warn!(
+                    error = %eyre::Report::new(error),
+                    %height,
+                    "failed reading finalized header from execution layer; falling back to hybrid store"
+                );
+            }
+        }
+
+        finalized_blocks
+            .get(Identifier::Index(height.get()))
+            .await
+            .wrap_err_with(|| {
+                format!("failed reading finalized header at height `{height}` from hybrid store")
+            })?
+            .map(|block| block.block().header().clone())
+            .ok_or_else(|| {
+                eyre!(
+                    "missing finalized header at height `{height}` in execution layer and hybrid store"
+                )
+            })
     }
 
     fn boundary_for_epoch(epoch_strategy: &FixedEpocher, epoch: Epoch) -> eyre::Result<Height> {

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -382,6 +382,7 @@ pub(crate) mod marshal {
         Ok(())
     }
 
+    #[instrument(skip_all, fields(%height), err)]
     async fn read_header<TContext>(
         execution_node: &TempoFullNode,
         finalized_blocks: &Hybrid<

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -69,36 +69,29 @@
 //! longer serve them. Repairing them here would be futile anyway — the
 //! prunable cache has evicted them too, so the re-fetched block's put would
 //! be silently absorbed (see "Stale puts") and the gap would reappear on
-//! the next repair tick. The marshal actor's repair path never asks for such
-//! heights; startup has a separate best-effort lookup described below.
+//! the next repair tick. The marshal never asks for such heights; see
+//! "Why reth pruning is not a concern" below.
 //!
-//! # Reth pruning behavior
+//! # Why reth pruning is not a concern
 //!
 //! Reth may be configured to retain only a window of recent history,
-//! creating a `reth.pruned_below ≤ reth.finalized` watermark. Indexed reads
-//! have different contracts during startup and regular marshal operation:
+//! creating a `reth.pruned_below ≤ reth.finalized` watermark. The
+//! marshal can never ask for a block panic-on-miss below
+//! `reth.pruned_below`:
 //!
 //! - **`Blocks::put(H)`**: marshal's `last_processed_height` is floored
 //!   to `max(stored_height, reth.finalized)` at startup
 //!   ([`alias::marshal::init`]), so every put has
 //!   `H > reth.finalized > reth.pruned_below`.
-//! - **Startup `Blocks::get(Index(H))`**: before constructing the marshal
-//!   actor, [`alias::marshal::init`] registers the finalized floor's scheme.
-//!   If direct execution-layer reads miss, it uses this store to look up the
-//!   finalized floor and its epoch boundary. These heights may be below
-//!   `reth.pruned_below`; a miss in both the cache and reth returns `Ok(None)`
-//!   and fails initialization rather than serving an unfinalized block.
-//! - **Actor `Blocks::get(Index(H))`**: only asks for the next contiguous
-//!   height or a `gap_end` already in the cache.
+//! - **`Blocks::get(Index(H))`**: only ever asks for the next
+//!   contiguous height or a `gap_end` already in the cache.
 //! - **`Blocks::get(Key(digest))`**: gap-repair parent walks may ask
 //!   for a digest below `reth.pruned_below`; on miss we return
 //!   `Ok(None)` and the marshal falls back to peer resolution.
 //!
 //! Configuring reth with a smaller retention window than
-//! `retention_blocks` causes more peer fetches during regular operation and
-//! can make the startup fallback unavailable. It is not a correctness issue:
-//! startup fails closed when neither backing store contains the requested
-//! block.
+//! `retention_blocks` is a perf concern (more peer fetches), not a
+//! correctness one.
 //!
 //! [`alias::marshal::init`]: crate::alias::marshal::init
 

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -69,29 +69,36 @@
 //! longer serve them. Repairing them here would be futile anyway — the
 //! prunable cache has evicted them too, so the re-fetched block's put would
 //! be silently absorbed (see "Stale puts") and the gap would reappear on
-//! the next repair tick. The marshal never asks for such heights; see
-//! "Why reth pruning is not a concern" below.
+//! the next repair tick. The marshal actor's repair path never asks for such
+//! heights; startup has a separate best-effort lookup described below.
 //!
-//! # Why reth pruning is not a concern
+//! # Reth pruning behavior
 //!
 //! Reth may be configured to retain only a window of recent history,
-//! creating a `reth.pruned_below ≤ reth.finalized` watermark. The
-//! marshal can never ask for a block panic-on-miss below
-//! `reth.pruned_below`:
+//! creating a `reth.pruned_below ≤ reth.finalized` watermark. Indexed reads
+//! have different contracts during startup and regular marshal operation:
 //!
 //! - **`Blocks::put(H)`**: marshal's `last_processed_height` is floored
 //!   to `max(stored_height, reth.finalized)` at startup
 //!   ([`alias::marshal::init`]), so every put has
 //!   `H > reth.finalized > reth.pruned_below`.
-//! - **`Blocks::get(Index(H))`**: only ever asks for the next
-//!   contiguous height or a `gap_end` already in the cache.
+//! - **Startup `Blocks::get(Index(H))`**: before constructing the marshal
+//!   actor, [`alias::marshal::init`] registers the finalized floor's scheme.
+//!   If direct execution-layer reads miss, it uses this store to look up the
+//!   finalized floor and its epoch boundary. These heights may be below
+//!   `reth.pruned_below`; a miss in both the cache and reth returns `Ok(None)`
+//!   and fails initialization rather than serving an unfinalized block.
+//! - **Actor `Blocks::get(Index(H))`**: only asks for the next contiguous
+//!   height or a `gap_end` already in the cache.
 //! - **`Blocks::get(Key(digest))`**: gap-repair parent walks may ask
 //!   for a digest below `reth.pruned_below`; on miss we return
 //!   `Ok(None)` and the marshal falls back to peer resolution.
 //!
 //! Configuring reth with a smaller retention window than
-//! `retention_blocks` is a perf concern (more peer fetches), not a
-//! correctness one.
+//! `retention_blocks` causes more peer fetches during regular operation and
+//! can make the startup fallback unavailable. It is not a correctness issue:
+//! startup fails closed when neither backing store contains the requested
+//! block.
 //!
 //! [`alias::marshal::init`]: crate::alias::marshal::init
 


### PR DESCRIPTION
This patch ensures that scheme registration looks at both - execution layer and finalized blocks archive.

Tempo snapshots provide both to ensure that the certificate anchor recorded in the snapshot can always be reached since the execution layer's durability guarantees are lower than those of the consensus layer.

Before this patch, initial scheme registration was only looking at the execution layer, potentially failing startup.