### PR TITLE
feat: bootstrap liquidity in dev mode

### DIFF
--- a/bin/tempo/src/cli.rs
+++ b/bin/tempo/src/cli.rs
@@ -90,6 +90,10 @@ pub struct TempoArgs {
     #[command(flatten)]
     pub(crate) faucet_args: FaucetArgs,
 
+    /// Start a bare dev node without the canonical faucet or liquidity bootstrap.
+    #[arg(long = "dev.no-bootstrap", requires = "dev")]
+    pub(crate) dev_no_bootstrap: bool,
+
     #[command(flatten)]
     pub(crate) node_args: TempoNodeArgs,
 

--- a/bin/tempo/src/dev.rs
+++ b/bin/tempo/src/dev.rs
@@ -1,0 +1,244 @@
+//! Bootstrap support for the built-in Tempo development chain.
+
+use std::time::Duration;
+
+use alloy::{
+    network::ReceiptResponse,
+    primitives::{Address, B256, U256, address, b256},
+    providers::{Provider, ProviderBuilder},
+    signers::local::PrivateKeySigner,
+};
+use eyre::{Context, Result, bail, eyre};
+use tempo_alloy::{TempoNetwork, fillers::FeeTokenFiller};
+use tempo_contracts::precompiles::{IStablecoinDEX, ITIP20, ITIPFeeAMM};
+use tempo_faucet::args::FaucetArgs;
+use tempo_precompiles::{PATH_USD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS};
+use tokio::time::{sleep, timeout};
+
+/// Well-known first development key used only for local bootstrap transactions.
+const DEV_PRIVATE_KEY: B256 =
+    b256!("ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80");
+/// Amount of each canonical token, in base units, issued by one faucet request.
+const FAUCET_AMOUNT: u128 = 1_000_000_000_000_000;
+/// Validator-token liquidity, in base units, seeded into each fee AMM pool.
+const FEE_LIQUIDITY: u128 = 1_000_000_000;
+/// Fee-pool validator reserve below which bootstrap restores liquidity.
+const MIN_FEE_RESERVE: u128 = 100_000_000;
+/// Liquidity, in base units, seeded on each side of every DEX market.
+const DEX_LIQUIDITY: u128 = 100_000_000_000;
+/// Canonical development tokens: pathUSD, AlphaUSD, BetaUSD, and ThetaUSD.
+const TOKENS: [Address; 4] = [
+    address!("0x20c0000000000000000000000000000000000000"),
+    address!("0x20c0000000000000000000000000000000000001"),
+    address!("0x20c0000000000000000000000000000000000002"),
+    address!("0x20c0000000000000000000000000000000000003"),
+];
+
+const MIN_RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Returns the canonical faucet configuration installed by `--dev`.
+pub(crate) fn faucet_args(rpc_url: String) -> FaucetArgs {
+    FaucetArgs {
+        enabled: true,
+        private_key: Some(DEV_PRIVATE_KEY),
+        amount: Some(U256::from(FAUCET_AMOUNT)),
+        token_addresses: Some(TOKENS.to_vec()),
+        node_address: rpc_url,
+    }
+}
+
+/// Seeds the canonical Fee AMM pools and Stablecoin DEX markets if needed.
+pub(crate) async fn bootstrap(rpc_url: &str, block_time: Option<Duration>) -> Result<()> {
+    let signer = PrivateKeySigner::from_bytes(&DEV_PRIVATE_KEY)?;
+    let admin = signer.address();
+    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .filler(FeeTokenFiller::new(PATH_USD_ADDRESS))
+        .wallet(signer)
+        .connect_http(rpc_url.parse()?);
+
+    wait_for_rpc(&provider).await?;
+
+    let fee_amm = ITIPFeeAMM::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
+    let dex = IStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, provider.clone());
+    let mut missing_fee_pools = Vec::new();
+    let mut missing_orders = Vec::new();
+
+    for token in TOKENS.into_iter().skip(1) {
+        let pool = fee_amm.getPool(token, PATH_USD_ADDRESS).call().await?;
+        if fee_pool_needs_repair(pool.reserveValidatorToken) {
+            missing_fee_pools.push(token);
+        }
+
+        for is_bid in [true, false] {
+            let has_liquidity = dex
+                .getTickLevel(token, 0, is_bid)
+                .call()
+                .await
+                .is_ok_and(|level| level.totalLiquidity > 0);
+            if !has_liquidity {
+                missing_orders.push((token, is_bid));
+            }
+        }
+    }
+
+    if missing_fee_pools.is_empty() && missing_orders.is_empty() {
+        return Ok(());
+    }
+
+    for token in TOKENS {
+        let hash = *ITIP20::new(token, provider.clone())
+            .mint(admin, U256::from(FAUCET_AMOUNT))
+            .send()
+            .await
+            .wrap_err_with(|| format!("failed to fund dev bootstrap account with {token}"))?
+            .tx_hash();
+        wait_for_receipt(&provider, hash, block_time).await?;
+    }
+
+    for token in missing_fee_pools {
+        let hash = *fee_amm
+            .mint(token, PATH_USD_ADDRESS, U256::from(FEE_LIQUIDITY), admin)
+            .send()
+            .await?
+            .tx_hash();
+        wait_for_receipt(&provider, hash, block_time).await?;
+
+        let pool = fee_amm.getPool(token, PATH_USD_ADDRESS).call().await?;
+        if fee_pool_needs_repair(pool.reserveValidatorToken) {
+            bail!("fee liquidity for {token} remains below the minimum reserve");
+        }
+    }
+
+    if !missing_orders.is_empty() {
+        for token in TOKENS {
+            let hash = *ITIP20::new(token, provider.clone())
+                .approve(STABLECOIN_DEX_ADDRESS, U256::MAX)
+                .send()
+                .await?
+                .tx_hash();
+            wait_for_receipt(&provider, hash, block_time).await?;
+        }
+
+        for (token, is_bid) in missing_orders {
+            let hash = *dex
+                .place(token, DEX_LIQUIDITY, is_bid, 0)
+                .send()
+                .await?
+                .tx_hash();
+            wait_for_receipt(&provider, hash, block_time).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Waits until the RPC is reachable and the canonical liquidity is present.
+pub async fn wait_until_ready(rpc_url: &str, seeded: bool) -> Result<()> {
+    let provider =
+        ProviderBuilder::new_with_network::<TempoNetwork>().connect_http(rpc_url.parse()?);
+    wait_for_rpc(&provider).await?;
+    if !seeded {
+        return Ok(());
+    }
+
+    for _ in 0..240 {
+        if is_seeded(&provider).await {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+    Err(eyre!("timed out waiting for Tempo dev bootstrap"))
+}
+
+async fn is_seeded(provider: &impl Provider<TempoNetwork>) -> bool {
+    let fee_amm = ITIPFeeAMM::new(TIP_FEE_MANAGER_ADDRESS, provider);
+    let dex = IStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, provider);
+    for token in TOKENS.into_iter().skip(1) {
+        let Ok(pool) = fee_amm.getPool(token, PATH_USD_ADDRESS).call().await else {
+            return false;
+        };
+        if fee_pool_needs_repair(pool.reserveValidatorToken) {
+            return false;
+        }
+        for is_bid in [true, false] {
+            if !dex
+                .getTickLevel(token, 0, is_bid)
+                .call()
+                .await
+                .is_ok_and(|level| level.totalLiquidity > 0)
+            {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+async fn wait_for_rpc(provider: &impl Provider<TempoNetwork>) -> Result<()> {
+    for _ in 0..120 {
+        if matches!(provider.get_chain_id().await, Ok(1337)) {
+            return Ok(());
+        }
+        sleep(Duration::from_millis(500)).await;
+    }
+    Err(eyre!("timed out waiting for Tempo dev RPC"))
+}
+
+fn fee_pool_needs_repair(reserve: u128) -> bool {
+    reserve < MIN_FEE_RESERVE
+}
+
+fn receipt_timeout(block_time: Option<Duration>) -> Duration {
+    block_time
+        .map(|interval| MIN_RECEIPT_TIMEOUT.max(interval.saturating_mul(4)))
+        .unwrap_or(MIN_RECEIPT_TIMEOUT)
+}
+
+async fn wait_for_receipt(
+    provider: &impl Provider<TempoNetwork>,
+    hash: B256,
+    block_time: Option<Duration>,
+) -> Result<()> {
+    match timeout(receipt_timeout(block_time), async {
+        loop {
+            if let Some(receipt) = provider.get_transaction_receipt(hash).await? {
+                if receipt.status() {
+                    return Ok(());
+                }
+                bail!("bootstrap transaction {hash} failed");
+            }
+            sleep(Duration::from_millis(250)).await;
+        }
+    })
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(eyre!("timed out waiting for bootstrap transaction {hash}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn depleted_fee_pools_are_repaired_before_bootstrap() {
+        for (reserve, needs_repair) in [
+            (0, true),
+            (MIN_FEE_RESERVE - 1, true),
+            (MIN_FEE_RESERVE, false),
+            (FEE_LIQUIDITY, false),
+        ] {
+            assert_eq!(fee_pool_needs_repair(reserve), needs_repair);
+        }
+    }
+
+    #[test]
+    fn receipt_timeout_accounts_for_slow_blocks() {
+        assert_eq!(receipt_timeout(None), MIN_RECEIPT_TIMEOUT);
+        assert_eq!(
+            receipt_timeout(Some(Duration::from_secs(10))),
+            Duration::from_secs(40)
+        );
+    }
+}

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -28,6 +28,8 @@ use opentelemetry_otlp as _;
 
 pub mod cli;
 mod defaults;
+#[doc(hidden)]
+pub mod dev;
 mod follow;
 pub mod init_state;
 mod overrides;
@@ -64,7 +66,12 @@ use reth_cli_runner::CliRunner;
 use reth_ethereum::{chainspec::EthChainSpec as _, cli::Commands};
 use reth_network_api::Peers;
 use reth_node_builder::{NodeHandle, WithLaunchContext};
-use std::{collections::BTreeMap, sync::Arc, thread};
+use std::{
+    collections::BTreeMap,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+    thread,
+};
 use tempo_chainspec::spec::{DEV, TempoChainSpec};
 use tempo_consensus::{feed as consensus_feed, run_consensus_stack, run_follow_stack};
 use tempo_contracts::precompiles::initial_zone_factory_state;
@@ -451,7 +458,24 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
         |spec: Arc<TempoChainSpec>| (TempoEvmConfig::new(spec.clone()), TempoConsensus::new(spec));
 
     cli.run_with_components::<TempoNode>(components, async move |builder, args| {
-        let faucet_args = args.faucet_args.clone();
+        let is_default_dev_chain =
+            builder.config().dev.dev && builder.config().chain.chain().id() == DEV.chain().id();
+        let bootstrap_dev = is_default_dev_chain && !args.dev_no_bootstrap;
+        let rpc_addr = match builder.config().rpc.http_addr {
+            IpAddr::V4(addr) if addr.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            IpAddr::V6(addr) if addr.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+            addr => addr,
+        };
+        let dev_rpc_url = format!(
+            "http://{}",
+            SocketAddr::new(rpc_addr, builder.config().rpc.http_port)
+        );
+        let dev_block_time = builder.config().dev.block_time;
+        let faucet_args = if bootstrap_dev && !args.faucet_args.enabled {
+            dev::faucet_args(dev_rpc_url.clone())
+        } else {
+            args.faucet_args.clone()
+        };
         let validator_key = args
             .consensus
             .public_key()
@@ -540,6 +564,13 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
             .launch_with_debug_capabilities()
             .await
             .wrap_err("failed launching execution node")?;
+
+        if bootstrap_dev {
+            dev::bootstrap(&dev_rpc_url, dev_block_time)
+                .await
+                .wrap_err("failed bootstrapping Tempo dev chain")?;
+            info!("Tempo dev chain bootstrap complete");
+        }
 
         // Fetch bootnodes from the endpoint in a background task and inject
         // them into the already-running discovery services.
@@ -1010,5 +1041,19 @@ mod tests {
                 .payload_builder_builder()
                 .enable_prewarming
         );
+    }
+
+    #[test]
+    fn dev_bootstrap_can_be_disabled_explicitly() {
+        init_defaults_once();
+
+        let cli =
+            TempoCli::try_parse_from(["tempo", "node", "--dev", "--dev.no-bootstrap"]).unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(node_cmd.ext.dev_no_bootstrap);
+
+        assert!(TempoCli::try_parse_from(["tempo", "node", "--dev.no-bootstrap"]).is_err());
     }
 }

--- a/bin/tempo/src/localnet.rs
+++ b/bin/tempo/src/localnet.rs
@@ -1,54 +1,27 @@
 //! Entrypoint for the batteries-included Tempo localnet container.
 
-use std::{path::Path, process::ExitStatus, str::FromStr, time::Duration};
+use std::{path::Path, process::ExitStatus, time::Duration};
 
-use alloy::{
-    network::ReceiptResponse,
-    primitives::{Address, B256, U256, address},
-    providers::{Provider, ProviderBuilder},
-    signers::local::PrivateKeySigner,
-};
+use alloy::providers::{Provider, ProviderBuilder};
 use clap::Parser;
 use eyre::{Context, Result, bail, eyre};
 use reth_cli_util::{parse_duration_from_secs_or_ms, parsers::format_duration_as_secs_or_ms};
-use tempo_alloy::{TempoNetwork, fillers::FeeTokenFiller};
-use tempo_contracts::precompiles::{IStablecoinDEX, ITIP20, ITIPFeeAMM};
-use tempo_precompiles::{PATH_USD_ADDRESS, STABLECOIN_DEX_ADDRESS, TIP_FEE_MANAGER_ADDRESS};
+use tempo_alloy::TempoNetwork;
 use tokio::{
     process::{Child, Command},
-    time::{sleep, timeout},
+    time::timeout,
 };
 
 /// Loopback RPC endpoint used by the bootstrapper and container health check.
 const RPC_URL: &str = "http://127.0.0.1:8545";
 /// Marker written only after the selected localnet bootstrap has completed.
 const READY_FILE: &str = "/tmp/tempo-localnet-ready";
-/// Well-known first Anvil development key used only for local bootstrap transactions.
-const DEV_PRIVATE_KEY: &str = "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
-/// Amount of each canonical token, in base units, issued by one faucet request.
-const FAUCET_AMOUNT: u128 = 1_000_000_000_000_000;
-/// Validator-token liquidity, in base units, seeded into each fee AMM pool.
-const FEE_LIQUIDITY: u128 = 1_000_000_000;
-/// Fee-pool validator reserve below which bootstrap restores liquidity.
-const MIN_FEE_RESERVE: u128 = 100_000_000;
-/// Liquidity, in base units, seeded on each side of every DEX market.
-const DEX_LIQUIDITY: u128 = 100_000_000_000;
 /// Maximum interval that keeps faucet expiring nonces safe.
 const MAX_BLOCK_TIME: Duration = Duration::from_secs(5);
 /// Maximum time allowed for all RPC readiness and liquidity setup.
 const BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(120);
-/// Minimum time allowed for one transaction to receive a receipt.
-const MIN_RECEIPT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Grace period kept below Docker's default 10-second stop timeout.
 const CHILD_STOP_TIMEOUT: Duration = Duration::from_secs(8);
-/// Canonical localnet tokens: pathUSD, AlphaUSD, BetaUSD, and ThetaUSD.
-const TOKENS: [Address; 4] = [
-    address!("0x20c0000000000000000000000000000000000000"),
-    address!("0x20c0000000000000000000000000000000000001"),
-    address!("0x20c0000000000000000000000000000000000002"),
-    address!("0x20c0000000000000000000000000000000000003"),
-];
-
 #[derive(Debug, Parser)]
 #[command(
     name = "tempo-localnet",
@@ -85,7 +58,10 @@ async fn main() -> Result<()> {
         .spawn()
         .wrap_err("failed to start Tempo node")?;
 
-    let setup = timeout(BOOTSTRAP_TIMEOUT, bootstrap(args.bare, args.block_time));
+    let setup = timeout(
+        BOOTSTRAP_TIMEOUT,
+        tempo::dev::wait_until_ready(RPC_URL, !args.bare),
+    );
     tokio::pin!(setup);
     let shutdown = shutdown_signal();
     tokio::pin!(shutdown);
@@ -150,147 +126,11 @@ fn node_args(args: &Args) -> Vec<String> {
         "3000000000".into(),
     ];
 
-    if !args.bare {
-        values.extend([
-            "--faucet.enabled".into(),
-            "--faucet.private-key".into(),
-            DEV_PRIVATE_KEY.into(),
-            "--faucet.amount".into(),
-            FAUCET_AMOUNT.to_string(),
-            "--faucet.node-address".into(),
-            RPC_URL.into(),
-            "--faucet.address".into(),
-        ]);
-        values.extend(TOKENS.map(|token| token.to_string()));
+    if args.bare {
+        values.push("--dev.no-bootstrap".into());
     }
 
     values
-}
-
-async fn bootstrap(bare: bool, block_time: Duration) -> Result<()> {
-    let signer = PrivateKeySigner::from_str(DEV_PRIVATE_KEY)?;
-    let admin = signer.address();
-    let provider = ProviderBuilder::new_with_network::<TempoNetwork>()
-        .filler(FeeTokenFiller::new(PATH_USD_ADDRESS))
-        .wallet(signer)
-        .connect_http(RPC_URL.parse()?);
-
-    wait_for_rpc(&provider).await?;
-    if bare {
-        return Ok(());
-    }
-
-    let fee_amm = ITIPFeeAMM::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
-    let dex = IStablecoinDEX::new(STABLECOIN_DEX_ADDRESS, provider.clone());
-    let mut missing_fee_pools = Vec::new();
-    let mut missing_orders = Vec::new();
-
-    for token in TOKENS.into_iter().skip(1) {
-        let pool = fee_amm.getPool(token, PATH_USD_ADDRESS).call().await?;
-        if fee_pool_needs_repair(pool.reserveValidatorToken) {
-            missing_fee_pools.push(token);
-        }
-
-        for is_bid in [true, false] {
-            let has_liquidity = dex
-                .getTickLevel(token, 0, is_bid)
-                .call()
-                .await
-                .is_ok_and(|level| level.totalLiquidity > 0);
-            if !has_liquidity {
-                missing_orders.push((token, is_bid));
-            }
-        }
-    }
-
-    if missing_fee_pools.is_empty() && missing_orders.is_empty() {
-        return Ok(());
-    }
-
-    let hashes: Vec<B256> = provider
-        .raw_request("tempo_fundAddress".into(), [admin])
-        .await
-        .wrap_err("failed to fund the localnet bootstrap account")?;
-    for hash in hashes {
-        wait_for_receipt(&provider, hash, block_time).await?;
-    }
-
-    for token in missing_fee_pools {
-        let hash = *fee_amm
-            .mint(token, PATH_USD_ADDRESS, U256::from(FEE_LIQUIDITY), admin)
-            .send()
-            .await?
-            .tx_hash();
-        wait_for_receipt(&provider, hash, block_time).await?;
-
-        let pool = fee_amm.getPool(token, PATH_USD_ADDRESS).call().await?;
-        if fee_pool_needs_repair(pool.reserveValidatorToken) {
-            bail!("fee liquidity for {token} remains below the minimum reserve");
-        }
-    }
-
-    if !missing_orders.is_empty() {
-        for token in TOKENS {
-            let hash = *ITIP20::new(token, provider.clone())
-                .approve(STABLECOIN_DEX_ADDRESS, U256::MAX)
-                .send()
-                .await?
-                .tx_hash();
-            wait_for_receipt(&provider, hash, block_time).await?;
-        }
-
-        for (token, is_bid) in missing_orders {
-            let hash = *dex
-                .place(token, DEX_LIQUIDITY, is_bid, 0)
-                .send()
-                .await?
-                .tx_hash();
-            wait_for_receipt(&provider, hash, block_time).await?;
-        }
-    }
-
-    Ok(())
-}
-
-fn fee_pool_needs_repair(reserve: u128) -> bool {
-    reserve < MIN_FEE_RESERVE
-}
-
-async fn wait_for_rpc(provider: &impl Provider<TempoNetwork>) -> Result<()> {
-    for _ in 0..120 {
-        if matches!(provider.get_chain_id().await, Ok(1337)) {
-            return Ok(());
-        }
-        sleep(Duration::from_millis(500)).await;
-    }
-    Err(eyre!("timed out waiting for Tempo localnet RPC"))
-}
-
-fn receipt_timeout(block_time: Duration) -> Duration {
-    MIN_RECEIPT_TIMEOUT.max(block_time.saturating_mul(4))
-}
-
-async fn wait_for_receipt(
-    provider: &impl Provider<TempoNetwork>,
-    hash: B256,
-    block_time: Duration,
-) -> Result<()> {
-    match timeout(receipt_timeout(block_time), async {
-        loop {
-            if let Some(receipt) = provider.get_transaction_receipt(hash).await? {
-                if receipt.status() {
-                    return Ok(());
-                }
-                bail!("bootstrap transaction {hash} failed");
-            }
-            sleep(Duration::from_millis(250)).await;
-        }
-    })
-    .await
-    {
-        Ok(result) => result,
-        Err(_) => Err(eyre!("timed out waiting for bootstrap transaction {hash}")),
-    }
 }
 
 async fn health() -> Result<()> {
@@ -363,7 +203,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn full_mode_enables_faucet_for_all_canonical_tokens() {
+    fn full_mode_relies_on_dev_bootstrap() {
         let args = node_args(&Args {
             bare: false,
             block_time: Duration::from_millis(200),
@@ -371,7 +211,8 @@ mod tests {
         });
 
         assert!(args.windows(2).any(|v| v == ["--dev.block-time", "200ms"]));
-        assert!(args.iter().any(|value| value == "--faucet.enabled"));
+        assert!(!args.iter().any(|value| value.starts_with("--faucet")));
+        assert!(!args.iter().any(|value| value == "--dev.no-bootstrap"));
         assert!(
             args.windows(2)
                 .any(|v| v == ["--tempo.bootnodes-endpoint", "none"])
@@ -383,9 +224,6 @@ mod tests {
                 .iter()
                 .any(|value| value == "--engine.disable-precompile-cache")
         );
-        for token in TOKENS {
-            assert!(args.iter().any(|value| value == &token.to_string()));
-        }
     }
 
     #[test]
@@ -397,6 +235,7 @@ mod tests {
         });
 
         assert!(!args.iter().any(|value| value.starts_with("--faucet")));
+        assert!(args.iter().any(|value| value == "--dev.no-bootstrap"));
         assert!(args.windows(2).any(|v| v == ["--datadir", "/data"]));
     }
 
@@ -410,18 +249,6 @@ mod tests {
                 parse_block_time(value).is_err(),
                 "{value} should be rejected"
             );
-        }
-    }
-
-    #[test]
-    fn depleted_fee_pools_are_repaired_before_bootstrap() {
-        for (reserve, needs_repair) in [
-            (0, true),
-            (MIN_FEE_RESERVE - 1, true),
-            (MIN_FEE_RESERVE, false),
-            (FEE_LIQUIDITY, false),
-        ] {
-            assert_eq!(fee_pool_needs_repair(reserve), needs_repair);
         }
     }
 }

--- a/docs/localnet.md
+++ b/docs/localnet.md
@@ -1,6 +1,6 @@
 # Tempo localnet container
 
-`tempo-localnet` is a batteries-included Tempo network for application development and CI. It starts a deterministic development node, waits for RPC, and prepares the payment features commonly needed by SDK and backend tests.
+`tempo-localnet` packages `tempo node --dev` for application development and CI. Dev mode starts a deterministic node and prepares the payment features commonly needed by SDK and backend tests; the container adds readiness checks and persistence conventions.
 
 ```bash
 docker run --rm -p 127.0.0.1:8545:8545 ghcr.io/tempoxyz/tempo-localnet:latest


### PR DESCRIPTION
Moves canonical TIP-20 faucet, Fee AMM, and Stablecoin DEX seeding into `tempo node --dev`; the localnet container now delegates to the node and retains `--bare` via `--dev.no-bootstrap`.

Prompted by: @brendanjryan