### PR TITLE
chore(consensus): log execution task lifecycle

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -402,6 +402,7 @@ where
             self.execution_task.replace(task).is_none(),
             "invariant violation: must not replace an in-flight execution task"
         );
+        info!("execution task scheduled");
     }
 
     #[instrument(

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -462,6 +462,7 @@ where
                 return Err(error.wrap_err("execution task failed"));
             }
         }
+        info!("execution task finished");
         Ok(())
     }
 

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -421,6 +421,7 @@ where
         &mut self,
         finished: ExecutionTaskFinished,
     ) -> eyre::Result<()> {
+        info!("execution task finished");
         let ExecutionTaskFinished { outcome, .. } = finished;
         match outcome {
             ExecutionTaskOutcome::Completed {
@@ -462,7 +463,6 @@ where
                 return Err(error.wrap_err("execution task failed"));
             }
         }
-        info!("execution task finished");
         Ok(())
     }
 

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -398,7 +398,6 @@ where
     )]
     fn set_execution_task(&mut self, mut task: ExecutionTask) {
         task.span = Span::current();
-        task.started_at = Some(Instant::now());
         assert!(
             self.execution_task.replace(task).is_none(),
             "invariant violation: must not replace an in-flight execution task"
@@ -1025,7 +1024,7 @@ struct ExecutionTask {
     task_type: ExecutionTaskType,
     on_top_of: LocalState,
     span: Span,
-    started_at: Option<Instant>,
+    started_at: Instant,
     fut: BoxFuture<'static, ExecutionTaskOutcome>,
 }
 
@@ -1038,7 +1037,7 @@ impl ExecutionTask {
             task_type,
             on_top_of,
             span: Span::none(),
-            started_at: None,
+            started_at: Instant::now(),
             fut: fut.boxed(),
         }
     }
@@ -1079,9 +1078,7 @@ impl Future for ExecutionTask {
             task_type: self.task_type,
             on_top_of: self.on_top_of,
             span,
-            started_at: self.started_at.expect(
-                "invariant violation: execution task must have a start timestamp before polling",
-            ),
+            started_at: self.started_at,
             outcome,
         })
     }

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -398,6 +398,7 @@ where
     )]
     fn set_execution_task(&mut self, mut task: ExecutionTask) {
         task.span = Span::current();
+        task.started_at = Some(Instant::now());
         assert!(
             self.execution_task.replace(task).is_none(),
             "invariant violation: must not replace an in-flight execution task"
@@ -421,7 +422,10 @@ where
         &mut self,
         finished: ExecutionTaskFinished,
     ) -> eyre::Result<()> {
-        info!("execution task finished");
+        info!(
+            elapsed = %tempo_telemetry_util::display_duration(finished.started_at.elapsed()),
+            "execution task finished"
+        );
         let ExecutionTaskFinished { outcome, .. } = finished;
         match outcome {
             ExecutionTaskOutcome::Completed {
@@ -1021,6 +1025,7 @@ struct ExecutionTask {
     task_type: ExecutionTaskType,
     on_top_of: LocalState,
     span: Span,
+    started_at: Option<Instant>,
     fut: BoxFuture<'static, ExecutionTaskOutcome>,
 }
 
@@ -1033,6 +1038,7 @@ impl ExecutionTask {
             task_type,
             on_top_of,
             span: Span::none(),
+            started_at: None,
             fut: fut.boxed(),
         }
     }
@@ -1042,6 +1048,7 @@ struct ExecutionTaskFinished {
     task_type: ExecutionTaskType,
     on_top_of: LocalState,
     span: Span,
+    started_at: Instant,
     outcome: ExecutionTaskOutcome,
 }
 
@@ -1072,6 +1079,9 @@ impl Future for ExecutionTask {
             task_type: self.task_type,
             on_top_of: self.on_top_of,
             span,
+            started_at: self.started_at.expect(
+                "invariant violation: execution task must have a start timestamp before polling",
+            ),
             outcome,
         })
     }


### PR DESCRIPTION
Logs when an execution task is scheduled and finished, including the elapsed time from scheduling through completion while retaining the instrumented task context.

Prompted by: @SuperFluffy