### PR TITLE
release: 1.13.1 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13258,7 +13258,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13420,7 +13420,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13488,7 +13488,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13518,7 +13518,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13532,7 +13532,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13584,7 +13584,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13636,7 +13636,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13655,7 +13655,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13663,7 +13663,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13688,7 +13688,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13760,7 +13760,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13798,7 +13798,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13818,7 +13818,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13852,7 +13852,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13901,7 +13901,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13934,7 +13934,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13959,7 +13959,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13968,7 +13968,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14011,7 +14011,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14023,7 +14023,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,8 +276,7 @@ dependencies = [
 [[package]]
 name = "alloy-dyn-abi"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04eb4abc2b5074a18e687ee63918f407cc7990083cba9b999445f839796060"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -443,8 +442,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -509,8 +507,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -947,8 +944,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5655c38d5f84955bf727b2eeb62fddd91ebb98fd1d7ae6eb77f73ea88f9b9cf"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -961,8 +957,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-expander"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6277c780e07b76951e09a59788dde230d1582612324177d11a43a61e21a6bb83"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -980,8 +975,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-input"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -998,8 +992,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1008,8 +1001,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96e74d6213180f78dbdccddce8af02a639c160c94b0a543fa35c77c58b8a7fc"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -13145,8 +13137,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
+source = "git+https://github.com/alloy-rs/core?rev=2d5870c3d62b8b9229d33160cbcc431aeb2cdc21#2d5870c3d62b8b9229d33160cbcc431aeb2cdc21"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13267,7 +13267,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13429,7 +13429,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13497,7 +13497,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13527,7 +13527,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13541,7 +13541,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13593,7 +13593,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13645,7 +13645,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13664,7 +13664,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13672,7 +13672,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13697,7 +13697,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13769,7 +13769,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13807,7 +13807,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13827,7 +13827,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13861,7 +13861,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13910,7 +13910,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13943,7 +13943,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "clap",
@@ -13968,7 +13968,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -13977,7 +13977,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14020,7 +14020,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14032,7 +14032,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.11.0"
+version = "1.13.0"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.13.0"
+version = "1.13.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.11.0"
+version = "1.13.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,6 +411,17 @@ vergen-git2 = "10.0.1"
 
 [patch.crates-io]
 
+# Alloy Core decoder memory limits
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-macro = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-macro-expander = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-macro-input = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-type-parser = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+syn-solidity = { git = "https://github.com/alloy-rs/core", rev = "2d5870c3d62b8b9229d33160cbcc431aeb2cdc21" }
+
 # Commonware v2026.7.0
 # commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
 # commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }

--- a/crates/precompiles/src/account_keychain/dispatch.rs
+++ b/crates/precompiles/src/account_keychain/dispatch.rs
@@ -110,7 +110,8 @@ mod tests {
     };
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
-        IAccountKeychain::IAccountKeychainCalls, UnknownFunctionSelector, legacyAuthorizeKeyCall,
+        IAccountKeychain::{IAccountKeychainCalls, setAllowedCallsCall},
+        UnknownFunctionSelector, legacyAuthorizeKeyCall,
     };
 
     #[test]
@@ -205,6 +206,69 @@ mod tests {
             let result = keychain.call(&calldata, account)?;
             assert!(result.is_revert());
 
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_set_allowed_calls_limits_aliased_calldata_memory() -> eyre::Result<()> {
+        fn word(value: usize) -> [u8; 32] {
+            let mut out = [0_u8; 32];
+            out[24..].copy_from_slice(&(value as u64).to_be_bytes());
+            out
+        }
+
+        /// Builds the aliased calldata from the original Account Keychain decoder regression.
+        fn aliased_set_allowed_calls_calldata(width: usize) -> Vec<u8> {
+            let mut data = Vec::new();
+            data.extend(setAllowedCallsCall::SELECTOR);
+
+            // Function head: account and offset to CallScope[].
+            data.extend(word(0));
+            data.extend(word(64));
+
+            // Every outer element aliases the same CallScope tail.
+            data.extend(word(width));
+            for _ in 0..width {
+                data.extend(word(width * 32));
+            }
+
+            // Shared CallScope: target and offset to SelectorRule[].
+            data.extend(word(1));
+            data.extend(word(64));
+
+            // Every rule aliases the same SelectorRule tail.
+            data.extend(word(width));
+            for _ in 0..width {
+                data.extend(word(width * 32));
+            }
+
+            // Shared SelectorRule: selector and offset to address[].
+            let mut selector = [0_u8; 32];
+            selector[..4].copy_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+            data.extend(selector);
+            data.extend(word(64));
+
+            // The only physical recipient array.
+            data.extend(word(width));
+            for i in 0..width {
+                data.extend(word(i + 1));
+            }
+
+            assert_eq!(data.len(), 292 + 96 * width);
+            data
+        }
+
+        let calldata = aliased_set_allowed_calls_calldata(500);
+        assert_eq!(calldata.len(), 48_292);
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T3);
+        StorageCtx::enter(&mut storage, || {
+            let mut keychain = AccountKeychain::new();
+            let output = keychain.call(&calldata, Address::ZERO)?;
+
+            assert!(output.is_revert());
+            assert!(output.bytes.is_empty());
             Ok(())
         })
     }

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -15,6 +15,15 @@ sol! {
     error StaticCallNotAllowed();
 }
 
+/// Maximum memory the ABI decoder may allocate for a precompile call.
+pub const ABI_DECODER_MEMORY_LIMIT: usize = 16 * 1024 * 1024;
+
+/// Returns the ABI decoder configuration used for precompile calls.
+#[inline]
+pub const fn abi_decoder_config() -> alloy::sol_types::abi::AbiDecoderConfig {
+    alloy::sol_types::abi::AbiDecoderConfig::new().memory_limit(ABI_DECODER_MEMORY_LIMIT)
+}
+
 pub mod typed {
     use super::*;
 
@@ -245,9 +254,18 @@ macro_rules! dispatch {
                 $(
                     if <$iface::$calls as alloy::sol_types::SolInterface>::valid_selector(selector) {
                         type Calls = $iface::$calls;
-                        return $crate::dispatch::dispatch_call($calldata, <Calls as alloy::sol_types::SolInterface>::abi_decode, |$call| match $match_call {
-                            $(Calls::$variant($binding) => $body,)*
-                        });
+                        return $crate::dispatch::dispatch_call(
+                            $calldata,
+                            |data| {
+                                <Calls as alloy::sol_types::SolInterface>::abi_decode_with_config(
+                                    data,
+                                    $crate::dispatch::abi_decoder_config(),
+                                )
+                            },
+                            |$call| match $match_call {
+                                $(Calls::$variant($binding) => $body,)*
+                            },
+                        );
                     }
                 )*
                 return $crate::dispatch::unknown_selector_result($calldata);
@@ -312,6 +330,10 @@ mod tests {
             function get(uint256 value) external view returns (uint256);
             function set(uint256 value) external returns (uint256);
             function clear(uint256 value) external;
+        }
+
+        interface ITestMemoryDispatch {
+            function setValues(uint256[] values) external;
         }
 
         error CustomTypedError(uint256 code);
@@ -405,6 +427,29 @@ mod tests {
             .into_precompile_result(0, 0)
             .unwrap_err();
         assert!(matches!(error, PrecompileError::Fatal(message) if message == "boom"));
+        Ok(())
+    }
+
+    #[test]
+    fn dispatch_limits_abi_decoder_memory() -> eyre::Result<()> {
+        let mut calldata = ITestMemoryDispatch::setValuesCall::SELECTOR.to_vec();
+        calldata.extend(U256::from(32).to_be_bytes::<32>());
+        calldata.extend(U256::from(ABI_DECODER_MEMORY_LIMIT as u64).to_be_bytes::<32>());
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T1);
+        let output = StorageCtx::enter(&mut storage, || {
+            dispatch!(
+                &calldata,
+                |call| match call {
+                    ITestMemoryDispatch::ITestMemoryDispatchCalls {
+                        setValues(_) => Ok(PrecompileOutput::new(0, Bytes::new(), 0)),
+                    }
+                }
+            )
+        })?;
+
+        assert!(output.is_revert());
+        assert!(output.bytes.is_empty());
         Ok(())
     }
 }

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -299,7 +299,7 @@ pub fn add_errors_to_registry<T: SolInterface>(
         registry.insert(
             selector.into(),
             Box::new(move |data: &[u8]| {
-                T::abi_decode(data)
+                T::abi_decode_with_config(data, crate::dispatch::abi_decoder_config())
                     .ok()
                     .map(|error| DecodedTempoPrecompileError {
                         error: converter(error),

--- a/crates/precompiles/src/zone_factory/mod.rs
+++ b/crates/precompiles/src/zone_factory/mod.rs
@@ -15,7 +15,7 @@ use alloy::{
     primitives::{Address, B256, IntoLogData, keccak256},
     sol_types::SolValue,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tempo_contracts::precompiles::{
     IZoneFactory, ZONE_MESSENGER_ADDRESS, ZONE_VERIFIER_ADDRESS, ZoneFactoryError,
     ZoneFactoryEvent, ZoneInfo, ZonePortalEvent, ZonePortalRole,
@@ -288,14 +288,19 @@ fn validate_closed_loop_config(
     zone_gateways: &[Address],
     sequencers: &[Address],
 ) -> Result<()> {
-    if allowed_accounts.contains(&ZONE_MESSENGER_ADDRESS)
-        || zone_gateways
-            .iter()
-            .any(|gateway| allowed_accounts.contains(gateway))
-        || sequencers.iter().any(|sequencer| {
-            allowed_accounts.contains(sequencer) || zone_gateways.contains(sequencer)
-        })
-    {
+    if allowed_accounts.contains(&ZONE_MESSENGER_ADDRESS) {
+        return Err(ZoneFactoryError::invalid_closed_loop_config().into());
+    }
+
+    let mut seen =
+        HashSet::with_capacity(allowed_accounts.len().saturating_add(zone_gateways.len()));
+    seen.extend(allowed_accounts.iter().copied());
+    if zone_gateways.iter().any(|gateway| seen.contains(gateway)) {
+        return Err(ZoneFactoryError::invalid_closed_loop_config().into());
+    }
+    seen.extend(zone_gateways.iter().copied());
+
+    if sequencers.iter().any(|sequencer| seen.contains(sequencer)) {
         return Err(ZoneFactoryError::invalid_closed_loop_config().into());
     }
     Ok(())


### PR DESCRIPTION
Caps ABI decoding for precompile calls and error decoding at 16 MiB, with regression coverage for aliased calldata. Pins Alloy Core crates to public commit [`2d5870c3`](https://github.com/alloy-rs/core/commit/2d5870c3d62b8b9229d33160cbcc431aeb2cdc21) from [alloy-rs/core#1165](https://github.com/alloy-rs/core/pull/1165).

Prompted by: @klkvr