### PR TITLE
feat(primitives): add fee payer service decoding for AASigned

### DIFF
--- a/.changelog/primitives-fee-payer-service-decode.md
+++ b/.changelog/primitives-fee-payer-service-decode.md
@@ -1,0 +1,5 @@
+---
+tempo-primitives: minor
+---
+
+Added `AASigned::decode_for_fee_payer_service`, the inverse of `encode_for_fee_payer_service`, so Rust fee payer services can decode sponsorship requests carrying the `0x00` fee payer signature placeholder.

--- a/.changelog/primitives-fee-payer-service-decode.md
+++ b/.changelog/primitives-fee-payer-service-decode.md
@@ -2,4 +2,4 @@
 tempo-primitives: minor
 ---
 
-Added `AASigned::decode_for_fee_payer_service`, the inverse of `encode_for_fee_payer_service`, so Rust fee payer services can decode sponsorship requests carrying the `0x00` fee payer signature placeholder.
+Added `AASigned::decode_for_fee_payer_service`, the inverse of `encode_for_fee_payer_service`, so Rust fee payer services can decode sponsorship requests. Both ox-compatible request forms are supported: the `0x00` fee payer signature placeholder and the bare sender address used by multisig finalize flows, which is returned alongside the transaction.

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -664,13 +664,15 @@ impl TempoTransaction {
     /// Decodes the inner `TempoTransaction` fields from the fee-payer service encoding.
     ///
     /// Inverse of the field encoding produced by [`Self::encode_for_fee_payer_service`]: the fee
-    /// payer signature field must carry the single-byte `0x00` sponsorship placeholder, which
-    /// decodes to [`FEE_PAYER_SIGNATURE_MARKER`]. All other fields decode exactly like
-    /// [`Self::rlp_decode_fields`]; in particular the fee token stays optional, since the service
-    /// encoding leaves it empty for the sponsor to fill.
+    /// payer signature field must carry a sponsorship request, which decodes to
+    /// [`FEE_PAYER_SIGNATURE_MARKER`]. Sponsorship is requested either with the single-byte
+    /// `0x00` placeholder or with the bare sender address used by multisig finalize flows; the
+    /// address is returned alongside the fields when present. All other fields decode exactly
+    /// like [`Self::rlp_decode_fields`]; in particular the fee token stays optional, since the
+    /// service encoding leaves it empty for the sponsor to fill.
     pub(crate) fn rlp_decode_fields_for_fee_payer_service(
         buf: &mut &[u8],
-    ) -> alloy_rlp::Result<Self> {
+    ) -> alloy_rlp::Result<(Self, Option<Address>)> {
         let chain_id = Decodable::decode(buf)?;
         let max_priority_fee_per_gas = Decodable::decode(buf)?;
         let max_fee_per_gas = Decodable::decode(buf)?;
@@ -694,13 +696,20 @@ impl TempoTransaction {
             return Err(alloy_rlp::Error::InputTooShort);
         };
 
-        let fee_payer_signature = if let Some(first) = buf.first() {
+        // `0x80 + 20` is the RLP string header of a 20-byte address item.
+        const ADDRESS_ITEM_HEADER: u8 = EMPTY_STRING_CODE + Address::len_bytes() as u8;
+        let (fee_payer_signature, explicit_sender) = if let Some(first) = buf.first() {
             if *first == 0x00 {
                 buf.advance(1);
-                Some(FEE_PAYER_SIGNATURE_MARKER)
+                (Some(FEE_PAYER_SIGNATURE_MARKER), None)
+            } else if *first == ADDRESS_ITEM_HEADER {
+                (
+                    Some(FEE_PAYER_SIGNATURE_MARKER),
+                    Some(Address::decode(buf)?),
+                )
             } else {
                 return Err(alloy_rlp::Error::Custom(
-                    "fee payer service encoding requires the 0x00 fee payer signature placeholder",
+                    "fee payer service encoding requires the 0x00 fee payer signature placeholder or a sender address",
                 ));
             }
         } else {
@@ -742,7 +751,7 @@ impl TempoTransaction {
         // Validate the transaction
         tx.validate().map_err(alloy_rlp::Error::Custom)?;
 
-        Ok(tx)
+        Ok((tx, explicit_sender))
     }
 
     /// Returns true if the nonce key of this transaction has the [`TEMPO_SUBBLOCK_NONCE_KEY_PREFIX`](crate::subblock::TEMPO_SUBBLOCK_NONCE_KEY_PREFIX).

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -661,6 +661,90 @@ impl TempoTransaction {
         Ok(tx)
     }
 
+    /// Decodes the inner `TempoTransaction` fields from the fee-payer service encoding.
+    ///
+    /// Inverse of the field encoding produced by [`Self::encode_for_fee_payer_service`]: the fee
+    /// payer signature field must carry the single-byte `0x00` sponsorship placeholder, which
+    /// decodes to [`FEE_PAYER_SIGNATURE_MARKER`]. All other fields decode exactly like
+    /// [`Self::rlp_decode_fields`]; in particular the fee token stays optional, since the service
+    /// encoding leaves it empty for the sponsor to fill.
+    pub(crate) fn rlp_decode_fields_for_fee_payer_service(
+        buf: &mut &[u8],
+    ) -> alloy_rlp::Result<Self> {
+        let chain_id = Decodable::decode(buf)?;
+        let max_priority_fee_per_gas = Decodable::decode(buf)?;
+        let max_fee_per_gas = Decodable::decode(buf)?;
+        let gas_limit = Decodable::decode(buf)?;
+        let calls = Decodable::decode(buf)?;
+        let access_list = Decodable::decode(buf)?;
+        let nonce_key = Decodable::decode(buf)?;
+        let nonce = Decodable::decode(buf)?;
+
+        let valid_before = u64::decode(buf).map(NonZeroU64::new)?;
+        let valid_after = u64::decode(buf).map(NonZeroU64::new)?;
+
+        let fee_token = if let Some(first) = buf.first() {
+            if *first == EMPTY_STRING_CODE {
+                buf.advance(1);
+                None
+            } else {
+                TxKind::decode(buf)?.into_to()
+            }
+        } else {
+            return Err(alloy_rlp::Error::InputTooShort);
+        };
+
+        let fee_payer_signature = if let Some(first) = buf.first() {
+            if *first == 0x00 {
+                buf.advance(1);
+                Some(FEE_PAYER_SIGNATURE_MARKER)
+            } else {
+                return Err(alloy_rlp::Error::Custom(
+                    "fee payer service encoding requires the 0x00 fee payer signature placeholder",
+                ));
+            }
+        } else {
+            return Err(alloy_rlp::Error::InputTooShort);
+        };
+
+        let tempo_authorization_list = Decodable::decode(buf)?;
+
+        // Decode optional key_authorization field at the end, mirroring `rlp_decode_fields`:
+        // a KeyAuthorization is always an RLP list, anything else is trailing data of the
+        // enclosing encoding (the sender signature bytes in the AASigned context).
+        let key_authorization = if let Some(&first) = buf.first() {
+            if first >= 0xc0 {
+                Some(Decodable::decode(buf)?)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        let tx = Self {
+            chain_id,
+            fee_token,
+            max_priority_fee_per_gas,
+            max_fee_per_gas,
+            gas_limit,
+            calls,
+            access_list,
+            nonce_key,
+            nonce,
+            fee_payer_signature,
+            valid_before,
+            valid_after,
+            key_authorization,
+            tempo_authorization_list,
+        };
+
+        // Validate the transaction
+        tx.validate().map_err(alloy_rlp::Error::Custom)?;
+
+        Ok(tx)
+    }
+
     /// Returns true if the nonce key of this transaction has the [`TEMPO_SUBBLOCK_NONCE_KEY_PREFIX`](crate::subblock::TEMPO_SUBBLOCK_NONCE_KEY_PREFIX).
     pub fn has_sub_block_nonce_key_prefix(&self) -> bool {
         has_sub_block_nonce_key_prefix(&self.nonce_key)

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -217,13 +217,18 @@ impl AASigned {
     /// Decodes a signed transaction from the fee-payer service encoding.
     ///
     /// Inverse of [`Self::encode_for_fee_payer_service`]: the fee payer signature field must
-    /// carry the `0x00` sponsorship placeholder, which decodes to
-    /// [`FEE_PAYER_SIGNATURE_MARKER`](super::FEE_PAYER_SIGNATURE_MARKER), matching how fee payer
-    /// services deserialize the placeholder to a pending fee payer signature. The sender
-    /// signature and all other fields decode exactly like the standard encoding, so a sponsor
-    /// can fill the sponsor-owned fields (fee token and fee payer signature) and re-encode the
-    /// transaction with [`Encodable2718::encode_2718`].
-    pub fn decode_for_fee_payer_service(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+    /// request sponsorship, which decodes to
+    /// [`FEE_PAYER_SIGNATURE_MARKER`](super::FEE_PAYER_SIGNATURE_MARKER). Matching `ox`/`viem`
+    /// deserialization, sponsorship is requested either with the `0x00` placeholder or with a
+    /// bare sender address in the signature slot; the latter is used by multisig finalize flows
+    /// where the sender cannot be recovered from the (still incomplete) sender signature, and is
+    /// returned as the second tuple element. The sender signature and all other fields decode
+    /// exactly like the standard encoding, so a sponsor can fill the sponsor-owned fields (fee
+    /// token and fee payer signature) and re-encode the transaction with
+    /// [`Encodable2718::encode_2718`].
+    pub fn decode_for_fee_payer_service(
+        buf: &mut &[u8],
+    ) -> alloy_rlp::Result<(Self, Option<Address>)> {
         match buf.split_first() {
             Some((&TEMPO_TX_TYPE_ID, rest)) => *buf = rest,
             Some(_) => {
@@ -244,8 +249,8 @@ impl AASigned {
             return Err(alloy_rlp::Error::InputTooShort);
         }
 
-        // Decode transaction fields with the fee payer signature placeholder
-        let tx = TempoTransaction::rlp_decode_fields_for_fee_payer_service(buf)?;
+        // Decode transaction fields with the fee payer signature sponsorship request
+        let (tx, explicit_sender) = TempoTransaction::rlp_decode_fields_for_fee_payer_service(buf)?;
 
         // Decode signature bytes
         let sig_bytes: Bytes = Decodable::decode(buf)?;
@@ -259,7 +264,7 @@ impl AASigned {
         // Parse signature
         let signature = TempoSignature::from_bytes(&sig_bytes).map_err(alloy_rlp::Error::Custom)?;
 
-        Ok(Self::new_unhashed(tx, signature))
+        Ok((Self::new_unhashed(tx, signature), explicit_sender))
     }
 
     /// Splits the transaction into parts.
@@ -652,8 +657,13 @@ mod tests {
         let (signed, _) = signed_pair_for_tx(tx);
 
         let encoded = service_encoded(&signed);
-        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+        let (decoded, explicit_sender) =
+            AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
 
+        assert_eq!(
+            explicit_sender, None,
+            "placeholder form carries no explicit sender"
+        );
         assert_eq!(decoded.tx(), signed.tx());
         assert_eq!(decoded.signature(), signed.signature());
         assert_eq!(*decoded.hash(), *signed.hash());
@@ -664,6 +674,39 @@ mod tests {
     }
 
     #[test]
+    fn test_decode_for_fee_payer_service_accepts_sender_address_form() {
+        let mut tx = make_tx();
+        tx.fee_payer_signature = Some(FEE_PAYER_SIGNATURE_MARKER);
+        let (signed, _) = signed_pair_for_tx(tx);
+        let sender = signed.recover_signer().unwrap();
+
+        // ox/viem also serialize sponsorship requests with the bare sender address in the fee
+        // payer signature slot; build that wire form with the address encoding closure.
+        let payload_length = signed
+            .tx()
+            .rlp_encoded_fields_length(|_| sender.length(), true)
+            + signed.signature().length();
+        let mut encoded = vec![TEMPO_TX_TYPE_ID];
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .encode(&mut encoded);
+        signed
+            .tx()
+            .rlp_encode_fields(&mut encoded, |_, out| sender.encode(out), true);
+        signed.signature().encode(&mut encoded);
+
+        let (decoded, explicit_sender) =
+            AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+
+        assert_eq!(explicit_sender, Some(sender));
+        assert_eq!(decoded.tx(), signed.tx());
+        assert_eq!(decoded.signature(), signed.signature());
+        assert_eq!(*decoded.hash(), *signed.hash());
+    }
+
+    #[test]
     fn test_decode_for_fee_payer_service_normalizes_sponsor_owned_fields() {
         let mut tx = make_tx();
         tx.fee_token = Some(Address::repeat_byte(0x20));
@@ -671,7 +714,7 @@ mod tests {
         let (signed, _) = signed_pair_for_tx(tx.clone());
 
         let encoded = service_encoded(&signed);
-        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+        let (decoded, _) = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
 
         // The service encoding strips the two sponsor-owned fields.
         tx.fee_token = None;
@@ -740,7 +783,7 @@ mod tests {
         let (signed, _) = signed_pair_for_tx(tx);
 
         let encoded = service_encoded(&signed);
-        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+        let (decoded, _) = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
 
         assert_eq!(decoded.tx(), signed.tx());
         assert_eq!(decoded.signature(), signed.signature());
@@ -755,7 +798,7 @@ mod tests {
         let sender = signed.recover_signer().unwrap();
 
         let encoded = service_encoded(&signed);
-        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+        let (decoded, _) = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
 
         // The sponsor fills the sponsor-owned fields: the fee token it pays with and its fee
         // payer signature over the digest, which commits to the fee token.
@@ -794,7 +837,7 @@ mod tests {
         assert_eq!(
             err,
             alloy_rlp::Error::Custom(
-                "fee payer service encoding requires the 0x00 fee payer signature placeholder"
+                "fee payer service encoding requires the 0x00 fee payer signature placeholder or a sender address"
             )
         );
 
@@ -806,7 +849,7 @@ mod tests {
         assert_eq!(
             err,
             alloy_rlp::Error::Custom(
-                "fee payer service encoding requires the 0x00 fee payer signature placeholder"
+                "fee payer service encoding requires the 0x00 fee payer signature placeholder or a sender address"
             )
         );
 
@@ -1201,7 +1244,8 @@ mod tests {
 
             let mut encoded = Vec::new();
             signed.encode_for_fee_payer_service(&mut encoded);
-            let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+            let (decoded, explicit_sender) = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+            prop_assert_eq!(explicit_sender, None);
 
             // The service encoding strips the sponsor-owned fields; everything else round-trips.
             let expected = TempoTransaction {

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -214,6 +214,54 @@ impl AASigned {
         self.signature.encode(out);
     }
 
+    /// Decodes a signed transaction from the fee-payer service encoding.
+    ///
+    /// Inverse of [`Self::encode_for_fee_payer_service`]: the fee payer signature field must
+    /// carry the `0x00` sponsorship placeholder, which decodes to
+    /// [`FEE_PAYER_SIGNATURE_MARKER`](super::FEE_PAYER_SIGNATURE_MARKER), matching how fee payer
+    /// services deserialize the placeholder to a pending fee payer signature. The sender
+    /// signature and all other fields decode exactly like the standard encoding, so a sponsor
+    /// can fill the sponsor-owned fields (fee token and fee payer signature) and re-encode the
+    /// transaction with [`Encodable2718::encode_2718`].
+    pub fn decode_for_fee_payer_service(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        match buf.split_first() {
+            Some((&TEMPO_TX_TYPE_ID, rest)) => *buf = rest,
+            Some(_) => {
+                return Err(alloy_rlp::Error::Custom(
+                    "fee payer service encoding must start with the Tempo transaction type",
+                ));
+            }
+            None => return Err(alloy_rlp::Error::InputTooShort),
+        }
+
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        let remaining = buf.len();
+
+        if header.payload_length > remaining {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        // Decode transaction fields with the fee payer signature placeholder
+        let tx = TempoTransaction::rlp_decode_fields_for_fee_payer_service(buf)?;
+
+        // Decode signature bytes
+        let sig_bytes: Bytes = Decodable::decode(buf)?;
+
+        // Check that we consumed the expected amount
+        let consumed = remaining - buf.len();
+        if consumed != header.payload_length {
+            return Err(alloy_rlp::Error::UnexpectedLength);
+        }
+
+        // Parse signature
+        let signature = TempoSignature::from_bytes(&sig_bytes).map_err(alloy_rlp::Error::Custom)?;
+
+        Ok(Self::new_unhashed(tx, signature))
+    }
+
     /// Splits the transaction into parts.
     pub fn into_parts(self) -> (TempoTransaction, TempoSignature, B256) {
         let hash = *self.hash();
@@ -555,12 +603,16 @@ mod serde_impl {
 mod tests {
     use super::*;
     use crate::transaction::{
+        Authorization, FEE_PAYER_SIGNATURE_MARKER, KeyAuthorization, SignatureType,
+        TempoSignedAuthorization, TokenLimit,
         tempo_transaction::Call,
         tt_authorization::tests::{generate_secp256k1_keypair, sign_hash},
         tt_signature::PrimitiveSignature,
     };
     use alloy_consensus::transaction::SignerRecoverable;
+    use alloy_eips::eip2930::AccessListItem;
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+    use alloy_signer::SignerSync;
     use alloy_signer_local::PrivateKeySigner;
     use core::num::NonZeroU64;
     use proptest::prelude::*;
@@ -585,6 +637,195 @@ mod tests {
             AASigned::new_unhashed(tx.clone(), signature.clone()),
             AASigned::new_unhashed(tx, signature),
         )
+    }
+
+    fn service_encoded(tx: &AASigned) -> Vec<u8> {
+        let mut buf = Vec::new();
+        tx.encode_for_fee_payer_service(&mut buf);
+        buf
+    }
+
+    #[test]
+    fn test_decode_for_fee_payer_service_roundtrips_sponsorship_request() {
+        let mut tx = make_tx();
+        tx.fee_payer_signature = Some(FEE_PAYER_SIGNATURE_MARKER);
+        let (signed, _) = signed_pair_for_tx(tx);
+
+        let encoded = service_encoded(&signed);
+        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded.tx(), signed.tx());
+        assert_eq!(decoded.signature(), signed.signature());
+        assert_eq!(*decoded.hash(), *signed.hash());
+        assert_eq!(
+            decoded.recover_signer().unwrap(),
+            signed.recover_signer().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_decode_for_fee_payer_service_normalizes_sponsor_owned_fields() {
+        let mut tx = make_tx();
+        tx.fee_token = Some(Address::repeat_byte(0x20));
+        tx.fee_payer_signature = Some(Signature::test_signature());
+        let (signed, _) = signed_pair_for_tx(tx.clone());
+
+        let encoded = service_encoded(&signed);
+        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+
+        // The service encoding strips the two sponsor-owned fields.
+        tx.fee_token = None;
+        tx.fee_payer_signature = Some(FEE_PAYER_SIGNATURE_MARKER);
+        assert_eq!(decoded.tx(), &tx);
+        assert_eq!(decoded.signature(), signed.signature());
+    }
+
+    #[test]
+    fn test_decode_for_fee_payer_service_roundtrips_all_fields() {
+        let key_authorization = KeyAuthorization {
+            chain_id: 42170,
+            key_type: SignatureType::Secp256k1,
+            key_id: Address::repeat_byte(0x77),
+            expiry: NonZeroU64::new(1_700_100_000),
+            limits: Some(vec![TokenLimit {
+                token: Address::repeat_byte(0x42),
+                limit: U256::from(1_000_000u64),
+                period: 86400,
+            }]),
+            allowed_calls: None,
+            witness: None,
+            is_admin: false,
+            account: None,
+        }
+        .into_signed(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+        let tx = TempoTransaction {
+            chain_id: 42170,
+            fee_token: None,
+            max_priority_fee_per_gas: 1_000_000_000,
+            max_fee_per_gas: 50_000_000_000,
+            gas_limit: 1_000_000,
+            calls: vec![
+                Call {
+                    to: TxKind::Call(Address::repeat_byte(0x42)),
+                    value: U256::from(7u64),
+                    input: Bytes::from(vec![1, 2, 3]),
+                },
+                Call {
+                    to: TxKind::Call(Address::repeat_byte(0x43)),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+            ],
+            access_list: AccessList(vec![AccessListItem {
+                address: Address::repeat_byte(0x01),
+                storage_keys: vec![B256::ZERO],
+            }]),
+            nonce_key: U256::from(7u64),
+            nonce: 42,
+            fee_payer_signature: Some(FEE_PAYER_SIGNATURE_MARKER),
+            valid_before: NonZeroU64::new(1_700_001_000),
+            valid_after: NonZeroU64::new(1_700_000_000),
+            key_authorization: Some(key_authorization),
+            tempo_authorization_list: vec![TempoSignedAuthorization::new_unchecked(
+                Authorization {
+                    chain_id: U256::from(42170u64),
+                    address: Address::repeat_byte(0x99),
+                    nonce: 1,
+                },
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                    Signature::test_signature(),
+                )),
+            )],
+        };
+        let (signed, _) = signed_pair_for_tx(tx);
+
+        let encoded = service_encoded(&signed);
+        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+
+        assert_eq!(decoded.tx(), signed.tx());
+        assert_eq!(decoded.signature(), signed.signature());
+        assert_eq!(*decoded.hash(), *signed.hash());
+    }
+
+    #[test]
+    fn test_decode_for_fee_payer_service_supports_sponsor_completion() {
+        let mut tx = make_tx();
+        tx.fee_payer_signature = Some(FEE_PAYER_SIGNATURE_MARKER);
+        let (signed, _) = signed_pair_for_tx(tx);
+        let sender = signed.recover_signer().unwrap();
+
+        let encoded = service_encoded(&signed);
+        let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+
+        // The sponsor fills the sponsor-owned fields: the fee token it pays with and its fee
+        // payer signature over the digest, which commits to the fee token.
+        let (mut tx, sender_signature, _) = decoded.into_parts();
+        tx.fee_token = Some(Address::repeat_byte(0x20));
+        let fee_payer = PrivateKeySigner::from_bytes(&B256::with_last_byte(2)).unwrap();
+        tx.fee_payer_signature = Some(
+            fee_payer
+                .sign_hash_sync(&tx.fee_payer_signature_hash(sender))
+                .unwrap(),
+        );
+        let sponsored = tx.into_signed(sender_signature);
+
+        // The completed transaction round-trips through the standard encoding with the sender
+        // signature intact.
+        let mut standard = Vec::new();
+        sponsored.encode_2718(&mut standard);
+        let sponsored = AASigned::decode_2718(&mut standard.as_slice()).unwrap();
+        assert_eq!(sponsored.recover_signer().unwrap(), sender);
+        assert_eq!(
+            sponsored.tx().recover_fee_payer(sender).unwrap(),
+            fee_payer.address()
+        );
+    }
+
+    #[test]
+    fn test_decode_for_fee_payer_service_rejects_other_encodings() {
+        let mut tx = make_tx();
+        tx.fee_payer_signature = Some(FEE_PAYER_SIGNATURE_MARKER);
+        let (signed, _) = signed_pair_for_tx(tx);
+
+        // The standard encoding stores the marker as a real signature list, not the placeholder.
+        let mut standard = Vec::new();
+        signed.encode_2718(&mut standard);
+        let err = AASigned::decode_for_fee_payer_service(&mut standard.as_slice()).unwrap_err();
+        assert_eq!(
+            err,
+            alloy_rlp::Error::Custom(
+                "fee payer service encoding requires the 0x00 fee payer signature placeholder"
+            )
+        );
+
+        // Unsponsored transactions (empty fee payer signature field) are rejected as well.
+        let (unsponsored, _) = signed_pair_for_tx(make_tx());
+        let mut standard = Vec::new();
+        unsponsored.encode_2718(&mut standard);
+        let err = AASigned::decode_for_fee_payer_service(&mut standard.as_slice()).unwrap_err();
+        assert_eq!(
+            err,
+            alloy_rlp::Error::Custom(
+                "fee payer service encoding requires the 0x00 fee payer signature placeholder"
+            )
+        );
+
+        // Non-Tempo transaction type byte.
+        let err = AASigned::decode_for_fee_payer_service(&mut [0x02, 0xc0].as_ref()).unwrap_err();
+        assert_eq!(
+            err,
+            alloy_rlp::Error::Custom(
+                "fee payer service encoding must start with the Tempo transaction type"
+            )
+        );
+
+        // Empty and truncated input.
+        assert!(AASigned::decode_for_fee_payer_service(&mut [].as_ref()).is_err());
+        let encoded = service_encoded(&signed);
+        assert!(
+            AASigned::decode_for_fee_payer_service(&mut encoded[..encoded.len() - 2].as_ref())
+                .is_err()
+        );
     }
 
     fn arb_address() -> impl Strategy<Value = Address> {
@@ -951,6 +1192,25 @@ mod tests {
 
             prop_assert_eq!(helper_signer, individual_signer);
             prop_assert_eq!(helper_expiring_nonce_hash, None);
+        }
+
+        #[test]
+        fn proptest_fee_payer_service_encoding_roundtrips(tx in arb_tempo_tx()) {
+            prop_assume!(tx.validate().is_ok());
+            let (signed, _) = signed_pair_for_tx(tx.clone());
+
+            let mut encoded = Vec::new();
+            signed.encode_for_fee_payer_service(&mut encoded);
+            let decoded = AASigned::decode_for_fee_payer_service(&mut encoded.as_slice()).unwrap();
+
+            // The service encoding strips the sponsor-owned fields; everything else round-trips.
+            let expected = TempoTransaction {
+                fee_token: None,
+                fee_payer_signature: Some(FEE_PAYER_SIGNATURE_MARKER),
+                ..tx
+            };
+            prop_assert_eq!(decoded.tx(), &expected);
+            prop_assert_eq!(decoded.signature(), signed.signature());
         }
     }
 }


### PR DESCRIPTION
Rust consumers of the fee payer service encoding had no decoder: `encode_for_fee_payer_service` exists, but the standard decoder rejects the `0x00` fee payer signature placeholder, so Rust fee payer services hand-roll RLP surgery today (the anvil built-in fee payer in foundry-rs/foundry#16278 and the mock sponsor in foundry's cast CLI tests).

Adds `AASigned::decode_for_fee_payer_service` as the purely additive inverse, mirroring how ox/viem deserialize sponsorship requests in [`TxEnvelopeTempo.deserialize`](https://github.com/wevm/ox/blob/main/src/tempo/TxEnvelopeTempo.ts) (what the hosted fee payer service uses): both request forms are accepted — the `0x00` placeholder and the bare sender address used by multisig finalize flows — decoding to `FEE_PAYER_SIGNATURE_MARKER`, with the explicit sender returned alongside the transaction. Everything else decodes exactly like the standard encoding and no existing functions changed. Covered by unit and property round-trip tests, including sponsor completion back through the standard encoding.

> Written primarily by Claude Code, reviewed by me.