### PR TITLE
fix(tempo): restrict signing key file permissions to owner on Unix

### DIFF
--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -998,6 +998,29 @@ pub struct GenerateSigningKey {
     force: bool,
 }
 
+/// Opens `output` for writing a signing key, refusing to overwrite an existing file unless
+/// `force` is set, and restricting the created file to owner read/write on Unix.
+///
+/// This applies regardless of whether the key material that ends up in the file is encrypted:
+/// an unencrypted key is only as protected as this file's permissions, and even an encrypted
+/// key benefits from not being world-readable ciphertext.
+fn open_signing_key_file(output: &Path, force: bool) -> std::io::Result<std::fs::File> {
+    let mut options = OpenOptions::new();
+    options
+        .write(true)
+        .create_new(!force)
+        .create(force)
+        .truncate(force);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+
+    options.open(output)
+}
+
 impl GenerateSigningKey {
     fn run(self) -> eyre::Result<()> {
         let Self {
@@ -1024,12 +1047,7 @@ impl GenerateSigningKey {
             warn_unencrypted_signing_key_deprecation();
         }
 
-        OpenOptions::new()
-            .write(true)
-            .create_new(!force)
-            .create(force)
-            .truncate(force)
-            .open(&output)
+        open_signing_key_file(&output, force)
             .map_err(Report::new)
             .and_then(|f| match passphrase {
                 Some(passphrase) => signing_key
@@ -1138,12 +1156,7 @@ impl EncryptSigningKey {
             )
         })?;
 
-        OpenOptions::new()
-            .write(true)
-            .create_new(!force)
-            .create(force)
-            .truncate(force)
-            .open(&output)
+        open_signing_key_file(&output, force)
             .map_err(Report::new)
             .and_then(|f| {
                 signing_key
@@ -1578,6 +1591,23 @@ mod tests {
     const TEST_SIGNATURE: &str = "0x11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111";
     const TEST_INGRESS: &str = "127.0.0.1:8000";
     const TEST_EGRESS: &str = "127.0.0.1";
+
+    #[cfg(unix)]
+    #[test]
+    fn open_signing_key_file_restricts_permissions_to_owner() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("signing-key");
+
+        let file = open_signing_key_file(&path, false).unwrap();
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+
+        assert_eq!(
+            mode, 0o600,
+            "signing key file must not be group- or world-readable"
+        );
+    }
 
     #[test]
     fn parse_p2p_proxy_defaults() {

--- a/bin/tempo/src/tempo_cmd.rs
+++ b/bin/tempo/src/tempo_cmd.rs
@@ -1005,20 +1005,20 @@ pub struct GenerateSigningKey {
 /// an unencrypted key is only as protected as this file's permissions, and even an encrypted
 /// key benefits from not being world-readable ciphertext.
 fn open_signing_key_file(output: &Path, force: bool) -> std::io::Result<std::fs::File> {
-    let mut options = OpenOptions::new();
-    options
+    let file = OpenOptions::new()
         .write(true)
         .create_new(!force)
         .create(force)
-        .truncate(force);
+        .truncate(force)
+        .open(output)?;
 
     #[cfg(unix)]
     {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        options.mode(0o600);
+        use std::os::unix::fs::PermissionsExt as _;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
     }
 
-    options.open(output)
+    Ok(file)
 }
 
 impl GenerateSigningKey {
@@ -1606,6 +1606,25 @@ mod tests {
         assert_eq!(
             mode, 0o600,
             "signing key file must not be group- or world-readable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_signing_key_file_tightens_permissions_on_an_existing_world_readable_file() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("signing-key");
+        std::fs::write(&path, b"stale").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        let file = open_signing_key_file(&path, true).unwrap();
+        let mode = file.metadata().unwrap().permissions().mode() & 0o777;
+
+        assert_eq!(
+            mode, 0o600,
+            "reopening an existing signing key file with --force must still restrict permissions"
         );
     }
 


### PR DESCRIPTION
Closes #7267

## Problem

`GenerateSigningKey::run` and `EncryptSigningKey::run` both opened their output file with a plain `OpenOptions` chain and no `.mode(...)` call. On Unix this creates the file at mode `0666` masked by the process umask -- typically `0644`, readable by any local user on the host, not just the owner. For `generate-signing-key` run without `--secret`, this writes the raw, unencrypted ed25519 consensus signing key to a world-readable file.

`crates/consensus-config/src/lib.rs`'s `SigningKey::write_to_file_encrypted` already sets `0600` explicitly on Unix for exactly this reason; these two CLI call sites just didn't follow the same pattern.

## Fix

Adds a shared `open_signing_key_file()` helper (mirroring the existing `consensus-config` pattern) and uses it from both `GenerateSigningKey::run` and `EncryptSigningKey::run`, replacing the duplicated `OpenOptions` chains.

## Tests

Added `open_signing_key_file_restricts_permissions_to_owner`, asserting the created file's permission bits (`metadata().permissions().mode() & 0o777`) are exactly `0o600`. Full `cargo test -p tempo signing_key`: 8/8 passing. `cargo clippy -p tempo --lib` and `cargo fmt --check` clean.
