### PR TITLE
feat(primitives): add has_fee_payer_signature_marker helpers

### DIFF
--- a/crates/primitives/src/transaction/envelope.rs
+++ b/crates/primitives/src/transaction/envelope.rs
@@ -159,6 +159,18 @@ impl TempoTxEnvelope {
         }
     }
 
+    /// Returns `true` if this is an AA transaction whose fee payer signature is the
+    /// [`FEE_PAYER_SIGNATURE_MARKER`](super::FEE_PAYER_SIGNATURE_MARKER) placeholder,
+    /// indicating it still needs to be signed by a fee payer.
+    ///
+    /// Other transaction types do not carry a fee payer signature.
+    pub fn has_fee_payer_signature_marker(&self) -> bool {
+        match self {
+            Self::AA(tx) => tx.tx().has_fee_payer_signature_marker(),
+            _ => false,
+        }
+    }
+
     /// Returns the sender-scoped transaction identifier used for replay-sensitive features.
     pub fn unique_tx_identifier(&self, sender: Address) -> B256 {
         match self {

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -433,6 +433,13 @@ impl TempoTransaction {
         keccak256(&buf)
     }
 
+    /// Returns `true` if the fee payer signature is the [`FEE_PAYER_SIGNATURE_MARKER`]
+    /// placeholder, indicating the transaction still needs to be signed by a fee payer.
+    #[inline]
+    pub fn has_fee_payer_signature_marker(&self) -> bool {
+        self.fee_payer_signature == Some(FEE_PAYER_SIGNATURE_MARKER)
+    }
+
     /// Recovers the fee payer for this transaction.
     ///
     /// This returns the given sender if the transaction doesn't include a fee payer signature


### PR DESCRIPTION
Checking whether a transaction carries the fee-payer signature placeholder requires manually comparing the field against `FEE_PAYER_SIGNATURE_MARKER`, which comes up repeatedly when handling sponsored transactions.

This adds `has_fee_payer_signature_marker` to `TempoTransaction` and to `TempoTxEnvelope`, where it returns `false` for non-AA transactions.