### PR TITLE
chore: remove broken registrar-delegation recipe

### DIFF
--- a/scripts/Justfile
+++ b/scripts/Justfile
@@ -42,10 +42,6 @@ basic-transfer:
 	#!/bin/bash
 	./basic-transfer.sh
 
-registrar-delegation:
-	#!/bin/bash
-	./registrar-delegation.sh
-
 create-tip20-token:
 	#!/bin/bash
 	./create-tip20-token.sh


### PR DESCRIPTION
Remove the broken registrar-delegation recipe from `scripts/Justfile`.

The recipe references `./registrar-delegation.sh`, but the script does not exist in `scripts/`.

Verified locally:
`File not found: scripts/registrar-delegation.sh`

This removes the broken entry point without affecting the existing scripts.