### PR TITLE
ci: authorize tempo-firedrill in the sync-from-upstream STS policy

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,13 +1,18 @@
-# Allow the sync-from-upstream workflow in tempo-private-fork (scheduled and
-# manually dispatched runs on main) to mint a short-lived token to force-push
-# main. `workflows: write` is required because the synced commits touch
-# .github/workflows files.
+# Allow the sync-from-upstream workflow in copies of this repo (scheduled and
+# manually dispatched runs on main) to mint a short-lived token to push the
+# synced main. `workflows: write` is required because the synced commits can
+# touch .github/workflows files.
 #
-# This file is mirrored into tempo-private-fork by the sync itself, where it
-# authorizes tokens scoped to the fork. Note that its presence in this repo
-# also lets the fork's main-branch workflows mint a token scoped to
-# tempoxyz/tempo, since a fork of this repo carries identical contents.
-subject: repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/heads/main
+# This file is mirrored into the copies by the sync itself, where it
+# authorizes tokens scoped to the copy: tempo-private-fork mirrors main
+# byte-for-byte, and tempo-firedrill takes everything except its own
+# .github/workflows — so this file, not the firedrill's checkout, is where
+# its sync authorization must live. Note that its presence in this repo also
+# lets those copies' main-branch workflows mint a token scoped to
+# tempoxyz/tempo, since they carry (nearly) identical contents.
+subject:
+  - repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/heads/main
+  - repo:tempoxyz@211589300/tempo-firedrill@1167619511:ref:refs/heads/main
 permissions:
   contents: write
   workflows: write


### PR DESCRIPTION
Follow-up to #7277. `tempo-firedrill` runs the same `sync-from-upstream` workflow, but manually dispatched only, and its sync script preserves the firedrill's own `.github/workflows` while taking everything else — including `.github/sts/` — from upstream. Its STS authorization therefore has to live in this file (upstream) to survive syncs; a policy committed only to the firedrill would be wiped on the next sync.