### PR TITLE
fix(ci): pin Clippy nightly toolchain

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb # nightly
         with:
+          toolchain: nightly-2026-08-21
           components: clippy
       - uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10


### PR DESCRIPTION
Pin Clippy to `nightly-2026-08-21`, the toolchain from the last successful `main` lint run before the regression (`rustc 1.100.0-nightly`, commit `8925ea358`).

Validation: `git diff --check`; confirmed the dated toolchain from GitHub Actions run 32524077016.

Prompted by: @pepyakin