### PR TITLE
chore(release): prepare v1.13.2

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: centaur/patch-tempo-alloy-core-1787329607
           path: foundry
           persist-credentials: false
 
@@ -260,7 +260,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          ref: centaur/patch-tempo-alloy-core-1787329607
           path: foundry
           persist-credentials: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13258,7 +13258,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13420,7 +13420,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13488,7 +13488,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13518,7 +13518,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13532,7 +13532,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13584,7 +13584,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13636,7 +13636,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13655,7 +13655,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "eyre",
  "indenter",
@@ -13663,7 +13663,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13688,7 +13688,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13760,7 +13760,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13798,7 +13798,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13818,7 +13818,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13852,7 +13852,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13901,7 +13901,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13934,7 +13934,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "clap",
@@ -13959,7 +13959,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "eyre",
  "jiff",
@@ -13968,7 +13968,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14011,7 +14011,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14023,7 +14023,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.13.1"
+version = "1.13.2"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5176,9 +5176,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.13.1"
+version = "1.13.2"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]

--- a/deny.toml
+++ b/deny.toml
@@ -89,6 +89,7 @@ unknown-registry = "warn"
 # in the allow list is encountered
 unknown-git = "deny"
 allow-git = [
+  "https://github.com/alloy-rs/core",
   "https://github.com/paradigmxyz/reth",
   "https://github.com/sigp/discv5",
 ]


### PR DESCRIPTION
Updates the workspace package versions in `Cargo.toml` and `Cargo.lock` to v1.13.2.

Backported PRs and their corresponding commits on `main`, in cherry-pick order:

- [#7203](https://github.com/tempoxyz/tempo/pull/7203) → [`cc3d2ed0d1ecf6071c8c81451e70a8aa58c95a7d`](https://github.com/tempoxyz/tempo/commit/cc3d2ed0d1ecf6071c8c81451e70a8aa58c95a7d): fixes rare race conditions where killing a node leaves its epoch-specific vote journal broken that would need operator intervention.
- [#6950](https://github.com/tempoxyz/tempo/pull/6950) → [`85316817f4809f38ea5bad8193bf6e9358671dd5`](https://github.com/tempoxyz/tempo/commit/85316817f4809f38ea5bad8193bf6e9358671dd5): resets stale DKG state on startup and attempts to recover threshold voting shares if revealed on chain; allows a fresh node to participate in consensus faster.
- [#7244](https://github.com/tempoxyz/tempo/pull/7244) → [`ae88794c4c37a0db531dae45abb41c2affee0ad8`](https://github.com/tempoxyz/tempo/commit/ae88794c4c37a0db531dae45abb41c2affee0ad8): ensures that nodes running `--minimal` able to start by reading both finalized headers and blocks; in certain scenarios headers for epoch boundaries were available but blocks already deleted, leading nodes to be unable to start even thought all data was present.
- [#7255](https://github.com/tempoxyz/tempo/pull/7255) → [`11a9182aaa11862197d33a5211e7fe51a3e40ad2`](https://github.com/tempoxyz/tempo/commit/11a9182aaa11862197d33a5211e7fe51a3e40ad2): noisily rejects startup if, due to manual intervention, available finalization certificates were older then persisted node metadata and expected certificates missing.
- [#7256](https://github.com/tempoxyz/tempo/pull/7256) → [`b51280901fdc5a0fcf642d7a62f0613cad7bfc7c`](https://github.com/tempoxyz/tempo/commit/b51280901fdc5a0fcf642d7a62f0613cad7bfc7c): `tempo download --force` now deletes the entire `consensus/` directory if present. This is because partial overwriting of snapshotted archive data can leave the node in an inconsistent state.
- [#7154](https://github.com/tempoxyz/tempo/pull/7154) → [`f7b32a421f540510cb1bf73e8d4b5fe02b7c453f`](https://github.com/tempoxyz/tempo/commit/f7b32a421f540510cb1bf73e8d4b5fe02b7c453f): includes consensus data by default when running `tempo download`. Improves operator UX by not forcing them to provide `--skip-consensus=false`.
- [#7251](https://github.com/tempoxyz/tempo/pull/7251) → [`4d248169172ff2602b1bc95930c70bbc72d23bb0`](https://github.com/tempoxyz/tempo/commit/4d248169172ff2602b1bc95930c70bbc72d23bb0): adds minimal logs to introspect how execution is driven by consensus.
- [#7264](https://github.com/tempoxyz/tempo/pull/7264) → [`2ed6c4dd3a75dd0c053fe879d96c6bc565c5746f`](https://github.com/tempoxyz/tempo/commit/2ed6c4dd3a75dd0c053fe879d96c6bc565c5746f): fixes datadir and manifest resolution when calling `tempo download` so operators need not provide `--datadir` or `--manifest-url` when downloading snapshots.

