### PR TITLE
ci: use GitHub STS for sync-from-upstream instead of app credentials

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,0 +1,13 @@
+# Allow the sync-from-upstream workflow in tempo-private-fork (scheduled and
+# manually dispatched runs on main) to mint a short-lived token to force-push
+# main. `workflows: write` is required because the synced commits touch
+# .github/workflows files.
+#
+# This file is mirrored into tempo-private-fork by the sync itself, where it
+# authorizes tokens scoped to the fork. Note that its presence in this repo
+# also lets the fork's main-branch workflows mint a token scoped to
+# tempoxyz/tempo, since a fork of this repo carries identical contents.
+subject: repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/heads/main
+permissions:
+  contents: write
+  workflows: write

--- a/.github/workflows/sync-from-upstream.yml
+++ b/.github/workflows/sync-from-upstream.yml
@@ -14,19 +14,18 @@ jobs:
   sync:
     if: ${{ github.repository != 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+      - name: Fetch GitHub token via STS
+        id: github-sts
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
         with:
-          client-id: ${{ vars.SYNC_APP_ID }}
-          private-key: ${{ secrets.SYNC_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-workflows: write
+          policy: sync-from-upstream
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 # zizmor: ignore[artipacked]
         with:
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ steps.github-sts.outputs.token }}
           fetch-depth: 0
 
       - name: Sync main with upstream
@@ -37,4 +36,4 @@ jobs:
           git reset --hard upstream/main
           git push origin main --force
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.github-sts.outputs.token }}


### PR DESCRIPTION
## Summary

Replaces the "Tempo Private Fork Syncer" GitHub App (app ID 2942696, `vars.SYNC_APP_ID` / `secrets.SYNC_APP_PRIVATE_KEY`) with a [github-sts](https://github.com/tempoxyz/gh-actions/tree/main/actions/github-sts) token exchange in the `sync-from-upstream` workflow.

- **`.github/workflows/sync-from-upstream.yml`** — drops the `create-github-app-token` step and stored credentials; the job now grants `id-token: write` and exchanges its OIDC token via STS (policy `sync-from-upstream`, default scope = the repo the workflow runs in, i.e. `tempo-private-fork`).
- **`.github/sts/sync-from-upstream.sts.yaml`** — trust policy granting `contents: write` and `workflows: write` to workflows running on `tempo-private-fork`'s `main` branch. `workflows: write` is required because force-pushing upstream `main` includes changes to `.github/workflows` files. The policy file reaches the fork via the sync itself (the fork's `main` mirrors this repo's `main`), so the first sync after this lands still runs with the old app credentials and bootstraps the STS version.

## Verified

- **No special "scheduled" subject context exists.** Per GitHub's OIDC docs, `schedule` and `workflow_dispatch` runs (no environment, not `pull_request`) both get `sub = repo:<org>/<repo>:ref:refs/heads/<branch>`, so a single `refs/heads/main` subject covers both of the workflow's triggers. No `pull_request` entry is needed.
- The subject uses the immutable ID-annotated form required by the STS worker's `subject_pattern` prefix rule; both repos already have it enabled (`gh api repos/tempoxyz/tempo-private-fork/actions/oidc/customization/sub` → `sub_claim_prefix: repo:tempoxyz@211589300/tempo-private-fork@1160043351`). The fork's repo ID (1160043351) is pinned in the policy.
- `workflows` is an accepted permission name in the STS worker's policy validator.
- `actionlint` and `zizmor` pass on the modified workflow.