### PR TITLE
docs(tip-1096): allow later Zone block timestamps

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -122,10 +122,10 @@ with this call:
 - MUST NOT change the processed deposit or enablement cursors;
 - MUST NOT execute or finalize withdrawals.
 
-The final header's timestamp and millisecond component MUST exactly match the
-executing Zone block's timestamp and millisecond component. Intermediate header
-timestamps do not need to match the Zone block. A mismatch in either final-header
-component invalidates the block.
+The executing Zone block's timestamp, including its millisecond component, MUST
+be greater than or equal to the final header's timestamp. Intermediate header
+timestamps do not need to match the Zone block. A final-header timestamp greater
+than the Zone block's timestamp invalidates the block.
 
 The block may cross deposits, token enablements, sequencer-set changes, and
 leadership changes because it performs no operation governed by that historical


### PR DESCRIPTION
Updates TIP-1096 so the executing Zone block timestamp may be greater than or equal to the final imported Tempo header timestamp, matching [tempoxyz/zones#1202](https://github.com/tempoxyz/zones/pull/1202).

Validation: `git diff --check`

Prompted by: @shekhirin