### PR TITLE
fix(ci): fetch history for changelog attribution

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -33,6 +33,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
+      - name: Fetch main history for changelog attribution
+        run: git fetch --unshallow --no-tags origin refs/heads/main
+
       - name: Keep only SDK changelog entries
         run: |
           python3 - <<'PY'


### PR DESCRIPTION
Fix changelog attribution by unshallowing only the current `main` ref, with tags disabled, after the default one-commit checkout. This gives `git log --follow` the ancestry needed to resolve each fragment without fetching every branch and tag.

Validation: `git diff --check`; reproduced the targeted fetch in a depth-1 clone and verified it retained zero tags and resolved all pending fragments to their distinct source commits.

Prompted by: @0xrusowsky