### PR TITLE
fix(bench): filter noisy HTTP transport logs

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1062,14 +1062,14 @@ def run-local-e2e-phase [run: record, ctx: record] {
         | append (if $ctx.gas_limit != "" { ["--builder.gaslimit" $ctx.gas_limit] } else { [] })
         | append (if $ctx.samply { ["--log.samply"] } else { [] })
         | append (if $ctx.tracy != "off" { ["--log.tracy" "--log.tracy.filter" $ctx.tracy_filter] } else { [] })
-        | append (if $ctx.tracing_otlp != "" { [$"--tracing-otlp=($ctx.tracing_otlp)"] } else { [] })
+        | append (benchmark-otlp-args $ctx.tracing_otlp)
     let b_base_args = (build-base-args $genesis $ctx.b.datadir $b_log_dir "0.0.0.0" 8645 9101)
         | append (build-e2e-consensus-args $ctx.b.node_dir $ctx.trusted_peers $ctx.b.consensus_port $ctx.b.ip)
         | append $local_reth_args
         | append (log-filter-args $ctx.loud)
         | append (if $ctx.gas_limit != "" { ["--builder.gaslimit" $ctx.gas_limit] } else { [] })
         | append (if $ctx.samply { ["--log.samply"] } else { [] })
-        | append (if $ctx.tracing_otlp != "" { [$"--tracing-otlp=($ctx.tracing_otlp)"] } else { [] })
+        | append (benchmark-otlp-args $ctx.tracing_otlp)
     let a_args = (dedup-args $a_base_args $extra_args)
     let b_args = (dedup-args $b_base_args $extra_args)
 

--- a/contrib/bench/bench-txgen.nu
+++ b/contrib/bench/bench-txgen.nu
@@ -74,7 +74,7 @@ def run-txgen-bench-single [
         | append (build-dev-args)
         | append (log-filter-args $loud)
         | append (if $tracy != "off" { ["--log.tracy" "--log.tracy.filter" $tracy_filter] } else { [] })
-        | append (if $tracing_otlp != "" { [$"--tracing-otlp=($tracing_otlp)"] } else { [] })
+        | append (benchmark-otlp-args $tracing_otlp)
     let args = (dedup-args $base_args $extra_args)
 
     let tracy_env_prefix = if $tracy == "on" {

--- a/tempo.nu
+++ b/tempo.nu
@@ -33,6 +33,18 @@ def log-filter-args [loud: bool] {
     if $loud { [] } else { ["--log.stdout.filter" "info"] }
 }
 
+# Keep benchmark OTLP logs useful without emitting high-volume HTTP transport internals.
+def benchmark-otlp-args [endpoint: string] {
+    if $endpoint == "" {
+        []
+    } else {
+        [
+            $"--tracing-otlp=($endpoint)"
+            "--logs-otlp.filter=debug,h2=off,hyper=off,hyper_util=off"
+        ]
+    }
+}
+
 def prepare-localnet-consensus-secret-fifo [node_dir: string] {
     let secret_path = $"($node_dir)/consensus-secret.fifo"
     rm -f $secret_path
@@ -676,7 +688,7 @@ def run-bench-single [
         | append (build-dev-args)
         | append (log-filter-args $loud)
         | append (if $tracy != "off" { ["--log.tracy" "--log.tracy.filter" $tracy_filter] } else { [] })
-        | append (if $tracing_otlp != "" { [$"--tracing-otlp=($tracing_otlp)"] } else { [] })
+        | append (benchmark-otlp-args $tracing_otlp)
     let args = (dedup-args $base_args $extra_args)
 
     # Tracy environment variables


### PR DESCRIPTION
## Summary

- add a shared benchmark OTLP argument helper
- retain DEBUG benchmark telemetry while disabling `h2`, `hyper`, and `hyper_util` targets
- apply the filter to standard, E2E, and txgen benchmark node launches

## Validation

- parsed all three Nushell benchmark entrypoints
- asserted the helper output for configured and empty OTLP endpoints
- `git diff --check`

Prompted by: @laibe