### PR TITLE
fix(ci): reduce Clippy build parallelism

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 45
     env:
-      CARGO_BUILD_JOBS: 8
+      CARGO_BUILD_JOBS: 4
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Limit Clippy to four concurrent Cargo build jobs to reduce peak memory usage on the Depot runner.

Validation: `git diff --check`.

Prompted by: @pepyakin