### PR TITLE
chore(release): prepare v1.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13267,7 +13267,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13429,7 +13429,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13497,7 +13497,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13527,7 +13527,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13541,7 +13541,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13593,7 +13593,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13645,7 +13645,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13664,7 +13664,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13672,7 +13672,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13697,7 +13697,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13775,7 +13775,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13813,7 +13813,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13833,7 +13833,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13869,7 +13869,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13918,7 +13918,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13951,7 +13951,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13976,7 +13976,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -13985,7 +13985,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14028,7 +14028,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14040,7 +14040,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.13.0"
+version = "1.13.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.13.0"
+version = "1.13.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Bumps the workspace and lockfile package versions to 1.13.1.

Prompted by: @emmajam