### PR TITLE
docs(tip-1096): allow header-only activation batches

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -181,8 +181,8 @@ Settlement behavior is derived from the proven block sequence. A settleable batc
 either contains only header-only blocks or ends in a full block. A batch that
 contains a full block but does not end in one is invalid.
 
-A header-only batch exposes identity deposit and `TokenEnablementTransition`
-values, except for the activation-only token-cursor initialization described
+A header-only batch normally reports no change to the deposit or token-enablement
+cursors, except for the activation-only token-cursor initialization described
 below. Its public withdrawal queue hash is zero, and the verifier checks that
 `ZoneOutbox.lastBatch` is unchanged instead of copying that storage value into
 the public withdrawal output. The portal MUST NOT increment
@@ -315,8 +315,8 @@ The proof requires the Zone pre-state `processedEnabledTokenCount` to equal
 and requires the Zone post-state count to equal `nextProcessedTokenCount`. For
 each full block, the resulting Zone count MUST equal `enabledTokenCount` at that
 block's final imported Tempo root. A header-only block advances neither count,
-and, outside activation initialization, a header-only batch therefore exposes an
-identity transition.
+so, outside activation initialization, a header-only batch MUST report equal
+previous and next processed-token counts.
 
 After accepting the proof, `submitBatch` sets
 `lastProcessedEnabledTokenCount` to `nextProcessedTokenCount`. Skipping,
@@ -345,10 +345,10 @@ Zone's `processedEnabledTokenCount` to `N` before executing the first block. For
 this one batch, `TokenEnablementTransition.prevProcessedTokenCount` MUST remain
 the physical pre-state value `0`; the proof authenticates `N` internally before
 processing any outstanding suffix. If the batch is header-only,
-`nextProcessedTokenCount` MUST equal `N`; this is the sole exception to the rule
-that a header-only batch exposes an identity token transition. If the batch is
-operational, its final full block processes the complete suffix from `N` through
-the count visible at its final imported Tempo root, and
+`nextProcessedTokenCount` MUST equal `N`; this is the sole case where a
+header-only batch reports different previous and next processed-token counts. If
+the batch is operational, its final full block processes the complete suffix
+from `N` through the count visible at its final imported Tempo root, and
 `nextProcessedTokenCount` MUST equal that final count. The verifier treats an
 uninitialized portal cursor as the activation case instead of requiring
 ordinary count continuity.

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -182,11 +182,13 @@ either contains only header-only blocks or ends in a full block. A batch that
 contains a full block but does not end in one is invalid.
 
 A header-only batch exposes identity deposit and `TokenEnablementTransition`
-values. Its public withdrawal queue hash is zero, and the verifier checks that
+values, except for the activation-only token-cursor initialization described
+below. Its public withdrawal queue hash is zero, and the verifier checks that
 `ZoneOutbox.lastBatch` is unchanged instead of copying that storage value into
 the public withdrawal output. The portal MUST NOT increment
 `withdrawalBatchIndex`; it updates only its settled Zone block hash,
-`lastSyncedTempoBlockNumber`, and Zone height.
+`lastSyncedTempoBlockNumber`, Zone height, and, during activation, the token
+enablement cursor.
 
 Its settlement certificate authorizes the exact header-only block transition as
 specified above; neither the proof nor `submitBatch` performs a separate leader
@@ -313,7 +315,8 @@ The proof requires the Zone pre-state `processedEnabledTokenCount` to equal
 and requires the Zone post-state count to equal `nextProcessedTokenCount`. For
 each full block, the resulting Zone count MUST equal `enabledTokenCount` at that
 block's final imported Tempo root. A header-only block advances neither count,
-and a header-only batch therefore exposes an identity transition.
+and, outside activation initialization, a header-only batch therefore exposes an
+identity transition.
 
 After accepting the proof, `submitBatch` sets
 `lastProcessedEnabledTokenCount` to `nextProcessedTokenCount`. Skipping,
@@ -323,9 +326,10 @@ When T11 replaces the T10 portal runtime, the new
 `tokenEnablementCursorInitialized` storage slot is false. This flag serves as the
 in-contract T11 activation gate for the new token cursor; it does not disable
 unrelated T11 functionality. While it is false, the portal MUST reject new token
-enablements and MUST reject settlement of a header-only batch. The first
-post-activation batch MUST use operational settlement, though it MAY contain
-header-only recovery blocks before its final full block.
+enablements. The first post-activation batch MAY use either header-only or
+operational settlement. This allows a Zone with a large Tempo header gap at the
+activation boundary to submit bounded checkpoint batches before it executes a
+full block.
 
 The first post-activation proof supplies a count `N` and authenticates the Tempo
 header stored in the parent Zone state. Against that header's state root, it MUST
@@ -340,11 +344,17 @@ The activation state transition internally derives `N` and initializes the
 Zone's `processedEnabledTokenCount` to `N` before executing the first block. For
 this one batch, `TokenEnablementTransition.prevProcessedTokenCount` MUST remain
 the physical pre-state value `0`; the proof authenticates `N` internally before
-processing the outstanding suffix. The verifier treats an uninitialized portal
-cursor as the activation case instead of requiring ordinary count continuity.
+processing any outstanding suffix. If the batch is header-only,
+`nextProcessedTokenCount` MUST equal `N`; this is the sole exception to the rule
+that a header-only batch exposes an identity token transition. If the batch is
+operational, its final full block processes the complete suffix from `N` through
+the count visible at its final imported Tempo root, and
+`nextProcessedTokenCount` MUST equal that final count. The verifier treats an
+uninitialized portal cursor as the activation case instead of requiring
+ordinary count continuity.
 
-The proof MUST additionally verify against the full block's final imported Tempo
-root that both outstanding-work bounds hold:
+The proof MUST additionally verify against the batch's final imported Tempo
+state root that both outstanding-work bounds hold:
 
 ```text
 ZonePortal.depositCount
@@ -352,15 +362,17 @@ ZonePortal.depositCount
     <= MAX_UNPROCESSED_DEPOSITS
 
 ZonePortal.enabledTokenCount
-    - TokenEnablementTransition.prevProcessedTokenCount
+    - N
     <= MAX_UNPROCESSED_TOKEN_ENABLEMENTS
 ```
 
-Only after accepting a proof that satisfies these checks does `submitBatch` set
+For a header-only activation batch, these count proofs are activation inputs and
+do not constitute Tempo account or storage reads by a Zone block. Only after
+accepting a proof that satisfies these checks does `submitBatch` set
 `lastProcessedEnabledTokenCount` to the transition's next count and set
 `tokenEnablementCursorInitialized` to true. This prevents replaying initialized
-tokens, treating post-checkpoint enablements as processed, or completing cursor
-initialization with more pending work than one full block can process.
+tokens, treating post-checkpoint enablements as processed, or reopening either
+queue with more pending work than a full block can process.
 
 ## Interface and Proof Changes
 
@@ -380,8 +392,9 @@ function finalizeTempo(bytes[] calldata headers) external;
 
 `IZonePortal.MAX_UNPROCESSED_TOKEN_ENABLEMENTS()` and
 `lastProcessedEnabledTokenCount()` are added. Portal storage also adds
-`tokenEnablementCursorInitialized()`, which records whether the first operational
-proof has initialized the token cursor and proven both outstanding-work bounds.
+`tokenEnablementCursorInitialized()`, which records whether the first
+post-activation proof has initialized the token cursor and proven both
+outstanding-work bounds.
 
 `ZonePortal.submitBatch` and `IVerifier.verify` add a
 `TokenEnablementTransition` parameter. The batch proof returns this transition as


### PR DESCRIPTION
## Summary

If the first batch post TIP-1096 activation turns out to be a header-only batch, we still need to be able to settle it and set the correct value for the new field `lastProcessedEnabledTokenCount`. It should be set to the current number of token enablements the zone has processed.

- Allow the first post-activation batch to use header-only settlement
- Initialize the token-enablement cursor as an activation-only pre-batch transition

## Validation

- `git diff --check`

Prompted by: @shekhirin
