### PR TITLE
fix(download): clear consensus state when forced

### DIFF
--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -304,8 +304,7 @@ async fn install_consensus_archive(
         );
     }
 
-    fs::create_dir_all(consensus_dir)
-        .wrap_err_with(|| format!("failed to create {}", consensus_dir.display()))?;
+    prepare_consensus_dir(consensus_dir, force)?;
     extract_zstd_tar_archive(archive_file.path(), consensus_dir, force)?;
     verify_consensus_output_files(
         consensus_dir,
@@ -314,6 +313,25 @@ async fn install_consensus_archive(
 
     info!("persisted consensus archive");
     Ok(())
+}
+
+fn prepare_consensus_dir(consensus_dir: &Path, force: bool) -> eyre::Result<()> {
+    if force {
+        let exists = consensus_dir
+            .try_exists()
+            .wrap_err_with(|| format!("failed to stat {}", consensus_dir.display()))?;
+        if exists {
+            info!(
+                path = %consensus_dir.display(),
+                "removing existing consensus state"
+            );
+            fs::remove_dir_all(consensus_dir)
+                .wrap_err_with(|| format!("failed to remove {}", consensus_dir.display()))?;
+        }
+    }
+
+    fs::create_dir_all(consensus_dir)
+        .wrap_err_with(|| format!("failed to create {}", consensus_dir.display()))
 }
 
 async fn write_consensus_archive_to_temp(
@@ -659,6 +677,32 @@ mod tests {
             fs::read(target.path().join(partition_name).join("nested").join("00")).unwrap(),
             b"abc"
         );
+    }
+
+    #[test]
+    fn prepare_consensus_dir_removes_existing_state_when_forced() {
+        let parent = tempfile::tempdir().unwrap();
+        let consensus_dir = parent.path().join("consensus");
+        fs::create_dir_all(consensus_dir.join("nested")).unwrap();
+        fs::write(consensus_dir.join("nested").join("stale"), b"stale").unwrap();
+
+        prepare_consensus_dir(&consensus_dir, true).unwrap();
+
+        assert!(consensus_dir.is_dir());
+        assert!(fs::read_dir(&consensus_dir).unwrap().next().is_none());
+    }
+
+    #[test]
+    fn prepare_consensus_dir_preserves_existing_state_without_force() {
+        let parent = tempfile::tempdir().unwrap();
+        let consensus_dir = parent.path().join("consensus");
+        fs::create_dir_all(&consensus_dir).unwrap();
+        let existing = consensus_dir.join("existing");
+        fs::write(&existing, b"existing").unwrap();
+
+        prepare_consensus_dir(&consensus_dir, false).unwrap();
+
+        assert_eq!(fs::read(existing).unwrap(), b"existing");
     }
 
     #[test]

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -23,7 +23,10 @@ use crate::snapshot_manifest::{TEMPO_CONSENSUS_MANIFEST_KEY, TempoConsensusManif
 #[derive(Debug, Parser)]
 #[command(
     name = "download",
-    about = "Downloads snapshot archives produced by `tempo snapshot-manifest`."
+    about = "Downloads snapshot archives produced by `tempo snapshot-manifest`.",
+    mut_arg("force", |arg| arg.help(
+        "Overwrite existing snapshot data by removing db, rocksdb, static_files, reth.toml, and the consensus directory."
+    ))
 )]
 pub(crate) struct Args {
     #[command(flatten)]
@@ -499,6 +502,15 @@ mod tests {
         let help = Args::command().render_long_help().to_string();
 
         assert!(!help.contains("--skip-consensus"));
+    }
+
+    #[test]
+    fn help_documents_force_removing_consensus_directory() {
+        let help = Args::command().render_long_help().to_string();
+
+        assert!(help.contains(
+            "Overwrite existing snapshot data by removing db, rocksdb, static_files, reth.toml, and the consensus directory."
+        ));
     }
 
     #[test]

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -306,7 +306,7 @@ async fn install_consensus_archive(
 
     prepare_consensus_directory(consensus_dir, force).wrap_err_with(|| {
         format!(
-            "failed to prepare consensus directory at {}",
+            "failed to prepare consensus directory at `{}`",
             consensus_dir.display()
         )
     })?;

--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -304,7 +304,12 @@ async fn install_consensus_archive(
         );
     }
 
-    prepare_consensus_dir(consensus_dir, force)?;
+    prepare_consensus_directory(consensus_dir, force).wrap_err_with(|| {
+        format!(
+            "failed to prepare consensus directory at {}",
+            consensus_dir.display()
+        )
+    })?;
     extract_zstd_tar_archive(archive_file.path(), consensus_dir, force)?;
     verify_consensus_output_files(
         consensus_dir,
@@ -315,23 +320,19 @@ async fn install_consensus_archive(
     Ok(())
 }
 
-fn prepare_consensus_dir(consensus_dir: &Path, force: bool) -> eyre::Result<()> {
-    if force {
-        let exists = consensus_dir
-            .try_exists()
-            .wrap_err_with(|| format!("failed to stat {}", consensus_dir.display()))?;
-        if exists {
-            info!(
-                path = %consensus_dir.display(),
-                "removing existing consensus state"
-            );
-            fs::remove_dir_all(consensus_dir)
-                .wrap_err_with(|| format!("failed to remove {}", consensus_dir.display()))?;
-        }
+#[tracing::instrument(
+    parent = None,
+    skip_all,
+    fields(path = %consensus_dir.display())
+)]
+fn prepare_consensus_directory(consensus_dir: &Path, force: bool) -> eyre::Result<()> {
+    if force && consensus_dir.try_exists()? {
+        info!("removing existing consensus state");
+        fs::remove_dir_all(consensus_dir)?;
     }
 
-    fs::create_dir_all(consensus_dir)
-        .wrap_err_with(|| format!("failed to create {}", consensus_dir.display()))
+    fs::create_dir_all(consensus_dir)?;
+    Ok(())
 }
 
 async fn write_consensus_archive_to_temp(
@@ -680,27 +681,27 @@ mod tests {
     }
 
     #[test]
-    fn prepare_consensus_dir_removes_existing_state_when_forced() {
+    fn prepare_consensus_directory_removes_existing_state_when_forced() {
         let parent = tempfile::tempdir().unwrap();
         let consensus_dir = parent.path().join("consensus");
         fs::create_dir_all(consensus_dir.join("nested")).unwrap();
         fs::write(consensus_dir.join("nested").join("stale"), b"stale").unwrap();
 
-        prepare_consensus_dir(&consensus_dir, true).unwrap();
+        prepare_consensus_directory(&consensus_dir, true).unwrap();
 
         assert!(consensus_dir.is_dir());
         assert!(fs::read_dir(&consensus_dir).unwrap().next().is_none());
     }
 
     #[test]
-    fn prepare_consensus_dir_preserves_existing_state_without_force() {
+    fn prepare_consensus_directory_preserves_existing_state_without_force() {
         let parent = tempfile::tempdir().unwrap();
         let consensus_dir = parent.path().join("consensus");
         fs::create_dir_all(&consensus_dir).unwrap();
         let existing = consensus_dir.join("existing");
         fs::write(&existing, b"existing").unwrap();
 
-        prepare_consensus_dir(&consensus_dir, false).unwrap();
+        prepare_consensus_directory(&consensus_dir, false).unwrap();
 
         assert_eq!(fs::read(existing).unwrap(), b"existing");
     }


### PR DESCRIPTION
Deletes the consensus directory before installing a snapshot when `--force` is set, preventing stale consensus files from surviving the download. Non-forced downloads retain the existing behavior.

Prompted by: @SuperFluffy