### PR TITLE
docs(tip-1099): replace nested AccountKeychain ABI inputs with RLP

### DIFF
--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -22,8 +22,7 @@ the complexity of decoding nested ABI input in a precompile.
 ## Motivation
 
 Nested, attacker-controlled ABI input can consume disproportionate CPU and
-memory during decoding. This was the root cause of a recent denial-of-service
-incident.
+memory during decoding.
 
 Key authorizations and call scopes already have a canonical RLP encoding in
 Tempo transactions. Reusing it gives the precompile a simpler encoding to decode

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -12,8 +12,9 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP removes the `AccountKeychain.authorizeKey` functions. New access keys
-must instead be authorized through a transaction's `key_authorization` field.
+This TIP removes the `AccountKeychain.authorizeKey` and `authorizeAdminKey`
+functions. All keys must instead be authorized through a transaction's
+`key_authorization` field.
 
 It also changes `setAllowedCalls` to accept RLP-encoded call scopes instead of
 nested ABI arrays. This preserves permission updates for existing keys without
@@ -33,10 +34,9 @@ hardware-backed keys need a way to change permissions without rotating the key.
 
 ## Assumptions
 
-- `key_authorization` can represent every non-admin key configuration currently
-  accepted by `authorizeKey`.
+- `key_authorization` can represent every key configuration currently accepted
+  by `authorizeKey` and `authorizeAdminKey`.
 - Existing keys and stored call scopes remain unchanged at activation.
-- `authorizeAdminKey` remains available because it has no nested input.
 
 ## Threat Model
 
@@ -48,7 +48,7 @@ covered by the transaction's gas.
 
 # Specification
 
-## Remove `authorizeKey`
+## Remove direct key authorization
 
 The following overloads are disabled at activation:
 
@@ -56,10 +56,11 @@ The following overloads are disabled at activation:
 authorizeKey(address, SignatureType, uint64, bool, LegacyTokenLimit[])
 authorizeKey(address, SignatureType, KeyRestrictions)
 authorizeKey(address, SignatureType, KeyRestrictions, bytes32)
+authorizeAdminKey(address, SignatureType, bytes32)
 ```
 
 Their selectors must revert as unknown function selectors without changing
-state. New non-admin keys must be authorized through transaction
+state. All keys, including admin keys, must be authorized through transaction
 `key_authorization`.
 
 All other keychain methods are unchanged.
@@ -126,8 +127,8 @@ old interfaces.
 # Tooling
 
 SDKs and wallets must use transaction `key_authorization` instead of constructing
-`authorizeKey` calls. Call-scope builders should RLP-encode `CallScope` values and
-construct the new `setAllowedCalls(address,bytes)` call.
+`authorizeKey` or `authorizeAdminKey` calls. Call-scope builders should RLP-encode
+`CallScope` values and construct the new `setAllowedCalls(address,bytes)` call.
 
 # Observability
 

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -1,0 +1,231 @@
+---
+id: TIP-1099
+title: RLP-Encoded Account Keychain Mutations
+description: Removes direct key-authorization methods and replaces nested ABI call-scope decoding with RLP.
+authors: Arsenii Kulikov @klkvr
+status: Draft
+related: TIP-1011, TIP-1049, https://gist.github.com/rappie/094e3a9f786a0a6766b4b0df9805fe0b
+protocolVersion: TBD
+---
+
+# TIP-1099: RLP-Encoded Account Keychain Mutations
+
+## Abstract
+
+This TIP removes the three `AccountKeychain.authorizeKey` ABI entrypoints and
+requires new non-admin keys to be authorized through a transaction's
+`key_authorization` field. It also replaces the nested ABI input to
+`setAllowedCalls` with the existing RLP call-scope encoding from TIP-1011.
+
+The change removes attacker-controlled nested ABI decoding from the keychain's
+mutable interface while preserving the ability to update an existing key's call
+scopes.
+
+## Motivation
+
+The `AccountKeychain` precompile currently decodes nested, attacker-controlled
+ABI arrays for `authorizeKey` and `setAllowedCalls`. General-purpose ABI
+decoding can allocate and copy intermediate arrays before the precompile has
+charged for the corresponding work. Deeply nested and oversized offsets can
+therefore consume disproportionate node CPU and memory relative to transaction
+gas.
+
+Key authorization already has a canonical, typed RLP representation in the
+Tempo transaction envelope. Using that path avoids a second, more complex
+encoding for the same state transition. Call scopes still need an update path
+for long-lived keys, so `setAllowedCalls` accepts their existing fixed-depth RLP
+schema behind a shallow Solidity `bytes` argument.
+
+Alternatives considered:
+
+1. Fully meter general ABI decoding. This would retain the current interface,
+   but requires accounting for allocations, offset traversal, and copies made by
+   a general-purpose decoder before normal precompile execution.
+2. Split call-scope updates into granular Solidity-compatible functions. This
+   removes nested inputs but turns one atomic policy update into a potentially
+   large multicall and duplicates the transaction authorization schema.
+3. Remove call-scope updates entirely. This is simpler, but requires rotating a
+   passkey or hardware-backed key whenever its permissions change.
+
+## Assumptions
+
+1. The transaction `key_authorization` path remains the canonical way to create
+   non-admin access keys and supports every restriction previously accepted by
+   `authorizeKey`.
+2. TIP-1011's RLP definitions for `CallScope` and `SelectorRule` remain
+   canonical. A future extension to those definitions applies to this method
+   only when its activating TIP explicitly updates this interface.
+3. Existing keys and stored call scopes remain valid across activation; only
+   the mutation interface changes.
+4. `authorizeAdminKey`, which has no nested dynamic input, remains available.
+
+If the transaction authorization path cannot represent a key configuration,
+that configuration cannot be created after this TIP activates until a later TIP
+extends the transaction schema.
+
+## Threat Model
+
+Any transaction sender may submit arbitrary calldata to the `AccountKeychain`
+precompile. Senders are assumed to choose malformed RLP, non-canonical values,
+maximal list sizes, duplicate entries, and inputs designed to maximize CPU,
+memory, or storage work before reverting.
+
+The implementation MUST charge calldata costs before decoding, decode the
+fixed-depth schema in a single forward pass, and avoid work that is superlinear
+in the encoded input length. Consensus rules, rather than trusted tooling, MUST
+enforce canonical encoding and the semantic constraints defined by TIP-1011.
+
+---
+
+# Specification
+
+## Removed authorization entrypoints
+
+At activation, all three existing `authorizeKey` selectors MUST be disabled:
+
+```solidity
+function authorizeKey(
+    address keyId,
+    SignatureType signatureType,
+    uint64 expiry,
+    bool enforceLimits,
+    LegacyTokenLimit[] calldata limits
+) external;
+
+function authorizeKey(
+    address keyId,
+    SignatureType signatureType,
+    KeyRestrictions calldata config
+) external;
+
+function authorizeKey(
+    address keyId,
+    SignatureType signatureType,
+    KeyRestrictions calldata config,
+    bytes32 witness
+) external;
+```
+
+Calls using these selectors MUST revert as unknown function selectors and MUST
+not read or write keychain state. After activation, a transaction MUST use its
+`key_authorization` field to authorize a new non-admin access key.
+
+This TIP does not change `authorizeAdminKey`, witness burning, key revocation,
+spending-limit updates, or read-only methods.
+
+## RLP call-scope updates
+
+The existing nested-ABI method is replaced by:
+
+```solidity
+/// @notice Creates or replaces one or more target scopes for a key.
+/// @dev `encodedScopes` is the canonical RLP encoding of a nonempty list of
+///      TIP-1011 CallScope values. Root or admin key only.
+function setAllowedCalls(
+    address keyId,
+    bytes calldata encodedScopes
+) external;
+```
+
+The former `setAllowedCalls(address,CallScope[])` selector MUST revert as an
+unknown function selector after activation.
+
+`encodedScopes` MUST encode exactly one canonical RLP value with this schema:
+
+```text
+AllowedCalls := RLP([CallScope, ...])
+
+CallScope := RLP([
+    target: address,
+    selector_rules: [SelectorRule, ...] | []
+])
+
+SelectorRule := RLP([
+    selector: bytes4,
+    recipients: [address, ...] | []
+])
+```
+
+The outer `AllowedCalls` list MUST be nonempty. Empty bytes, an RLP empty list,
+an RLP string, trailing bytes, non-canonical RLP, excessive nesting, and fields
+of the wrong encoded length MUST revert without changing state.
+
+All TIP-1011 semantic rules continue to apply, including unique targets, unique
+selectors per target, unique nonzero recipients, constrained recipient-aware
+selectors, TIP-20 target checks, and create-or-replace behavior per target. The
+entire input MUST be decoded and validated before the first storage write. A
+failure MUST revert the update atomically.
+
+`removeAllowedCalls(address,address)` remains the only way to remove a target
+scope. An empty `selector_rules` list continues to mean that any selector is
+allowed for the target; it does not remove or deny the target.
+
+## Decoding and resource accounting
+
+Before inspecting the RLP payload, the precompile MUST charge the active
+calldata/input cost for the complete call. The decoder MUST:
+
+1. parse only the fixed-depth schema above;
+2. borrow from the calldata buffer where possible rather than copying nested
+   payloads;
+3. visit each encoded byte no more than a constant number of times;
+4. use linear-time set construction for duplicate detection; and
+5. validate the full input before performing storage writes.
+
+Storage reads and writes retain their normal precompile gas charges. An
+implementation MAY impose an additional fork-gated byte or element bound if
+benchmarks show that calldata gas alone does not safely cover worst-case decode
+and validation cost; such a bound MUST be consensus-defined before this TIP is
+scheduled.
+
+## Activation
+
+Selector changes MUST be hardfork-gated. Pre-activation blocks replay with the
+old selectors and ABI semantics. Post-activation blocks use only the interfaces
+specified above.
+
+# Tooling
+
+SDKs and wallets MUST stop constructing `authorizeKey` calls and use transaction
+`key_authorization` instead. The existing call-scope builders SHOULD expose a
+helper that canonically RLP-encodes `Vec<CallScope>` and constructs the new
+`setAllowedCalls(address,bytes)` call. Low-level tooling SHOULD reject an empty
+scope list before submission and direct callers to `removeAllowedCalls`.
+
+# Observability
+
+No new event is required. Successful scope updates retain the existing state
+transition, while malformed input and disabled selectors are observable as
+ordinary reverted precompile calls in transaction traces. Implementations SHOULD
+separately count failures by selector and decode error class in node metrics so
+operators can identify probing or attempted resource exhaustion.
+
+# Invariants
+
+1. No post-activation call to an old `authorizeKey` selector can create or
+   modify a key.
+2. No post-activation call to the old nested-ABI `setAllowedCalls` selector can
+   modify call scopes.
+3. The new method accepts exactly the canonical TIP-1011 call-scope RLP schema.
+4. Invalid input causes no keychain storage write.
+5. For every valid input, the resulting call-scope state is identical to the
+   state produced by the pre-activation ABI method with the same logical scopes.
+6. Existing keys and scopes are unchanged at activation.
+7. Decode and validation work is linear in encoded input size, excluding the
+   separately metered storage operations.
+
+Critical test cases:
+
+1. Every removed selector reverts without reading or writing keychain state.
+2. A valid one-target and multi-target RLP update succeeds.
+3. Empty bytes, empty outer list, strings in place of lists, trailing bytes, and
+   non-canonical lengths revert.
+4. Incorrect address and selector widths revert.
+5. Duplicate targets, selectors, and recipients revert before any write.
+6. A late-invalid element leaves all prior scopes unchanged.
+7. Empty selector rules retain allow-any-selector semantics.
+8. The old and new interfaces produce identical state from equivalent scopes on
+   opposite sides of the activation boundary.
+9. Existing keys can be updated and removed after activation.
+10. Maximum consensus-accepted input stays within benchmarked CPU and memory
+    budgets.

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1099
 title: RLP-Encoded Account Keychain Mutations
-description: Removes direct key-authorization methods and replaces nested ABI call-scope decoding with RLP.
+description: Removes direct key authorization and replaces nested ABI call-scope decoding with RLP.
 authors: Arsenii Kulikov @klkvr
 status: Draft
 related: TIP-1011, TIP-1049, https://gist.github.com/rappie/094e3a9f786a0a6766b4b0df9805fe0b
@@ -12,125 +12,79 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP removes the three `AccountKeychain.authorizeKey` ABI entrypoints and
-requires new non-admin keys to be authorized through a transaction's
-`key_authorization` field. It also replaces the nested ABI input to
-`setAllowedCalls` with the existing RLP call-scope encoding from TIP-1011.
+This TIP removes the `AccountKeychain.authorizeKey` functions. New access keys
+must instead be authorized through a transaction's `key_authorization` field.
 
-The change removes attacker-controlled nested ABI decoding from the keychain's
-mutable interface while preserving the ability to update an existing key's call
-scopes.
+It also changes `setAllowedCalls` to accept RLP-encoded call scopes instead of
+nested ABI arrays. This preserves permission updates for existing keys without
+the complexity of decoding nested ABI input in a precompile.
 
 ## Motivation
 
-The `AccountKeychain` precompile currently decodes nested, attacker-controlled
-ABI arrays for `authorizeKey` and `setAllowedCalls`. General-purpose ABI
-decoding can allocate and copy intermediate arrays before the precompile has
-charged for the corresponding work. Deeply nested and oversized offsets can
-therefore consume disproportionate node CPU and memory relative to transaction
-gas.
+Nested, attacker-controlled ABI input can consume disproportionate CPU and
+memory during decoding. This was the root cause of a recent denial-of-service
+incident.
 
-Key authorization already has a canonical, typed RLP representation in the
-Tempo transaction envelope. Using that path avoids a second, more complex
-encoding for the same state transition. Call scopes still need an update path
-for long-lived keys, so `setAllowedCalls` accepts their existing fixed-depth RLP
-schema behind a shallow Solidity `bytes` argument.
+Key authorizations and call scopes already have a canonical RLP encoding in
+Tempo transactions. Reusing it gives the precompile a simpler encoding to decode
+and meter, while tooling can hide the encoding from application developers.
 
-Alternatives considered:
-
-1. Fully meter general ABI decoding. This would retain the current interface,
-   but requires accounting for allocations, offset traversal, and copies made by
-   a general-purpose decoder before normal precompile execution.
-2. Split call-scope updates into granular Solidity-compatible functions. This
-   removes nested inputs but turns one atomic policy update into a potentially
-   large multicall and duplicates the transaction authorization schema.
-3. Remove call-scope updates entirely. This is simpler, but requires rotating a
-   passkey or hardware-backed key whenever its permissions change.
+Removing `setAllowedCalls` entirely was considered, but long-lived passkeys and
+hardware-backed keys need a way to change permissions without rotating the key.
 
 ## Assumptions
 
-1. The transaction `key_authorization` path remains the canonical way to create
-   non-admin access keys and supports every restriction previously accepted by
-   `authorizeKey`.
-2. TIP-1011's RLP definitions for `CallScope` and `SelectorRule` remain
-   canonical. A future extension to those definitions applies to this method
-   only when its activating TIP explicitly updates this interface.
-3. Existing keys and stored call scopes remain valid across activation; only
-   the mutation interface changes.
-4. `authorizeAdminKey`, which has no nested dynamic input, remains available.
-
-If the transaction authorization path cannot represent a key configuration,
-that configuration cannot be created after this TIP activates until a later TIP
-extends the transaction schema.
+- `key_authorization` can represent every non-admin key configuration currently
+  accepted by `authorizeKey`.
+- Existing keys and stored call scopes remain unchanged at activation.
+- `authorizeAdminKey` remains available because it has no nested input.
 
 ## Threat Model
 
-Any transaction sender may submit arbitrary calldata to the `AccountKeychain`
-precompile. Senders are assumed to choose malformed RLP, non-canonical values,
-maximal list sizes, duplicate entries, and inputs designed to maximize CPU,
-memory, or storage work before reverting.
-
-The implementation MUST charge calldata costs before decoding, decode the
-fixed-depth schema in a single forward pass, and avoid work that is superlinear
-in the encoded input length. Consensus rules, rather than trusted tooling, MUST
-enforce canonical encoding and the semantic constraints defined by TIP-1011.
+Any sender can submit malformed or oversized calldata to the precompile. RLP
+decoding must be metered or bounded so its worst-case CPU and memory cost is
+covered by the transaction's gas.
 
 ---
 
 # Specification
 
-## Removed authorization entrypoints
+## Remove `authorizeKey`
 
-At activation, all three existing `authorizeKey` selectors MUST be disabled:
-
-```solidity
-function authorizeKey(
-    address keyId,
-    SignatureType signatureType,
-    uint64 expiry,
-    bool enforceLimits,
-    LegacyTokenLimit[] calldata limits
-) external;
-
-function authorizeKey(
-    address keyId,
-    SignatureType signatureType,
-    KeyRestrictions calldata config
-) external;
-
-function authorizeKey(
-    address keyId,
-    SignatureType signatureType,
-    KeyRestrictions calldata config,
-    bytes32 witness
-) external;
-```
-
-Calls using these selectors MUST revert as unknown function selectors and MUST
-not read or write keychain state. After activation, a transaction MUST use its
-`key_authorization` field to authorize a new non-admin access key.
-
-This TIP does not change `authorizeAdminKey`, witness burning, key revocation,
-spending-limit updates, or read-only methods.
-
-## RLP call-scope updates
-
-The existing nested-ABI method is replaced by:
+The following overloads are disabled at activation:
 
 ```solidity
-/// @notice Creates or replaces one or more target scopes for a key.
-/// @dev `encodedScopes` is the canonical RLP encoding of a nonempty list of
-///      TIP-1011 CallScope values. Root or admin key only.
-function setAllowedCalls(
-    address keyId,
-    bytes calldata encodedScopes
-) external;
+authorizeKey(address, SignatureType, uint64, bool, LegacyTokenLimit[])
+authorizeKey(address, SignatureType, KeyRestrictions)
+authorizeKey(address, SignatureType, KeyRestrictions, bytes32)
 ```
 
-The former `setAllowedCalls(address,CallScope[])` selector MUST revert as an
-unknown function selector after activation.
+Their selectors must revert as unknown function selectors without changing
+state. New non-admin keys must be authorized through transaction
+`key_authorization`.
 
-`encodedScopes` MUST encode exactly one canonical RLP value with this schema:
+All other keychain methods are unchanged.
+
+## Change `setAllowedCalls`
+
+Replace:
+
+```solidity
+function setAllowedCalls(address keyId, CallScope[] calldata scopes) external;
+```
+
+with:
+
+```solidity
+/// @notice Creates or replaces call scopes for an existing key.
+/// @param keyId The key whose scopes are updated.
+/// @param scopes Canonical RLP encoding of a non-empty CallScope list.
+function setAllowedCalls(address keyId, bytes calldata scopes) external;
+```
+
+The old selector must revert as an unknown function selector after activation.
+
+`scopes` uses the existing TIP-1011 schema:
 
 ```text
 AllowedCalls := RLP([CallScope, ...])
@@ -146,86 +100,46 @@ SelectorRule := RLP([
 ])
 ```
 
-The outer `AllowedCalls` list MUST be nonempty. Empty bytes, an RLP empty list,
-an RLP string, trailing bytes, non-canonical RLP, excessive nesting, and fields
-of the wrong encoded length MUST revert without changing state.
+The input must contain exactly one canonical, non-empty `AllowedCalls` list.
+Malformed RLP, trailing bytes, incorrect field lengths, and an empty outer list
+must revert.
 
-All TIP-1011 semantic rules continue to apply, including unique targets, unique
-selectors per target, unique nonzero recipients, constrained recipient-aware
-selectors, TIP-20 target checks, and create-or-replace behavior per target. The
-entire input MUST be decoded and validated before the first storage write. A
-failure MUST revert the update atomically.
+All TIP-1011 rules remain unchanged, including uniqueness checks, valid
+recipient-aware selectors, TIP-20 target checks, and create-or-replace behavior
+per target. The complete input must be decoded and validated before any storage
+write so failures are atomic.
 
-`removeAllowedCalls(address,address)` remains the only way to remove a target
-scope. An empty `selector_rules` list continues to mean that any selector is
-allowed for the target; it does not remove or deny the target.
+`removeAllowedCalls(address,address)` remains the way to remove a target scope.
+An empty `selector_rules` list continues to allow every selector for that target.
 
-## Decoding and resource accounting
+## Resource accounting
 
-Before inspecting the RLP payload, the precompile MUST charge the active
-calldata/input cost for the complete call. The decoder MUST:
-
-1. parse only the fixed-depth schema above;
-2. borrow from the calldata buffer where possible rather than copying nested
-   payloads;
-3. visit each encoded byte no more than a constant number of times;
-4. use linear-time set construction for duplicate detection; and
-5. validate the full input before performing storage writes.
-
-Storage reads and writes retain their normal precompile gas charges. An
-implementation MAY impose an additional fork-gated byte or element bound if
-benchmarks show that calldata gas alone does not safely cover worst-case decode
-and validation cost; such a bound MUST be consensus-defined before this TIP is
-scheduled.
+The precompile must charge for the complete calldata before decoding it. Before
+activation, benchmarks must confirm that calldata gas covers the worst valid and
+invalid RLP inputs; otherwise the implementation must add an explicit byte or
+element limit.
 
 ## Activation
 
-Selector changes MUST be hardfork-gated. Pre-activation blocks replay with the
-old selectors and ABI semantics. Post-activation blocks use only the interfaces
-specified above.
+The selector changes are hardfork-gated. Historical blocks continue to use the
+old interfaces.
 
 # Tooling
 
-SDKs and wallets MUST stop constructing `authorizeKey` calls and use transaction
-`key_authorization` instead. The existing call-scope builders SHOULD expose a
-helper that canonically RLP-encodes `Vec<CallScope>` and constructs the new
-`setAllowedCalls(address,bytes)` call. Low-level tooling SHOULD reject an empty
-scope list before submission and direct callers to `removeAllowedCalls`.
+SDKs and wallets must use transaction `key_authorization` instead of constructing
+`authorizeKey` calls. Call-scope builders should RLP-encode `CallScope` values and
+construct the new `setAllowedCalls(address,bytes)` call.
 
 # Observability
 
-No new event is required. Successful scope updates retain the existing state
-transition, while malformed input and disabled selectors are observable as
-ordinary reverted precompile calls in transaction traces. Implementations SHOULD
-separately count failures by selector and decode error class in node metrics so
-operators can identify probing or attempted resource exhaustion.
+No new events are required. Failed decoding and disabled selectors are visible
+as reverted precompile calls.
 
 # Invariants
 
-1. No post-activation call to an old `authorizeKey` selector can create or
-   modify a key.
-2. No post-activation call to the old nested-ABI `setAllowedCalls` selector can
-   modify call scopes.
-3. The new method accepts exactly the canonical TIP-1011 call-scope RLP schema.
-4. Invalid input causes no keychain storage write.
-5. For every valid input, the resulting call-scope state is identical to the
-   state produced by the pre-activation ABI method with the same logical scopes.
-6. Existing keys and scopes are unchanged at activation.
-7. Decode and validation work is linear in encoded input size, excluding the
-   separately metered storage operations.
-
-Critical test cases:
-
-1. Every removed selector reverts without reading or writing keychain state.
-2. A valid one-target and multi-target RLP update succeeds.
-3. Empty bytes, empty outer list, strings in place of lists, trailing bytes, and
-   non-canonical lengths revert.
-4. Incorrect address and selector widths revert.
-5. Duplicate targets, selectors, and recipients revert before any write.
-6. A late-invalid element leaves all prior scopes unchanged.
-7. Empty selector rules retain allow-any-selector semantics.
-8. The old and new interfaces produce identical state from equivalent scopes on
-   opposite sides of the activation boundary.
-9. Existing keys can be updated and removed after activation.
-10. Maximum consensus-accepted input stays within benchmarked CPU and memory
-    budgets.
+1. The removed selectors cannot modify keychain state after activation.
+2. Invalid RLP causes no storage writes.
+3. Valid RLP produces the same scope state as the old ABI method for the same
+   logical input.
+4. Existing keys and scopes are unchanged at activation.
+5. Existing TIP-1011 call-scope semantics are unchanged.

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -4,8 +4,8 @@ title: RLP-Encoded Account Keychain Mutations
 description: Removes direct key authorization and replaces nested ABI call-scope decoding with RLP.
 authors: Arsenii Kulikov (@klkvr)
 status: Draft
-related: TIP-1011, TIP-1049, https://gist.github.com/rappie/094e3a9f786a0a6766b4b0df9805fe0b
-protocolVersion: TBD
+related: TIP-1011, TIP-1049, TIP-1100, https://gist.github.com/rappie/094e3a9f786a0a6766b4b0df9805fe0b
+protocolVersion: T11
 ---
 
 # TIP-1099: RLP-Encoded Account Keychain Mutations
@@ -27,10 +27,16 @@ CPU and memory usage during decoding. This TIP removes them from
 `AccountKeychain` by reusing the canonical RLP encodings already used in Tempo
 transactions.
 
+Worst-case RLP decoding measured about 400 MB/s, or 12.5 million 32-byte words
+per second. Pricing this work at 1 GGas/s requires 80 gas per word. TIP-1100
+charges 30 gas per word of precompile input, so this TIP charges another 50 gas
+per word of RLP input.
+
 ## Assumptions
 
 - `key_authorization` can represent every key configuration currently accepted
   by `authorizeKey` and `authorizeAdminKey`.
+- TIP-1100 activates no later than this TIP.
 - Existing keys and stored call scopes remain unchanged at activation.
 
 ---
@@ -92,6 +98,17 @@ SelectorRule := RLP([
 The input must contain exactly one canonical, non-empty `AllowedCalls` list.
 Malformed RLP, trailing bytes, incorrect field lengths, and an empty outer list
 must revert.
+
+Before decoding `scopes`, deduct:
+
+```text
+rlp_words = ceil(scopes.length / 32)
+rlp_cost = rlp_words * 50
+```
+
+This charge is in addition to TIP-1100's 30 gas per word of precompile input. If
+the caller has insufficient gas, execution must halt with out-of-gas before RLP
+decoding.
 
 All TIP-1011 rules remain unchanged, including uniqueness checks, valid
 recipient-aware selectors, TIP-20 target checks, and create-or-replace behavior

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -101,13 +101,6 @@ write so failures are atomic.
 `removeAllowedCalls(address,address)` remains the way to remove a target scope.
 An empty `selector_rules` list continues to allow every selector for that target.
 
-## Resource accounting
-
-The precompile must charge for the complete calldata before decoding it. Before
-activation, benchmarks must confirm that calldata gas covers the worst valid and
-invalid RLP inputs; otherwise the implementation must add an explicit byte or
-element limit.
-
 ## Activation
 
 The selector changes are hardfork-gated. Historical blocks continue to use the

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -33,12 +33,6 @@ transactions.
   by `authorizeKey` and `authorizeAdminKey`.
 - Existing keys and stored call scopes remain unchanged at activation.
 
-## Threat Model
-
-Any sender can submit malformed or oversized calldata to the precompile. RLP
-decoding must be metered or bounded so its worst-case CPU and memory cost is
-covered by the transaction's gas.
-
 ---
 
 # Specification

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -2,7 +2,7 @@
 id: TIP-1099
 title: RLP-Encoded Account Keychain Mutations
 description: Removes direct key authorization and replaces nested ABI call-scope decoding with RLP.
-authors: Arsenii Kulikov @klkvr
+authors: Arsenii Kulikov (@klkvr)
 status: Draft
 related: TIP-1011, TIP-1049, https://gist.github.com/rappie/094e3a9f786a0a6766b4b0df9805fe0b
 protocolVersion: TBD

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -23,12 +23,9 @@ the complexity of decoding nested ABI input in a precompile.
 ## Motivation
 
 Nested ABI structures in precompile interfaces can be abused to force increased
-CPU and memory usage during decoding. Tempo should remove them from these
-interfaces and use simpler encodings whose resource usage is easier to bound and
-meter.
-
-This TIP removes nested ABI inputs from `AccountKeychain` by reusing the
-canonical RLP encodings already used in Tempo transactions.
+CPU and memory usage during decoding. This TIP removes them from
+`AccountKeychain` by reusing the canonical RLP encodings already used in Tempo
+transactions.
 
 ## Assumptions
 

--- a/tips/tip-1099.md
+++ b/tips/tip-1099.md
@@ -22,15 +22,13 @@ the complexity of decoding nested ABI input in a precompile.
 
 ## Motivation
 
-Nested, attacker-controlled ABI input can consume disproportionate CPU and
-memory during decoding.
+Nested ABI structures in precompile interfaces can be abused to force increased
+CPU and memory usage during decoding. Tempo should remove them from these
+interfaces and use simpler encodings whose resource usage is easier to bound and
+meter.
 
-Key authorizations and call scopes already have a canonical RLP encoding in
-Tempo transactions. Reusing it gives the precompile a simpler encoding to decode
-and meter, while tooling can hide the encoding from application developers.
-
-Removing `setAllowedCalls` entirely was considered, but long-lived passkeys and
-hardware-backed keys need a way to change permissions without rotating the key.
+This TIP removes nested ABI inputs from `AccountKeychain` by reusing the
+canonical RLP encodings already used in Tempo transactions.
 
 ## Assumptions
 


### PR DESCRIPTION
Depends on #7281.

Removes the direct AccountKeychain authorization entrypoints and replaces nested setAllowedCalls ABI input with TIP-1011 RLP. The RLP payload pays another 50 gas per 32-byte word on top of TIP-1100 input pricing.