### PR TITLE
perf(precompiles): reduce expiring nonce buffer capacity

### DIFF
--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -297,7 +297,7 @@ impl TempoHardfork {
     /// Returns the expiring nonce replay-protection capacity.
     pub const fn expiring_nonce_set_capacity(&self) -> u32 {
         const PRE_T11_CAPACITY: u32 = 300_000;
-        const POST_T11_CAPACITY: u32 = 3_000_000;
+        const POST_T11_CAPACITY: u32 = 300_000;
 
         if self.is_t11() {
             POST_T11_CAPACITY

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(TempoHardfork::T10.expiring_nonce_max_expiry_secs(), 30);
         assert_eq!(TempoHardfork::T10.expiring_nonce_set_capacity(), 300_000);
         assert_eq!(TempoHardfork::T11.expiring_nonce_max_expiry_secs(), 300);
-        assert_eq!(TempoHardfork::T11.expiring_nonce_set_capacity(), 3_000_000);
+        assert_eq!(TempoHardfork::T11.expiring_nonce_set_capacity(), 300_000);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reduce the T11+ expiring nonce ring-buffer capacity from 3,000,000 to 300,000, matching the pre-T11 capacity.
- The E2E benchmark was mixed: mean TPS was neutral (+0.24%, +/-2.99%), while validator gas throughput regressed 7.61% despite improvements in block-time mean and builder P90 latency.

## Profile
- This is a direct capacity experiment; it does not change the per-transaction precompile path before the pointer wraps.
- Main-vs-main noise floor with Samply: https://github.com/tempoxyz/tempo/actions/runs/32784306158 (the headline itself reported an improvement, with mean TPS varying -1.4%).
- Main-vs-branch benchmark and profiles: https://github.com/tempoxyz/tempo/pull/7297#issuecomment-5402283213

## Verification
- `cargo +nightly fmt --check`
- `cargo test -p tempo-hardfork --lib` (25 passed)
- `cargo test -p tempo-precompiles --features test-utils nonce --lib` (16 passed)
- Main-vs-branch E2E benchmark: mixed results; TPS +0.24% (neutral), block-time mean -6.68% (win), builder P90 -5.46% (win), validator gas throughput -7.61% (loss).

## Risk
- A 300,000-entry buffer can return `ExpiringNonceSetFull` if it wraps before entries expire; the benchmark workload uses 10-second expiring nonces.

Prompted by: @onbjerg
