### PR TITLE
docs(tip-1101): define offchain multisig operations

### DIFF
--- a/tips/tip-1101.md
+++ b/tips/tip-1101.md
@@ -167,17 +167,6 @@ type Operation = TransactionOperation | KeyAuthorizationOperation
 
 ## Storage
 
-The persistence format is private to the relay. A versioned implementation SHOULD use a wrapper like this:
-
-```ts
-type StoredOperation = {
-  operation: Operation
-  version: 1
-}
-```
-
-The store `version` and `configVersion` describe different things. The first identifies the persistence format. The second identifies the onchain owner configuration.
-
 The relay stores an operation under a key derived from its full 32-byte hash. An update MUST compare the value read with the value it replaces. The relay may retry conflicts, but it MUST cap those retries and return a server error when it cannot make progress.
 
 Direct store writes are outside this TIP. Public services SHOULD expose the validated approval methods. They may expose read-only operation lookup.
@@ -421,7 +410,7 @@ type Request = {
 type Response = Operation | null
 ```
 
-The method returns the JSON object at `hash`, or `null` when no operation exists. It never returns the store's serialized wrapper.
+The method returns the JSON object at `hash`, or `null` when no operation exists. It never returns the store's private representation.
 
 There is no list or search method. A caller must know the full operation hash. A deployment may restrict reads, but public lookup also conforms to this TIP.
 
@@ -548,7 +537,7 @@ An implementation meets this TIP when:
 - **Hash semantics.** `hash` always identifies the approval operation. `transactionHash` exists only after downstream acceptance and equals the hash returned downstream. Standard lookup methods may accept the operation hash as a documented alias, but successful transaction and receipt responses expose the downstream hash.
 - **Key authorization completion.** A successful key authorization contains canonical signed RLP and causes no broadcast.
 - **Terminal success.** A successful operation is terminal. Later requests cannot change its payload, approvals, signed key authorization, or transaction hash.
-- **RPC encoding.** A JSON-RPC method that returns an operation returns the operation object, never the serialized persistence wrapper.
+- **RPC encoding.** A JSON-RPC method that returns an operation returns the operation object, never the private stored representation.
 - **Standard submission.** `eth_sendRawTransaction` and `eth_sendRawTransactionSync` never collect approvals.
 
 Tests MUST cover:

--- a/tips/tip-1101.md
+++ b/tips/tip-1101.md
@@ -1,0 +1,566 @@
+---
+id: TIP-1101
+title: Offchain Multisig Operations
+description: Defines JSON-RPC operations for coordinating multisig transaction and key authorization approvals.
+authors: Jake Moxey (@jxom)
+status: Draft
+related: TIP-0001, TIP-1011, TIP-1061
+protocolVersion: n/a
+---
+
+# TIP-1101: Offchain Multisig Operations
+
+## Abstract
+
+Independent owners cannot submit a TIP-1061 transaction or use a TIP-1061 key authorization until they have assembled a full quorum. This TIP defines JSON-RPC methods that collect those approvals and expose their status.
+
+A relay verifies each approval against the current account configuration, stores it, and chooses one canonical weighted quorum. It submits a transaction once that quorum exists. For a key authorization, it returns the completed signed value instead.
+
+## Motivation
+
+A partial multisig signature is not a transaction. Owners need a place to store it while the rest of the quorum approves the same payload.
+
+Without a common interface, each wallet or API has to invent that mailbox. The hard parts are easy to get wrong. Concurrent writes can lose an approval. Caller-provided weights may be stale or dishonest. Arrival order can change the final signature. A service may even make `eth_sendRawTransaction` return an operation hash, although callers expect a transaction hash.
+
+This TIP gives coordination its own `multisig_*` methods. Standard Ethereum submission methods keep their usual meaning. Transactions and key authorizations share approval handling, but keep separate completion flows because only a transaction causes an external broadcast.
+
+### Alternatives
+
+- **Local aggregation.** This works when one process controls enough owner keys, but not when owners sign through separate devices or services.
+- **Intercepting `eth_sendRawTransaction`.** This makes the method transport-dependent and treats a partial approval as a transaction submission.
+- **One approval method.** Its request and response would have to hide the difference between submitting a transaction and producing signed data.
+- **Opaque operation responses.** Returning the store's serialized value ties clients to one persistence format and makes store migrations part of the public API.
+
+## Assumptions
+
+- TIP-1061 defines account identity, configuration versions, approval digests, limits, nesting, ordering, and final signature validation. This TIP does not change those rules.
+- The relay can read current root and nested configurations from an authoritative Tempo RPC endpoint. If it cannot resolve a required configuration, it rejects the request.
+- A bootstrap signature contains the initial configuration. The relay checks that the configuration derives the claimed account and uses configuration version `0`.
+- A shared production store supports linearizable compare-and-set for each operation key. A single writer may fall back to separate reads and writes, but that fallback does not protect concurrent updates.
+- The downstream handler keeps the behavior of `eth_sendRawTransaction` and `eth_sendRawTransactionSync`. Fee sponsorship, authentication, billing, and routing may run there.
+- An operation hash is a lookup key, not an authentication secret. A deployment may allow public reads.
+- These methods require no protocol activation. A deployment can enable them once its target chain supports TIP-1061.
+
+A relay that uses stale configuration, non-atomic shared storage, or a downstream handler that changes sender-signed fields does not conform to this TIP.
+
+## Threat model
+
+| Actor | Expected behavior |
+| --- | --- |
+| RPC caller | May submit malformed payloads, duplicate approvals, stale signatures, wrong digests, non-owner signatures, or unknown hashes. The relay validates every request. |
+| Owner | May be unavailable, compromised, or malicious. An owner contributes only its configured weight. |
+| Nested owner | May submit a partial, cyclic, stale, or oversized signature tree. The relay applies TIP-1061 limits and membership checks at every node. |
+| Relay | Several instances may process the same operation. Atomic updates protect approvals, and a fenced lease gives one instance ownership of a broadcast attempt. |
+| Store | May return malformed or stale data. The relay checks stored payloads, hashes, and configurations before it accepts an approval or submits a transaction. |
+| Downstream submitter | May fail before or after broadcast and may add a fee-payer signature. The operation records the transaction hash that it returns. |
+| Operation reader | May see unsigned payloads and collected signatures. A deployment that needs privacy before submission must restrict reads. |
+| Denial-of-service attacker | May create many pending operations. Authentication, quotas, storage billing, and cleanup policy remain deployment concerns. TIP-1061 limits bound work within one operation. |
+
+---
+
+# Specification
+
+## Scope and terminology
+
+This TIP defines two operation kinds:
+
+- A **transaction operation** collects approvals over a Tempo transaction's TIP-1061 digest. The relay submits one canonical signed transaction at quorum.
+- A **key authorization operation** collects approvals over a key authorization's TIP-1061 digest. The relay returns one canonical signed authorization at quorum and does not submit a transaction.
+
+In this TIP, a **relay** is the service that implements these methods and stores operations. A **fee-payer relay** sponsors transaction fees. One service may perform both roles, but the roles remain separate.
+
+Owners sign the **operation hash**:
+
+```text
+operation_hash = keccak256(
+  "tempo:multisig:signature" ||
+  inner_digest ||
+  account ||
+  uint64(config_version)
+)
+```
+
+For a transaction, `inner_digest` is the Tempo transaction signing digest. For a key authorization, it is the key authorization signing digest. The hash stays the same for one payload, account, and configuration version.
+
+The operation hash and transaction hash are different values. The transaction hash commits to the submitted envelope, including any fee-payer signature added after owner quorum.
+
+## JSON-RPC methods
+
+A relay implements four methods:
+
+| Method | Result |
+| --- | --- |
+| `multisig_approveRawTransaction` | Adds transaction approvals and returns the operation hash. |
+| `multisig_approveRawTransactionSync` | Adds transaction approvals and returns the current operation. |
+| `multisig_approveKeyAuthorization` | Creates or updates a key authorization operation. |
+| `multisig_getOperation` | Returns either operation kind. |
+
+The relay MUST NOT collect approvals through `eth_sendRawTransaction` or `eth_sendRawTransactionSync`. A complete multisig transaction may use those methods without a relay.
+
+## Operation data
+
+The following TypeScript describes the JSON-RPC values. Quantities use canonical hexadecimal quantity encoding. Addresses, hashes, approvals, transactions, and key authorizations use `0x`-prefixed hexadecimal strings.
+
+```ts
+type MultisigOwner = {
+  owner: Address
+  weight: number
+}
+
+type MultisigConfig = {
+  owners: readonly MultisigOwner[]
+  threshold: number
+}
+
+type OperationBase = {
+  account: Address
+  approvals: readonly Hex[]
+  config: MultisigConfig
+  configVersion: Quantity
+  createdAt: number
+  hash: Hash
+  init: boolean
+  signatures: number
+  threshold: number
+  updatedAt: number
+  weight: number
+}
+
+type TransactionOperation = OperationBase & {
+  expiresAt?: number
+  status: 'pending' | 'submitting' | 'success'
+  submissionId?: Hash
+  transaction: Hex
+  transactionHash?: Hash
+  type: 'transaction'
+}
+
+type KeyAuthorizationOperation = OperationBase & {
+  keyAuthorization: Hex
+  status: 'pending' | 'success'
+  type: 'keyAuthorization'
+}
+
+type Operation = TransactionOperation | KeyAuthorizationOperation
+```
+
+| Field | Meaning |
+| --- | --- |
+| `account` | Root multisig account. |
+| `approvals` | Every owner approval retained after validation, including approvals not selected for the final quorum. |
+| `config` | Root configuration used to verify approvals. |
+| `configVersion` | Root configuration version. Bootstrap uses `0x0`. |
+| `createdAt` | Unix creation time in milliseconds. |
+| `expiresAt` | Unix time in milliseconds when another relay may reclaim the submission lease. Present only while a transaction operation is `submitting`. |
+| `hash` | Operation hash. |
+| `init` | `true` when the operation bootstraps the root account. Version `0` alone does not imply bootstrap. |
+| `keyAuthorization` | Canonical unsigned RLP while pending, then canonical signed RLP after success. |
+| `signatures` | Number of approvals selected for quorum evaluation. This may differ from `approvals.length`. |
+| `status` | Current operation state. |
+| `submissionId` | Random fencing token owned by one submitter. Present only while a transaction operation is `submitting`. It MUST differ from the operation hash, which every relay knows. |
+| `threshold` | Required root weight. This MUST equal `config.threshold`. |
+| `transaction` | Canonical serialized Tempo envelope with its outer sender signature removed. It keeps the fee-payer form and any fee-payer signature already supplied. |
+| `transactionHash` | Hash returned by the downstream submitter. Present only after a transaction operation succeeds. A fee-payer relay may add a signature, so the multisig relay cannot always derive this hash from `transaction`. |
+| `type` | Operation kind. |
+| `updatedAt` | Unix time of the last update in milliseconds. |
+| `weight` | Root weight reached by the selected approvals. |
+
+## Storage
+
+The persistence format is private to the relay. A versioned implementation SHOULD use a wrapper like this:
+
+```ts
+type StoredOperation = {
+  operation: Operation
+  version: 1
+}
+```
+
+The store `version` and `configVersion` describe different things. The first identifies the persistence format. The second identifies the onchain owner configuration.
+
+The relay stores an operation under a key derived from its full 32-byte hash. An update MUST compare the value read with the value it replaces. The relay may retry conflicts, but it MUST cap those retries and return a server error when it cannot make progress.
+
+Direct store writes are outside this TIP. Public services SHOULD expose the validated approval methods. They may expose read-only operation lookup.
+
+## Configuration
+
+The relay resolves configuration at every multisig signature node:
+
+- A bootstrap root uses its inline configuration and version `0`.
+- An initialized root uses its current onchain configuration and version.
+- A nested multisig owner MUST already exist onchain and use its current configuration and version.
+- A nested multisig signature MUST NOT contain an initial configuration.
+
+The relay applies every TIP-1061 configuration rule, including owner count, ordering, uniqueness, weights, threshold reachability, signature count, and nesting depth.
+
+It may cache configuration reads within one request. Before it accepts another approval or submits a transaction, it reads each initialized configuration again.
+
+A root configuration change invalidates the operation because it changes the operation hash. A nested configuration change invalidates that nested branch but leaves unrelated root approvals intact. A bootstrap operation cannot finish after another transaction initializes the account.
+
+## Approval handling
+
+For each submitted signature tree, the relay MUST:
+
+1. Compute the TIP-1061 digest at each node.
+2. Recover each direct signer and identify each nested multisig owner.
+3. Check that each address belongs to the relevant configuration.
+4. Verify direct signatures against the node digest.
+5. Verify nested signatures recursively against the parent digest.
+6. Reject keychain signatures as owner approvals.
+7. Reject malformed, oversized, cyclic, stale, wrong-digest, and non-owner approvals.
+8. Deduplicate approvals by owner address at each node.
+9. Treat an identical retry as a no-op.
+10. If one direct owner supplies two valid encodings, retain the bytewise smaller encoding.
+
+A partial nested approval stays in the store but contributes no parent weight. It contributes the nested owner's configured parent weight once the nested account reaches quorum.
+
+Before every update, the relay recomputes the hash from the stored payload. It rejects stored data whose key, hash, operation kind, account, or payload does not match.
+
+## Quorum selection
+
+The relay stores every valid approval, but serializes only one quorum. At each multisig node, it MUST:
+
+1. Consider direct signatures and nested signatures that have reached quorum.
+2. Rank them by descending weight, then ascending owner address.
+3. Select approvals until their weight reaches the threshold, subject to TIP-1061's eight-approval limit.
+4. Sort the selected approvals by ascending owner address.
+5. Check that the final sorted approval is the first one that reaches the threshold.
+
+For a fixed stored approval set, this produces one deterministic minimum-size quorum. `signatures` and `weight` report that selected set. More than eight low-weight approvals cannot make an operation ready.
+
+For example:
+
+```text
+threshold = 3
+Alice = 2
+Bob = 1
+Carol = 1
+
+Alice + Bob   -> quorum
+Alice + Carol -> quorum
+Bob + Carol   -> pending at weight 2
+
+Alice + Bob + Carol stored -> serialize Alice + Bob
+```
+
+Carol remains in the store. The final envelope omits her approval because TIP-1061 rejects any approval after quorum.
+
+## Transaction approvals
+
+### `multisig_approveRawTransaction`
+
+```ts
+type Request = {
+  method: 'multisig_approveRawTransaction'
+  params: [serializedTransaction: Hex]
+}
+
+type Response = Hash
+```
+
+The transaction MUST have an outer TIP-1061 multisig signature with at least one owner approval. The method always returns the operation hash, including after submission.
+
+At quorum, the relay sends the final envelope downstream through `eth_sendRawTransaction`. It stores the returned transaction hash on the operation.
+
+### `multisig_approveRawTransactionSync`
+
+```ts
+type Request = {
+  method: 'multisig_approveRawTransactionSync'
+  params: [serializedTransaction: Hex, timeout?: number]
+}
+
+type Response = TransactionOperation
+```
+
+Below quorum, the method returns a transaction operation with `status: 'pending'`. If another relay already owns the submission lease, it waits up to `timeout` and then returns the current operation with `status: 'submitting'`.
+
+At quorum, the relay calls `eth_sendRawTransactionSync`. After the downstream handler accepts the transaction, the method returns an operation with `status: 'success'`. The downstream receipt is not part of this response.
+
+The optional nonnegative `timeout` limits how long the request waits for another submitter. The server chooses a default when the caller omits it.
+
+Both transaction methods return as soon as they know the operation remains below quorum. The synchronous method waits only for the final broadcast.
+
+### First approval
+
+The relay processes the first approval in this order:
+
+1. Deserialize the Tempo transaction and require an outer multisig signature.
+2. Remove that signature and serialize the canonical unsigned envelope.
+3. Resolve the root account, configuration, and version.
+4. Compute the transaction signing digest and operation hash.
+5. Validate every submitted owner approval.
+6. Create the operation or merge it into the existing operation atomically.
+7. Return a pending result or start submission.
+
+One request may contain several owner approvals. The relay validates and merges each one.
+
+### Later approvals
+
+An SDK may load the stored transaction by operation hash, sign that hash with another owner, and build another approval envelope. It submits that envelope to the same method.
+
+The unsigned envelope MUST match the stored operation. The relay rejects changes to calls, chain ID, nonce, fees, validity bounds, authorization data, and every other sender-signed field.
+
+### Fee payers
+
+Coordination supports transactions without sponsorship, transactions signed by a local fee payer, and transactions sponsored by a fee-payer relay after owner quorum.
+
+For one operation:
+
+- A valid fee-payer signature MAY replace its unsigned marker.
+- An unsigned marker MUST NOT remove a stored fee-payer signature.
+- The relay MUST reject two different non-null fee-payer signatures.
+- A downstream fee-payer relay MAY add a signature after quorum without changing the owners' signing digest.
+
+The relay MUST send the final sender-signed envelope through the downstream handler. It MUST NOT bypass fee-payer policy, authentication, billing, or routing configured there.
+
+## Transaction submission
+
+Transaction operations move through these states:
+
+```text
+             quorum and lease acquired
+pending ---------------------------------> submitting
+   ^                                            |
+   | failed attempt or expired lease            | downstream accepted
+   +--------------------------------------------+---------> success
+```
+
+`pending` means the operation needs more weight or can retry submission. `submitting` means one relay owns a temporary broadcast lease. `success` means the downstream submitter accepted the transaction. It does not mean execution succeeded. A later receipt can still have status `reverted`.
+
+The relay claims a lease by atomically writing a transaction operation with `status: 'submitting'`, a new `submissionId`, and `expiresAt`. Only the relay whose `submissionId` remains current can finish or release that attempt.
+
+Before broadcast, the lease owner reads initialized configurations again, rechecks stored approvals, chooses the canonical quorum, and serializes the final sender-signed envelope. Every retry uses the same envelope.
+
+After a confirmed response, the relay stores the transaction operation with `status: 'success'` and the returned transaction hash. If the downstream handler definitely rejected the transaction, the relay returns the operation to `pending` and keeps its approvals.
+
+If the response is ambiguous, the relay SHOULD query the predicted transaction hash when it knows the exact submitted bytes. Otherwise it retries the same sender-signed request after the lease expires. A fee-payer relay that changes the full transaction bytes MUST handle repeated submission of the same sender-signed envelope idempotently.
+
+## Key authorization approvals
+
+### `multisig_approveKeyAuthorization`
+
+The first request contains a TIP-1061 key authorization with a partial multisig signature:
+
+```ts
+type InitialRequest = {
+  keyAuthorization: KeyAuthorizationRpc
+}
+```
+
+Later requests contain the operation hash and one direct or nested owner signature:
+
+```ts
+type SubsequentRequest = {
+  hash: Hash
+  signature: Hex
+}
+```
+
+`signature` is the canonical serialized Tempo signature envelope for one direct or nested owner approval.
+
+The complete contract is:
+
+```ts
+type Request = {
+  method: 'multisig_approveKeyAuthorization'
+  params: [InitialRequest | SubsequentRequest]
+}
+
+type Response = KeyAuthorizationOperation
+```
+
+### First approval
+
+The relay MUST:
+
+1. Decode the key authorization and require a multisig signature with at least one approval.
+2. Remove the signature and serialize the unsigned authorization.
+3. Resolve the root account from the signature's initial configuration or account field.
+4. Check that the authorization binds the same account.
+5. Resolve and validate the configuration.
+6. Compute the key authorization signing digest and operation hash.
+7. Validate and merge every submitted approval atomically.
+8. Return the resulting operation.
+
+### Later approvals
+
+The relay MUST:
+
+1. Read the operation at `hash` and require a key authorization operation.
+2. Recompute the hash from the stored unsigned authorization, root account, and configuration version.
+3. Read initialized root and nested configurations again.
+4. Verify the new approval against the operation hash.
+5. Merge it atomically and return the updated operation.
+
+An owner can sign the 32-byte operation hash without downloading the full authorization. A client SHOULD still show the authorization details before asking for a signature.
+
+### Completion
+
+Key authorization operations have two states:
+
+```text
+pending -------------------------------> success
+                  canonical quorum
+```
+
+At quorum, the relay chooses the canonical weighted quorum, builds the TIP-1061 multisig signature, attaches it to the stored unsigned authorization, and stores the signed RLP.
+
+There is no submission lease. Completing a key authorization only produces signed data. A later transaction must include it before it has any onchain effect.
+
+## Operation lookup
+
+### `multisig_getOperation`
+
+```ts
+type Request = {
+  method: 'multisig_getOperation'
+  params: [hash: Hash]
+}
+
+type Response = Operation | null
+```
+
+The method returns the JSON object at `hash`, or `null` when no operation exists. It never returns the store's serialized wrapper.
+
+There is no list or search method. A caller must know the full operation hash. A deployment may restrict reads, but public lookup also conforms to this TIP.
+
+## Transaction lookup aliases
+
+A relay may also recognize operation hashes in standard lookup methods:
+
+- `eth_getTransactionByHash(operationHash)` returns a synthetic transaction with `multisig` attached while the operation is pending or submitting. After success, it looks up `transactionHash` downstream and attaches the successful operation.
+- `eth_getTransactionReceipt(operationHash)` returns `null` before success. After success, it looks up `transactionHash` downstream and attaches the successful operation.
+- Unknown hashes pass through unchanged.
+
+Outside these lookup responses, an implementation MUST NOT present an operation hash as an onchain transaction hash.
+
+## Errors
+
+The relay returns JSON-RPC `InvalidParams` for:
+
+- malformed request values or serialized payloads;
+- an outer signature that is missing, empty, or not multisig;
+- a bootstrap configuration that does not derive the claimed account;
+- a key authorization bound to another account;
+- an unknown hash in a later approval request;
+- the wrong operation kind;
+- a non-owner, wrong-digest, keychain, stale, or nested bootstrap signature; and
+- any TIP-1061 limit violation.
+
+The relay returns a JSON-RPC server error when stored data is inconsistent, compare-and-set retries run out, or it cannot reconcile a lease conflict.
+
+It returns downstream transaction errors unchanged. A failed submission keeps every valid approval so another request can retry it.
+
+## Backward compatibility
+
+These namespaced methods do not change consensus encoding. Complete multisig transactions still use standard submission methods. Local key authorization signing still works when one process can produce a full quorum.
+
+Clients and servers advertise support outside this TIP. An endpoint that does not support a method returns the standard JSON-RPC method-not-found error.
+
+# Tooling
+
+SDKs SHOULD route partial multisig envelopes from their normal Tempo transaction actions:
+
+```ts
+const pending = await client.sendTransactionSync({
+  account: owner_1,
+  calls,
+  multisig,
+})
+
+const receipt = await client.sendTransactionSync({
+  account: owner_2,
+  hash: pending.transactionHash,
+})
+```
+
+When coordination is enabled, a Tempo action may call `multisig_approveRawTransaction` or `multisig_approveRawTransactionSync`. A direct `eth_sendRawTransaction` request remains a direct submission.
+
+`multisig_approveRawTransactionSync` returns the operation, not a receipt. An SDK that keeps a receipt-shaped `sendTransactionSync` API may build its pending result when `status` is `pending` or fetch the real receipt by `transactionHash` after `status` becomes `success`.
+
+SDKs SHOULD also expose key authorization coordination:
+
+```ts
+const pending = await client.accessKey.signMultisigAuthorization({
+  account: owner_1,
+  accessKey,
+  expiry,
+  multisig,
+  scopes,
+})
+
+const success = await client.accessKey.signMultisigAuthorization({
+  account: owner_2,
+  hash: pending.hash,
+})
+```
+
+Each action call MUST create exactly one local owner approval. Before signing, a wallet SHOULD show the account, payload, configuration version, threshold, and collected weight.
+
+`wallet_authorizeAccessKey` still returns a completed authorization. A wallet may run its owner ceremony through `multisig_approveKeyAuthorization`, but this TIP does not add a pending wallet response.
+
+A store adapter SHOULD implement `getItem`, `setItem`, and linearizable `compareAndSet`. In-memory storage is suitable for tests and one process. Coordination across processes needs shared atomic storage.
+
+Debugging tools SHOULD be able to:
+
+- decode both operation kinds;
+- recompute the operation hash;
+- show stored and current configuration versions;
+- recover approval owner addresses;
+- distinguish stored approvals from selected approvals;
+- rebuild the canonical final signature;
+- inspect submission lease ownership and expiry; and
+- derive the transaction hash when the final submitted bytes are known.
+
+# Observability
+
+N/A. This TIP adds no onchain events. Logging, metrics, tracing, and alerts are deployment concerns.
+
+# Success criteria
+
+An implementation meets this TIP when:
+
+- owners can finish a transaction by sharing only the operation hash after the first approval;
+- owners can finish a key authorization through the same operation model;
+- both operation kinds enforce TIP-1061 weights, limits, ordering, nesting, and configuration versions;
+- standard raw transaction methods keep their submission behavior;
+- compare-and-set prevents lost approvals and concurrent active submitters;
+- a failed submission can retry without collecting approvals again;
+- a completed key authorization causes no transaction broadcast;
+- lookup returns a JSON object for either operation kind; and
+- local fee payment, fee-payer-first signing, and fee-payer relay sponsorship all report the actual submitted transaction hash.
+
+# Invariants
+
+- **Operation identity.** An operation's `hash` equals the TIP-1061 digest computed from the canonical unsigned payload's signing digest, root account, and root configuration version. Its storage key uses the complete hash without truncation.
+- **Payload immutability.** An approval cannot change any sender-signed transaction or key authorization field.
+- **Configuration provenance.** A bootstrap root uses its validated inline configuration. Every initialized root and nested configuration comes from authoritative chain state. Before accepting an approval or finalizing an operation, the relay reads current initialized configurations again. Caller-supplied configuration claims outside bootstrap have no authority.
+- **Bootstrap.** A bootstrap configuration derives `account`, uses version `0`, and cannot finish after another transaction initializes the account.
+- **Owner uniqueness.** One owner contributes weight at most once at each multisig node.
+- **Nested quorum.** A nested owner contributes parent weight only after its own quorum.
+- **Protocol limits.** A final signature node stays within TIP-1061 size and depth limits, contains at most eight approvals, and first reaches threshold on its last owner-sorted approval.
+- **Deterministic signatures.** For a fixed canonical payload, configuration versions, and stored approval bytes, quorum selection and serialization produce the same sender signature.
+- **Extra approvals.** Extra valid approvals may stay in storage, but never appear after quorum in the final signature.
+- **Derived quorum.** `threshold` equals `config.threshold`. `signatures` is the count and `weight` is the total weight of the deterministically selected approvals. A transaction enters `submitting` or `success`, and a key authorization enters `success`, only after reaching quorum.
+- **Submission fencing.** Each `submitting` operation has one current `submissionId`. Only a transition presenting that token may finish or release the attempt. After `expiresAt`, an atomic replacement fences the previous token.
+- **Retry safety.** A failed attempt or expired lease does not remove approvals. Configuration revalidation may separately invalidate stale approvals.
+- **Hash semantics.** `hash` always identifies the approval operation. `transactionHash` exists only after downstream acceptance and equals the hash returned downstream. Standard lookup methods may accept the operation hash as a documented alias, but successful transaction and receipt responses expose the downstream hash.
+- **Key authorization completion.** A successful key authorization contains canonical signed RLP and causes no broadcast.
+- **Terminal success.** A successful operation is terminal. Later requests cannot change its payload, approvals, signed key authorization, or transaction hash.
+- **RPC encoding.** A JSON-RPC method that returns an operation returns the operation object, never the serialized persistence wrapper.
+- **Standard submission.** `eth_sendRawTransaction` and `eth_sendRawTransactionSync` never collect approvals.
+
+Tests MUST cover:
+
+- bootstrap and initialized accounts;
+- flat, weighted, direct, nested, and mixed-key owners;
+- several approvals in one request and later approval by operation hash;
+- duplicates, different arrival orders, and extra valid approvals;
+- root and nested configuration changes;
+- wrong accounts, wrong digests, malformed input, and TIP-1061 limits;
+- concurrent updates, lease recovery, and ambiguous submission failures;
+- derived quorum fields, legal state transitions, and terminal success;
+- operation lookup and both transaction submission modes;
+- key authorization completion followed by use; and
+- local fee payment, fee-payer-first signing, and fee-payer relay sponsorship.

--- a/tips/tip-1101.md
+++ b/tips/tip-1101.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1101
 title: Offchain Multisig Operations
-description: Defines JSON-RPC operations for coordinating multisig transaction and key authorization approvals.
+description: Defines JSON-RPC operations for coordinating multisig approvals and resolving cached account configurations.
 authors: Jake Moxey (@jxom)
 status: Draft
 related: TIP-0001, TIP-1011, TIP-1061
@@ -12,9 +12,9 @@ protocolVersion: n/a
 
 ## Abstract
 
-Independent owners cannot submit a TIP-1061 transaction or use a TIP-1061 key authorization until they have assembled a full quorum. This TIP defines JSON-RPC methods that collect those approvals and expose their status.
+Independent owners cannot submit a TIP-1061 transaction or use a TIP-1061 key authorization until they have assembled a full quorum. This TIP defines JSON-RPC methods that collect those approvals, expose their status, and resolve previously validated configurations by account.
 
-A relay verifies each approval against the current account configuration, stores it, and chooses one canonical weighted quorum. It submits a transaction once that quorum exists. For a key authorization, it returns the completed signed value instead.
+A relay validates each supplied configuration against the account's current commitment, verifies each approval, stores it, and chooses one canonical weighted quorum. It submits a transaction once that quorum exists. For a key authorization, it returns the completed signed value instead.
 
 ## Motivation
 
@@ -33,15 +33,15 @@ This TIP gives coordination its own `multisig_*` methods. Standard Ethereum subm
 
 ## Assumptions
 
-- TIP-1061 defines account identity, configuration versions, approval digests, limits, nesting, ordering, and final signature validation. This TIP does not change those rules.
-- The relay can read current root and nested configurations from an authoritative Tempo RPC endpoint. If it cannot resolve a required configuration, it rejects the request.
-- A bootstrap signature contains the initial configuration. The relay checks that the configuration derives the claimed account and uses configuration version `0`.
+- TIP-1061 defines account identity, configuration commitments, configuration versions, approval digests, limits, nesting, ordering, and final signature validation. This TIP does not change those rules.
+- Every multisig signature carries its complete applicable configuration. The relay reads authoritative root and nested commitments from a Tempo RPC endpoint and validates each supplied configuration against the commitment observed at one block.
+- A version-`0` configuration must derive the claimed account and find a zero commitment. A nonzero version must produce the account's nonzero stored commitment.
 - A shared production store supports linearizable compare-and-set for each operation key. A single writer may fall back to separate reads and writes, but that fallback does not protect concurrent updates.
 - The downstream handler keeps the behavior of `eth_sendRawTransaction` and `eth_sendRawTransactionSync`. Fee sponsorship, authentication, billing, and routing may run there.
 - An operation hash is a lookup key, not an authentication secret. A deployment may allow public reads.
 - These methods require no protocol activation. A deployment can enable them once its target chain supports TIP-1061.
 
-A relay that uses stale configuration, non-atomic shared storage, or a downstream handler that changes sender-signed fields does not conform to this TIP.
+A relay that accepts a stale configuration, uses non-atomic shared storage, or allows a downstream handler to change sender-signed fields does not conform to this TIP.
 
 ## Threat model
 
@@ -51,7 +51,7 @@ A relay that uses stale configuration, non-atomic shared storage, or a downstrea
 | Owner | May be unavailable, compromised, or malicious. An owner contributes only its configured weight. |
 | Nested owner | May submit a partial, cyclic, stale, or oversized signature tree. The relay applies TIP-1061 limits and membership checks at every node. |
 | Relay | Several instances may process the same operation. Atomic updates protect approvals, and a fenced lease gives one instance ownership of a broadcast attempt. |
-| Store | May return malformed or stale data. The relay checks stored payloads, hashes, and configurations before it accepts an approval or submits a transaction. |
+| Store | May return malformed or stale data. The relay checks stored payloads, hashes, and cached configurations before it accepts an approval, returns a configuration, or submits a transaction. |
 | Downstream submitter | May fail before or after broadcast and may add a fee-payer signature. The operation records the transaction hash that it returns. |
 | Operation reader | May see unsigned payloads and collected signatures. A deployment that needs privacy before submission must restrict reads. |
 | Denial-of-service attacker | May create many pending operations. Authentication, quotas, storage billing, and cleanup policy remain deployment concerns. TIP-1061 limits bound work within one operation. |
@@ -86,13 +86,14 @@ The operation hash and transaction hash are different values. The transaction ha
 
 ### JSON-RPC methods
 
-A relay implements four methods:
+A relay implements five methods:
 
 | Method | Result |
 | --- | --- |
 | `multisig_approveRawTransaction` | Adds transaction approvals and returns the operation hash. |
 | `multisig_approveRawTransactionSync` | Adds transaction approvals and returns the current operation. |
 | `multisig_approveKeyAuthorization` | Creates or updates a key authorization operation. |
+| `multisig_getConfig` | Returns the cached configuration selected by the account's current commitment. |
 | `multisig_getOperation` | Returns either operation kind. |
 
 The relay MUST NOT collect approvals through `eth_sendRawTransaction` or `eth_sendRawTransactionSync`. A complete multisig transaction may use those methods without a relay.
@@ -109,18 +110,18 @@ type MultisigOwner = {
 
 type MultisigConfig = {
   owners: readonly MultisigOwner[]
+  salt: Hex
   threshold: number
+  version: Quantity
 }
 
 type OperationBase = {
   account: Address
   approvals: readonly Hex[]
   config: MultisigConfig
-  configVersion: Quantity
   createdAt: number
   hash: Hash
-  init: boolean
-  signatures: number
+  signatureCount: number
   threshold: number
   updatedAt: number
   weight: number
@@ -148,14 +149,12 @@ type Operation = TransactionOperation | KeyAuthorizationOperation
 | --- | --- |
 | `account` | Root multisig account. |
 | `approvals` | Every owner approval retained after validation, including approvals not selected for the final quorum. |
-| `config` | Root configuration used to verify approvals. |
-| `configVersion` | Root configuration version. Bootstrap uses `0x0`. |
+| `config` | Complete root configuration used to verify approvals. Its `version` is `0x0` for an initial configuration. |
 | `createdAt` | Unix creation time in milliseconds. |
 | `expiresAt` | Unix time in milliseconds when another relay may reclaim the submission lease. Present only while a transaction operation is `submitting`. |
 | `hash` | Operation hash. |
-| `init` | `true` when the operation bootstraps the root account. Version `0` alone does not imply bootstrap. |
 | `keyAuthorization` | Canonical unsigned RLP while pending, then canonical signed RLP after success. |
-| `signatures` | Number of approvals selected for quorum evaluation. This may differ from `approvals.length`. |
+| `signatureCount` | Number of approvals selected for quorum evaluation. This may differ from `approvals.length`. |
 | `status` | Current operation state. |
 | `submissionId` | Random fencing token owned by one submitter. Present only while a transaction operation is `submitting`. It MUST differ from the operation hash, which every relay knows. |
 | `threshold` | Required root weight. This MUST equal `config.threshold`. |
@@ -169,37 +168,39 @@ type Operation = TransactionOperation | KeyAuthorizationOperation
 
 The relay stores an operation under a key derived from its full 32-byte hash. An update MUST compare the value read with the value it replaces. The relay may retry conflicts, but it MUST cap those retries and return a server error when it cannot make progress.
 
-Direct store writes are outside this TIP. Public services SHOULD expose the validated approval methods. They may expose read-only operation lookup.
+Direct store writes are outside this TIP. Public services SHOULD expose the validated approval methods. They may expose read-only configuration and operation lookup.
 
 ### Configuration
 
-The relay resolves configuration at every multisig signature node:
+Every root and nested multisig signature supplies its complete applicable configuration. The relay MUST resolve one concrete block for each validation attempt and read every affected account's configuration commitment at that block.
 
-- A bootstrap root uses its inline configuration and version `0`.
-- An initialized root uses its current onchain configuration and version.
-- A nested multisig owner MUST already exist onchain and use its current configuration and version.
-- A nested multisig signature MUST NOT contain an initial configuration.
+- A version-`0` configuration MUST derive its claimed account and find a zero commitment.
+- A nonzero configuration MUST produce the claimed account's nonzero stored commitment.
+- A nested signature MAY use an initial or current configuration when the same commitment rules hold.
 
-The relay applies every TIP-1061 configuration rule, including owner count, ordering, uniqueness, weights, threshold reachability, signature count, and nesting depth.
+The relay applies every TIP-1061 configuration rule, including owner count, ordering, uniqueness, weights, threshold reachability, signature count, and nesting depth. It cannot reconstruct owners or weights from a commitment.
 
-It may cache configuration reads within one request. Before it accepts another approval or submits a transaction, it reads each initialized configuration again.
+The relay MAY cache a configuration only after validating it. Cache entries MUST be keyed by account and commitment. Chain state remains authoritative, and a cached value never proves that it is current.
 
-A root configuration change invalidates the operation because it changes the operation hash. A nested configuration change invalidates that nested branch but leaves unrelated root approvals intact. A bootstrap operation cannot finish after another transaction initializes the account.
+A root version change normally produces a different operation hash. A reorg can instead select a different configuration at the same account and version without changing the operation hash. In that case, the relay MUST replace the stored root configuration, revalidate every retained approval, and discard approvals that are no longer valid before recomputing quorum. It MUST NOT combine weight from two configurations without revalidation.
+
+A nested commitment change invalidates that nested branch but leaves unrelated root approvals intact. Ordinary transactions do not invalidate a version-`0` operation. That operation becomes stale only when `updateConfig` changes the account's commitment from zero.
 
 ### Approval handling
 
 For each submitted signature tree, the relay MUST:
 
-1. Compute the TIP-1061 digest at each node.
-2. Recover each direct signer and identify each nested multisig owner.
-3. Check that each address belongs to the relevant configuration.
-4. Verify direct signatures against the node digest.
-5. Verify nested signatures recursively against the parent digest.
-6. Reject keychain signatures as owner approvals.
-7. Reject malformed, oversized, cyclic, stale, wrong-digest, and non-owner approvals.
-8. Deduplicate approvals by owner address at each node.
-9. Treat an identical retry as a no-op.
-10. If one direct owner supplies two valid encodings, retain the bytewise smaller encoding.
+1. Validate every supplied configuration against commitments read at one block.
+2. Compute the TIP-1061 digest at each node.
+3. Recover each direct signer and identify each nested multisig owner.
+4. Check that each address belongs to the relevant configuration.
+5. Verify direct signatures against the node digest.
+6. Verify nested signatures recursively against the parent digest.
+7. Reject keychain signatures as owner approvals.
+8. Reject malformed, oversized, cyclic, stale, wrong-digest, and non-owner approvals.
+9. Deduplicate approvals by owner address at each node.
+10. Treat an identical retry as a no-op.
+11. If one direct owner supplies two valid encodings, retain the bytewise smaller encoding.
 
 A partial nested approval stays in the store but contributes no parent weight. It contributes the nested owner's configured parent weight once the nested account reaches quorum.
 
@@ -215,7 +216,7 @@ The relay stores every valid approval, but serializes only one quorum. At each m
 4. Sort the selected approvals by ascending owner address.
 5. Check that the final sorted approval is the first one that reaches the threshold.
 
-For a fixed stored approval set, this produces one deterministic minimum-size quorum. `signatures` and `weight` report that selected set. More than eight low-weight approvals cannot make an operation ready.
+For a fixed stored approval set, this produces one deterministic minimum-size quorum. `signatureCount` and `weight` report that selected set. More than eight low-weight approvals cannot make an operation ready.
 
 For example:
 
@@ -276,8 +277,8 @@ The relay processes the first approval in this order:
 
 1. Deserialize the Tempo transaction and require an outer multisig signature.
 2. Remove that signature and serialize the canonical unsigned envelope.
-3. Resolve the root account, configuration, and version.
-4. Compute the transaction signing digest and operation hash.
+3. Read the root account and configuration from the signature and validate that configuration against the account's commitment at one block.
+4. Compute the transaction signing digest and operation hash from `config.version`.
 5. Validate every submitted owner approval.
 6. Create the operation or merge it into the existing operation atomically.
 7. Return a pending result or start submission.
@@ -319,7 +320,7 @@ pending ---------------------------------> submitting
 
 The relay claims a lease by atomically writing a transaction operation with `status: 'submitting'`, a new `submissionId`, and `expiresAt`. Only the relay whose `submissionId` remains current can finish or release that attempt.
 
-Before broadcast, the lease owner reads initialized configurations again, rechecks stored approvals, chooses the canonical quorum, and serializes the final sender-signed envelope. Every retry uses the same envelope.
+Before broadcast, the lease owner validates the stored root configuration and every nested configuration against commitments read at one block, rechecks stored approvals, chooses the canonical quorum, and serializes the final sender-signed envelope. Every retry uses the same envelope.
 
 After a confirmed response, the relay stores the transaction operation with `status: 'success'` and the returned transaction hash. If the downstream handler definitely rejected the transaction, the relay returns the operation to `pending` and keeps its approvals.
 
@@ -365,9 +366,9 @@ The relay MUST:
 
 1. Decode the key authorization and require a multisig signature with at least one approval.
 2. Remove the signature and serialize the unsigned authorization.
-3. Resolve the root account from the signature's initial configuration or account field.
+3. Read the root account and configuration from the signature.
 4. Check that the authorization binds the same account.
-5. Resolve and validate the configuration.
+5. Validate the configuration against the account's commitment at one block.
 6. Compute the key authorization signing digest and operation hash.
 7. Validate and merge every submitted approval atomically.
 8. Return the resulting operation.
@@ -377,8 +378,8 @@ The relay MUST:
 The relay MUST:
 
 1. Read the operation at `hash` and require a key authorization operation.
-2. Recompute the hash from the stored unsigned authorization, root account, and configuration version.
-3. Read initialized root and nested configurations again.
+2. Recompute the hash from the stored unsigned authorization, root account, and `config.version`.
+3. Revalidate the stored root configuration and every submitted nested configuration against commitments read at one block.
 4. Verify the new approval against the operation hash.
 5. Merge it atomically and return the updated operation.
 
@@ -396,6 +397,27 @@ pending -------------------------------> success
 At quorum, the relay chooses the canonical weighted quorum, builds the TIP-1061 multisig signature, attaches it to the stored unsigned authorization, and stores the signed RLP.
 
 There is no submission lease. Completing a key authorization only produces signed data. A later transaction must include it before it has any onchain effect.
+
+### Configuration lookup
+
+#### `multisig_getConfig`
+
+```ts
+type Request = {
+  method: 'multisig_getConfig'
+  params: [{ address: Address }]
+}
+
+type Response = MultisigConfig | null
+```
+
+The method resolves one concrete block, reads the account's commitment at that block, and returns the cached configuration stored under that address and commitment. It returns `null` when the relay has not cached that configuration.
+
+Before returning a value, the relay MUST validate it again. A version-`0` configuration must derive `address` and the observed commitment must be zero. A nonzero configuration must produce the observed nonzero commitment. A malformed or mismatched stored value is a server error, not a successful response.
+
+The method does not recover a configuration from its commitment. A valid root or nested approval must first provide the configuration to the relay. A relay MAY also cache a candidate next configuration from a valid `updateConfig` call, but it MUST NOT return that candidate until the account's commitment selects it.
+
+There is no configuration list or search method. A deployment that exposes this method publicly also exposes the owner list of every returned configuration.
 
 ### Operation lookup
 
@@ -430,14 +452,15 @@ The relay returns JSON-RPC `InvalidParams` for:
 
 - malformed request values or serialized payloads;
 - an outer signature that is missing, empty, or not multisig;
-- a bootstrap configuration that does not derive the claimed account;
+- a version-`0` configuration that does not derive the claimed account or finds a nonzero commitment;
+- a nonzero configuration that does not match the account's stored commitment;
 - a key authorization bound to another account;
 - an unknown hash in a later approval request;
 - the wrong operation kind;
-- a non-owner, wrong-digest, keychain, stale, or nested bootstrap signature; and
+- a non-owner, wrong-digest, keychain, or stale signature; and
 - any TIP-1061 limit violation.
 
-The relay returns a JSON-RPC server error when stored data is inconsistent, compare-and-set retries run out, or it cannot reconcile a lease conflict.
+The relay returns a JSON-RPC server error when stored operation or configuration data is inconsistent, compare-and-set retries run out, or it cannot reconcile a lease conflict.
 
 It returns downstream transaction errors unchanged. A failed submission keeps every valid approval so another request can retry it.
 
@@ -453,7 +476,8 @@ An implementation meets this TIP when:
 
 - owners can finish a transaction by sharing only the operation hash after the first approval;
 - owners can finish a key authorization through the same operation model;
-- both operation kinds enforce TIP-1061 weights, limits, ordering, nesting, and configuration versions;
+- both operation kinds enforce TIP-1061 weights, limits, ordering, nesting, and configuration commitments;
+- configuration lookup returns only a cached configuration selected by the account's commitment at one block;
 - standard raw transaction methods keep their submission behavior;
 - compare-and-set prevents lost approvals and concurrent active submitters;
 - a failed submission can retry without collecting approvals again;
@@ -501,6 +525,8 @@ const success = await client.accessKey.signMultisigAuthorization({
 
 Each action call MUST create exactly one local owner approval. Before signing, a wallet SHOULD show the account, payload, configuration version, threshold, and collected weight.
 
+SDKs MAY resolve an address-only multisig account through `multisig_getConfig`. A returned configuration is advisory until the SDK or relay validates it against the account's commitment at one block.
+
 `wallet_authorizeAccessKey` still returns a completed authorization. A wallet may run its owner ceremony through `multisig_approveKeyAuthorization`, but this TIP does not add a pending wallet response.
 
 A store adapter SHOULD implement `getItem`, `setItem`, and linearizable `compareAndSet`. In-memory storage is suitable for tests and one process. Coordination across processes needs shared atomic storage.
@@ -509,7 +535,7 @@ Debugging tools SHOULD be able to:
 
 - decode both operation kinds;
 - recompute the operation hash;
-- show stored and current configuration versions;
+- show the stored configuration and current commitment;
 - recover approval owner addresses;
 - distinguish stored approvals from selected approvals;
 - rebuild the canonical final signature;
@@ -522,16 +548,18 @@ N/A. This TIP adds no onchain events. Logging, metrics, tracing, and alerts are 
 
 ## Invariants
 
-- **Operation identity.** An operation's `hash` equals the TIP-1061 digest computed from the canonical unsigned payload's signing digest, root account, and root configuration version. Its storage key uses the complete hash without truncation.
+- **Operation identity.** An operation's `hash` equals the TIP-1061 digest computed from the canonical unsigned payload's signing digest, root account, and `config.version`. Its storage key uses the complete hash without truncation.
 - **Payload immutability.** An approval cannot change any sender-signed transaction or key authorization field.
-- **Configuration provenance.** A bootstrap root uses its validated inline configuration. Every initialized root and nested configuration comes from authoritative chain state. Before accepting an approval or finalizing an operation, the relay reads current initialized configurations again. Caller-supplied configuration claims outside bootstrap have no authority.
-- **Bootstrap.** A bootstrap configuration derives `account`, uses version `0`, and cannot finish after another transaction initializes the account.
+- **Configuration validation.** Every root and nested signature supplies its complete configuration. A version-`0` configuration derives its account and requires a zero commitment. A nonzero configuration produces the nonzero commitment read at the pinned block.
+- **Configuration replacement.** When chain state selects a different configuration for the same operation hash, the relay revalidates retained approvals under that configuration before recomputing quorum. It never combines unvalidated weight from different configurations.
+- **Initial configuration.** Ordinary transactions do not invalidate a version-`0` operation. Only a configuration update that changes the account's zero commitment makes it stale.
+- **Configuration lookup.** `multisig_getConfig` returns only a cached configuration selected by the account's commitment at one block. It never reconstructs a configuration from a commitment or enumerates cached accounts.
 - **Owner uniqueness.** One owner contributes weight at most once at each multisig node.
 - **Nested quorum.** A nested owner contributes parent weight only after its own quorum.
 - **Protocol limits.** A final signature node stays within TIP-1061 size and depth limits, contains at most eight approvals, and first reaches threshold on its last owner-sorted approval.
 - **Deterministic signatures.** For a fixed canonical payload, configuration versions, and stored approval bytes, quorum selection and serialization produce the same sender signature.
 - **Extra approvals.** Extra valid approvals may stay in storage, but never appear after quorum in the final signature.
-- **Derived quorum.** `threshold` equals `config.threshold`. `signatures` is the count and `weight` is the total weight of the deterministically selected approvals. A transaction enters `submitting` or `success`, and a key authorization enters `success`, only after reaching quorum.
+- **Derived quorum.** `threshold` equals `config.threshold`. `signatureCount` is the count and `weight` is the total weight of the deterministically selected approvals. A transaction enters `submitting` or `success`, and a key authorization enters `success`, only after reaching quorum.
 - **Submission fencing.** Each `submitting` operation has one current `submissionId`. Only a transition presenting that token may finish or release the attempt. After `expiresAt`, an atomic replacement fences the previous token.
 - **Retry safety.** A failed attempt or expired lease does not remove approvals. Configuration revalidation may separately invalidate stale approvals.
 - **Hash semantics.** `hash` always identifies the approval operation. `transactionHash` exists only after downstream acceptance and equals the hash returned downstream. Standard lookup methods may accept the operation hash as a documented alias, but successful transaction and receipt responses expose the downstream hash.
@@ -542,11 +570,13 @@ N/A. This TIP adds no onchain events. Logging, metrics, tracing, and alerts are 
 
 Tests MUST cover:
 
-- bootstrap and initialized accounts;
+- initial and current configurations;
+- configuration lookup for initial, current, unknown, stale, and malformed cached values;
+- ordinary activity during version-`0` collection and invalidation by the first configuration update;
 - flat, weighted, direct, nested, and mixed-key owners;
 - several approvals in one request and later approval by operation hash;
 - duplicates, different arrival orders, and extra valid approvals;
-- root and nested configuration changes;
+- root and nested commitment changes, including a same-version reorg replacement;
 - wrong accounts, wrong digests, malformed input, and TIP-1061 limits;
 - concurrent updates, lease recovery, and ambiguous submission failures;
 - derived quorum fields, legal state transitions, and terminal success;

--- a/tips/tip-1101.md
+++ b/tips/tip-1101.md
@@ -58,9 +58,9 @@ A relay that uses stale configuration, non-atomic shared storage, or a downstrea
 
 ---
 
-# Specification
+## Specification
 
-## Scope and terminology
+### Scope and terminology
 
 This TIP defines two operation kinds:
 
@@ -84,7 +84,7 @@ For a transaction, `inner_digest` is the Tempo transaction signing digest. For a
 
 The operation hash and transaction hash are different values. The transaction hash commits to the submitted envelope, including any fee-payer signature added after owner quorum.
 
-## JSON-RPC methods
+### JSON-RPC methods
 
 A relay implements four methods:
 
@@ -97,7 +97,7 @@ A relay implements four methods:
 
 The relay MUST NOT collect approvals through `eth_sendRawTransaction` or `eth_sendRawTransactionSync`. A complete multisig transaction may use those methods without a relay.
 
-## Operation data
+### Operation data
 
 The following TypeScript describes the JSON-RPC values. Quantities use canonical hexadecimal quantity encoding. Addresses, hashes, approvals, transactions, and key authorizations use `0x`-prefixed hexadecimal strings.
 
@@ -165,13 +165,13 @@ type Operation = TransactionOperation | KeyAuthorizationOperation
 | `updatedAt` | Unix time of the last update in milliseconds. |
 | `weight` | Root weight reached by the selected approvals. |
 
-## Storage
+### Storage
 
 The relay stores an operation under a key derived from its full 32-byte hash. An update MUST compare the value read with the value it replaces. The relay may retry conflicts, but it MUST cap those retries and return a server error when it cannot make progress.
 
 Direct store writes are outside this TIP. Public services SHOULD expose the validated approval methods. They may expose read-only operation lookup.
 
-## Configuration
+### Configuration
 
 The relay resolves configuration at every multisig signature node:
 
@@ -186,7 +186,7 @@ It may cache configuration reads within one request. Before it accepts another a
 
 A root configuration change invalidates the operation because it changes the operation hash. A nested configuration change invalidates that nested branch but leaves unrelated root approvals intact. A bootstrap operation cannot finish after another transaction initializes the account.
 
-## Approval handling
+### Approval handling
 
 For each submitted signature tree, the relay MUST:
 
@@ -205,7 +205,7 @@ A partial nested approval stays in the store but contributes no parent weight. I
 
 Before every update, the relay recomputes the hash from the stored payload. It rejects stored data whose key, hash, operation kind, account, or payload does not match.
 
-## Quorum selection
+### Quorum selection
 
 The relay stores every valid approval, but serializes only one quorum. At each multisig node, it MUST:
 
@@ -234,9 +234,9 @@ Alice + Bob + Carol stored -> serialize Alice + Bob
 
 Carol remains in the store. The final envelope omits her approval because TIP-1061 rejects any approval after quorum.
 
-## Transaction approvals
+### Transaction approvals
 
-### `multisig_approveRawTransaction`
+#### `multisig_approveRawTransaction`
 
 ```ts
 type Request = {
@@ -251,7 +251,7 @@ The transaction MUST have an outer TIP-1061 multisig signature with at least one
 
 At quorum, the relay sends the final envelope downstream through `eth_sendRawTransaction`. It stores the returned transaction hash on the operation.
 
-### `multisig_approveRawTransactionSync`
+#### `multisig_approveRawTransactionSync`
 
 ```ts
 type Request = {
@@ -270,7 +270,7 @@ The optional nonnegative `timeout` limits how long the request waits for another
 
 Both transaction methods return as soon as they know the operation remains below quorum. The synchronous method waits only for the final broadcast.
 
-### First approval
+#### First approval
 
 The relay processes the first approval in this order:
 
@@ -284,13 +284,13 @@ The relay processes the first approval in this order:
 
 One request may contain several owner approvals. The relay validates and merges each one.
 
-### Later approvals
+#### Later approvals
 
 An SDK may load the stored transaction by operation hash, sign that hash with another owner, and build another approval envelope. It submits that envelope to the same method.
 
 The unsigned envelope MUST match the stored operation. The relay rejects changes to calls, chain ID, nonce, fees, validity bounds, authorization data, and every other sender-signed field.
 
-### Fee payers
+#### Fee payers
 
 Coordination supports transactions without sponsorship, transactions signed by a local fee payer, and transactions sponsored by a fee-payer relay after owner quorum.
 
@@ -303,7 +303,7 @@ For one operation:
 
 The relay MUST send the final sender-signed envelope through the downstream handler. It MUST NOT bypass fee-payer policy, authentication, billing, or routing configured there.
 
-## Transaction submission
+### Transaction submission
 
 Transaction operations move through these states:
 
@@ -325,9 +325,9 @@ After a confirmed response, the relay stores the transaction operation with `sta
 
 If the response is ambiguous, the relay SHOULD query the predicted transaction hash when it knows the exact submitted bytes. Otherwise it retries the same sender-signed request after the lease expires. A fee-payer relay that changes the full transaction bytes MUST handle repeated submission of the same sender-signed envelope idempotently.
 
-## Key authorization approvals
+### Key authorization approvals
 
-### `multisig_approveKeyAuthorization`
+#### `multisig_approveKeyAuthorization`
 
 The first request contains a TIP-1061 key authorization with a partial multisig signature:
 
@@ -359,7 +359,7 @@ type Request = {
 type Response = KeyAuthorizationOperation
 ```
 
-### First approval
+#### First approval
 
 The relay MUST:
 
@@ -372,7 +372,7 @@ The relay MUST:
 7. Validate and merge every submitted approval atomically.
 8. Return the resulting operation.
 
-### Later approvals
+#### Later approvals
 
 The relay MUST:
 
@@ -384,7 +384,7 @@ The relay MUST:
 
 An owner can sign the 32-byte operation hash without downloading the full authorization. A client SHOULD still show the authorization details before asking for a signature.
 
-### Completion
+#### Completion
 
 Key authorization operations have two states:
 
@@ -397,9 +397,9 @@ At quorum, the relay chooses the canonical weighted quorum, builds the TIP-1061 
 
 There is no submission lease. Completing a key authorization only produces signed data. A later transaction must include it before it has any onchain effect.
 
-## Operation lookup
+### Operation lookup
 
-### `multisig_getOperation`
+#### `multisig_getOperation`
 
 ```ts
 type Request = {
@@ -414,7 +414,7 @@ The method returns the JSON object at `hash`, or `null` when no operation exists
 
 There is no list or search method. A caller must know the full operation hash. A deployment may restrict reads, but public lookup also conforms to this TIP.
 
-## Transaction lookup aliases
+### Transaction lookup aliases
 
 A relay may also recognize operation hashes in standard lookup methods:
 
@@ -424,7 +424,7 @@ A relay may also recognize operation hashes in standard lookup methods:
 
 Outside these lookup responses, an implementation MUST NOT present an operation hash as an onchain transaction hash.
 
-## Errors
+### Errors
 
 The relay returns JSON-RPC `InvalidParams` for:
 
@@ -441,13 +441,27 @@ The relay returns a JSON-RPC server error when stored data is inconsistent, comp
 
 It returns downstream transaction errors unchanged. A failed submission keeps every valid approval so another request can retry it.
 
-## Backward compatibility
+### Backward compatibility
 
 These namespaced methods do not change consensus encoding. Complete multisig transactions still use standard submission methods. Local key authorization signing still works when one process can produce a full quorum.
 
 Clients and servers advertise support outside this TIP. An endpoint that does not support a method returns the standard JSON-RPC method-not-found error.
 
-# Tooling
+### Success criteria
+
+An implementation meets this TIP when:
+
+- owners can finish a transaction by sharing only the operation hash after the first approval;
+- owners can finish a key authorization through the same operation model;
+- both operation kinds enforce TIP-1061 weights, limits, ordering, nesting, and configuration versions;
+- standard raw transaction methods keep their submission behavior;
+- compare-and-set prevents lost approvals and concurrent active submitters;
+- a failed submission can retry without collecting approvals again;
+- a completed key authorization causes no transaction broadcast;
+- lookup returns a JSON object for either operation kind; and
+- local fee payment, fee-payer-first signing, and fee-payer relay sponsorship all report the actual submitted transaction hash.
+
+## Tooling
 
 SDKs SHOULD route partial multisig envelopes from their normal Tempo transaction actions:
 
@@ -502,25 +516,11 @@ Debugging tools SHOULD be able to:
 - inspect submission lease ownership and expiry; and
 - derive the transaction hash when the final submitted bytes are known.
 
-# Observability
+## Observability
 
 N/A. This TIP adds no onchain events. Logging, metrics, tracing, and alerts are deployment concerns.
 
-# Success criteria
-
-An implementation meets this TIP when:
-
-- owners can finish a transaction by sharing only the operation hash after the first approval;
-- owners can finish a key authorization through the same operation model;
-- both operation kinds enforce TIP-1061 weights, limits, ordering, nesting, and configuration versions;
-- standard raw transaction methods keep their submission behavior;
-- compare-and-set prevents lost approvals and concurrent active submitters;
-- a failed submission can retry without collecting approvals again;
-- a completed key authorization causes no transaction broadcast;
-- lookup returns a JSON object for either operation kind; and
-- local fee payment, fee-payer-first signing, and fee-payer relay sponsorship all report the actual submitted transaction hash.
-
-# Invariants
+## Invariants
 
 - **Operation identity.** An operation's `hash` equals the TIP-1061 digest computed from the canonical unsigned payload's signing digest, root account, and root configuration version. Its storage key uses the complete hash without truncation.
 - **Payload immutability.** An approval cannot change any sender-signed transaction or key authorization field.


### PR DESCRIPTION
Defines relay-coordinated approval operations for TIP-1061 transactions and key authorizations through namespaced JSON-RPC methods. Keeps standard raw transaction submission behavior unchanged.
