### PR TITLE
feat(node): prewarm expiring nonce ring at startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8972,7 +8972,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8999,7 +8999,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9030,7 +9030,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9050,7 +9050,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9063,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9147,7 +9147,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9226,7 +9226,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9253,7 +9253,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9278,7 +9278,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9307,7 +9307,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9333,7 +9333,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9363,7 +9363,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9378,7 +9378,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9403,7 +9403,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9427,7 +9427,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9451,7 +9451,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9486,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9543,7 +9543,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9593,7 +9593,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9620,7 +9620,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9677,7 +9677,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9707,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9741,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9765,7 +9765,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9776,7 +9776,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9804,7 +9804,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9826,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9867,7 +9867,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "clap",
  "eyre",
@@ -9890,7 +9890,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9906,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9922,7 +9922,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9935,7 +9935,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9965,7 +9965,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9979,7 +9979,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -9989,7 +9989,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10015,7 +10015,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10035,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10066,7 +10066,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10123,7 +10123,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "serde",
  "serde_json",
@@ -10147,7 +10147,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10173,7 +10173,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "bytes",
  "futures",
@@ -10193,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10210,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "bindgen",
  "cc",
@@ -10219,7 +10219,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "futures",
  "libc",
@@ -10233,7 +10233,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10242,7 +10242,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10256,7 +10256,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10340,7 +10340,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10364,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10379,7 +10379,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10393,7 +10393,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10410,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10434,7 +10434,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10502,7 +10502,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10557,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10606,7 +10606,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10630,7 +10630,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10654,7 +10654,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "bytes",
  "eyre",
@@ -10683,7 +10683,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10695,7 +10695,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10731,7 +10731,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10754,7 +10754,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10797,7 +10797,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10846,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10873,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10889,7 +10889,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10904,7 +10904,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10981,7 +10981,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11011,7 +11011,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11054,7 +11054,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11074,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11105,7 +11105,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11152,7 +11152,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11203,7 +11203,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11217,7 +11217,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11248,7 +11248,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11299,7 +11299,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11327,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11341,7 +11341,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11361,7 +11361,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11402,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11419,7 +11419,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11466,7 +11466,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11482,7 +11482,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11492,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "clap",
  "eyre",
@@ -11512,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11574,7 +11574,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11600,7 +11600,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11627,7 +11627,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11643,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11668,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.4.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=10aa6a512ba7c4f5f01ff489b1f513da0745821f#10aa6a512ba7c4f5f01ff489b1f513da0745821f"
+source = "git+https://github.com/paradigmxyz/reth?rev=1f2eb130111951a037c83a7a29e2714308ea29e2#1f2eb130111951a037c83a7a29e2714308ea29e2"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -13314,6 +13314,7 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-cli",
  "reth-etl",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-network-api",
  "reth-network-peers",
@@ -13733,6 +13734,7 @@ dependencies = [
  "reth-errors",
  "reth-ethereum",
  "reth-evm",
+ "reth-execution-cache",
  "reth-metrics",
  "reth-network-api",
  "reth-node-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "10aa6a512ba7c4f5f01ff489b1f513da0745821f", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "1f2eb130111951a037c83a7a29e2714308ea29e2", features = [
   "std",
   "optional-checks",
 ] }

--- a/bin/tempo/Cargo.toml
+++ b/bin/tempo/Cargo.toml
@@ -71,6 +71,7 @@ futures = { workspace = true, features = ["executor"] }
 rand.workspace = true
 reth-chainspec.workspace = true
 reth-cli.workspace = true
+reth-execution-cache.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempo-alloy = { workspace = true, features = ["reth"] }

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -59,12 +59,19 @@ use futures::{
     FutureExt as _,
     future::{Either, FusedFuture as _},
 };
+use reth_chainspec::ChainSpecProvider as _;
 use reth_cli_runner::CliRunner;
 use reth_ethereum::{chainspec::EthChainSpec as _, cli::Commands};
+use reth_execution_cache::{CachedStateProvider, PayloadExecutionCache};
 use reth_network_api::Peers;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
-use std::{collections::BTreeMap, sync::Arc, thread};
-use tempo_chainspec::spec::{DEV, TempoChainSpec};
+use reth_primitives_traits::AlloyBlockHeader as _;
+use reth_storage_api::{BlockReaderIdExt as _, StateProvider as _, StateProviderFactory as _};
+use std::{collections::BTreeMap, sync::Arc, thread, time::Instant};
+use tempo_chainspec::{
+    TempoHardforks as _,
+    spec::{DEV, TempoChainSpec},
+};
 use tempo_consensus::{feed as consensus_feed, run_consensus_stack, run_follow_stack};
 use tempo_contracts::precompiles::initial_zone_factory_state;
 use tempo_evm::{TempoEvmConfig, consensus::TempoConsensus};
@@ -83,6 +90,7 @@ use tempo_node::{
         install_prometheus_metrics,
     },
 };
+use tempo_precompiles::{NONCE_PRECOMPILE_ADDRESS, nonce::NonceManager};
 use tokio::sync::oneshot;
 use tracing::{debug, info, info_span, warn, warn_span};
 
@@ -91,6 +99,47 @@ use nix as _;
 
 const DEFAULT_DEV_ZONE_FACTORY_OWNER: Address =
     alloy_primitives::address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+fn spawn_expiring_nonce_ring_prewarm(node: &TempoFullNode, execution_cache: PayloadExecutionCache) {
+    let provider = node.provider.clone();
+    node.tasks()
+        .spawn_blocking_named("expiring-nonce-ring-prewarm", move || {
+            let started_at = Instant::now();
+            let result = (|| -> eyre::Result<u32> {
+                let latest_header = provider
+                    .latest_header()?
+                    .ok_or_eyre("latest block header is unavailable")?;
+                let capacity = provider
+                    .chain_spec()
+                    .tempo_hardfork_at(latest_header.timestamp())
+                    .expiring_nonce_set_capacity();
+                let cache = execution_cache
+                    .get_cache_for(latest_header.hash())
+                    .ok_or_eyre("shared execution cache is unavailable")?;
+                let state =
+                    CachedStateProvider::new_prewarm(provider.latest()?, cache.cache().clone());
+                let nonce_manager = NonceManager::new();
+
+                for idx in 0..capacity {
+                    state.storage(
+                        NONCE_PRECOMPILE_ADDRESS,
+                        nonce_manager.expiring_nonce_ring[idx].slot().into(),
+                    )?;
+                }
+
+                Ok(capacity)
+            })();
+
+            match result {
+                Ok(capacity) => info!(
+                    capacity,
+                    elapsed = ?started_at.elapsed(),
+                    "Prewarmed expiring nonce ring"
+                ),
+                Err(err) => warn!(%err, "Failed to prewarm expiring nonce ring"),
+            }
+        });
+}
 
 fn apply_tempo_cli_overrides(cli: &mut TempoCli) -> eyre::Result<()> {
     if let Commands::Node(node_cmd) = &mut cli.command
@@ -494,14 +543,17 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
             url => Some(url.to_string()),
         };
 
+        let tempo_node = overrides.apply_tempo_node(TempoNode::new(
+            &args.node_args,
+            validator_key,
+        ));
+        let execution_cache = tempo_node.execution_cache();
+
         let NodeHandle {
             node,
             node_exit_future,
         } = builder
-            .node(overrides.apply_tempo_node(TempoNode::new(
-                &args.node_args,
-                validator_key,
-            )))
+            .node(tempo_node)
             .apply(|mut builder: WithLaunchContext<_>| {
                 // Uncertified follower mode: set debug RPC when certification is off
                 if args.is_following_uncertified() {
@@ -535,6 +587,10 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
 
                     Ok(())
                 })
+            })
+            .on_node_started(move |node| {
+                spawn_expiring_nonce_ring_prewarm(&node, execution_cache);
+                Ok(())
             })
             .launch_with_debug_capabilities()
             .await

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -30,6 +30,7 @@ thiserror.workspace = true
 
 reth-chainspec.workspace = true
 reth-errors.workspace = true
+reth-execution-cache.workspace = true
 reth-ethereum = { workspace = true, features = ["node", "rpc"] }
 reth-primitives-traits = { workspace = true, features = ["secp256k1", "rayon"] }
 reth-node-builder.workspace = true

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -12,6 +12,7 @@ use crate::{
 use alloy_primitives::B256;
 use reth_chainspec::{ChainKind, EthChainSpec, Hardforks, NamedChain};
 use reth_ethereum::network::{NetworkHandle, PeersInfo as _, primitives::BasicNetworkPrimitives};
+use reth_execution_cache::PayloadExecutionCache;
 use reth_node_api::{
     AddOnsContext, FullNodeComponents, FullNodeTypes, NodeAddOns, NodeTypes,
     PayloadAttributesBuilder, PayloadTypes, PrimitivesTy, TxTy,
@@ -216,6 +217,8 @@ pub struct TempoNode {
     validator_key: Option<B256>,
     /// Network builder with optional `tempo/1` support.
     network_builder: TempoNetworkBuilder,
+    /// Execution cache shared between the engine and startup warmers.
+    execution_cache: PayloadExecutionCache,
 }
 
 impl TempoNode {
@@ -226,7 +229,13 @@ impl TempoNode {
             payload_builder_builder: args.payload_builder_builder(),
             validator_key,
             network_builder: TempoNetworkBuilder::default(),
+            execution_cache: PayloadExecutionCache::default(),
         }
+    }
+
+    /// Returns the execution cache shared with the engine validator.
+    pub fn execution_cache(&self) -> PayloadExecutionCache {
+        self.execution_cache.clone()
     }
 
     /// Announces `tempo/1` for finalization certificate gossip on every session.
@@ -338,13 +347,13 @@ where
     N: FullNodeTypes<Types = TempoNode>,
 {
     /// Creates a new instance from the inner `RpcAddOns`.
-    pub fn new(validator_key: Option<B256>) -> Self {
+    pub fn new(validator_key: Option<B256>, execution_cache: PayloadExecutionCache) -> Self {
         Self {
             inner: RpcAddOns::new(
                 TempoEthApiBuilder::new(validator_key),
                 TempoEngineValidatorBuilder,
                 NoopEngineApiBuilder::default(),
-                BasicEngineValidatorBuilder::default(),
+                BasicEngineValidatorBuilder::default().with_execution_cache(execution_cache),
                 Identity::default(),
                 Default::default(),
             ),
@@ -446,7 +455,7 @@ where
     }
 
     fn add_ons(&self) -> Self::AddOns {
-        TempoAddOns::new(self.validator_key)
+        TempoAddOns::new(self.validator_key, self.execution_cache.clone())
     }
 }
 


### PR DESCRIPTION
Prewarms every active expiring nonce ring slot once from the node-start hook into the engine-owned shared execution cache.

The cache handle is injected through the engine validator builder; payload construction only consumes the warmed cache and does not trigger the scan.

Depends on paradigmxyz/reth#26793.

Benchmark: [paired e2e run](https://github.com/tempoxyz/tempo/actions/runs/32755172373) classified as a regression. TPS was +2.51% (within the ±6.51% CI), while validator P50 increased 5.28% (±2.27%). The 3,000,000-slot startup warm completed in 3.30–3.84s across feature nodes.

Prompted by: @onbjerg