### PR TITLE
docs(tip-1061): specify stateless config commitments

### DIFF
--- a/.changelog/native-multisig.md
+++ b/.changelog/native-multisig.md
@@ -8,4 +8,4 @@ tempo-revm: minor
 tempo-node: minor
 ---
 
-Activates native multisig accounts at T11, including a new multisig precompile, signature-carried `InitMultisig` bootstrap configs, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Native 1-of-1 secp256k1 multisigs pay an 8,400 gas authorization surcharge over equivalent primitive secp256k1 transactions.
+Activates counterfactual native multisig accounts at T11, including signature-carried configuration witnesses, single-slot configuration commitments, owner updates through the multisig precompile, and recursively metered `MultisigSignature` validation across the EVM, transaction pool, and RPC layers.

--- a/.changelog/native-multisig.md
+++ b/.changelog/native-multisig.md
@@ -8,4 +8,4 @@ tempo-revm: minor
 tempo-node: minor
 ---
 
-Activates counterfactual native multisig accounts at T11, including signature-carried configuration witnesses, single-slot configuration commitments, owner updates through the multisig precompile, and recursively metered `MultisigSignature` validation across the EVM, transaction pool, and RPC layers.
+Activates counterfactual native multisig accounts at T11, including a new multisig precompile, signature-carried configuration witnesses, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Owner updates persist one configuration commitment slot.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -96,7 +96,7 @@ pub struct InitMultisig {
     pub owners: Vec<MultisigOwner>,
 }
 
-/// Current owner configuration carried by an account after its first update.
+/// Current owner configuration carried in a signature after an account's first update.
 pub struct MultisigConfig {
     /// Nonzero configuration version.
     pub version: u64,
@@ -253,7 +253,7 @@ Rules:
 
 ## Transaction Execution
 
-Multisig accounts are counterfactual: deriving or first using one does not create configuration storage. Every direct quorum authorization supplies the applicable configuration witness, while access-key transactions continue to use the account keychain without repeating the parent configuration.
+Initial transactions authorize counterfactual accounts without establishing multisig state. Current transactions supply the committed owner configuration and otherwise behave as ordinary Tempo transactions from that account. Access-key transactions continue to use the account keychain without repeating the parent configuration.
 
 Rules:
 
@@ -313,7 +313,7 @@ tx.signature =
   ])
 ```
 
-Validation derives the sender, confirms that its commitment slot is zero, verifies the quorum, and executes the call batch. The transaction consumes its ordinary nonce but creates no multisig configuration state or initialization event.
+After validation, the account is available to the transaction's call batch. The transaction consumes its ordinary nonce but creates no multisig configuration state or initialization event.
 
 Rules:
 
@@ -328,7 +328,7 @@ Rules:
 A current transaction uses the configuration witness matching its block-position commitment to authorize the full call batch. Configuration updates are visible to later calls in the batch but do not change that transaction's authorization.
 
 ```text
-// Build a transaction from the account.
+// Build a later transaction from the account.
 tx = transaction(
   from = account,
   calls = [...]
@@ -541,20 +541,11 @@ Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is r
 
 Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 
-The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 node costs 39,900 gas plus its configuration-witness data gas.
+The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 authorization adds 39,900 gas plus its configuration-witness data gas.
 
 When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
 
 Initial use writes no multisig state. The first update pays a warm zero-to-nonzero commitment write; later updates pay a warm nonzero-to-nonzero write.
-
-Under the gas schedule active when this TIP was drafted, representative first-use costs for an 8-of-48 account before executed calls are:
-
-| Case | Current owner-row design | Stateless commitment design | Savings |
-| --- | ---: | ---: | ---: |
-| First use with 8 secp256k1 approvals | ~24.5M gas | ~79k gas | ~310x |
-| First use with 8 WebAuthn approvals | ~24.6M-24.8M gas | ~119k-365k gas | ~68x-207x |
-
-The table compares storage-writing bootstrap with storage-free initial authorization. Estimates include 21,000 base gas and about 18,000 witness gas; a first update adds about 250,100 gas and later updates about 5,000 gas. The formulas above are normative.
 
 Rules:
 
@@ -678,7 +669,7 @@ execute(tx)
 
 ### Nested Ownership
 
-Each multisig account wraps the digest approved by its parent and carries its own witness. This example uses current configurations for both accounts.
+Each multisig account wraps the digest approved by its parent and carries its own witness. This example uses a current multisig account as an owner of another current multisig account.
 
 ```text
 // Build a transaction from the parent multisig account.
@@ -1062,7 +1053,7 @@ next_tx.signature =
 
 ## Backwards Compatibility
 
-Under the address-collision assumption, primitive-signed fee payers, access keys, and authorization-list authorities require no commitment read, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
+Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless under the address-collision assumption, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
 
 Rules:
 
@@ -1077,16 +1068,16 @@ Rules:
 - **Stable identity.** Initial authorization MUST satisfy `tx.from == multisig_address`. `updateConfig` MUST NOT change the address.
 - **Witness selection.** A zero commitment MUST accept only the derived initial witness; a nonzero commitment MUST accept only a matching current witness.
 - **Configuration validity.** Configurations MUST satisfy all owner, weight, total-weight, and threshold limits above, and MUST NOT include their own account as an owner.
-- **Single-slot state.** Multisig configuration storage MUST contain only the current nonzero commitment and MUST NOT persist owner rows.
+- **Single-slot state.** Multisig configuration storage MUST contain only the current commitment and MUST NOT persist owner rows.
 - **No account code.** An account directly or recursively authorized by a multisig signature MUST NOT have EVM bytecode or EIP-7702 delegation code at validation time.
 - **Owner signatures.** Owner signatures MUST be primitive over the current digest or nested with the parent digest as `inner_digest`. Every nested multisig signature MUST carry and validate its own initial or current witness. Keychain signatures MUST NOT be accepted as owner signatures.
 - **Owner set membership.** Recovered or nested owner addresses MUST be sorted and belong to the applicable owner configuration.
-- **Threshold enforcement.** Current owner weights MUST reach threshold on the final owner signature, not before.
+- **Threshold enforcement.** Applicable owner weights MUST reach threshold on the final owner signature, not before.
 - **Current-state authorization.** Current authorization MUST match the configuration commitment at its block position.
 - **Multisig account sender.** Direct quorum transactions MUST use `TempoSignature::Multisig` as the outer signature.
 - **Signature contexts.** Multisig signatures MUST be outer, nested owner, or key authorization signatures.
 - **Key authorization.** Transactions MAY carry `key_authorization`. A multisig key authorization MUST independently carry an initial or current witness and match `key_authorization.account`.
-- **Account keychain access.** Multisig accounts MAY own access keys, but multisig signatures MUST NOT authorize keychain access and access keys MUST NOT replace parent owner sets.
+- **Account keychain access.** Multisig accounts MAY own access keys. Multisig signatures MUST NOT authorize keychain access. Access keys MUST NOT replace parent owner sets.
 - **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-commitment read.
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
 - **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -205,15 +205,14 @@ Rules:
 
 ## Transaction Execution
 
-Initial transactions authorize counterfactual accounts without establishing multisig state. Current transactions supply the committed owner configuration and otherwise behave as ordinary Tempo transactions from that account. Access-key transactions continue to use the account keychain without repeating the parent configuration.
+Initial transactions authorize counterfactual accounts without establishing multisig state. Current transactions supply the committed owner configuration and otherwise behave as ordinary Tempo transactions from that account.
 
 Rules:
 
-- Direct initial and current transactions MUST use the authorized account as `tx.from`, `tx.origin`, and top-level `msg.sender`; one authorization covers the call batch.
+- `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
 - An initial transaction MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; balance and storage MUST NOT prevent authorization.
 - When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
-- At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics, is visible to later calls in the batch, and affects authorization only for later transactions.
-- Each account directly or recursively authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
+- A successful `updateConfig` write follows ordinary call-batch revert semantics, is visible to later calls in the batch, and affects authorization only for later transactions.
 - Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
 - Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-commitment read. Address collisions with derived multisig accounts are outside this TIP's security scope.
 - Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
@@ -929,7 +928,7 @@ Rules:
 - **Witness selection.** A zero commitment MUST accept only the derived initial witness; a nonzero commitment MUST accept only a matching current witness.
 - **Configuration validity.** Configurations MUST satisfy all owner, weight, total-weight, and threshold limits above, and MUST NOT include their own account as an owner.
 - **Single-slot state.** Multisig configuration storage MUST contain only the current commitment and MUST NOT persist owner rows.
-- **No account code.** An account directly or recursively authorized by a multisig signature MUST NOT have EVM bytecode or EIP-7702 delegation code at validation time.
+- **No account code.** A multisig account MUST NOT have EVM bytecode or EIP-7702 delegation code.
 - **Owner signatures.** Owner signatures MUST be primitive over the current digest or nested with the parent digest as `inner_digest`. Every nested multisig signature MUST carry and validate its own initial or current witness. Keychain signatures MUST NOT be accepted as owner signatures.
 - **Owner set membership.** Recovered or nested owner addresses MUST be sorted and belong to the applicable owner configuration.
 - **Threshold enforcement.** Applicable owner weights MUST reach threshold on the final owner signature, not before.
@@ -941,6 +940,5 @@ Rules:
 - **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-commitment read.
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
 - **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
-- **Config update count.** At most one `updateConfig` call MAY succeed per transaction.
 - **Config update version.** `updateConfig` MUST preserve the salt, persist the nonzero commitment of version `current_version + 1`, and emit that complete configuration.
 - **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -511,7 +511,7 @@ Multisig account authorization is charged as regular intrinsic gas. Costs scale 
 ```text
 witness_bytes(signature) =
   initial: rlp(init)
-  current: rlp([account, config])
+  current: rlp(account) || rlp(config)
 
 node(signature) =
     2,100

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -210,7 +210,6 @@ Rules:
 
 - `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
 - An initial transaction MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; balance and storage MUST NOT prevent authorization.
-- A successful `updateConfig` write follows ordinary call-batch revert semantics, is visible to later calls in the batch, and affects authorization only for later transactions.
 - Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
 - Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-commitment read. Address collisions with derived multisig accounts are outside this TIP's security scope.
 - Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -57,7 +57,7 @@ pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 /// Domain prefix for persisted multisig configuration commitments.
 pub const MULTISIG_CONFIG_DOMAIN: &[u8] = b"tempo:multisig:config";
 
-/// Maximum owner count under transaction gas and pool byte limits.
+/// Maximum owner count that leaves room for fresh nonce creation and transaction overhead.
 pub const MAX_MULTISIG_OWNERS: usize = 48;
 
 /// Maximum threshold for one account configuration.
@@ -70,7 +70,8 @@ pub const MAX_MULTISIG_SIGNATURES: usize = 8;
 pub const MAX_MULTISIG_NESTING_DEPTH: usize = 2;
 
 /// Maximum encoded byte length of one primitive owner signature.
-pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 768;
+pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize =
+    1 + MAX_WEBAUTHN_SIGNATURE_LENGTH;
 
 /// Weighted owner in an account configuration.
 pub struct MultisigOwner {
@@ -109,7 +110,7 @@ pub struct MultisigSignature {
 }
 ```
 
-An account may have up to 48 owners so a worst-case initial authorization, including complete validation of eight depth-2 nested-owner configuration witnesses and eight maximum-size WebAuthn signatures in each, fits within the transaction gas cap while leaving room for fresh nonce creation and transaction overhead. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound multisig authorization size and recursive signature-verification work. The primitive byte limit also keeps an otherwise minimal transaction carrying maximum outer and key-authorization trees below Tempo's default transaction-pool byte limit.
+An account may have up to 48 owners so a worst-case initial authorization, including complete validation of eight depth-2 nested-owner configuration witnesses and eight maximum-size WebAuthn signatures in each, fits within the transaction gas cap while leaving room for fresh nonce creation and transaction overhead. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound transaction size and recursive signature-verification work.
 
 Rules:
 
@@ -350,8 +351,8 @@ The access key signs the existing V2 account keychain digest, and the transactio
 Rules:
 
 - Quorums MAY add ordinary or admin access keys directly or via `key_authorization`, including during initial authorization; existing key rules MUST apply.
-- A multisig signature MUST NOT be accepted as an account-keychain access-key signature. An existing access key recovered from a primitive signature MUST NOT require a commitment read for the key ID under the address-collision assumption.
-- An account with a nonzero multisig commitment MUST NOT be newly registered as an access key for another account. A pre-existing access-key row whose key ID later acquires a nonzero commitment cannot be exercised with a multisig signature and MAY remain stored.
+- A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
+- An account with a nonzero multisig commitment MUST NOT be newly registered as an access key for another account.
 - A multisig key authorization signature MUST set its account to `key_authorization.account`, carry the complete applicable configuration, and use the digest above.
 - A multisig key authorization MUST complete stateful witness and quorum verification before satisfying root authorization and MUST NOT use the admin-delegated signer path.
 - A version-0 key authorization MAY register the key without persisting multisig configuration state.
@@ -362,7 +363,6 @@ Rules:
 - Stateless TIP-1020 `recover` and `verify` MUST reject bare multisig account signatures.
 - Access keys MUST NOT call `updateConfig` for their parent.
 - Only a direct multisig account signature with a zero keychain transaction key MAY replace the parent's owner set.
-- Configuration updates MUST NOT modify or revoke existing access keys.
 
 ## Gas
 
@@ -403,8 +403,6 @@ The direct subtraction accounts for the secp256k1 transaction signature already 
 
 When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
 
-Commitment gating checks newly authorized access-key IDs because they do not sign. It also checks a keychain caller with code or delegation to enforce the multisig no-code invariant. These reads use the active precompile storage schedule, including warm pricing when a prior check read the same slot.
-
 Initial use writes no multisig state. Configuration updates use the active warm SSTORE schedule for the slot's transaction-original and current values.
 
 Rules:
@@ -427,7 +425,7 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 Rules:
 
 - Tooling MUST support the T11 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
-- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept an RPC-only recursive witness containing every account configuration and, for each approved owner, either a primitive signature type and variable-length data or a nested witness. The witness MUST be accepted only under `ExecutionContext::Simulation`, MUST NOT alter signed transaction encoding, and MUST NOT be consulted during transaction execution.
+- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept an RPC-only recursive witness containing every account configuration and, for each approved owner, either a primitive signature type and variable-length data or a nested witness. The witness MUST NOT alter signed transaction encoding.
 - Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas; only cryptographic owner-signature verification MAY be skipped.
 
 ## Observability
@@ -914,7 +912,7 @@ next_tx.signature =
 
 ## Backwards Compatibility
 
-Newly authorized access-key IDs require a commitment read because they do not sign. Existing-key validation requires one only when the parent has code or delegation. Primitive-signed fee payers and authorization-list authorities remain stateless under the address-collision assumption, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
+Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless under the address-collision assumption, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
 
 Rules:
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -286,7 +286,6 @@ interface INativeMultisig {
     error DuplicateOwner();
     error InvalidOwnerOrder();
     error UnauthorizedCaller();
-    error MultipleConfigUpdates();
 }
 ```
 
@@ -298,10 +297,9 @@ Rules:
 - `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
 - `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST use the outer multisig authorization context's account, salt, and authorized witness version. Access-key authorization MUST NOT call it.
-- At most one `updateConfig` call MAY succeed per transaction; a later call MUST revert with `MultipleConfigUpdates`.
+- It MUST use the outer multisig authorization context's account and salt. The first successful call MUST increment the authorized witness version; each later successful call in the transaction MUST increment the version written by the preceding call. Access-key authorization MUST NOT call it.
 - `updateConfig` MUST NOT accept a separate authorization signature.
-- `updateConfig` MUST preserve the authorized configuration salt, increment the authorized configuration version by one, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
+- Each successful `updateConfig` MUST preserve the authorized configuration salt, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
   - `InvalidOwner` for an empty owner list.
   - `TooManyOwners` above `MAX_MULTISIG_OWNERS`.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -353,11 +353,12 @@ Rules:
 - `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
 - At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics and affects authorization only for later transactions.
 - Each account authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
-- Authorization lists MUST reject bare multisig account signatures.
-- Primitive and keychain authorization-list signatures MUST remain stateless with respect to multisig configuration commitments. Address collisions with derived multisig accounts are outside this TIP's security scope.
+- Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
+- Primitive authorization-list signatures MUST remain stateless with respect to multisig configuration commitments. Address collisions with derived multisig accounts are outside this TIP's security scope.
+- Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
-- Pools MAY index by stateless recovery but MUST revalidate current signatures after the named account's commitment changes.
+- Pools MAY index by stateless recovery but MUST revalidate all initial and current signatures that name an account whenever its commitment changes.
 
 ## Storage
 
@@ -1058,7 +1059,7 @@ next_tx.signature =
 
 This change is additive for transactions and accounts that do not use multisig signatures. Applications can move assets or state from an existing EOA through their current flows.
 
-Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless with respect to multisig commitments under the address-collision assumption. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
+Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless with respect to multisig commitments under the address-collision assumption. Keychain-signed authorization-list entries retain their existing skipped behavior and also require no commitment read. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
 
 Rules:
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -14,7 +14,9 @@ protocolVersion: T11
 
 Configurable accounts can change who controls them and their configuration without changing their identity. They support multisig control, recovery, key rotation, and permissioned access (via access keys) while remaining the same Tempo account to applications and counterparties.
 
-This TIP implements configurable accounts as counterfactual native multisig accounts; protocol names use `multisig`. Their initial configuration derives the address, signatures carry the applicable configuration, and owner updates persist one commitment slot.
+This TIP implements configurable accounts as native multisig accounts. Protocol identifiers, signatures, and ABI names use the term `multisig`.
+
+Accounts are counterfactual: multisig signatures carry their configurations, and owner updates persist one commitment slot.
 
 ## Motivation
 
@@ -36,7 +38,7 @@ Today, these needs typically require a contract wallet or external account abstr
 - Nested multisig owners are untrusted authorization principals. Nesting depth, ordering, membership, cycle, and per-node threshold checks prevent them from bypassing the parent configuration.
 - Access keys and fee payers are untrusted delegates, not owners. Access keys remain subject to account keychain restrictions and cannot update the owner configuration; fee sponsorship grants no account authority.
 - Attackers may choose salts, owner sets, and primitive keys while searching for address collisions. Reserved namespace outputs are rejected. Finding an EOA key and multisig input with the same 160-bit address, with generic work of approximately 2^80, is outside this TIP's security scope.
-- RPC simulators and transaction pools may use stale configuration commitments. Their results are advisory; consensus validation MUST compare each witness with the commitment at the transaction's block position, and pools MUST revalidate affected transactions after configuration changes.
+- RPC simulators and transaction pools may use stale or incomplete configuration data. Their results are advisory; consensus validation MUST compare each witness with the commitment at the transaction's block position, and pools MUST revalidate affected transactions after configuration changes.
 
 ---
 
@@ -131,7 +133,7 @@ pub enum MultisigSignature {
 }
 ```
 
-Each signature carries its configuration: initial witnesses derive version-0 accounts; current witnesses match stored nonzero commitments. Configurations allow up to 48 owners and one approval per owner; depth 2 permits one nested level. Size, depth, and gas limits bound validation.
+Configurations allow up to 48 owners and one approval per owner. Nesting depth 2 permits one nested level; encoded-size and gas limits bound validation.
 
 Rules:
 
@@ -145,7 +147,7 @@ Rules:
 
 ## Signature Encoding
 
-Signature type `0x05` has two forms, both of which carry the complete applicable configuration:
+Signature type `0x05` has two forms:
 
 - **Initial.** Used while the account has no persisted configuration commitment. The witness derives the counterfactual account and implicitly has version `0`.
 - **Current.** Used after an owner update has persisted a configuration commitment. The witness names the account and supplies the committed configuration.
@@ -188,7 +190,7 @@ Rules:
 
 ## Account Identity
 
-The initial configuration and salt derive a stable account address:
+The initial owner configuration and salt establish an account identity that remains stable across later owner changes. The salt lets identical owner configurations derive distinct accounts:
 
 ```text
 multisig_address = address(keccak256(
@@ -356,7 +358,7 @@ Rules:
 
 ## Storage
 
-The precompile stores one commitment per account; signatures and update events carry full configurations. `pad32` encodes a value as a 32-byte big-endian word, and `mapping_slot` returns Keccak-256 as a big-endian `uint256`.
+The precompile stores one commitment per account; signatures and update events carry full configurations. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
 
 ```text
 mapping_slot(key, base) = keccak256(pad32(key) || pad32(base))
@@ -450,7 +452,7 @@ Rules:
 
 ### Access Keys on Multisig Accounts
 
-A multisig account can delegate ordinary or admin authority through the existing account keychain. The owner quorum can register an access key directly or through transaction-level key authorization while using either an initial or current configuration witness.
+A multisig account can delegate ordinary or admin authority through the existing account keychain. The owner quorum can register an access key directly or through transaction-level key authorization, including with an initial configuration witness.
 
 The owner quorum authorizes a key authorization with this digest:
 
@@ -561,7 +563,9 @@ Rules:
 
 ## Tooling
 
-Commitments verify but do not reveal configurations. Wallets and indexers recover them from initial signatures and update events; multisig simulation requires an RPC-only complete witness and approval shape. Access-key transactions require no parent witness.
+Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, signing, transaction decoding, and configuration history.
+
+Commitments do not reveal configurations. Multisig simulation therefore requires an RPC-only complete witness and approval shape; access-key transactions require no parent witness.
 
 Rules:
 
@@ -1048,9 +1052,7 @@ next_tx.signature =
 
 ## Backwards Compatibility
 
-This change is additive for transactions and accounts that do not use multisig signatures. Applications can move assets or state from an existing EOA through their current flows.
-
-Under the address-collision assumption, primitive-signed fee payers, access keys, and authorization-list authorities require no commitment read; keychain authorization-list entries remain skipped. `SignedKeyAuthorization` accepts multisig at T11 without changing primitive encodings.
+Under the address-collision assumption, primitive-signed fee payers, access keys, and authorization-list authorities require no commitment read, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
 
 Rules:
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -299,7 +299,7 @@ Rules:
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
 - It MUST use the outer multisig authorization context's account and salt. The first successful call MUST increment the authorized witness version; each later successful call in the transaction MUST increment the version written by the preceding call. Access-key authorization MUST NOT call it.
 - `updateConfig` MUST NOT accept a separate authorization signature.
-- Each successful `updateConfig` MUST preserve the authorized configuration salt, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
+- Each successful `updateConfig` MUST revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
   - `InvalidOwner` for an empty owner list.
   - `TooManyOwners` above `MAX_MULTISIG_OWNERS`.
@@ -938,5 +938,5 @@ Rules:
 - **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-commitment read.
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
 - **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
-- **Config update version.** `updateConfig` MUST preserve the salt, persist the nonzero commitment of version `current_version + 1`, and emit that complete configuration.
+- **Config update version.** `updateConfig` MUST persist the nonzero commitment of version `current_version + 1` and emit that complete configuration.
 - **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -16,6 +16,8 @@ Configurable accounts can change who controls them and their configuration witho
 
 This TIP implements configurable accounts as native multisig accounts. Protocol identifiers, signatures, and ABI names use the term `multisig`.
 
+Accounts are counterfactual: their initial owner configuration derives the address without a creation transaction. Owner-authorized transactions carry the complete current configuration, and owner updates persist only one configuration commitment slot.
+
 ## Motivation
 
 A team should be able to change its members or control policy without replacing the account, and a lost or compromised key should not require moving assets to a new address.
@@ -26,17 +28,17 @@ Today, these needs typically require a contract wallet or external account abstr
 
 - T11 activates consensus acceptance and validation of multisig signatures, the native multisig precompile, and the signed key authorization changes together.
 - The existing Tempo transaction, key authorization, and sponsorship digests bind the fields documented by their respective TIPs. Multisig authorization inherits those digest guarantees and adds the account and configuration version bindings defined below.
-- Only protocol bootstrap and the native multisig precompile can modify multisig configuration storage.
+- Only the native multisig precompile can modify multisig configuration commitments.
 - Account keychain validation continues to enforce access-key expiry, scope, spending limits, and admin permissions. Multisig authorization does not weaken those restrictions.
 
 ## Threat Model
 
-- Transaction submitters are untrusted and may supply malformed, oversized, deeply nested, cyclic, duplicate, stale, or insufficient owner data. Decoding and validation limits MUST bound work before rejecting these transactions.
+- Transaction submitters are untrusted and may supply malformed, oversized, deeply nested, cyclic, duplicate, stale, or insufficient configuration witnesses and owner data. Decoding, transaction-size, and gas limits MUST bound work before rejecting these transactions.
 - Owners may be unavailable, compromised, or malicious. Only the current configuration's threshold is trusted; no individual owner receives authority beyond its configured weight.
 - Nested multisig owners are untrusted authorization principals. Nesting depth, ordering, membership, cycle, and per-node threshold checks prevent them from bypassing the parent configuration.
 - Access keys and fee payers are untrusted delegates, not owners. Access keys remain subject to account keychain restrictions and cannot update the owner configuration; fee sponsorship grants no account authority.
 - Attackers may choose salts, owner sets, and primitive keys while searching for address collisions. Reserved namespace outputs are rejected. Finding an EOA key and multisig input with the same 160-bit address, with generic work of approximately 2^80, is outside this TIP's security scope.
-- RPC simulators and transaction pools may use stale or incomplete configuration data. Their results are advisory; consensus validation MUST use the configuration and version at the transaction's block position, and pools MUST revalidate affected transactions after configuration changes.
+- RPC simulators and transaction pools may use stale configuration commitments. Their results are advisory; consensus validation MUST compare each witness with the commitment at the transaction's block position, and pools MUST revalidate affected transactions after configuration changes.
 
 ---
 
@@ -54,17 +56,20 @@ pub const MULTISIG_ACCOUNT_DOMAIN: &[u8] = b"tempo:multisig:account";
 /// Domain prefix for multisig account owner signatures.
 pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 
-/// Maximum owner count that leaves room for fresh nonce creation and transaction overhead.
+/// Domain prefix for persisted multisig configuration commitments.
+pub const MULTISIG_CONFIG_DOMAIN: &[u8] = b"tempo:multisig:config";
+
+/// Maximum owner count in one configuration witness.
 pub const MAX_MULTISIG_OWNERS: usize = 48;
 
 /// Maximum threshold for one account configuration.
 pub const MAX_MULTISIG_THRESHOLD: u8 = u8::MAX;
 
-/// Maximum number of owner signatures in one multisig account signature.
-pub const MAX_MULTISIG_SIGNATURES: usize = 8;
-
 /// Maximum number of multisig account signatures in one nested authorization path.
 pub const MAX_MULTISIG_NESTING_DEPTH: usize = 2;
+
+/// Maximum encoded byte length of one complete multisig signature, including nested signatures.
+pub const MAX_MULTISIG_SIGNATURE_BYTES: usize = 128 * 1024;
 
 /// Maximum encoded byte length of one primitive owner signature.
 pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize =
@@ -79,7 +84,7 @@ pub struct MultisigOwner {
     pub weight: u8,
 }
 
-/// Initial owner configuration used to derive and bootstrap an account.
+/// Initial owner configuration used to derive a counterfactual account.
 pub struct InitMultisig {
     /// Caller-chosen value that permits distinct accounts with otherwise identical configurations.
     pub salt: B256,
@@ -91,10 +96,22 @@ pub struct InitMultisig {
     pub owners: Vec<MultisigOwner>,
 }
 
+/// Current owner configuration carried by an account after its first update.
+pub struct MultisigConfig {
+    /// Nonzero configuration version.
+    pub version: u64,
+
+    /// Minimum total owner weight required for authorization.
+    pub threshold: u8,
+
+    /// Strictly ascending weighted owners.
+    pub owners: Vec<MultisigOwner>,
+}
+
 /// Signature payload for a multisig account.
 pub enum MultisigSignature {
-    /// Carries the initial configuration that derives the account.
-    Bootstrap {
+    /// Carries the initial configuration that derives a counterfactual account.
+    Initial {
         /// Initial owner configuration.
         init: InitMultisig,
 
@@ -102,10 +119,13 @@ pub enum MultisigSignature {
         signatures: Vec<TempoSignature>,
     },
 
-    /// Carries the account directly.
-    Initialized {
+    /// Carries an updated configuration whose commitment is stored for the account.
+    Current {
         /// Account authorized by the owner signatures.
         account: Address,
+
+        /// Complete current configuration witness.
+        config: MultisigConfig,
 
         /// Ordered primitive or nested multisig account owner signatures.
         signatures: Vec<TempoSignature>,
@@ -113,33 +133,37 @@ pub enum MultisigSignature {
 }
 ```
 
-An account may store up to 48 owners so a worst-case bootstrap, including complete validation of eight depth-2 registered-owner configurations and eight maximum-size WebAuthn signatures in each, fits within the transaction gas cap while leaving room for fresh nonce creation and transaction overhead. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound transaction size and recursive signature-verification work.
+Every multisig signature carries the complete configuration used to validate it. An initial witness contains the salt and version-0 configuration that derive a counterfactual account. After an owner update, a current witness contains the account and the complete nonzero-version configuration whose commitment is stored on-chain.
+
+An account may have up to 48 owners. A signature may contain up to one approval per configured owner instead of an independent fixed approval cap. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. Owner count, nesting depth, primitive signature length, transaction size, and recursively computed intrinsic gas together bound decoding and verification work. A recursively valid shape whose intrinsic gas exceeds the transaction gas limit MUST be rejected before cryptographic signature verification.
 
 Rules:
 
 - Configurations MUST contain 1 to 48 unique, nonzero, address-sorted owners. Weights MUST be nonzero and total at most 255.
 - A configuration MUST NOT include the multisig account itself as an owner.
-- Threshold MUST be nonzero and reachable by at most `MAX_MULTISIG_SIGNATURES` owners. Equivalently, it MUST NOT exceed the sum of the eight highest owner weights.
+- Threshold MUST be nonzero and MUST NOT exceed the sum of all owner weights.
+- Each multisig signature MUST contain 1 to the applicable witness's owner count in owner signatures.
 - Each owner signature MUST be a `TempoSignature::Primitive` or `TempoSignature::Multisig`.
+- The complete type-prefixed encoding of each multisig signature, including all nested signatures, MUST NOT exceed `MAX_MULTISIG_SIGNATURE_BYTES`.
 - Primitive owner signatures MUST NOT exceed `MAX_MULTISIG_OWNER_SIGNATURE_BYTES`; nested owner signatures are bounded recursively by the signature-count and nesting-depth limits.
 
 ## Signature Encoding
 
-Signature type `0x05` has two forms:
+Signature type `0x05` has two forms, both of which carry the complete applicable configuration:
 
-- **Bootstrap.** Used to establish a multisig account's initial configuration during its first transaction.
-- **Initialized.** Used after bootstrap, when authorization can use the account's stored configuration.
+- **Initial.** Used while the account has no persisted configuration commitment. The witness derives the counterfactual account and implicitly has version `0`.
+- **Current.** Used after an owner update has persisted a configuration commitment. The witness names the account and supplies the committed configuration.
 
 Rules:
 
 - Exactly 65 signature bytes MUST decode as secp256k1 regardless of the first byte. Type `0x05` MUST be considered only at other lengths.
 - Transactions carrying type `0x05` MUST be rejected before T11. Generic wire-format decoders MAY parse the type without hardfork context, but consensus validation MUST NOT accept it before T11.
-- `signatures` MUST contain 1 to `MAX_MULTISIG_SIGNATURES` owner signatures, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list before intrinsic gas is computed.
+- `signatures` MUST contain 1 to the witness's owner count, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list or a list longer than the owner count.
 - Decoders MUST reject malformed encodings, trailing fields, limit violations, and excessive nesting.
 
-### Bootstrap
+### Initial
 
-The bootstrap form establishes a multisig account during its first transaction. It can authorize the transaction directly or authorize an access key that signs that transaction.
+The initial form authorizes a counterfactual multisig account without creating configuration state. It remains valid across transactions until the account performs its first configuration update.
 
 ```text
 0x05 || rlp([init, signatures])
@@ -150,22 +174,25 @@ owner = rlp([owner, weight])
 
 Rules:
 
-- A bootstrap signature MUST use `0x05 || rlp([init, signatures])` and derive its account from `init`.
-- A top-level bootstrap MUST carry this encoding in either the outer signature or its key authorization signature, but not both.
+- An initial signature MUST use `0x05 || rlp([init, signatures])`, derive its account from `init`, and use configuration version `0`.
+- The account's persisted configuration commitment MUST be zero.
 
-### Initialized
+### Current
 
-The initialized form is used once the account configuration exists. It identifies the account so validation can authorize owner signatures against the current stored configuration.
+The current form is used after the first configuration update. It identifies the account and carries the complete configuration witness checked against its stored commitment.
 
 ```text
-0x05 || rlp([account, signatures])
+0x05 || rlp([account, config, signatures])
+
+config = rlp([version, threshold, owners])
+owner  = rlp([owner, weight])
 ```
 
 Rules:
 
-- An initialized signature MUST use `0x05 || rlp([account, signatures])`.
-- Nested owner signatures MUST use the initialized encoding.
-- Key authorization signatures MUST use initialized encoding unless the key authorization supplies `init` for a top-level bootstrap.
+- A current signature MUST use `0x05 || rlp([account, config, signatures])` with `config.version > 0`.
+- The stored commitment for `account` MUST be nonzero and equal the commitment of `config`.
+- Initial and current signatures MAY appear as nested owner or key authorization signatures when their respective commitment-state rules hold.
 
 ## Account Identity
 
@@ -182,11 +209,27 @@ multisig_address = address(keccak256(
 )[12:32])
 ```
 
+Owner updates persist a commitment to the complete new configuration:
+
+```text
+config_commitment = keccak256(
+  "tempo:multisig:config" ||
+  uint64(version) ||
+  uint8(threshold) ||
+  uint8(owners.len()) ||
+  owners[0].owner || uint8(owners[0].weight) ||
+  ...
+)
+```
+
 Rules:
 
 - Derivation MUST use the formula exactly: ASCII domain, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
+- Configuration commitments MUST use the formula exactly: ASCII domain, eight-byte big-endian version, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
 - The derived address MUST be nonzero and outside virtual, active-precompile, TIP-20, and ZonePortal namespaces.
 - Configuration updates MUST replace the current threshold and owners without changing the account address.
+- Version `0` MUST identify only the initial derived configuration and MUST NOT be persisted. Updated configurations MUST use monotonically increasing nonzero versions.
+- A configuration update whose commitment equals zero MUST revert with `InvalidConfig`; zero is reserved to mean that the account still uses its initial derived configuration.
 
 ## Authorization
 
@@ -205,20 +248,20 @@ The account binding prevents an owner signature from being reused for another mu
 
 Rules:
 
-- The digest MUST encode `config_version` as an eight-byte, big-endian integer. Bootstrap authorization MUST use version `0`; initialized authorization MUST use the current stored version.
+- The digest MUST encode `config_version` as an eight-byte, big-endian integer. Initial authorization MUST use version `0`; current authorization MUST use the version in the committed witness.
 - `inner_digest` MUST be `tx.signature_hash()` when direct or the parent's multisig account digest when nested.
 - Owner signatures MUST be owner-ordered, belong to the applicable configuration, and reach threshold on the final item.
 - Validation MUST reject missing quorum, duplicate or unsorted owners, cycles, and any owner signature submitted after quorum is reached.
-- Stateless recovery MUST validate the shape and return the claimed or derived account, without proving membership or quorum.
-- Stateful validation MUST complete before the account is treated as an authorized sender.
+- Stateless recovery MUST validate the shape and return the claimed or derived account, without proving commitment equality, membership, or quorum.
+- Stateful validation MUST compare the witness with the account's block-position commitment and complete quorum verification before the account is treated as authorized.
 
 ## Transaction Execution
 
-Bootstrap transactions establish account state before executing their call batch. Later transactions use the stored owner configuration and behave as ordinary Tempo transactions from that account.
+Multisig accounts are counterfactual: deriving or first using one does not create configuration storage. Every direct quorum authorization supplies the applicable configuration witness, while access-key transactions continue to use the account keychain without repeating the parent configuration.
 
-### Bootstrap
+### Initial Configuration
 
-A bootstrap transaction is the account's first transaction. It derives the account from its initial owner configuration and establishes that configuration before its calls execute, whether the quorum or a newly authorized access key signs the transaction.
+An account may use its initial derived configuration in any number of transactions while its persisted commitment remains zero.
 
 The example assumes `alice_address < bob_address`, each owner has weight 1, and the threshold is 2.
 
@@ -237,7 +280,7 @@ init = multisig_init(
 // Ref: Account Identity formula
 account = multisig_address
 
-// Build the account's first transaction.
+// Build a transaction from the counterfactual account.
 tx = transaction(
   from = account,
   calls = [...]
@@ -254,7 +297,7 @@ digest = multisig_digest(
 alice_signature = sign(alice_key, digest)
 bob_signature   = sign(bob_key, digest)
 
-// Attach the bootstrap signature containing the initial configuration.
+// Attach the initial signature containing the complete configuration.
 tx.signature =
   0x05 || rlp([
     init,
@@ -262,27 +305,23 @@ tx.signature =
   ])
 ```
 
-After validation, the account is available to the transaction's call batch. Initialization and nonce consumption are transaction-level effects rather than EVM call effects.
+Validation derives the sender, confirms that its commitment slot is zero, verifies the quorum, and executes the call batch. The transaction consumes its ordinary nonce but creates no multisig configuration state or initialization event.
 
 Rules:
 
-- Bootstrap MUST target the account derived from `init`, without an existing account header.
-- `init` MUST be carried by either the outer signature or `key_authorization.signature`.
-- When `key_authorization.signature` carries `init`, the outer V2 account keychain signature MUST use the key authorized by that same key authorization.
-- The target MUST have a zero protocol nonce.
-- Prior 2D or expiring-nonce activity MUST NOT affect bootstrap eligibility.
+- An initial signature MUST target the account derived from `init` and MUST be rejected when that account's commitment slot is nonzero.
+- When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
+- An initial transaction MUST NOT require a zero protocol nonce. Ordinary nonce validation and consumption apply.
 - The target MAY already have a balance or storage.
 - The target MUST have empty code and no EIP-7702 delegation.
-- When bootstrap validation succeeds, the protocol MUST store the header and owner rows, emit `MultisigInitialized(account)`, and consume the nonce. These effects MUST survive later call reverts.
-- Failed bootstrap validation MUST write no account state and consume no nonce.
-- `updateConfig` MUST reject same-transaction bootstrap accounts.
+- Successful initial authorization MUST NOT write multisig configuration state.
 
-### Initialized
+### Current Configuration
 
-An initialized transaction uses the account configuration at its block position to authorize the full call batch. Configuration updates are visible to later calls in the batch but do not change that transaction's authorization.
+A current transaction carries a nonzero-version configuration witness and uses the account's block-position commitment to authorize the full call batch.
 
 ```text
-// Build a transaction from the initialized account.
+// Build a transaction from an account that has updated its configuration.
 tx = transaction(
   from = account,
   calls = [...]
@@ -299,76 +338,55 @@ digest = multisig_digest(
 alice_signature = sign(alice_key, digest)
 bob_signature   = sign(bob_key, digest)
 
-// Attach the initialized signature containing the account address.
+// Attach the current signature containing the account and configuration witness.
 tx.signature =
   0x05 || rlp([
     account,
+    config,
     [alice_signature, bob_signature]
   ])
 ```
 
 Rules:
 
-- Direct transactions MUST use initialized encoding and the block-position owner configuration.
+- A current signature MUST be rejected when the account's commitment is zero or differs from the supplied configuration witness.
 - `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
-- Configuration updates MUST be immediately visible to later calls in the batch. If the batch succeeds, its final update MUST be stored and affect authorization only for later transactions.
-- Multisig accounts MUST have no EVM code or EIP-7702 delegation.
-- Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
-- Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-registry read. Address collisions with derived multisig accounts are outside this TIP's security scope.
-- Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-registry read.
+- At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics and affects authorization only for later transactions.
+- Each account authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
+- Authorization lists MUST reject bare multisig account signatures.
+- Primitive and keychain authorization-list signatures MUST remain stateless with respect to multisig configuration commitments. Address collisions with derived multisig accounts are outside this TIP's security scope.
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
-- Pools MAY index by stateless recovery but MUST revalidate affected authorizations after initialization or owner updates, including transactions that name a newly initialized account as `key_authorization.key_id`.
+- Pools MAY index by stateless recovery but MUST revalidate current signatures after the named account's commitment changes.
 
 ## Storage
 
-The multisig account precompile stores a compact header, ordered owner rows for enumeration, and direct owner-weight rows for authorization. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
+The multisig account precompile stores at most one configuration commitment per account. Full configurations remain in signatures and update events rather than persistent storage. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
 
 ```text
 mapping_slot(key, base) = keccak256(pad32(key) || pad32(base))
 
-header_slot(account) = mapping_slot(account, 0)
-owner_root(account)   = mapping_slot(account, 1)
-owner_slot(account, index) = mapping_slot(uint32(index), owner_root(account))
-weight_root(account)  = mapping_slot(account, 2)
-weight_slot(account, owner) = mapping_slot(owner, weight_root(account))
+config_slot(account) = mapping_slot(account, 0)
 
-storage[header_slot(account)] =
-  uint256(threshold) |
-  uint256(owner_count) << 8 |
-  uint256(config_version) << 16
-
-storage[owner_slot(account, index)] =
-  uint256(uint160(owner)) |
-  uint256(weight) << 160
-
-storage[weight_slot(account, owner)] = uint256(weight)
+storage[config_slot(account)] = config_commitment
 ```
 
 Rules:
 
-- The header, ordered owners, and direct weights MUST use mapping base slots `0`, `1`, and `2`, respectively, with the key order above.
-- Ordered owner rows MUST use zero-based `uint32` indices satisfying `0 <= index < owner_count`.
-- Unused bits in every stored word MUST be zero. A zero header word MUST mean uninitialized; a nonzero header with a zero threshold, zero owner count, zero version, nonzero unused bits, or out-of-range value MUST be rejected as `InvalidConfig`.
-- Bootstrap authorization MUST use version `0`, but bootstrap MUST store configuration version `1`. Every successful `updateConfig` MUST increment the stored version by one and MUST revert with `InvalidConfig` on `uint64` overflow.
-- Ordered owner rows and direct weight rows MUST encode the same configuration.
-- Replacing a configuration MUST clear stale ordered rows and direct owner-weight rows.
+- Mapping base slot `0` MUST hold the configuration commitment with the key order above. This TIP MUST NOT store owner arrays or direct owner-weight rows.
+- A zero slot means no configuration update has occurred. It does not prove that the address is not a counterfactual multisig account.
+- A nonzero slot MUST be interpreted only as the commitment of the complete current configuration supplied by signatures and update events.
+- Configuration commitment storage MUST never return to zero.
 
 ## Native Multisig Precompile
 
-A dedicated precompile exposes account derivation, detection, configuration reads, and owner updates:
+A dedicated precompile exposes account derivation, commitment reads, and owner updates:
 
 ```solidity
 interface INativeMultisig {
     struct MultisigOwner {
         address owner;
         uint8 weight;
-    }
-
-    struct MultisigConfig {
-        uint64 version;
-        uint8 threshold;
-        MultisigOwner[] owners;
     }
 
     /// Derives an account address from an initial configuration.
@@ -379,31 +397,25 @@ interface INativeMultisig {
         MultisigOwner[] calldata owners
     ) external pure returns (address account);
 
-    /// Returns whether account has a complete multisig account header.
-    /// Reverts with InvalidConfig for a partial header.
-    function isMultisigAccount(address account) external view returns (bool);
-
-    /// Returns account's current configuration.
-    /// Reverts with NotMultisigAccount or InvalidConfig.
-    function getConfig(
+    /// Returns the persisted configuration commitment, or zero before the first update.
+    function getConfigCommitment(
         address account
-    ) external view returns (MultisigConfig memory);
+    ) external view returns (bytes32 commitment);
 
-    /// Replaces msg.sender's current configuration.
+    /// Commits to msg.sender's next configuration.
     /// Requires direct current-quorum authorization and a top-level batch call.
     function updateConfig(
         uint8 threshold,
         MultisigOwner[] calldata owners
     ) external;
 
-    event MultisigInitialized(address indexed account);
     event MultisigConfigUpdated(
         address indexed account,
+        uint64 version,
         uint8 threshold,
         MultisigOwner[] owners
     );
 
-    error NotMultisigAccount();
     error InvalidAccount();
     error InvalidConfig();
     error InvalidThreshold();
@@ -412,9 +424,8 @@ interface INativeMultisig {
     error TooManyOwners();
     error DuplicateOwner();
     error InvalidOwnerOrder();
-    error AccountAlreadyInitialized();
     error UnauthorizedCaller();
-    error SameTransactionUpdateNotAllowed();
+    error MultipleConfigUpdates();
 }
 ```
 
@@ -423,28 +434,28 @@ Configuration updates are authorized by the account's current owner quorum.
 Rules:
 
 - The precompile MUST be deployed at `0xAACC000000000000000000000000000000000000` from T11.
-- `deriveAccount` MUST use the account identity formula above and enforce the same configuration and address constraints as bootstrap, without reading account state.
-- `isMultisigAccount` MUST revert with `InvalidConfig` for partial headers.
-- `getConfig` MUST return the current version, threshold, and owners or revert with `NotMultisigAccount` or `InvalidConfig`.
+- `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
+- `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST require a complete header and valid configuration, and reject same-transaction bootstrap accounts.
+- It MUST use the outer multisig authorization context's account and current version. Access-key authorization MUST NOT call it.
+- At most one `updateConfig` call MAY succeed per transaction; a later call MUST revert with `MultipleConfigUpdates`.
 - `updateConfig` MUST NOT accept a separate authorization signature.
+- `updateConfig` MUST increment the authorized configuration version by one, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
   - `InvalidOwner` for an empty owner list.
   - `TooManyOwners` above `MAX_MULTISIG_OWNERS`.
   - `InvalidThreshold` when the threshold is zero.
   - For each owner: `InvalidOwner` for the zero address or the multisig account itself, `InvalidWeight` for zero weight, `DuplicateOwner` when equal to the previous owner, or `InvalidOwnerOrder` when below it.
   - `InvalidWeight` when the weight sum overflows or exceeds `u8::MAX`.
-  - `InvalidThreshold` when the threshold exceeds the weight reachable from the eight highest-weight owners.
-- Address derivation and bootstrap MUST return `InvalidAccount` when the derived address is zero or reserved. Bootstrap MUST return `AccountAlreadyInitialized` when the account already has a complete header.
-- `getConfig` and `updateConfig` MUST return `NotMultisigAccount` for an absent header. `isMultisigAccount`, `getConfig`, and `updateConfig` MUST return `InvalidConfig` for a partial header.
-- `updateConfig` MUST return `UnauthorizedCaller` for an indirect call, `msg.sender != tx.origin`, or a nonzero keychain transaction key, and `SameTransactionUpdateNotAllowed` for an account bootstrapped in the same transaction.
+  - `InvalidThreshold` when the threshold exceeds the sum of all owner weights.
+- Address derivation MUST return `InvalidAccount` when the derived address is zero or reserved.
+- `updateConfig` MUST return `UnauthorizedCaller` for an indirect call, `msg.sender != tx.origin`, a nonzero keychain transaction key, or a transaction not directly authorized by the current owner quorum.
 
 ## Account Keychain
 
 ### Access Keys on Multisig Accounts
 
-A multisig account can delegate ordinary or admin authority through the existing account keychain. The owner quorum can register an access key directly or through transaction-level key authorization, including while bootstrapping the account.
+A multisig account can delegate ordinary or admin authority through the existing account keychain. The owner quorum can register an access key directly or through transaction-level key authorization while using either an initial or current configuration witness.
 
 The owner quorum authorizes a key authorization with this digest:
 
@@ -469,7 +480,7 @@ Rules:
 
 - Before T11, the field MUST decode as `PrimitiveSignature`; multisig and keychain signatures MUST be rejected.
 - At and after T11, the field MUST decode as `TempoSignature::Primitive` or `TempoSignature::Multisig`; `TempoSignature::Keychain` MUST be rejected.
-- Multisig signatures MUST follow the bootstrap and initialized context rules above.
+- Multisig signatures MUST follow the initial and current witness rules above.
 - Decoders MUST reject a list-valued signature field, malformed signature bytes, and trailing fields.
 
 An active access key for a multisig account uses the existing V2 account keychain envelope:
@@ -482,14 +493,14 @@ The access key signs the existing V2 account keychain digest, and the transactio
 
 Rules:
 
-- Quorums MAY add ordinary or admin access keys directly or via `key_authorization`, including at bootstrap; existing key rules MUST apply.
-- A registered multisig account MUST NOT be newly registered as an access key for another account. A pre-existing access-key row whose key ID later bootstraps as a multisig account cannot be exercised with a multisig signature and MAY remain stored.
+- Quorums MAY add ordinary or admin access keys directly or via `key_authorization`; existing key rules MUST apply.
+- A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
 - When a multisig account's owners authorize a key for that account, `key_authorization.account` MUST equal the multisig account address.
-- The multisig signature MUST carry the same address in initialized encoding or derive it from `init` in bootstrap encoding, and MUST use the digest above.
+- The multisig signature MUST carry the same address in current encoding or derive it from `init` in initial encoding, carry the complete applicable configuration, and use the digest above.
 - A multisig key authorization MUST complete stateful configuration and quorum validation and satisfy root, rather than delegated-admin, authorization.
-- A bootstrap key authorization MAY carry `init`; validation MUST establish the account and register the key atomically.
-- When the outer signature carries `init`, an accompanying key authorization signature MUST use initialized encoding and validate against that initial configuration.
-- Authorize-and-use MAY occur in one transaction, including bootstrap, when the outer signature uses the new key.
+- An initial key authorization MAY carry `init`; successful validation registers the key without persisting multisig configuration state.
+- When both the outer signature and `key_authorization.signature` are multisig signatures, each MUST independently carry and validate the applicable configuration witness.
+- Authorize-and-use MAY occur in one transaction when the outer signature uses the new key.
 - Access key transactions MUST use the V2 envelope, execute as the account under stored restrictions, and skip the parent quorum.
 - Access key transactions MUST reject a registered multisig parent with EVM code or EIP-7702 delegation.
 - Stateless TIP-1020 `recover` and `verify` MUST reject bare multisig account signatures.
@@ -501,13 +512,15 @@ Rules:
 Multisig account authorization is charged as regular intrinsic gas. Costs scale with submitted owner signatures and nested account nodes:
 
 ```text
+witness_bytes(signature) =
+  initial: rlp(init)
+  current: rlp([account, config])
+
 node(signature) =
     2,100
+  + calldata_gas(witness_bytes(signature))
   + 2,100 * signature.signatures.len()
   + sum(full_primitive_cost(owner) or 2,600 + node(nested_owner))
-
-registered_config_validation(config) =
-  4,200 * config.owners.len()
 
 full_primitive_cost(signature) =
   secp256k1: 3,000
@@ -516,76 +529,73 @@ full_primitive_cost(signature) =
 
 direct_multisig_surcharge =
   node(outer_signature)
-  + sum(registered_config_validation(config) for each registered node)
   - 3,000
 
 key_authorization_multisig_surcharge =
   node(key_authorization.signature)
-  + sum(registered_config_validation(config) for each registered node)
 
-registry_gating_surcharge =
-  gas consumed by required multisig-registry reads for:
-  - each newly authorized access-key ID
-  - a keychain caller with code or delegation
-
-bootstrap_storage(config) =
-    active_sstore_set(warm_header)
-  + 2 * config.owners.len() * active_sstore_set(cold_slot)
-  + 2 * warm_storage_read_cost
-  + 375 + 2 * 375
+first_config_update_storage = active_sstore_set(warm_config_slot)
+later_config_update_storage = active_sstore_reset(warm_config_slot)
 ```
 
-Each registered configuration is validated by reading every ordered owner row and direct weight row before its threshold and version are used. The validation term charges those two reads per configured owner. Bootstrap nodes carry their configuration inline and do not add this term.
+The leading 2,100 gas charges the cold configuration-commitment read for each multisig node. Witness bytes are charged using the ordinary zero/nonzero calldata schedule even though they are encoded in the signature field. The per-signature term charges owner matching and quorum processing; there are no owner-row storage reads.
 
 Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 
-The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A registered 1-of-1 secp256k1 multisig account therefore adds 8,400 gas; a registered 2-of-2 adds 17,700 gas.
+The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 node costs 39,900 gas plus its configuration-witness data gas.
 
 When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
 
-Bootstrap also creates one packed header, one ordered row per owner, and one direct weight row per owner. The header is warm after the registration check; the newly created owner rows and direct weight rows are charged as cold. Bootstrap additionally charges the repeated warm header read, the warm transient bootstrap guard write, and the exact LOG2/no-data cost of `MultisigInitialized`.
+Initial use creates no multisig storage and has no storage surcharge. Signature validation warms the commitment slot, so the first owner update pays one warm zero-to-nonzero write and later updates pay one warm nonzero-to-nonzero write under the active precompile storage schedule. Update event data is charged by ordinary precompile execution gas.
 
-Registry gating checks a newly authorized access-key ID because that address does not sign. It also checks a keychain caller with code or delegation to enforce the multisig no-code invariant. Explicit fee payers and primitive authorization-list authorities are recovered directly from primitive signatures and do not require registry reads under this TIP's address-collision assumption. Keychain-signed authorization-list entries remain skipped under existing Tempo rules and also require no registry read. Successful checks use the active precompile storage schedule, including warm pricing when a prior check read the same header.
+Under the gas schedule active when this TIP was drafted, representative 8-of-48 authorization costs before executed calls are:
+
+| Case | Current owner-row design | Stateless commitment design | Savings |
+| --- | ---: | ---: | ---: |
+| 8 secp256k1 approvals | ~24.5M gas | ~79k gas | ~310x |
+| 8 WebAuthn approvals | ~24.6M-24.8M gas | ~119k-365k gas | ~68x-207x |
+
+The witness column includes the 21,000 base transaction cost and approximately 18,000 gas for a 48-owner witness. Counterfactual creation itself costs zero gas. A first configuration update adds approximately 250,100 gas for one new commitment slot; later updates add approximately 5,000 gas for one warm nonzero-to-nonzero write. These figures are informative and change with the active storage or calldata schedule; the formulas above are normative.
 
 Rules:
 
 - Intrinsic gas MUST use the formulas above.
 - Non-subblock transactions MUST validate fee affordability before verifying multisig owner approvals.
-- State-dependent intrinsic gas MUST be computed from registry headers and checked against `gas_limit` before complete configuration loading or owner-signature verification.
-- Every registered multisig account node MUST add `registered_config_validation` for its complete stored configuration, including nested nodes and RPC simulation.
+- Recursive intrinsic gas MUST be fully computed and checked against `gas_limit` before cryptographic owner-signature verification, including for nested nodes and RPC simulation.
 - A multisig key authorization MUST add `key_authorization_multisig_surcharge` independently of any outer multisig surcharge.
 - The 3,000 gas subtraction MUST apply once at the outer account node, never to nested nodes or key authorization sidecars.
 - Direct multisig authorization MUST NOT add the account keychain's 900 gas processing buffer.
-- Bootstrap MUST charge one warm header SSTORE and `2 * owners.len()` cold SSTOREs, including the active TIP-1060 creditable portion, plus its warm header read, transient guard write, and `MultisigInitialized` event.
-- State-dependent role restrictions MUST add `registry_gating_surcharge` to intrinsic gas.
-- Precompile reads and updates MUST use the active precompile storage schedule.
+- Every initial and current node MUST charge its exact witness bytes once. WebAuthn data gas MUST continue to be charged only by `full_primitive_cost`.
+- Initial authorization MUST NOT charge any configuration-storage write.
+- `updateConfig` MUST charge exactly one warm configuration-slot write plus its event and normal precompile execution costs.
+- Commitment reads and updates MUST use the active precompile storage schedule.
 
 ## Tooling
 
-Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, signing, transaction decoding, and configuration history.
+Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, witness construction, signing, transaction decoding, and configuration history.
 
 Rules:
 
-- Tooling MUST support the T11 signature encodings, signed key authorization shape, current configuration version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
+- Tooling MUST support the T11 initial and current witness encodings, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
 
 ## Observability
 
-Bootstrap transaction signatures and owner-update events expose enough data to reconstruct an account's configuration history.
+Initial signatures and owner-update events expose enough data to reconstruct an account's configuration history without storing owner rows on-chain.
 
 Rules:
 
-- Reconstructing the initial configuration MUST decode `init` from the transaction's outer or key authorization bootstrap signature.
-- A successful owner update MUST emit `MultisigConfigUpdated(account, threshold, owners)`.
-- The initial stored configuration version is `1`; each successful owner-update event increments the reconstructed version by one. Bootstrap approvals use version `0` only.
+- Reconstructing the initial configuration MUST decode `init` from an initial outer or key authorization signature.
+- A successful owner update MUST emit `MultisigConfigUpdated(account, version, threshold, owners)`.
+- The initial configuration uses version `0`; the first owner-update event uses version `1`, and each later event increments it by one.
 - Account keychain paths MUST retain their existing events.
 
 ## Examples
 
 These examples illustrate the canonical signing flows and main authorization edge cases. They add no normative rules.
 
-### Bootstrap
+### Initial Configuration
 
-A bootstrap transaction creates the multisig account and stores its initial owner configuration. Its signature carries `init` because no configuration exists in state yet.
+An initial transaction carries `init`, derives its counterfactual account, and creates no multisig configuration storage.
 
 ```text
 // Define and derive the account with alice_address < bob_address.
@@ -602,7 +612,7 @@ init = multisig_init(
 // Ref: Account Identity formula
 account = multisig_address
 
-// Build the account's first transaction.
+// Build a transaction from the counterfactual account.
 tx = transaction(
   from = account,
   calls = [...]
@@ -628,12 +638,12 @@ tx.signature =
 execute(tx)
 ```
 
-### Initialized
+### Current Configuration
 
-An initialized transaction uses the configuration already stored for the account. Its signature carries the account address instead of `init` so validation can load the current owners and threshold.
+A current transaction supplies the complete configuration whose commitment is stored for the account.
 
 ```text
-// Build a later transaction from the initialized account.
+// Build a transaction after an owner update.
 tx = transaction(
   from = account,
   calls = [...]
@@ -650,6 +660,7 @@ digest = multisig_digest(
 tx.signature =
   0x05 || rlp([
     account,
+    config,
     [
       sign(alice_key, digest),
       sign(bob_key, digest)
@@ -661,7 +672,7 @@ execute(tx)
 
 ### Nested Ownership
 
-Each multisig account wraps the digest approved by its parent. This example uses an initialized multisig account as an owner of another initialized multisig account.
+Each multisig account wraps the digest approved by its parent and carries its own witness. This example uses current configurations for both accounts.
 
 ```text
 // Build a transaction from the parent multisig account.
@@ -692,6 +703,7 @@ bob_signature   = sign(bob_key, child_digest)
 child_owner_signature =
   0x05 || rlp([
     child_account,
+    child_config,
     [alice_signature, bob_signature]
   ])
 
@@ -699,6 +711,7 @@ child_owner_signature =
 tx.signature =
   0x05 || rlp([
     parent_account,
+    parent_config,
     [child_owner_signature]
   ])
 
@@ -733,6 +746,7 @@ bob_signature   = sign(bob_key, digest)
 tx.signature =
   0x05 || rlp([
     account,
+    config,
     [alice_signature, bob_signature]
   ])
 
@@ -770,6 +784,7 @@ bob_signature   = sign(bob_key, digest)
 tx.signature =
   0x05 || rlp([
     account,
+    config,
     [alice_signature, bob_signature]
   ])
 ```
@@ -806,9 +821,9 @@ signatures = [bob_signature, carol_signature]
 signatures = [alice_signature, bob_signature, carol_signature]
 ```
 
-### Bootstrap and Immediate Access Key Use
+### Initial Configuration and Immediate Access Key Use
 
-This transaction initializes the multisig account and registers an access key at the same time. The owner quorum signs the key authorization, and the new access key signs the transaction.
+This transaction uses the counterfactual account and registers an access key at the same time. The owner quorum signs the key authorization, and the new access key signs the transaction.
 
 ```text
 // Define and derive the new multisig account.
@@ -850,7 +865,7 @@ key_authorization_signature =
     ]
   ])
 
-// Include the signed key authorization in the bootstrap transaction.
+// Include the signed key authorization in the initial transaction.
 tx = transaction(
   from = account,
   calls = [...],
@@ -875,11 +890,11 @@ tx.signature =
 execute(tx)
 ```
 
-Validation establishes the account from `init`, registers the access key, and executes the same transaction as `account` under the key's restrictions.
+Validation derives the account from `init`, registers the access key, and executes the same transaction as `account` under the key's restrictions without persisting a multisig configuration commitment.
 
-### Bootstrap and Subsequent Access Key Use
+### Initial Configuration and Subsequent Access Key Use
 
-The owner quorum can initialize the account and register an access key without using that key for the bootstrap transaction. The access key can then authorize a subsequent transaction.
+The owner quorum can use the initial configuration to register an access key without using that key for the same transaction. The access key can then authorize a subsequent transaction.
 
 ```text
 // Define and derive the new multisig account.
@@ -912,17 +927,17 @@ key_authorization_digest = multisig_digest(
   0
 )
 
-// The outer bootstrap supplies init, so this signature uses initialized encoding.
+// The key authorization independently carries the initial witness.
 key_authorization_signature =
   0x05 || rlp([
-    account,
+    init,
     [
       sign(alice_key, key_authorization_digest),
       sign(bob_key, key_authorization_digest)
     ]
   ])
 
-bootstrap_tx = transaction(
+initial_tx = transaction(
   from = account,
   calls = [...],
   // Ref: Signed Key Authorization Encoding
@@ -932,24 +947,24 @@ bootstrap_tx = transaction(
   )
 )
 
-// The owner quorum authorizes the bootstrap transaction.
+// The owner quorum independently carries the same initial witness.
 // Ref: Authorization formula
-bootstrap_digest = multisig_digest(
-  bootstrap_tx.signature_hash(),
+initial_digest = multisig_digest(
+  initial_tx.signature_hash(),
   account,
   0
 )
 
-bootstrap_tx.signature =
+initial_tx.signature =
   0x05 || rlp([
     init,
     [
-      sign(alice_key, bootstrap_digest),
-      sign(bob_key, bootstrap_digest)
+      sign(alice_key, initial_digest),
+      sign(bob_key, initial_digest)
     ]
   ])
 
-execute(bootstrap_tx)
+execute(initial_tx)
 
 // The registered access key authorizes a later transaction.
 access_key_tx = transaction(
@@ -970,7 +985,7 @@ access_key_tx.signature =
 execute(access_key_tx)
 ```
 
-The bootstrap transaction initializes the account and registers the access key. The later transaction executes as `account` under the key's stored restrictions without another owner quorum.
+The initial transaction registers the access key without writing a multisig commitment. The later transaction executes as `account` under the key's stored restrictions without another owner quorum.
 
 ### Configuration Rotation
 
@@ -991,18 +1006,17 @@ rotate_tx = transaction(
   ]
 )
 
-// The current owners authorize the update.
+// The initial owners authorize the first update with version 0.
 // Ref: Authorization formula
-current_version = getConfig(account).version
 rotate_digest = multisig_digest(
   rotate_tx.signature_hash(),
   account,
-  current_version
+  0
 )
 
 rotate_tx.signature =
   0x05 || rlp([
-    account,
+    init,
     [
       sign(alice_key, rotate_digest),
       sign(bob_key, rotate_digest)
@@ -1011,6 +1025,14 @@ rotate_tx.signature =
 
 execute(rotate_tx)
 
+next_config = multisig_config(
+  version = 1,
+  threshold = 1,
+  owners = [[carol_address, 1]]
+)
+
+require getConfigCommitment(account) == commitment(next_config)
+
 // The next transaction uses Carol and keeps the same account address.
 next_tx = transaction(
   from = account,
@@ -1018,7 +1040,6 @@ next_tx = transaction(
 )
 
 // Ref: Authorization formula
-next_config = getConfig(account)
 next_digest = multisig_digest(
   next_tx.signature_hash(),
   account,
@@ -1028,42 +1049,43 @@ next_digest = multisig_digest(
 next_tx.signature =
   0x05 || rlp([
     account,
+    next_config,
     [sign(carol_key, next_digest)]
   ])
 ```
 
 ## Backwards Compatibility
 
-This change is additive for transactions and accounts that do not use registered multisig accounts. Applications can move assets or state from an existing EOA through their current flows.
+This change is additive for transactions and accounts that do not use multisig signatures. Applications can move assets or state from an existing EOA through their current flows.
 
-Registration also affects transactions that name a multisig account as a newly authorized access key. That role gains state-dependent intrinsic gas and is rejected by this TIP. Primitive-signed fee payers and authorization-list authorities remain stateless under the address-collision assumption, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
+Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless with respect to multisig commitments under the address-collision assumption. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
 
 Rules:
 
 - This TIP MUST NOT add or reorder transaction fields.
 - Transactions that do not use multisig accounts MUST remain byte-identical.
-- An address with a nonzero protocol nonce, EVM code, or EIP-7702 delegation MUST NOT bootstrap.
+- Direct and nested multisig authorization MUST require empty EVM code and no EIP-7702 delegation at the authorized account. Balance, storage, and prior nonce use MUST NOT prevent initial configuration authorization.
 
 ## Invariants
 
 Rules:
 
-- **Stable identity.** Bootstrap MUST satisfy `tx.from == multisig_address`. `updateConfig` MUST NOT change the address.
-- **Bootstrap exclusivity.** When a multisig account signature authorizes a caller without a header, the transaction MUST carry exactly one bootstrap signature as its outer or key authorization signature. Transactions that do not use multisig account authorization do not require bootstrap. After a header exists for that account, bootstrap signatures MUST be rejected.
-- **Bootstrap eligibility.** Bootstrap MUST require no header, a zero protocol nonce, empty code, and no delegation. Balance and storage MUST NOT block it.
+- **Stable identity.** Initial authorization MUST satisfy `tx.from == multisig_address`. `updateConfig` MUST NOT change the address.
+- **Witness selection.** A zero commitment MUST accept only the derived initial witness; a nonzero commitment MUST accept only a matching current witness.
 - **Configuration validity.** Configurations MUST satisfy all owner, weight, total-weight, and threshold limits above, and MUST NOT include their own account as an owner.
-- **Marker consistency.** An initialized header MUST have complete matching ordered owner and direct weight rows.
-- **No account code.** A multisig account MUST NOT have EVM bytecode or EIP-7702 delegation code.
-- **Owner signatures.** Owner signatures MUST be primitive over the current digest or nested with the parent digest as `inner_digest`, without `init`. Keychain signatures MUST NOT be accepted as owner signatures.
+- **Single-slot state.** Multisig configuration storage MUST contain only the current nonzero commitment and MUST NOT persist owner rows.
+- **No account code.** An account directly or recursively authorized by a multisig signature MUST NOT have EVM bytecode or EIP-7702 delegation code at validation time.
+- **Owner signatures.** Owner signatures MUST be primitive over the current digest or nested with the parent digest as `inner_digest`. Every nested multisig signature MUST carry and validate its own initial or current witness. Keychain signatures MUST NOT be accepted as owner signatures.
 - **Owner set membership.** Recovered or nested owner addresses MUST be sorted and belong to the applicable owner configuration.
 - **Threshold enforcement.** Current owner weights MUST reach threshold on the final owner signature, not before.
-- **Current-state authorization.** Initialized authorization MUST use the owner configuration and version at its block position.
+- **Current-state authorization.** Current authorization MUST match the configuration commitment at its block position.
 - **Multisig account sender.** Direct quorum transactions MUST use `TempoSignature::Multisig` as the outer signature.
-- **Signature contexts.** Multisig signatures MUST be outer, nested owner, or key authorization signatures. Bootstrap MUST be outer or authorize the outer access key.
-- **Key authorization.** Transactions MAY carry `key_authorization`, including at bootstrap. Its signature MUST use bootstrap encoding only when it supplies `init`; otherwise it MUST use initialized encoding.
-- **Account keychain access.** Multisig accounts MAY own access keys. A registered multisig account MUST NOT be newly registered as an access key for another account, and multisig signatures MUST NOT authorize keychain access. Access keys MUST NOT replace parent owner sets.
-- **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-registry read.
+- **Signature contexts.** Multisig signatures MUST be outer, nested owner, or key authorization signatures.
+- **Key authorization.** Transactions MAY carry `key_authorization`. A multisig key authorization MUST independently carry an initial or current witness and match `key_authorization.account`.
+- **Account keychain access.** Multisig accounts MAY own access keys, but multisig signatures MUST NOT authorize keychain access and access keys MUST NOT replace parent owner sets.
+- **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-commitment read.
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
-- **Config update identity.** `updateConfig` MUST require a complete multisig account header for `msg.sender`.
-- **Config update bootstrap exclusion.** `updateConfig` MUST reject accounts initialized earlier in the same transaction.
+- **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
+- **Config update count.** At most one `updateConfig` call MAY succeed per transaction.
+- **Config update version.** `updateConfig` MUST persist the nonzero commitment of version `current_version + 1` and emit that complete configuration.
 - **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -36,7 +36,7 @@ Today, these needs typically require a contract wallet or external account abstr
 - Nested multisig owners are untrusted authorization principals. Nesting depth, ordering, membership, cycle, and per-node threshold checks prevent them from bypassing the parent configuration.
 - Access keys and fee payers are untrusted delegates, not owners. Access keys remain subject to account keychain restrictions and cannot update the owner configuration; fee sponsorship grants no account authority.
 - Attackers may choose salts, owner sets, and primitive keys while searching for address collisions. Reserved namespace outputs are rejected. Finding an EOA key and multisig input with the same 160-bit address, with generic work of approximately 2^80, is outside this TIP's security scope.
-- RPC simulators and transaction pools may use stale or incomplete configuration data. Their results are advisory; consensus validation MUST compare each witness with the commitment at the transaction's block position, and pools MUST revalidate affected transactions after configuration changes.
+- RPC simulators and transaction pools may use stale or incomplete configuration data. Their results are advisory; consensus validation MUST compare each witness with the commitment at the transaction's block position.
 
 ---
 
@@ -216,7 +216,7 @@ Rules:
 - Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
-- Pools MAY index by stateless recovery but MUST revalidate affected transactions whenever an account's commitment changes, including transactions carrying an initial or current signature for that account and transactions naming it as `key_authorization.key_id`. Pools MUST repeat that revalidation after reorgs.
+- Pools MUST revalidate transactions carrying an initial or current signature for an account, or naming it as `key_authorization.key_id`, whenever that account's commitment changes, including after reorgs.
 
 ## Storage
 
@@ -295,7 +295,7 @@ Rules:
 - `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
 - `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST use the outer multisig authorization context's account and salt. Each successful call MUST increment the latest non-reverted configuration version in the transaction, starting from the authorized witness version. Access-key authorization MUST NOT call it.
+- It MUST use the outer multisig authorization context's account and salt. Each successful call MUST increment the latest non-reverted configuration version in the transaction, starting from the authorized witness version.
 - `updateConfig` MUST NOT accept a separate authorization signature.
 - Each successful `updateConfig` MUST revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
@@ -351,15 +351,14 @@ The access key signs the existing V2 account keychain digest, and the transactio
 Rules:
 
 - Quorums MAY add ordinary or admin access keys directly or via `key_authorization`, including during initial authorization; existing key rules MUST apply.
-- A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
 - An account with a nonzero multisig commitment MUST NOT be newly registered as an access key for another account.
 - A multisig key authorization signature MUST set its account to `key_authorization.account`, carry the complete applicable configuration, and use the digest above.
-- A multisig key authorization MUST complete stateful witness and quorum verification before satisfying root authorization and MUST NOT use the admin-delegated signer path.
+- A multisig key authorization MUST complete stateful configuration and quorum validation and satisfy root, rather than delegated-admin, authorization.
 - A version-0 key authorization MAY register the key without persisting multisig configuration state.
 - When both the outer signature and `key_authorization.signature` are multisig signatures, each MUST independently carry and validate the applicable configuration witness.
 - Authorize-and-use MAY occur in one transaction, including during initial authorization, when the outer signature uses the new key.
 - Access key transactions MUST use the V2 envelope, execute as the account under stored restrictions, and skip the parent quorum.
-- If the parent account in an access-key transaction has code or delegation, validation MUST read its multisig commitment and reject a nonzero value.
+- Access key transactions MUST reject a parent with a nonzero multisig commitment and EVM code or EIP-7702 delegation.
 - Stateless TIP-1020 `recover` and `verify` MUST reject bare multisig account signatures.
 - Access keys MUST NOT call `updateConfig` for their parent.
 - Only a direct multisig account signature with a zero keychain transaction key MAY replace the parent's owner set.
@@ -425,7 +424,7 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 Rules:
 
 - Tooling MUST support the T11 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
-- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept an RPC-only recursive witness containing every account configuration and, for each approved owner, either a primitive signature type and variable-length data or a nested witness. The witness MUST NOT alter signed transaction encoding.
+- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept recursive configuration witnesses without altering signed transaction encoding.
 - Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas; only cryptographic owner-signature verification MAY be skipped.
 
 ## Observability

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -57,7 +57,7 @@ pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 /// Domain prefix for persisted multisig configuration commitments.
 pub const MULTISIG_CONFIG_DOMAIN: &[u8] = b"tempo:multisig:config";
 
-/// Maximum owner count that leaves room for fresh nonce creation and transaction overhead.
+/// Maximum owner count under transaction gas and pool byte limits.
 pub const MAX_MULTISIG_OWNERS: usize = 48;
 
 /// Maximum threshold for one account configuration.
@@ -70,8 +70,7 @@ pub const MAX_MULTISIG_SIGNATURES: usize = 8;
 pub const MAX_MULTISIG_NESTING_DEPTH: usize = 2;
 
 /// Maximum encoded byte length of one primitive owner signature.
-pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize =
-    1 + MAX_WEBAUTHN_SIGNATURE_LENGTH;
+pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 768;
 
 /// Weighted owner in an account configuration.
 pub struct MultisigOwner {
@@ -110,7 +109,7 @@ pub struct MultisigSignature {
 }
 ```
 
-An account may have up to 48 owners so a worst-case initial authorization, including complete validation of eight depth-2 nested-owner configuration witnesses and eight maximum-size WebAuthn signatures in each, fits within the transaction gas cap while leaving room for fresh nonce creation and transaction overhead. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound transaction size and recursive signature-verification work.
+An account may have up to 48 owners so a worst-case initial authorization, including complete validation of eight depth-2 nested-owner configuration witnesses and eight maximum-size WebAuthn signatures in each, fits within the transaction gas cap while leaving room for fresh nonce creation and transaction overhead. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound multisig authorization size and recursive signature-verification work. The primitive byte limit also keeps an otherwise minimal transaction carrying maximum outer and key-authorization trees below Tempo's default transaction-pool byte limit.
 
 Rules:
 
@@ -211,14 +210,13 @@ Rules:
 
 - `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
 - An initial transaction MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; balance and storage MUST NOT prevent authorization.
-- When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
 - A successful `updateConfig` write follows ordinary call-batch revert semantics, is visible to later calls in the batch, and affects authorization only for later transactions.
 - Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
 - Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-commitment read. Address collisions with derived multisig accounts are outside this TIP's security scope.
 - Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
-- Pools MAY index by stateless recovery but MUST revalidate affected initial and current signatures whenever the account's commitment changes, including after reorgs.
+- Pools MAY index by stateless recovery but MUST revalidate affected transactions whenever an account's commitment changes, including transactions carrying an initial or current signature for that account and transactions naming it as `key_authorization.key_id`. Pools MUST repeat that revalidation after reorgs.
 
 ## Storage
 
@@ -297,7 +295,7 @@ Rules:
 - `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
 - `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST use the outer multisig authorization context's account and salt. The first successful call MUST increment the authorized witness version; each later successful call in the transaction MUST increment the version written by the preceding call. Access-key authorization MUST NOT call it.
+- It MUST use the outer multisig authorization context's account and salt. Each successful call MUST increment the latest non-reverted configuration version in the transaction, starting from the authorized witness version. Access-key authorization MUST NOT call it.
 - `updateConfig` MUST NOT accept a separate authorization signature.
 - Each successful `updateConfig` MUST revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
@@ -353,17 +351,19 @@ The access key signs the existing V2 account keychain digest, and the transactio
 Rules:
 
 - Quorums MAY add ordinary or admin access keys directly or via `key_authorization`, including during initial authorization; existing key rules MUST apply.
-- A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
+- A multisig signature MUST NOT be accepted as an account-keychain access-key signature. An existing access key recovered from a primitive signature MUST NOT require a commitment read for the key ID under the address-collision assumption.
+- An account with a nonzero multisig commitment MUST NOT be newly registered as an access key for another account. A pre-existing access-key row whose key ID later acquires a nonzero commitment cannot be exercised with a multisig signature and MAY remain stored.
 - A multisig key authorization signature MUST set its account to `key_authorization.account`, carry the complete applicable configuration, and use the digest above.
-- A multisig key authorization MUST complete stateful configuration and quorum validation and satisfy root, rather than delegated-admin, authorization.
+- A multisig key authorization MUST complete stateful witness and quorum verification before satisfying root authorization and MUST NOT use the admin-delegated signer path.
 - A version-0 key authorization MAY register the key without persisting multisig configuration state.
 - When both the outer signature and `key_authorization.signature` are multisig signatures, each MUST independently carry and validate the applicable configuration witness.
 - Authorize-and-use MAY occur in one transaction, including during initial authorization, when the outer signature uses the new key.
 - Access key transactions MUST use the V2 envelope, execute as the account under stored restrictions, and skip the parent quorum.
-- Access key transactions MUST reject a registered multisig parent with EVM code or EIP-7702 delegation.
+- If the parent account in an access-key transaction has code or delegation, validation MUST read its multisig commitment and reject a nonzero value.
 - Stateless TIP-1020 `recover` and `verify` MUST reject bare multisig account signatures.
 - Access keys MUST NOT call `updateConfig` for their parent.
 - Only a direct multisig account signature with a zero keychain transaction key MAY replace the parent's owner set.
+- Configuration updates MUST NOT modify or revoke existing access keys.
 
 ## Gas
 
@@ -390,8 +390,10 @@ direct_multisig_surcharge =
 key_authorization_multisig_surcharge =
   node(key_authorization.signature)
 
-first_config_update_storage = active_sstore_set(warm_config_slot)
-later_config_update_storage = active_sstore_reset(warm_config_slot)
+commitment_gating_surcharge =
+  gas consumed by required multisig-commitment reads for:
+  - each newly authorized access-key ID
+  - a keychain caller with code or delegation
 ```
 
 Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus witness calldata and owner-processing costs. There are no owner-row storage reads.
@@ -402,7 +404,9 @@ The direct subtraction accounts for the secp256k1 transaction signature already 
 
 When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
 
-Initial use writes no multisig state. The first update pays a warm zero-to-nonzero commitment write; later updates pay a warm nonzero-to-nonzero write.
+Commitment gating checks newly authorized access-key IDs because they do not sign. It also checks a keychain caller with code or delegation to enforce the multisig no-code invariant. These reads use the active precompile storage schedule, including warm pricing when a prior check read the same slot.
+
+Initial use writes no multisig state. Configuration updates use the active warm SSTORE schedule for the slot's transaction-original and current values.
 
 Rules:
 
@@ -414,6 +418,7 @@ Rules:
 - Direct multisig authorization MUST NOT add the account keychain's 900 gas processing buffer.
 - Every initial and current node MUST charge its exact witness bytes once. WebAuthn data gas MUST continue to be charged only by `full_primitive_cost`.
 - Initial authorization MUST NOT charge any configuration-storage write.
+- State-dependent role restrictions MUST add `commitment_gating_surcharge` to intrinsic gas.
 - `updateConfig` MUST charge exactly one warm configuration-slot write under the active precompile storage schedule, plus its event and normal precompile execution costs.
 
 ## Tooling
@@ -423,7 +428,7 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 Rules:
 
 - Tooling MUST support the T11 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
-- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept an RPC-only recursive witness containing every account configuration and, for each approved owner, either a primitive signature type and variable-length data or a nested witness. The witness MUST NOT alter signed transaction encoding.
+- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept an RPC-only recursive witness containing every account configuration and, for each approved owner, either a primitive signature type and variable-length data or a nested witness. The witness MUST be accepted only under `ExecutionContext::Simulation`, MUST NOT alter signed transaction encoding, and MUST NOT be consulted during transaction execution.
 - Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas; only cryptographic owner-signature verification MAY be skipped.
 
 ## Observability
@@ -910,13 +915,12 @@ next_tx.signature =
 
 ## Backwards Compatibility
 
-Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless under the address-collision assumption, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
+Newly authorized access-key IDs require a commitment read because they do not sign. Existing-key validation requires one only when the parent has code or delegation. Primitive-signed fee payers and authorization-list authorities remain stateless under the address-collision assumption, while keychain-signed authorization-list entries retain their existing skipped behavior. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
 
 Rules:
 
 - This TIP MUST NOT add or reorder transaction fields.
 - Transactions that do not use multisig accounts MUST remain byte-identical.
-- Direct and nested multisig authorization MUST require empty EVM code and no EIP-7702 delegation at the authorized account. Balance, storage, and prior nonce use MUST NOT prevent initial configuration authorization.
 
 ## Invariants
 
@@ -938,5 +942,4 @@ Rules:
 - **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-commitment read.
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
 - **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
-- **Config update version.** `updateConfig` MUST persist the nonzero commitment of version `current_version + 1` and emit that complete configuration.
 - **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -247,6 +247,13 @@ interface INativeMultisig {
         uint8 weight;
     }
 
+    struct MultisigConfig {
+        bytes32 salt;
+        uint64 version;
+        uint8 threshold;
+        MultisigOwner[] owners;
+    }
+
     /// Derives an account address from an initial configuration.
     /// Reverts when the configuration or derived address is invalid.
     function deriveAccount(
@@ -260,9 +267,10 @@ interface INativeMultisig {
         address account
     ) external view returns (bytes32 commitment);
 
-    /// Commits to msg.sender's next configuration.
+    /// Commits to msg.sender's next configuration after proving its current configuration.
     /// Requires direct owner-quorum authorization and a top-level batch call.
     function updateConfig(
+        MultisigConfig calldata current,
         uint8 threshold,
         MultisigOwner[] calldata owners
     ) external;
@@ -295,7 +303,8 @@ Rules:
 - `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
 - `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST use the outer multisig authorization context's account and salt. Each successful call MUST increment the latest non-reverted configuration version in the transaction, starting from the authorized witness version.
+- When `current.version == 0`, `current` MUST derive `msg.sender` and its commitment slot MUST be zero. Otherwise, its commitment MUST match the slot at call time.
+- The new configuration MUST preserve `current.salt` and use `current.version + 1`.
 - `updateConfig` MUST NOT accept a separate authorization signature.
 - Configuration validation MUST return the first applicable error in this order:
   - `InvalidOwner` for an empty owner list.
@@ -853,6 +862,7 @@ rotate_tx = transaction(
   calls = [
     // Ref: Native Multisig Precompile
     updateConfig(
+      current = config,
       threshold = 1,
       owners = [[carol_address, 1]]
     )

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -259,6 +259,18 @@ Rules:
 
 Multisig accounts are counterfactual: deriving or first using one does not create configuration storage. Every direct quorum authorization supplies the applicable configuration witness, while access-key transactions continue to use the account keychain without repeating the parent configuration.
 
+Rules:
+
+- Direct initial and current transactions MUST use the authorized account as `tx.from`, `tx.origin`, and top-level `msg.sender`; one authorization covers the call batch.
+- At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics and affects authorization only for later transactions.
+- Each account directly or recursively authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
+- Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
+- Primitive authorization-list signatures MUST remain stateless with respect to multisig configuration commitments. Address collisions with derived multisig accounts are outside this TIP's security scope.
+- Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
+- Subblock transactions MUST NOT use multisig outer or key authorization signatures.
+- Sponsorship MUST use existing sponsored signing hashes.
+- Pools MAY index by stateless recovery but MUST revalidate all pending initial and current signatures that derive or name an account whenever its commitment changes, including after reorgs.
+
 ### Initial Configuration
 
 An account may use its initial derived configuration in any number of transactions while its persisted commitment remains zero.
@@ -313,7 +325,6 @@ Rules:
 - When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
 - An initial transaction MUST NOT require a zero protocol nonce. Ordinary nonce validation and consumption apply.
 - The target MAY already have a balance or storage.
-- The target MUST have empty code and no EIP-7702 delegation.
 - Successful initial authorization MUST NOT write multisig configuration state.
 
 ### Current Configuration
@@ -350,15 +361,6 @@ tx.signature =
 Rules:
 
 - A current signature MUST be rejected when the account's commitment is zero or differs from the supplied configuration witness.
-- `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
-- At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics and affects authorization only for later transactions.
-- Each account authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
-- Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
-- Primitive authorization-list signatures MUST remain stateless with respect to multisig configuration commitments. Address collisions with derived multisig accounts are outside this TIP's security scope.
-- Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
-- Subblock transactions MUST NOT use multisig outer or key authorization signatures.
-- Sponsorship MUST use existing sponsored signing hashes.
-- Pools MAY index by stateless recovery but MUST revalidate all initial and current signatures that name an account whenever its commitment changes.
 
 ## Storage
 
@@ -404,7 +406,7 @@ interface INativeMultisig {
     ) external view returns (bytes32 commitment);
 
     /// Commits to msg.sender's next configuration.
-    /// Requires direct current-quorum authorization and a top-level batch call.
+    /// Requires direct owner-quorum authorization and a top-level batch call.
     function updateConfig(
         uint8 threshold,
         MultisigOwner[] calldata owners
@@ -430,7 +432,7 @@ interface INativeMultisig {
 }
 ```
 
-Configuration updates are authorized by the account's current owner quorum.
+Configuration updates are authorized by the applicable initial or current owner quorum.
 
 Rules:
 
@@ -438,7 +440,7 @@ Rules:
 - `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
 - `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST use the outer multisig authorization context's account and current version. Access-key authorization MUST NOT call it.
+- It MUST use the outer multisig authorization context's account and authorized witness version. Access-key authorization MUST NOT call it.
 - At most one `updateConfig` call MAY succeed per transaction; a later call MUST revert with `MultipleConfigUpdates`.
 - `updateConfig` MUST NOT accept a separate authorization signature.
 - `updateConfig` MUST increment the authorized configuration version by one, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
@@ -450,7 +452,7 @@ Rules:
   - `InvalidWeight` when the weight sum overflows or exceeds `u8::MAX`.
   - `InvalidThreshold` when the threshold exceeds the sum of all owner weights.
 - Address derivation MUST return `InvalidAccount` when the derived address is zero or reserved.
-- `updateConfig` MUST return `UnauthorizedCaller` for an indirect call, `msg.sender != tx.origin`, a nonzero keychain transaction key, or a transaction not directly authorized by the current owner quorum.
+- `updateConfig` MUST return `UnauthorizedCaller` for an indirect call, `msg.sender != tx.origin`, a nonzero keychain transaction key, or a transaction not directly authorized by the applicable initial or current owner quorum.
 
 ## Account Keychain
 
@@ -539,9 +541,9 @@ first_config_update_storage = active_sstore_set(warm_config_slot)
 later_config_update_storage = active_sstore_reset(warm_config_slot)
 ```
 
-The leading 2,100 gas charges the cold configuration-commitment read for each multisig node. Witness bytes are charged using the ordinary zero/nonzero calldata schedule even though they are encoded in the signature field. The per-signature term charges owner matching and quorum processing; there are no owner-row storage reads.
+The leading 2,100 gas is a fixed per-node configuration-commitment validation charge priced at one cold read. It is charged for every node even when an earlier node read the same slot or the implementation reuses a cached result. Witness bytes are charged using the ordinary zero/nonzero calldata schedule even though they are encoded in the signature field. The per-signature term charges owner matching and quorum processing; there are no owner-row storage reads.
 
-Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
+Each nested node adds a fixed 2,600 gas account-validation charge for checking that the nested multisig owner has no bytecode or EIP-7702 delegation, without a warm-access discount for repeated accounts. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 
 The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 node costs 39,900 gas plus its configuration-witness data gas.
 
@@ -549,14 +551,14 @@ When a signed key authorization uses a multisig signature, its existing signatur
 
 Initial use creates no multisig storage and has no storage surcharge. Signature validation warms the commitment slot, so the first owner update pays one warm zero-to-nonzero write and later updates pay one warm nonzero-to-nonzero write under the active precompile storage schedule. Update event data is charged by ordinary precompile execution gas.
 
-Under the gas schedule active when this TIP was drafted, representative 8-of-48 authorization costs before executed calls are:
+Under the gas schedule active when this TIP was drafted, representative first-use costs for an 8-of-48 account before executed calls are:
 
 | Case | Current owner-row design | Stateless commitment design | Savings |
 | --- | ---: | ---: | ---: |
-| 8 secp256k1 approvals | ~24.5M gas | ~79k gas | ~310x |
-| 8 WebAuthn approvals | ~24.6M-24.8M gas | ~119k-365k gas | ~68x-207x |
+| First use with 8 secp256k1 approvals | ~24.5M gas | ~79k gas | ~310x |
+| First use with 8 WebAuthn approvals | ~24.6M-24.8M gas | ~119k-365k gas | ~68x-207x |
 
-The witness column includes the 21,000 base transaction cost and approximately 18,000 gas for a 48-owner witness. Counterfactual creation itself costs zero gas. A first configuration update adds approximately 250,100 gas for one new commitment slot; later updates add approximately 5,000 gas for one warm nonzero-to-nonzero write. These figures are informative and change with the active storage or calldata schedule; the formulas above are normative.
+The table compares the owner-row design's storage-writing bootstrap with the commitment design's storage-free initial authorization. The witness column includes the 21,000 base transaction cost and approximately 18,000 gas for a 48-owner witness. Counterfactual creation itself costs zero gas. A first configuration update adds approximately 250,100 gas for one new commitment slot; later updates add approximately 5,000 gas for one warm nonzero-to-nonzero write. These figures are informative and change with the active storage or calldata schedule; the formulas above are normative.
 
 Rules:
 
@@ -569,15 +571,21 @@ Rules:
 - Every initial and current node MUST charge its exact witness bytes once. WebAuthn data gas MUST continue to be charged only by `full_primitive_cost`.
 - Initial authorization MUST NOT charge any configuration-storage write.
 - `updateConfig` MUST charge exactly one warm configuration-slot write plus its event and normal precompile execution costs.
-- Commitment reads and updates MUST use the active precompile storage schedule.
+- Commitment validation MUST charge the fixed per-node amount above. Configuration updates MUST use the active precompile storage schedule.
 
 ## Tooling
 
 Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, witness construction, signing, transaction decoding, and configuration history.
 
+A commitment verifies a supplied current configuration but cannot reconstruct it. Before the first on-chain initial signature, the salt and initial configuration are likewise available only from the account creator. Unsigned simulation and gas-estimation requests therefore need an RPC-only witness that supplies the applicable initial or current configuration and the planned primitive or nested approval encodings needed for exact gas calculation.
+
 Rules:
 
 - Tooling MUST support the T11 initial and current witness encodings, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
+- Wallets MUST retain the initial witness until it is recoverable from an on-chain transaction and MUST track the latest complete configuration from successful update events.
+- Unsigned multisig simulation and gas estimation MUST accept an RPC-only complete witness and approval shape. These fields MUST NOT alter the signed transaction encoding.
+- The RPC witness MUST distinguish initial from current encoding and recursively identify each approved owner, primitive signature type and variable-length data, or nested witness; an owner-count-only hint is insufficient.
+- Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas. Only cryptographic owner-signature verification MAY be skipped in simulation context.
 
 ## Observability
 
@@ -585,6 +593,7 @@ Initial signatures and owner-update events expose enough data to reconstruct an 
 
 Rules:
 
+- Before the first on-chain initial signature, the account's initial witness is not discoverable from its address or zero commitment alone.
 - Reconstructing the initial configuration MUST decode `init` from an initial outer or key authorization signature.
 - A successful owner update MUST emit `MultisigConfigUpdated(account, version, threshold, owners)`.
 - The initial configuration uses version `0`; the first owner-update event uses version `1`, and each later event increments it by one.
@@ -990,7 +999,7 @@ The initial transaction registers the access key without writing a multisig comm
 
 ### Configuration Rotation
 
-The current quorum authorizes an owner update, which preserves the account address and applies to later transactions.
+The applicable initial or current quorum authorizes an owner update, which preserves the account address and applies to later transactions. This example performs the first update with the initial version-0 witness.
 
 Assume Alice and Bob are both required. They replace themselves with Carol:
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -33,7 +33,7 @@ Today, these needs typically require a contract wallet or external account abstr
 
 ## Threat Model
 
-- Transaction submitters are untrusted and may supply malformed, oversized, deeply nested, cyclic, duplicate, stale, or insufficient configuration witnesses and owner data. Decoding, transaction-size, and gas limits MUST bound work before rejecting these transactions.
+- Transaction submitters are untrusted and may supply malformed, oversized, deeply nested, cyclic, duplicate, stale, or insufficient configuration witnesses and owner data. Decoding and validation limits MUST bound work before rejecting these transactions.
 - Owners may be unavailable, compromised, or malicious. Only the current configuration's threshold is trusted; no individual owner receives authority beyond its configured weight.
 - Nested multisig owners are untrusted authorization principals. Nesting depth, ordering, membership, cycle, and per-node threshold checks prevent them from bypassing the parent configuration.
 - Access keys and fee payers are untrusted delegates, not owners. Access keys remain subject to account keychain restrictions and cannot update the owner configuration; fee sponsorship grants no account authority.
@@ -59,17 +59,17 @@ pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
 /// Domain prefix for persisted multisig configuration commitments.
 pub const MULTISIG_CONFIG_DOMAIN: &[u8] = b"tempo:multisig:config";
 
-/// Maximum owner count in one configuration witness.
+/// Maximum owner count that leaves room for fresh nonce creation and transaction overhead.
 pub const MAX_MULTISIG_OWNERS: usize = 48;
 
 /// Maximum threshold for one account configuration.
 pub const MAX_MULTISIG_THRESHOLD: u8 = u8::MAX;
 
+/// Maximum number of owner signatures in one multisig account signature.
+pub const MAX_MULTISIG_SIGNATURES: usize = 8;
+
 /// Maximum number of multisig account signatures in one nested authorization path.
 pub const MAX_MULTISIG_NESTING_DEPTH: usize = 2;
-
-/// Maximum encoded byte length of one complete multisig signature, including nested signatures.
-pub const MAX_MULTISIG_SIGNATURE_BYTES: usize = 128 * 1024;
 
 /// Maximum encoded byte length of one primitive owner signature.
 pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize =
@@ -110,7 +110,7 @@ pub struct MultisigConfig {
 
 /// Signature payload for a multisig account.
 pub enum MultisigSignature {
-    /// Carries the initial configuration that derives a counterfactual account.
+    /// Carries the initial configuration that derives the account.
     Initial {
         /// Initial owner configuration.
         init: InitMultisig,
@@ -133,16 +133,14 @@ pub enum MultisigSignature {
 }
 ```
 
-Configurations allow up to 48 owners and one approval per owner. Nesting depth 2 permits one nested level; encoded-size and gas limits bound validation.
+An account may have up to 48 owners. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound transaction size and recursive signature-verification work.
 
 Rules:
 
 - Configurations MUST contain 1 to 48 unique, nonzero, address-sorted owners. Weights MUST be nonzero and total at most 255.
 - A configuration MUST NOT include the multisig account itself as an owner.
-- Threshold MUST be nonzero and MUST NOT exceed the sum of all owner weights.
-- Each multisig signature MUST contain 1 to the applicable witness's owner count in owner signatures.
+- Threshold MUST be nonzero and reachable by at most `MAX_MULTISIG_SIGNATURES` owners. Equivalently, it MUST NOT exceed the sum of the eight highest owner weights.
 - Each owner signature MUST be a `TempoSignature::Primitive` or `TempoSignature::Multisig`.
-- The complete type-prefixed encoding of each multisig signature, including all nested signatures, MUST NOT exceed `MAX_MULTISIG_SIGNATURE_BYTES`.
 - Primitive owner signatures MUST NOT exceed `MAX_MULTISIG_OWNER_SIGNATURE_BYTES`; nested owner signatures are bounded recursively by the signature-count and nesting-depth limits.
 
 ## Signature Encoding
@@ -156,7 +154,7 @@ Rules:
 
 - Exactly 65 signature bytes MUST decode as secp256k1 regardless of the first byte. Type `0x05` MUST be considered only at other lengths.
 - Transactions carrying type `0x05` MUST be rejected before T11. Generic wire-format decoders MAY parse the type without hardfork context, but consensus validation MUST NOT accept it before T11.
-- `signatures` MUST contain 1 to the witness's owner count, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list or a list longer than the owner count.
+- `signatures` MUST contain 1 to `MAX_MULTISIG_SIGNATURES` owner signatures, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list before intrinsic gas is computed.
 - Decoders MUST reject malformed encodings, trailing fields, limit violations, and excessive nesting.
 
 ### Initial
@@ -303,7 +301,7 @@ digest = multisig_digest(
 alice_signature = sign(alice_key, digest)
 bob_signature   = sign(bob_key, digest)
 
-// Attach the initial signature containing the complete configuration.
+// Attach the initial signature containing the initial configuration.
 tx.signature =
   0x05 || rlp([
     init,
@@ -326,7 +324,7 @@ Rules:
 A current transaction carries a nonzero-version configuration witness and uses the account's block-position commitment to authorize the full call batch.
 
 ```text
-// Build a transaction from an account that has updated its configuration.
+// Build a transaction from the account.
 tx = transaction(
   from = account,
   calls = [...]
@@ -343,7 +341,7 @@ digest = multisig_digest(
 alice_signature = sign(alice_key, digest)
 bob_signature   = sign(bob_key, digest)
 
-// Attach the current signature containing the account and configuration witness.
+// Attach the current signature containing the account address and configuration.
 tx.signature =
   0x05 || rlp([
     account,
@@ -358,7 +356,7 @@ Rules:
 
 ## Storage
 
-The precompile stores one commitment per account; signatures and update events carry full configurations. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
+The multisig account precompile stores one commitment per account; signatures and update events carry full configurations. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
 
 ```text
 mapping_slot(key, base) = keccak256(pad32(key) || pad32(base))
@@ -444,7 +442,7 @@ Rules:
   - `InvalidThreshold` when the threshold is zero.
   - For each owner: `InvalidOwner` for the zero address or the multisig account itself, `InvalidWeight` for zero weight, `DuplicateOwner` when equal to the previous owner, or `InvalidOwnerOrder` when below it.
   - `InvalidWeight` when the weight sum overflows or exceeds `u8::MAX`.
-  - `InvalidThreshold` when the threshold exceeds the sum of all owner weights.
+  - `InvalidThreshold` when the threshold exceeds the weight reachable from the eight highest-weight owners.
 - Address derivation MUST return `InvalidAccount` when the derived address is zero or reserved.
 - `updateConfig` MUST return `UnauthorizedCaller` for an indirect call, `msg.sender != tx.origin`, a nonzero keychain transaction key, or a transaction not directly authorized by the applicable initial or current owner quorum.
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -210,7 +210,7 @@ Initial transactions authorize counterfactual accounts without establishing mult
 Rules:
 
 - Direct initial and current transactions MUST use the authorized account as `tx.from`, `tx.origin`, and top-level `msg.sender`; one authorization covers the call batch.
-- Initial authorization MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; an existing balance or storage MUST NOT prevent authorization.
+- An initial transaction MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; balance and storage MUST NOT prevent authorization.
 - When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
 - At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics, is visible to later calls in the batch, and affects authorization only for later transactions.
 - Each account directly or recursively authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
@@ -237,8 +237,7 @@ Rules:
 
 - Mapping base slot `0` MUST hold the configuration commitment with the key order above. This TIP MUST NOT store owner arrays or direct owner-weight rows.
 - A zero slot means no configuration update has occurred. It does not prove that the address is not a counterfactual multisig account.
-- A nonzero slot MUST be interpreted only as the commitment of the complete current configuration supplied by signatures and update events.
-- Configuration commitment storage MUST never return to zero.
+- A nonzero slot MUST contain the current configuration commitment and MUST never return to zero.
 
 ## Native Multisig Precompile
 
@@ -358,8 +357,7 @@ Rules:
 
 - Quorums MAY add ordinary or admin access keys directly or via `key_authorization`, including during initial authorization; existing key rules MUST apply.
 - A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
-- When a multisig account's owners authorize a key for that account, `key_authorization.account` MUST equal the multisig account address.
-- The multisig signature MUST carry the account and complete applicable configuration and use the digest above.
+- A multisig key authorization signature MUST set its account to `key_authorization.account`, carry the complete applicable configuration, and use the digest above.
 - A multisig key authorization MUST complete stateful configuration and quorum validation and satisfy root, rather than delegated-admin, authorization.
 - A version-0 key authorization MAY register the key without persisting multisig configuration state.
 - When both the outer signature and `key_authorization.signature` are multisig signatures, each MUST independently carry and validate the applicable configuration witness.
@@ -419,31 +417,25 @@ Rules:
 - Direct multisig authorization MUST NOT add the account keychain's 900 gas processing buffer.
 - Every initial and current node MUST charge its exact witness bytes once. WebAuthn data gas MUST continue to be charged only by `full_primitive_cost`.
 - Initial authorization MUST NOT charge any configuration-storage write.
-- `updateConfig` MUST charge exactly one warm configuration-slot write plus its event and normal precompile execution costs.
-- Commitment validation MUST charge the fixed per-node amount above. Configuration updates MUST use the active precompile storage schedule.
+- `updateConfig` MUST charge exactly one warm configuration-slot write under the active precompile storage schedule, plus its event and normal precompile execution costs.
 
 ## Tooling
 
 Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, signing, transaction decoding, and configuration history.
 
-Commitments do not reveal configurations. Multisig simulation therefore requires an RPC-only complete witness and approval shape; access-key transactions require no parent witness.
-
 Rules:
 
 - Tooling MUST support the T11 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
-- Wallets MUST retain the initial witness until it is recoverable from an on-chain transaction and MUST track the latest complete configuration from successful update events.
-- Unsigned simulation and gas estimation that model multisig outer or key authorization MUST accept an RPC-only complete witness and approval shape. These fields MUST NOT alter the signed transaction encoding.
-- The RPC witness MUST include the account and complete versioned configuration and recursively identify each approved owner, primitive signature type and variable-length data, or nested witness; an owner-count-only hint is insufficient.
-- Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas. Only cryptographic owner-signature verification MAY be skipped in simulation context.
+- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept an RPC-only recursive witness containing every account configuration and, for each approved owner, either a primitive signature type and variable-length data or a nested witness. The witness MUST NOT alter signed transaction encoding.
+- Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas; only cryptographic owner-signature verification MAY be skipped.
 
 ## Observability
 
-Initial transaction signatures and owner-update events expose enough data to reconstruct an account's configuration history.
+Multisig signatures and owner-update events expose enough data to reconstruct an account's configuration history.
 
 Rules:
 
-- Before the first on-chain initial signature, the account's initial witness is not discoverable from its address or zero commitment alone.
-- Reconstructing the initial configuration MUST decode the version-0 config from an outer or key authorization signature.
+- The initial configuration MUST be reconstructed from a version-0 multisig signature; the account address and zero commitment do not reveal it.
 - A successful owner update MUST emit `MultisigConfigUpdated(account, salt, version, threshold, owners)`.
 - The initial configuration uses version `0`; the first owner-update event uses version `1`, and each later event increments it by one.
 - Account keychain paths MUST retain their existing events.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -375,38 +375,38 @@ Rules:
 
 Multisig account authorization is charged as regular intrinsic gas. Costs scale with submitted owner signatures and nested account nodes:
 
+| Component | Gas |
+|---|---:|
+| Per-node configuration commitment read | 2,100 |
+| Nested-node account code/delegation check | 2,600 |
+| `full_primitive_cost(secp256k1)` | 3,000 |
+| `full_primitive_cost(P256)` | 8,000 |
+| `full_primitive_cost(WebAuthn)` | 8,000 + `calldata_gas(webauthn_data)` |
+
+Hashing uses the exact preimages defined in [Account Identity](#account-identity) and [Authorization](#authorization), charged with the standard EVM Keccak schedule. The preimage names below refer to those byte strings and do not introduce additional encoding.
+
 ```text
-witness_bytes(signature) = rlp(account) || rlp(config)
-
-KECCAK_BASE_GAS = 30
-KECCAK_WORD_GAS = 6
-B256_BYTES = 32
-EVM_WORD_BYTES = B256_BYTES
-ADDRESS_BYTES = 20
-U64_BYTES = 8
-U8_BYTES = 1
-
-OWNER_PREIMAGE_BYTES = ADDRESS_BYTES + U8_BYTES
-ACCOUNT_PREIMAGE_FIXED_BYTES = MULTISIG_ACCOUNT_DOMAIN.len() + B256_BYTES + 2 * U8_BYTES
-CONFIG_PREIMAGE_FIXED_BYTES =
-  MULTISIG_CONFIG_DOMAIN.len() + B256_BYTES + U64_BYTES + 2 * U8_BYTES
-MULTISIG_DIGEST_PREIMAGE_BYTES =
-  MULTISIG_SIGNATURE_DOMAIN.len() + B256_BYTES + ADDRESS_BYTES + U64_BYTES
-
 keccak_cost(byte_len) =
-  KECCAK_BASE_GAS + KECCAK_WORD_GAS * ceil(byte_len / EVM_WORD_BYTES)
+  30 + 6 * ceil(byte_len / 32)
 
 account_derivation_hash_cost(config) =
-  keccak_cost(ACCOUNT_PREIMAGE_FIXED_BYTES + OWNER_PREIMAGE_BYTES * config.owners.len())
+  keccak_cost(account_derivation_preimage(config).len())
 
 config_commitment_hash_cost(config) =
-  keccak_cost(CONFIG_PREIMAGE_FIXED_BYTES + OWNER_PREIMAGE_BYTES * config.owners.len())
+  keccak_cost(config_commitment_preimage(config).len())
 
-multisig_digest_hash_cost = keccak_cost(MULTISIG_DIGEST_PREIMAGE_BYTES)
+multisig_digest_hash_cost =
+  keccak_cost(multisig_digest_preimage.len())
 
 config_proof_hash_cost(config) =
   account_derivation_hash_cost(config)  if config.version == 0
   config_commitment_hash_cost(config)   otherwise
+```
+
+The recursive authorization charge is:
+
+```text
+witness_bytes(signature) = rlp(account) || rlp(config)
 
 node(signature) =
     2,100
@@ -414,12 +414,11 @@ node(signature) =
   + config_proof_hash_cost(signature.config)
   + multisig_digest_hash_cost
   + sum(full_primitive_cost(owner) or 2,600 + node(nested_owner))
+```
 
-full_primitive_cost(signature) =
-  secp256k1: 3,000
-  P256: 8,000
-  WebAuthn: 8,000 + calldata_gas(webauthn_data)
+Role-specific surcharges are:
 
+```text
 direct_multisig_surcharge =
   node(outer_signature)
   - 3,000
@@ -433,7 +432,7 @@ commitment_gating_surcharge =
   - a keychain caller with code or delegation
 ```
 
-Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus its configuration-proof and owner-approval-digest hashes. The witness calldata charge scales with complete configuration parsing and validation. There are no owner-row or owner-weight storage reads.
+Commitment reads are charged per node even when the slot is reused or cached. The witness calldata charge scales with complete configuration parsing and validation. There are no owner-row or owner-weight storage reads.
 
 Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -297,7 +297,6 @@ Rules:
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
 - It MUST use the outer multisig authorization context's account and salt. Each successful call MUST increment the latest non-reverted configuration version in the transaction, starting from the authorized witness version.
 - `updateConfig` MUST NOT accept a separate authorization signature.
-- Each successful `updateConfig` MUST revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
   - `InvalidOwner` for an empty owner list.
   - `TooManyOwners` above `MAX_MULTISIG_OWNERS`.
@@ -424,8 +423,6 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 Rules:
 
 - Tooling MUST support the T11 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
-- Because commitments do not reveal configurations, unsigned simulation and gas estimation MUST accept recursive configuration witnesses without altering signed transaction encoding.
-- Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas; only cryptographic owner-signature verification MAY be skipped.
 
 ## Observability
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -133,7 +133,7 @@ pub enum MultisigSignature {
 }
 ```
 
-An account may have up to 48 owners. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound transaction size and recursive signature-verification work.
+An account may have up to 48 owners so a worst-case initial authorization, including complete validation of eight depth-2 nested-owner configuration witnesses and eight maximum-size WebAuthn signatures in each, fits within the transaction gas cap while leaving room for fresh nonce creation and transaction overhead. Each multisig account signature may contain at most 8 owner signatures, and primitive owner signatures have a byte limit. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. These limits bound transaction size and recursive signature-verification work.
 
 Rules:
 
@@ -159,6 +159,8 @@ Rules:
 
 ### Initial
 
+The initial form authorizes a multisig account without storing configuration state. It can authorize the transaction directly or authorize an access key that signs that transaction.
+
 ```text
 0x05 || rlp([init, signatures])
 
@@ -172,6 +174,8 @@ Rules:
 - The account's persisted configuration commitment MUST be zero.
 
 ### Current
+
+The current form is used after the first configuration update. It identifies the account so validation can authorize owner signatures against the supplied configuration and stored commitment.
 
 ```text
 0x05 || rlp([account, config, signatures])
@@ -321,7 +325,7 @@ Rules:
 
 ### Current Configuration
 
-A current transaction carries a nonzero-version configuration witness and uses the account's block-position commitment to authorize the full call batch.
+A current transaction uses the configuration witness matching its block-position commitment to authorize the full call batch. Configuration updates are visible to later calls in the batch but do not change that transaction's authorization.
 
 ```text
 // Build a transaction from the account.
@@ -533,9 +537,15 @@ first_config_update_storage = active_sstore_set(warm_config_slot)
 later_config_update_storage = active_sstore_reset(warm_config_slot)
 ```
 
-Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus witness calldata and owner-processing costs. Nested nodes add 2,600 gas for a code-hash/delegation check; implementations MUST NOT load bytecode. There are no owner-row reads.
+Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus witness calldata and owner-processing costs. There are no owner-row storage reads.
 
-The 3,000 gas direct subtraction accounts for the transaction signature already included in intrinsic gas; key authorizations are charged independently without that subtraction. Initial use writes no multisig state. The first update pays a warm zero-to-nonzero commitment write; later updates pay a warm nonzero-to-nonzero write.
+Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
+
+The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 node costs 39,900 gas plus its configuration-witness data gas.
+
+When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
+
+Initial use writes no multisig state. The first update pays a warm zero-to-nonzero commitment write; later updates pay a warm nonzero-to-nonzero write.
 
 Under the gas schedule active when this TIP was drafted, representative first-use costs for an 8-of-48 account before executed calls are:
 
@@ -575,6 +585,8 @@ Rules:
 
 ## Observability
 
+Initial transaction signatures and owner-update events expose enough data to reconstruct an account's configuration history.
+
 Rules:
 
 - Before the first on-chain initial signature, the account's initial witness is not discoverable from its address or zero commitment alone.
@@ -589,7 +601,7 @@ These examples illustrate the canonical signing flows and main authorization edg
 
 ### Initial Configuration
 
-An initial transaction carries `init`, derives its counterfactual account, and creates no multisig configuration storage.
+An initial transaction authorizes the account without storing its initial owner configuration. Its signature carries `init` because no configuration exists in state yet.
 
 ```text
 // Define and derive the account with alice_address < bob_address.
@@ -634,7 +646,7 @@ execute(tx)
 
 ### Current Configuration
 
-A current transaction supplies the complete configuration whose commitment is stored for the account.
+A current transaction uses the configuration commitment stored for the account. Its signature carries the account address and complete configuration so validation can check the current owners and threshold.
 
 ```text
 // Build a transaction after an owner update.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -577,13 +577,13 @@ Rules:
 
 Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, witness construction, signing, transaction decoding, and configuration history.
 
-A commitment verifies a supplied current configuration but cannot reconstruct it. Before the first on-chain initial signature, the salt and initial configuration are likewise available only from the account creator. Unsigned simulation and gas-estimation requests therefore need an RPC-only witness that supplies the applicable initial or current configuration and the planned primitive or nested approval encodings needed for exact gas calculation.
+A commitment verifies a supplied current configuration but cannot reconstruct it. Before the first on-chain initial signature, the salt and initial configuration are likewise available only from the account creator. Unsigned requests that simulate multisig outer or key authorization therefore need an RPC-only witness that supplies the applicable initial or current configuration and the planned primitive or nested approval encodings needed for exact gas calculation. Access-key transactions continue to require no parent witness.
 
 Rules:
 
 - Tooling MUST support the T11 initial and current witness encodings, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
 - Wallets MUST retain the initial witness until it is recoverable from an on-chain transaction and MUST track the latest complete configuration from successful update events.
-- Unsigned multisig simulation and gas estimation MUST accept an RPC-only complete witness and approval shape. These fields MUST NOT alter the signed transaction encoding.
+- Unsigned simulation and gas estimation that model multisig outer or key authorization MUST accept an RPC-only complete witness and approval shape. These fields MUST NOT alter the signed transaction encoding.
 - The RPC witness MUST distinguish initial from current encoding and recursively identify each approved owner, primitive signature type and variable-length data, or nested witness; an owner-count-only hint is insufficient.
 - Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas. Only cryptographic owner-signature verification MAY be skipped in simulation context.
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -14,9 +14,7 @@ protocolVersion: T11
 
 Configurable accounts can change who controls them and their configuration without changing their identity. They support multisig control, recovery, key rotation, and permissioned access (via access keys) while remaining the same Tempo account to applications and counterparties.
 
-This TIP implements configurable accounts as native multisig accounts. Protocol identifiers, signatures, and ABI names use the term `multisig`.
-
-Accounts are counterfactual: multisig signatures carry their configurations, and owner updates persist one commitment slot.
+This TIP implements configurable accounts as counterfactual native multisig accounts. Protocol identifiers, signatures, and ABI names use the term `multisig`.
 
 ## Motivation
 
@@ -33,7 +31,7 @@ Today, these needs typically require a contract wallet or external account abstr
 
 ## Threat Model
 
-- Transaction submitters are untrusted and may supply malformed, oversized, deeply nested, cyclic, duplicate, stale, or insufficient configuration witnesses and owner data. Decoding and validation limits MUST bound work before rejecting these transactions.
+- Transaction submitters are untrusted and may supply malformed, oversized, deeply nested, cyclic, duplicate, stale, or insufficient owner data. Decoding and validation limits MUST bound work before rejecting these transactions.
 - Owners may be unavailable, compromised, or malicious. Only the current configuration's threshold is trusted; no individual owner receives authority beyond its configured weight.
 - Nested multisig owners are untrusted authorization principals. Nesting depth, ordering, membership, cycle, and per-node threshold checks prevent them from bypassing the parent configuration.
 - Access keys and fee payers are untrusted delegates, not owners. Access keys remain subject to account keychain restrictions and cannot update the owner configuration; fee sponsorship grants no account authority.
@@ -232,11 +230,11 @@ Rules:
 - At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics and affects authorization only for later transactions.
 - Each account directly or recursively authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
 - Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
-- Primitive authorization-list signatures MUST remain stateless with respect to multisig configuration commitments. Address collisions with derived multisig accounts are outside this TIP's security scope.
+- Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-commitment read. Address collisions with derived multisig accounts are outside this TIP's security scope.
 - Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
-- Pools MAY index by stateless recovery but MUST revalidate all pending initial and current signatures that derive or name an account whenever its commitment changes, including after reorgs.
+- Pools MAY index by stateless recovery but MUST revalidate affected initial and current signatures whenever the account's commitment changes, including after reorgs.
 
 ### Initial Configuration
 
@@ -466,14 +464,14 @@ The access key signs the existing V2 account keychain digest, and the transactio
 
 Rules:
 
-- Quorums MAY add ordinary or admin access keys directly or via `key_authorization`; existing key rules MUST apply.
+- Quorums MAY add ordinary or admin access keys directly or via `key_authorization`, including during initial authorization; existing key rules MUST apply.
 - A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
 - When a multisig account's owners authorize a key for that account, `key_authorization.account` MUST equal the multisig account address.
 - The multisig signature MUST carry the account and complete applicable configuration and use the digest above.
 - A multisig key authorization MUST complete stateful configuration and quorum validation and satisfy root, rather than delegated-admin, authorization.
 - A version-0 key authorization MAY register the key without persisting multisig configuration state.
 - When both the outer signature and `key_authorization.signature` are multisig signatures, each MUST independently carry and validate the applicable configuration witness.
-- Authorize-and-use MAY occur in one transaction when the outer signature uses the new key.
+- Authorize-and-use MAY occur in one transaction, including during initial authorization, when the outer signature uses the new key.
 - Access key transactions MUST use the V2 envelope, execute as the account under stored restrictions, and skip the parent quorum.
 - Access key transactions MUST reject a registered multisig parent with EVM code or EIP-7702 delegation.
 - Stateless TIP-1020 `recover` and `verify` MUST reject bare multisig account signatures.
@@ -513,7 +511,7 @@ Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is r
 
 Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 
-The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 authorization adds 39,900 gas plus its configuration-witness data gas.
+The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas.
 
 When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
 
@@ -643,7 +641,7 @@ execute(tx)
 
 ### Nested Ownership
 
-Each multisig account wraps the digest approved by its parent and carries its own witness. This example uses a current multisig account as an owner of another current multisig account.
+Each multisig account wraps the digest approved by its parent. This example uses a current multisig account as an owner of another current multisig account.
 
 ```text
 // Build a transaction from the parent multisig account.
@@ -1002,15 +1000,6 @@ rotate_tx.signature =
 
 execute(rotate_tx)
 
-next_config = multisig_config(
-  salt = config.salt,
-  version = 1,
-  threshold = 1,
-  owners = [[carol_address, 1]]
-)
-
-require getConfigCommitment(account) == commitment(next_config)
-
 // The next transaction uses Carol and keeps the same account address.
 next_tx = transaction(
   from = account,
@@ -1018,6 +1007,12 @@ next_tx = transaction(
 )
 
 // Ref: Authorization formula
+next_config = multisig_config(
+  salt = config.salt,
+  version = 1,
+  threshold = 1,
+  owners = [[carol_address, 1]]
+)
 next_digest = multisig_digest(
   next_tx.signature_hash(),
   account,

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -378,10 +378,41 @@ Multisig account authorization is charged as regular intrinsic gas. Costs scale 
 ```text
 witness_bytes(signature) = rlp(account) || rlp(config)
 
+KECCAK_BASE_GAS = 30
+KECCAK_WORD_GAS = 6
+B256_BYTES = 32
+EVM_WORD_BYTES = B256_BYTES
+ADDRESS_BYTES = 20
+U64_BYTES = 8
+U8_BYTES = 1
+
+OWNER_PREIMAGE_BYTES = ADDRESS_BYTES + U8_BYTES
+ACCOUNT_PREIMAGE_FIXED_BYTES = MULTISIG_ACCOUNT_DOMAIN.len() + B256_BYTES + 2 * U8_BYTES
+CONFIG_PREIMAGE_FIXED_BYTES =
+  MULTISIG_CONFIG_DOMAIN.len() + B256_BYTES + U64_BYTES + 2 * U8_BYTES
+MULTISIG_DIGEST_PREIMAGE_BYTES =
+  MULTISIG_SIGNATURE_DOMAIN.len() + B256_BYTES + ADDRESS_BYTES + U64_BYTES
+
+keccak_cost(byte_len) =
+  KECCAK_BASE_GAS + KECCAK_WORD_GAS * ceil(byte_len / EVM_WORD_BYTES)
+
+account_derivation_hash_cost(config) =
+  keccak_cost(ACCOUNT_PREIMAGE_FIXED_BYTES + OWNER_PREIMAGE_BYTES * config.owners.len())
+
+config_commitment_hash_cost(config) =
+  keccak_cost(CONFIG_PREIMAGE_FIXED_BYTES + OWNER_PREIMAGE_BYTES * config.owners.len())
+
+multisig_digest_hash_cost = keccak_cost(MULTISIG_DIGEST_PREIMAGE_BYTES)
+
+config_proof_hash_cost(config) =
+  account_derivation_hash_cost(config)  if config.version == 0
+  config_commitment_hash_cost(config)   otherwise
+
 node(signature) =
     2,100
   + calldata_gas(witness_bytes(signature))
-  + 2,100 * signature.signatures.len()
+  + config_proof_hash_cost(signature.config)
+  + multisig_digest_hash_cost
   + sum(full_primitive_cost(owner) or 2,600 + node(nested_owner))
 
 full_primitive_cost(signature) =
@@ -402,7 +433,7 @@ commitment_gating_surcharge =
   - a keychain caller with code or delegation
 ```
 
-Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus witness calldata and owner-processing costs. There are no owner-row storage reads.
+Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus its configuration-proof and owner-approval-digest hashes. The witness calldata charge scales with complete configuration parsing and validation. There are no owner-row or owner-weight storage reads.
 
 Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 
@@ -423,7 +454,8 @@ Rules:
 - Every initial and current node MUST charge its exact witness bytes once. WebAuthn data gas MUST continue to be charged only by `full_primitive_cost`.
 - Initial authorization MUST NOT charge any configuration-storage write.
 - State-dependent role restrictions MUST add `commitment_gating_surcharge` to intrinsic gas.
-- `updateConfig` MUST charge exactly one warm configuration-slot write under the active precompile storage schedule, plus its event and normal precompile execution costs.
+- `deriveAccount` MUST add `account_derivation_hash_cost(config)` to its normal precompile execution costs.
+- `updateConfig` MUST add `config_proof_hash_cost(current) + config_commitment_hash_cost(next)`, exactly one warm configuration-slot read and write under the active precompile storage schedule, plus its event and normal precompile execution costs.
 
 ## Tooling
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -122,7 +122,7 @@ Rules:
 
 ## Signature Encoding
 
-Signature type `0x05` carries the account and its complete applicable configuration:
+A type `0x05` multisig signature MUST be encoded as:
 
 ```text
 0x05 || rlp([account, config, signatures])
@@ -135,27 +135,10 @@ Rules:
 
 - Exactly 65 signature bytes MUST decode as secp256k1 regardless of the first byte. Type `0x05` MUST be considered only at other lengths.
 - Transactions carrying type `0x05` MUST be rejected before T11. Generic wire-format decoders MAY parse the type without hardfork context, but consensus validation MUST NOT accept it before T11.
-- A multisig signature MUST use `0x05 || rlp([account, config, signatures])`.
 - `signatures` MUST contain 1 to `MAX_MULTISIG_SIGNATURES` owner signatures, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list before intrinsic gas is computed.
 - Decoders MUST reject malformed encodings, trailing fields, limit violations, and excessive nesting.
-
-### Initial
-
-An initial signature has configuration version `0` and authorizes the account without storing configuration state. It can authorize the transaction directly or authorize an access key that signs that transaction.
-
-Rules:
-
-- An initial signature MUST have `config.version == 0` and derive `account` from `config.salt`, `config.threshold`, and `config.owners`.
-- The account's persisted configuration commitment MUST be zero.
-
-### Current
-
-The same encoding carries the current configuration after the first owner update.
-
-Rules:
-
-- A current signature MUST have `config.version > 0`.
-- The stored commitment for `account` MUST be nonzero and equal the commitment of `config`.
+- When `config.version == 0`, `account` MUST be derived from `config.salt`, `config.threshold`, and `config.owners`, and its persisted configuration commitment MUST be zero.
+- When `config.version > 0`, the stored commitment for `account` MUST be nonzero and equal the commitment of `config`.
 - Initial and current signatures MAY appear as nested owner or key authorization signatures when their respective commitment-state rules hold.
 
 ## Account Identity
@@ -227,7 +210,9 @@ Initial transactions authorize counterfactual accounts without establishing mult
 Rules:
 
 - Direct initial and current transactions MUST use the authorized account as `tx.from`, `tx.origin`, and top-level `msg.sender`; one authorization covers the call batch.
-- At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics and affects authorization only for later transactions.
+- Initial authorization MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; an existing balance or storage MUST NOT prevent authorization.
+- When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
+- At most one `updateConfig` call MAY succeed per transaction. Its write follows ordinary call-batch revert semantics, is visible to later calls in the batch, and affects authorization only for later transactions.
 - Each account directly or recursively authorized by a multisig signature MUST have no EVM code or EIP-7702 delegation at validation time.
 - Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
 - Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-commitment read. Address collisions with derived multisig accounts are outside this TIP's security scope.
@@ -235,99 +220,6 @@ Rules:
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
 - Pools MAY index by stateless recovery but MUST revalidate affected initial and current signatures whenever the account's commitment changes, including after reorgs.
-
-### Initial Configuration
-
-An account may use its initial derived configuration in any number of transactions while its persisted commitment remains zero.
-
-The example assumes `alice_address < bob_address`, each owner has weight 1, and the threshold is 2.
-
-```text
-// Define the initial owner configuration.
-// Ref: Types and Limits
-config = multisig_config(
-  salt = salt,
-  version = 0,
-  threshold = 2,
-  owners = [
-    [alice_address, 1],
-    [bob_address, 1]
-  ]
-)
-
-// Ref: Account Identity formula
-account = multisig_address
-
-// Build a transaction from the counterfactual account.
-tx = transaction(
-  from = account,
-  calls = [...]
-)
-
-// Sign the account-bound transaction digest.
-// Ref: Authorization formula
-digest = multisig_digest(
-  tx.signature_hash(),
-  account,
-  0
-)
-
-alice_signature = sign(alice_key, digest)
-bob_signature   = sign(bob_key, digest)
-
-// Attach the initial signature containing the initial configuration.
-tx.signature =
-  0x05 || rlp([
-    account,
-    config,
-    [alice_signature, bob_signature]
-  ])
-```
-
-After validation, the account is available to the transaction's call batch. The transaction consumes its ordinary nonce but creates no multisig configuration state or initialization event.
-
-Rules:
-
-- An initial signature MUST target the account derived from `config` and MUST be rejected when that account's commitment slot is nonzero.
-- When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
-- An initial transaction MUST NOT require a zero protocol nonce. Ordinary nonce validation and consumption apply.
-- The target MAY already have a balance or storage.
-- Successful initial authorization MUST NOT write multisig configuration state.
-
-### Current Configuration
-
-A current transaction uses the configuration witness matching its block-position commitment to authorize the full call batch. Configuration updates are visible to later calls in the batch but do not change that transaction's authorization.
-
-```text
-// Build a later transaction from the account.
-tx = transaction(
-  from = account,
-  calls = [...]
-)
-
-// Sign the account-bound transaction digest.
-// Ref: Authorization formula
-digest = multisig_digest(
-  tx.signature_hash(),
-  account,
-  config.version
-)
-
-alice_signature = sign(alice_key, digest)
-bob_signature   = sign(bob_key, digest)
-
-// Attach the current signature containing the account address and configuration.
-tx.signature =
-  0x05 || rlp([
-    account,
-    config,
-    [alice_signature, bob_signature]
-  ])
-```
-
-Rules:
-
-- A current signature MUST be rejected when the account's commitment is zero or differs from the supplied configuration witness.
 
 ## Storage
 

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -84,21 +84,12 @@ pub struct MultisigOwner {
     pub weight: u8,
 }
 
-/// Initial owner configuration used to derive a counterfactual account.
-pub struct InitMultisig {
+/// Owner configuration carried by a multisig account signature.
+pub struct MultisigConfig {
     /// Caller-chosen value that permits distinct accounts with otherwise identical configurations.
     pub salt: B256,
 
-    /// Minimum total owner weight required for authorization.
-    pub threshold: u8,
-
-    /// Strictly ascending weighted owners.
-    pub owners: Vec<MultisigOwner>,
-}
-
-/// Current owner configuration carried in a signature after an account's first update.
-pub struct MultisigConfig {
-    /// Nonzero configuration version.
+    /// Configuration version. Zero identifies the initial configuration.
     pub version: u64,
 
     /// Minimum total owner weight required for authorization.
@@ -109,27 +100,15 @@ pub struct MultisigConfig {
 }
 
 /// Signature payload for a multisig account.
-pub enum MultisigSignature {
-    /// Carries the initial configuration that derives the account.
-    Initial {
-        /// Initial owner configuration.
-        init: InitMultisig,
+pub struct MultisigSignature {
+    /// Account authorized by the owner signatures.
+    pub account: Address,
 
-        /// Ordered primitive or nested multisig account owner signatures.
-        signatures: Vec<TempoSignature>,
-    },
+    /// Complete applicable configuration.
+    pub config: MultisigConfig,
 
-    /// Carries an updated configuration whose commitment is stored for the account.
-    Current {
-        /// Account authorized by the owner signatures.
-        account: Address,
-
-        /// Complete current configuration witness.
-        config: MultisigConfig,
-
-        /// Ordered primitive or nested multisig account owner signatures.
-        signatures: Vec<TempoSignature>,
-    },
+    /// Ordered primitive or nested multisig account owner signatures.
+    pub signatures: Vec<TempoSignature>,
 }
 ```
 
@@ -145,48 +124,39 @@ Rules:
 
 ## Signature Encoding
 
-Signature type `0x05` has two forms:
-
-- **Initial.** Used while the account has no persisted configuration commitment. The witness derives the counterfactual account and implicitly has version `0`.
-- **Current.** Used after an owner update has persisted a configuration commitment. The witness names the account and supplies the committed configuration.
-
-Rules:
-
-- Exactly 65 signature bytes MUST decode as secp256k1 regardless of the first byte. Type `0x05` MUST be considered only at other lengths.
-- Transactions carrying type `0x05` MUST be rejected before T11. Generic wire-format decoders MAY parse the type without hardfork context, but consensus validation MUST NOT accept it before T11.
-- `signatures` MUST contain 1 to `MAX_MULTISIG_SIGNATURES` owner signatures, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list before intrinsic gas is computed.
-- Decoders MUST reject malformed encodings, trailing fields, limit violations, and excessive nesting.
-
-### Initial
-
-The initial form authorizes a multisig account without storing configuration state. It can authorize the transaction directly or authorize an access key that signs that transaction.
-
-```text
-0x05 || rlp([init, signatures])
-
-init  = rlp([salt, threshold, owners])
-owner = rlp([owner, weight])
-```
-
-Rules:
-
-- An initial signature MUST use `0x05 || rlp([init, signatures])`, derive its account from `init`, and use configuration version `0`.
-- The account's persisted configuration commitment MUST be zero.
-
-### Current
-
-The current form is used after the first configuration update. It identifies the account so validation can authorize owner signatures against the supplied configuration and stored commitment.
+Signature type `0x05` carries the account and its complete applicable configuration:
 
 ```text
 0x05 || rlp([account, config, signatures])
 
-config = rlp([version, threshold, owners])
+config = rlp([salt, version, threshold, owners])
 owner  = rlp([owner, weight])
 ```
 
 Rules:
 
-- A current signature MUST use `0x05 || rlp([account, config, signatures])` with `config.version > 0`.
+- Exactly 65 signature bytes MUST decode as secp256k1 regardless of the first byte. Type `0x05` MUST be considered only at other lengths.
+- Transactions carrying type `0x05` MUST be rejected before T11. Generic wire-format decoders MAY parse the type without hardfork context, but consensus validation MUST NOT accept it before T11.
+- A multisig signature MUST use `0x05 || rlp([account, config, signatures])`.
+- `signatures` MUST contain 1 to `MAX_MULTISIG_SIGNATURES` owner signatures, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list before intrinsic gas is computed.
+- Decoders MUST reject malformed encodings, trailing fields, limit violations, and excessive nesting.
+
+### Initial
+
+An initial signature has configuration version `0` and authorizes the account without storing configuration state. It can authorize the transaction directly or authorize an access key that signs that transaction.
+
+Rules:
+
+- An initial signature MUST have `config.version == 0` and derive `account` from `config.salt`, `config.threshold`, and `config.owners`.
+- The account's persisted configuration commitment MUST be zero.
+
+### Current
+
+The same encoding carries the current configuration after the first owner update.
+
+Rules:
+
+- A current signature MUST have `config.version > 0`.
 - The stored commitment for `account` MUST be nonzero and equal the commitment of `config`.
 - Initial and current signatures MAY appear as nested owner or key authorization signatures when their respective commitment-state rules hold.
 
@@ -210,6 +180,7 @@ Owner updates commit to the complete new configuration:
 ```text
 config_commitment = keccak256(
   "tempo:multisig:config" ||
+  salt ||
   uint64(version) ||
   uint8(threshold) ||
   uint8(owners.len()) ||
@@ -221,9 +192,9 @@ config_commitment = keccak256(
 Rules:
 
 - Derivation MUST use the formula exactly: ASCII domain, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
-- Configuration commitments MUST use the formula exactly: ASCII domain, eight-byte big-endian version, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
+- Configuration commitments MUST use the formula exactly: ASCII domain, raw 32-byte salt, eight-byte big-endian version, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
 - The derived address MUST be nonzero and outside virtual, active-precompile, TIP-20, and ZonePortal namespaces.
-- Configuration updates MUST replace the current threshold and owners without changing the account address.
+- Configuration updates MUST preserve the salt and replace the current threshold and owners without changing the account address.
 - Version `0` MUST identify only the initial derived configuration and MUST NOT be persisted. Updated configurations MUST use monotonically increasing nonzero versions.
 - A configuration update whose commitment equals zero MUST revert with `InvalidConfig`; zero is reserved to mean that the account still uses its initial derived configuration.
 
@@ -248,7 +219,7 @@ Rules:
 - `inner_digest` MUST be `tx.signature_hash()` when direct or the parent's multisig account digest when nested.
 - Owner signatures MUST be owner-ordered, belong to the applicable configuration, and reach threshold on the final item.
 - Validation MUST reject missing quorum, duplicate or unsorted owners, cycles, and any owner signature submitted after quorum is reached.
-- Stateless recovery MUST validate the shape and return the claimed or derived account, without proving commitment equality, membership, or quorum.
+- Stateless recovery MUST validate the shape, including version-0 account derivation, and return `account` without proving commitment equality, membership, or quorum.
 - Stateful validation MUST compare the witness with the account's block-position commitment and complete quorum verification before the account is treated as authorized.
 
 ## Transaction Execution
@@ -276,8 +247,9 @@ The example assumes `alice_address < bob_address`, each owner has weight 1, and 
 ```text
 // Define the initial owner configuration.
 // Ref: Types and Limits
-init = multisig_init(
+config = multisig_config(
   salt = salt,
+  version = 0,
   threshold = 2,
   owners = [
     [alice_address, 1],
@@ -308,7 +280,8 @@ bob_signature   = sign(bob_key, digest)
 // Attach the initial signature containing the initial configuration.
 tx.signature =
   0x05 || rlp([
-    init,
+    account,
+    config,
     [alice_signature, bob_signature]
   ])
 ```
@@ -317,7 +290,7 @@ After validation, the account is available to the transaction's call batch. The 
 
 Rules:
 
-- An initial signature MUST target the account derived from `init` and MUST be rejected when that account's commitment slot is nonzero.
+- An initial signature MUST target the account derived from `config` and MUST be rejected when that account's commitment slot is nonzero.
 - When an initial `key_authorization.signature` authorizes the outer V2 account keychain signature, the outer signature MUST use the key authorized by that same key authorization.
 - An initial transaction MUST NOT require a zero protocol nonce. Ordinary nonce validation and consumption apply.
 - The target MAY already have a balance or storage.
@@ -410,6 +383,7 @@ interface INativeMultisig {
 
     event MultisigConfigUpdated(
         address indexed account,
+        bytes32 salt,
         uint64 version,
         uint8 threshold,
         MultisigOwner[] owners
@@ -436,10 +410,10 @@ Rules:
 - `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
 - `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
 - `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- It MUST use the outer multisig authorization context's account and authorized witness version. Access-key authorization MUST NOT call it.
+- It MUST use the outer multisig authorization context's account, salt, and authorized witness version. Access-key authorization MUST NOT call it.
 - At most one `updateConfig` call MAY succeed per transaction; a later call MUST revert with `MultipleConfigUpdates`.
 - `updateConfig` MUST NOT accept a separate authorization signature.
-- `updateConfig` MUST increment the authorized configuration version by one, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
+- `updateConfig` MUST preserve the authorized configuration salt, increment the authorized configuration version by one, revert with `InvalidConfig` on `uint64` overflow or a zero resulting commitment, store that commitment, and emit the complete new configuration and version.
 - Configuration validation MUST return the first applicable error in this order:
   - `InvalidOwner` for an empty owner list.
   - `TooManyOwners` above `MAX_MULTISIG_OWNERS`.
@@ -495,9 +469,9 @@ Rules:
 - Quorums MAY add ordinary or admin access keys directly or via `key_authorization`; existing key rules MUST apply.
 - A multisig signature MUST NOT be accepted as an account-keychain access-key signature. Primitive access-key identities remain stateless under the address-collision assumption.
 - When a multisig account's owners authorize a key for that account, `key_authorization.account` MUST equal the multisig account address.
-- The multisig signature MUST carry the same address in current encoding or derive it from `init` in initial encoding, carry the complete applicable configuration, and use the digest above.
+- The multisig signature MUST carry the account and complete applicable configuration and use the digest above.
 - A multisig key authorization MUST complete stateful configuration and quorum validation and satisfy root, rather than delegated-admin, authorization.
-- An initial key authorization MAY carry `init`; successful validation registers the key without persisting multisig configuration state.
+- A version-0 key authorization MAY register the key without persisting multisig configuration state.
 - When both the outer signature and `key_authorization.signature` are multisig signatures, each MUST independently carry and validate the applicable configuration witness.
 - Authorize-and-use MAY occur in one transaction when the outer signature uses the new key.
 - Access key transactions MUST use the V2 envelope, execute as the account under stored restrictions, and skip the parent quorum.
@@ -511,9 +485,7 @@ Rules:
 Multisig account authorization is charged as regular intrinsic gas. Costs scale with submitted owner signatures and nested account nodes:
 
 ```text
-witness_bytes(signature) =
-  initial: rlp(init)
-  current: rlp(account) || rlp(config)
+witness_bytes(signature) = rlp(account) || rlp(config)
 
 node(signature) =
     2,100
@@ -568,10 +540,10 @@ Commitments do not reveal configurations. Multisig simulation therefore requires
 
 Rules:
 
-- Tooling MUST support the T11 initial and current witness encodings, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
+- Tooling MUST support the T11 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
 - Wallets MUST retain the initial witness until it is recoverable from an on-chain transaction and MUST track the latest complete configuration from successful update events.
 - Unsigned simulation and gas estimation that model multisig outer or key authorization MUST accept an RPC-only complete witness and approval shape. These fields MUST NOT alter the signed transaction encoding.
-- The RPC witness MUST distinguish initial from current encoding and recursively identify each approved owner, primitive signature type and variable-length data, or nested witness; an owner-count-only hint is insufficient.
+- The RPC witness MUST include the account and complete versioned configuration and recursively identify each approved owner, primitive signature type and variable-length data, or nested witness; an owner-count-only hint is insufficient.
 - Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas. Only cryptographic owner-signature verification MAY be skipped in simulation context.
 
 ## Observability
@@ -581,8 +553,8 @@ Initial transaction signatures and owner-update events expose enough data to rec
 Rules:
 
 - Before the first on-chain initial signature, the account's initial witness is not discoverable from its address or zero commitment alone.
-- Reconstructing the initial configuration MUST decode `init` from an initial outer or key authorization signature.
-- A successful owner update MUST emit `MultisigConfigUpdated(account, version, threshold, owners)`.
+- Reconstructing the initial configuration MUST decode the version-0 config from an outer or key authorization signature.
+- A successful owner update MUST emit `MultisigConfigUpdated(account, salt, version, threshold, owners)`.
 - The initial configuration uses version `0`; the first owner-update event uses version `1`, and each later event increments it by one.
 - Account keychain paths MUST retain their existing events.
 
@@ -592,13 +564,14 @@ These examples illustrate the canonical signing flows and main authorization edg
 
 ### Initial Configuration
 
-An initial transaction authorizes the account without storing its initial owner configuration. Its signature carries `init` because no configuration exists in state yet.
+An initial transaction authorizes the account without storing its initial owner configuration. Its signature carries the version-0 config because no configuration exists in state yet.
 
 ```text
 // Define and derive the account with alice_address < bob_address.
 // Ref: Types and Limits
-init = multisig_init(
+config = multisig_config(
   salt = salt,
+  version = 0,
   threshold = 2,
   owners = [
     [alice_address, 1],
@@ -625,7 +598,8 @@ digest = multisig_digest(
 
 tx.signature =
   0x05 || rlp([
-    init,
+    account,
+    config,
     [
       sign(alice_key, digest),
       sign(bob_key, digest)
@@ -825,8 +799,9 @@ This transaction uses the counterfactual account and registers an access key at 
 ```text
 // Define and derive the new multisig account.
 // Ref: Types and Limits
-init = multisig_init(
+config = multisig_config(
   salt = salt,
+  version = 0,
   threshold = 2,
   owners = [
     [alice_address, 1],
@@ -855,7 +830,8 @@ key_authorization_digest = multisig_digest(
 
 key_authorization_signature =
   0x05 || rlp([
-    init,
+    account,
+    config,
     [
       sign(alice_key, key_authorization_digest),
       sign(bob_key, key_authorization_digest)
@@ -887,7 +863,7 @@ tx.signature =
 execute(tx)
 ```
 
-Validation derives the account from `init`, registers the access key, and executes the same transaction as `account` under the key's restrictions without persisting a multisig configuration commitment.
+Validation derives the account from `config`, registers the access key, and executes the same transaction as `account` under the key's restrictions without persisting a multisig configuration commitment.
 
 ### Initial Configuration and Subsequent Access Key Use
 
@@ -896,8 +872,9 @@ The owner quorum can use the initial configuration to register an access key wit
 ```text
 // Define and derive the new multisig account.
 // Ref: Types and Limits
-init = multisig_init(
+config = multisig_config(
   salt = salt,
+  version = 0,
   threshold = 2,
   owners = [
     [alice_address, 1],
@@ -927,7 +904,8 @@ key_authorization_digest = multisig_digest(
 // The key authorization independently carries the initial witness.
 key_authorization_signature =
   0x05 || rlp([
-    init,
+    account,
+    config,
     [
       sign(alice_key, key_authorization_digest),
       sign(bob_key, key_authorization_digest)
@@ -954,7 +932,8 @@ initial_digest = multisig_digest(
 
 initial_tx.signature =
   0x05 || rlp([
-    init,
+    account,
+    config,
     [
       sign(alice_key, initial_digest),
       sign(bob_key, initial_digest)
@@ -1013,7 +992,8 @@ rotate_digest = multisig_digest(
 
 rotate_tx.signature =
   0x05 || rlp([
-    init,
+    account,
+    config,
     [
       sign(alice_key, rotate_digest),
       sign(bob_key, rotate_digest)
@@ -1023,6 +1003,7 @@ rotate_tx.signature =
 execute(rotate_tx)
 
 next_config = multisig_config(
+  salt = config.salt,
   version = 1,
   threshold = 1,
   owners = [[carol_address, 1]]
@@ -1082,5 +1063,5 @@ Rules:
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
 - **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
 - **Config update count.** At most one `updateConfig` call MAY succeed per transaction.
-- **Config update version.** `updateConfig` MUST persist the nonzero commitment of version `current_version + 1` and emit that complete configuration.
+- **Config update version.** `updateConfig` MUST preserve the salt, persist the nonzero commitment of version `current_version + 1`, and emit that complete configuration.
 - **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -14,9 +14,7 @@ protocolVersion: T11
 
 Configurable accounts can change who controls them and their configuration without changing their identity. They support multisig control, recovery, key rotation, and permissioned access (via access keys) while remaining the same Tempo account to applications and counterparties.
 
-This TIP implements configurable accounts as native multisig accounts. Protocol identifiers, signatures, and ABI names use the term `multisig`.
-
-Accounts are counterfactual: their initial owner configuration derives the address without a creation transaction. Owner-authorized transactions carry the complete current configuration, and owner updates persist only one configuration commitment slot.
+This TIP implements configurable accounts as counterfactual native multisig accounts; protocol names use `multisig`. Their initial configuration derives the address, signatures carry the applicable configuration, and owner updates persist one commitment slot.
 
 ## Motivation
 
@@ -133,9 +131,7 @@ pub enum MultisigSignature {
 }
 ```
 
-Every multisig signature carries the complete configuration used to validate it. An initial witness contains the salt and version-0 configuration that derive a counterfactual account. After an owner update, a current witness contains the account and the complete nonzero-version configuration whose commitment is stored on-chain.
-
-An account may have up to 48 owners. A signature may contain up to one approval per configured owner instead of an independent fixed approval cap. Nested multisig account owner signatures are limited to one level: the outer account is depth 1 and the nested owner account is depth 2. Owner count, nesting depth, primitive signature length, transaction size, and recursively computed intrinsic gas together bound decoding and verification work. A recursively valid shape whose intrinsic gas exceeds the transaction gas limit MUST be rejected before cryptographic signature verification.
+Each signature carries its configuration: initial witnesses derive version-0 accounts; current witnesses match stored nonzero commitments. Configurations allow up to 48 owners and one approval per owner; depth 2 permits one nested level. Size, depth, and gas limits bound validation.
 
 Rules:
 
@@ -163,8 +159,6 @@ Rules:
 
 ### Initial
 
-The initial form authorizes a counterfactual multisig account without creating configuration state. It remains valid across transactions until the account performs its first configuration update.
-
 ```text
 0x05 || rlp([init, signatures])
 
@@ -178,8 +172,6 @@ Rules:
 - The account's persisted configuration commitment MUST be zero.
 
 ### Current
-
-The current form is used after the first configuration update. It identifies the account and carries the complete configuration witness checked against its stored commitment.
 
 ```text
 0x05 || rlp([account, config, signatures])
@@ -196,7 +188,7 @@ Rules:
 
 ## Account Identity
 
-The initial owner configuration and salt establish an account identity that remains stable across later owner changes. The salt lets identical owner configurations derive distinct accounts:
+The initial configuration and salt derive a stable account address:
 
 ```text
 multisig_address = address(keccak256(
@@ -209,7 +201,7 @@ multisig_address = address(keccak256(
 )[12:32])
 ```
 
-Owner updates persist a commitment to the complete new configuration:
+Owner updates commit to the complete new configuration:
 
 ```text
 config_commitment = keccak256(
@@ -364,7 +356,7 @@ Rules:
 
 ## Storage
 
-The multisig account precompile stores at most one configuration commitment per account. Full configurations remain in signatures and update events rather than persistent storage. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
+The precompile stores one commitment per account; signatures and update events carry full configurations. `pad32` encodes a value as a 32-byte big-endian word, and `mapping_slot` returns Keccak-256 as a big-endian `uint256`.
 
 ```text
 mapping_slot(key, base) = keccak256(pad32(key) || pad32(base))
@@ -541,15 +533,9 @@ first_config_update_storage = active_sstore_set(warm_config_slot)
 later_config_update_storage = active_sstore_reset(warm_config_slot)
 ```
 
-The leading 2,100 gas is a fixed per-node configuration-commitment validation charge priced at one cold read. It is charged for every node even when an earlier node read the same slot or the implementation reuses a cached result. Witness bytes are charged using the ordinary zero/nonzero calldata schedule even though they are encoded in the signature field. The per-signature term charges owner matching and quorum processing; there are no owner-row storage reads.
+Each node pays a fixed 2,100 gas commitment-read charge, even when the slot is reused or cached, plus witness calldata and owner-processing costs. Nested nodes add 2,600 gas for a code-hash/delegation check; implementations MUST NOT load bytecode. There are no owner-row reads.
 
-Each nested node adds a fixed 2,600 gas account-validation charge for checking that the nested multisig owner has no bytecode or EIP-7702 delegation, without a warm-access discount for repeated accounts. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
-
-The direct subtraction accounts for the secp256k1 transaction signature already included in ordinary intrinsic gas. A direct 8-approval secp256k1 node costs 39,900 gas plus its configuration-witness data gas.
-
-When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
-
-Initial use creates no multisig storage and has no storage surcharge. Signature validation warms the commitment slot, so the first owner update pays one warm zero-to-nonzero write and later updates pay one warm nonzero-to-nonzero write under the active precompile storage schedule. Update event data is charged by ordinary precompile execution gas.
+The 3,000 gas direct subtraction accounts for the transaction signature already included in intrinsic gas; key authorizations are charged independently without that subtraction. Initial use writes no multisig state. The first update pays a warm zero-to-nonzero commitment write; later updates pay a warm nonzero-to-nonzero write.
 
 Under the gas schedule active when this TIP was drafted, representative first-use costs for an 8-of-48 account before executed calls are:
 
@@ -558,7 +544,7 @@ Under the gas schedule active when this TIP was drafted, representative first-us
 | First use with 8 secp256k1 approvals | ~24.5M gas | ~79k gas | ~310x |
 | First use with 8 WebAuthn approvals | ~24.6M-24.8M gas | ~119k-365k gas | ~68x-207x |
 
-The table compares the owner-row design's storage-writing bootstrap with the commitment design's storage-free initial authorization. The witness column includes the 21,000 base transaction cost and approximately 18,000 gas for a 48-owner witness. Counterfactual creation itself costs zero gas. A first configuration update adds approximately 250,100 gas for one new commitment slot; later updates add approximately 5,000 gas for one warm nonzero-to-nonzero write. These figures are informative and change with the active storage or calldata schedule; the formulas above are normative.
+The table compares storage-writing bootstrap with storage-free initial authorization. Estimates include 21,000 base gas and about 18,000 witness gas; a first update adds about 250,100 gas and later updates about 5,000 gas. The formulas above are normative.
 
 Rules:
 
@@ -575,9 +561,7 @@ Rules:
 
 ## Tooling
 
-Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across address derivation, witness construction, signing, transaction decoding, and configuration history.
-
-A commitment verifies a supplied current configuration but cannot reconstruct it. Before the first on-chain initial signature, the salt and initial configuration are likewise available only from the account creator. Unsigned requests that simulate multisig outer or key authorization therefore need an RPC-only witness that supplies the applicable initial or current configuration and the planned primitive or nested approval encodings needed for exact gas calculation. Access-key transactions continue to require no parent witness.
+Commitments verify but do not reveal configurations. Wallets and indexers recover them from initial signatures and update events; multisig simulation requires an RPC-only complete witness and approval shape. Access-key transactions require no parent witness.
 
 Rules:
 
@@ -588,8 +572,6 @@ Rules:
 - Simulation MUST enforce witness shape, resource bounds, commitment equality, and intrinsic gas. Only cryptographic owner-signature verification MAY be skipped in simulation context.
 
 ## Observability
-
-Initial signatures and owner-update events expose enough data to reconstruct an account's configuration history without storing owner rows on-chain.
 
 Rules:
 
@@ -1068,7 +1050,7 @@ next_tx.signature =
 
 This change is additive for transactions and accounts that do not use multisig signatures. Applications can move assets or state from an existing EOA through their current flows.
 
-Primitive-signed fee payers, access keys, and authorization-list authorities remain stateless with respect to multisig commitments under the address-collision assumption. Keychain-signed authorization-list entries retain their existing skipped behavior and also require no commitment read. Generic `SignedKeyAuthorization` decoders also accept the new multisig signature form, while consensus rejects it before T11 and primitive encodings remain unchanged.
+Under the address-collision assumption, primitive-signed fee payers, access keys, and authorization-list authorities require no commitment read; keychain authorization-list entries remain skipped. `SignedKeyAuthorization` accepts multisig at T11 without changing primitive encodings.
 
 Rules:
 


### PR DESCRIPTION
Stacks on #7242.

Reworks TIP-1061 around counterfactual accounts that carry full configuration witnesses and persist one commitment slot after rotation. It replaces linear owner storage reads with one commitment read while retaining the eight-approval cap; the 8-of-48 secp256k1 first-use example drops from ~24.5M to ~79k gas before calls.

Prompted by: @joshieDo