### PR TITLE
fix(tip-1095): preserve legacy channel policy sender

### DIFF
--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -60,6 +60,11 @@ struct PackedChannelState {
     settled: U96,
     deposit: U96,
     close_requested_at: u32,
+    /// Whether TIP-1028 should see the logical payer during capture.
+    ///
+    /// This field occupies previously unused bytes in the packed slot. Channels created before
+    /// T11 decode it as false and retain the reserve sender accepted when they were funded.
+    uses_logical_receive_policy_sender: bool,
 }
 
 impl PackedChannelState {
@@ -71,6 +76,15 @@ impl PackedChannelState {
     /// Returns the payer's close request timestamp, if the close timer is active.
     fn close_requested_at(self) -> Option<u32> {
         (self.close_requested_at != 0).then_some(self.close_requested_at)
+    }
+
+    /// Returns the sender presented to the payee's TIP-1028 receive policy.
+    fn receive_policy_sender(self, payer: Address) -> Address {
+        if self.uses_logical_receive_policy_sender {
+            payer
+        } else {
+            TIP20_CHANNEL_RESERVE_ADDRESS
+        }
     }
 
     /// Converts packed native storage to the public Solidity ABI shape.
@@ -186,6 +200,7 @@ impl TIP20ChannelReserve {
                 settled: U96::ZERO,
                 deposit,
                 close_requested_at: 0,
+                uses_logical_receive_policy_sender: self.storage.spec().is_t11(),
             },
         )?;
         self.opened_this_tx[channel_id].t_write(true)?;
@@ -249,7 +264,7 @@ impl TIP20ChannelReserve {
                 self.address,
                 payee,
                 U256::from(delta),
-                call.descriptor.payer,
+                state.receive_policy_sender(call.descriptor.payer),
             )?;
 
             state.settled = cumulative;
@@ -318,7 +333,10 @@ impl TIP20ChannelReserve {
             if self.storage.spec().is_t11() {
                 let payee = Recipient::resolve(call.descriptor.payee)?.target;
                 token.ensure_transfer_authorized(msg_sender, payee)?;
-                token.ensure_receive_policy_authorized(msg_sender, payee)?;
+                token.ensure_receive_policy_authorized(
+                    state.receive_policy_sender(msg_sender),
+                    payee,
+                )?;
                 token.channel_reserve_transfer(
                     msg_sender,
                     Recipient::direct(self.address),
@@ -450,7 +468,7 @@ impl TIP20ChannelReserve {
                     self.address,
                     payee,
                     U256::from(delta),
-                    call.descriptor.payer,
+                    state.receive_policy_sender(call.descriptor.payer),
                 )?;
             }
             if !refund.is_zero() {
@@ -1515,6 +1533,118 @@ mod tests {
                     })?
                     .deposit,
                 U96::from(100)
+            );
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t11_grandfathers_pre_t11_receive_policy_sender() -> eyre::Result<()> {
+        assert_eq!(
+            <PackedChannelState as crate::storage::StorableType>::SLOTS,
+            1
+        );
+
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+        let payer_signer = PrivateKeySigner::random();
+        let payer = payer_signer.address();
+        let payee = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::path_usd(payer)
+                .with_issuer(payer)
+                .with_mint(payer, U256::from(1_000u128))
+                .apply()?;
+            let mut reserve = TIP20ChannelReserve::new();
+            reserve.initialize()?;
+
+            // This payee accepts the reserve but not the individual payer, matching the policy
+            // under which pre-T11 channel captures were funded.
+            install_receive_sender_blacklist(payee, payer)?;
+
+            let salt = B256::random();
+            let expiring_nonce_hash = seed_expiring_nonce_hash(&mut reserve)?;
+            let channel_id = reserve.open(
+                payer,
+                open_call(
+                    payee,
+                    Address::ZERO,
+                    token.address(),
+                    100,
+                    salt,
+                    Address::ZERO,
+                ),
+            )?;
+            let descriptor = descriptor(
+                payer,
+                payee,
+                Address::ZERO,
+                token.address(),
+                salt,
+                Address::ZERO,
+                expiring_nonce_hash,
+            );
+
+            StorageCtx.set_spec(TempoHardfork::T11);
+
+            // Post-activation top-ups and captures retain the reserve sender for this channel.
+            reserve.top_up(
+                payer,
+                ITIP20ChannelReserve::topUpCall {
+                    descriptor: descriptor.clone(),
+                    additionalDeposit: U96::from(20),
+                },
+            )?;
+
+            let cumulative = U96::from(40);
+            let digest =
+                reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                    channelId: channel_id,
+                    cumulativeAmount: cumulative,
+                })?;
+            let signature =
+                Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&digest)?.as_bytes());
+            reserve.settle(
+                payee,
+                ITIP20ChannelReserve::settleCall {
+                    descriptor: descriptor.clone(),
+                    cumulativeAmount: cumulative,
+                    signature,
+                },
+            )?;
+
+            let close_cumulative = U96::from(60);
+            let close_digest =
+                reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
+                    channelId: channel_id,
+                    cumulativeAmount: close_cumulative,
+                })?;
+            let close_signature =
+                Bytes::copy_from_slice(&payer_signer.sign_hash_sync(&close_digest)?.as_bytes());
+            reserve.close(
+                payee,
+                ITIP20ChannelReserve::closeCall {
+                    descriptor,
+                    cumulativeAmount: close_cumulative,
+                    captureAmount: close_cumulative,
+                    signature: close_signature,
+                },
+            )?;
+
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payer })?,
+                U256::from(940u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall { account: payee })?,
+                U256::from(60u128)
+            );
+            assert_eq!(
+                token.balance_of(ITIP20::balanceOfCall {
+                    account: TIP20_CHANNEL_RESERVE_ADDRESS,
+                })?,
+                U256::ZERO
             );
 
             Ok(())

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -75,8 +75,10 @@ the resolved descriptor payee as the TIP-403 recipient under the token's current
 moves the physical balance without separately applying TIP-403 to the reserve address.
 
 Before `open` or a nonzero `topUp` moves funds, the reserve must also check that the payee's current
-TIP-1028 policy accepts the channel token from the payer. This check does not lock the policy. If
-the payee later changes it, capture may fail until the payee accepts the payment again.
+TIP-1028 policy accepts the channel token from the sender that will be presented during capture:
+the payer for channels opened at or after T11, and the reserve for older channels. This check does
+not lock the policy. If the payee later changes it, capture may fail until the payment is accepted
+again.
 
 All existing channel checks still apply. Token pause state, balances, access-key limits, recipient
 validity, and TIP-1028 policy must be enforced as they are for native TIP-20 transfers.
@@ -110,14 +112,14 @@ physical `Transfer` events as ordinary TIP-20 movements.
 
 ## Activation and Compatibility
 
-This behavior activates at T11 and applies to both new and existing channels. Before T11, TIP-1034
-keeps its original physical transfer-policy checks.
+This behavior activates at T11 for channels opened at or after T11. Before T11, TIP-1034 keeps its
+original physical transfer-policy checks. Channels opened before T11 continue presenting the
+channel reserve as the TIP-1028 sender during capture, including after T11 activation.
 
-No on-chain channel migration is required. Existing channels continue to work, but a payee that
-previously allowed the channel reserve in its TIP-1028 policy may need to allow the channel payer
-after T11. Otherwise, future settlements or captures can revert until the policy is updated.
-This TIP changes no public ABI, channel ID, voucher, event, or storage layout, and does not change
-TIP-403 behavior outside the channel reserve.
+No on-chain channel migration or receive-policy update is required for existing channels. A channel
+records which receive-policy sender rule was active when it opened without changing its public ABI,
+channel ID, voucher, event, or storage-slot count.
+This TIP does not change TIP-403 behavior outside the channel reserve.
 
 # Tooling
 
@@ -134,17 +136,19 @@ movement:
 | TIP-20 `Transfer` event | Physical token movement and custody | For settlement and capture, the physical path is `channel reserve -> payee`. It does not identify the payer used for policy authorization |
 | TIP-1034 channel events | Logical channel parties and accounting | Use the payer, payee, and operation-specific amount fields to correlate the movement with the logical payment |
 
-Before this TIP, settlement and capture presented the channel reserve as the sender to the payee's
-receive policy. Under this TIP, authorization uses the `payer -> payee` path while the physical
-movement and `Transfer` event remain `channel reserve -> payee`. Consequently, an unchanged policy
-can change whether settlement or capture succeeds, and a `Transfer` from the channel reserve to
-the payee does not by itself mean that the channel reserve was authorized as the policy sender.
+For channels opened before T11, settlement and capture continue presenting the channel reserve as
+the sender to the payee's receive policy. For channels opened at or after T11, authorization uses
+the `payer -> payee` path while the physical movement and `Transfer` event remain
+`channel reserve -> payee`. A `Transfer` from the channel reserve to the payee therefore does not by
+itself identify which sender was evaluated by the receive policy.
 
 # Invariants
 
 - Ordinary TIP-20 transfers remain subject to the token's TIP-403 policy.
 - Funding and capture succeed only while the logical `payer -> payee` transfer is authorized.
-- Funding requires the payee's current TIP-1028 policy to accept the token from the payer.
+- Existing channels retain the TIP-1028 sender rule under which they were funded.
+- Funding requires the payee's current TIP-1028 policy to accept the token from the channel's
+  receive-policy sender.
 - Captured funds can go only to the descriptor payee.
 - A refund can go only to the descriptor payer and cannot exceed the refundable channel balance.
 - The payer can recover refundable funds without being an authorized TIP-403 recipient.


### PR DESCRIPTION
Preserves the TIP-1028 receive-policy sender chosen when a channel opens. Pre-T12 channels continue presenting the channel reserve after T12 activation, while new T12 channels present the logical payer. The marker fits in the existing packed state slot, so no channel migration or additional storage slot is required.

Adds a regression covering a T11 channel that is topped up, settled, and closed after T12 while the payee allows the reserve but blocks the payer. Updates TIP-1095 compatibility and observability text accordingly.

Addresses https://github.com/tempoxyz/tempo/pull/6957#discussion_r3823521160

Validation:
- `rustup run nightly cargo test -p tempo-precompiles --features test-utils tip20_channel_reserve`
- `rustup run nightly cargo clippy -p tempo-precompiles --all-targets --features test-utils -- -D warnings`
- `rustup run nightly cargo fmt --all -- --check`
- `git diff --check`
