### PR TITLE
feat(evm): add Zone verifier debug utility

### DIFF
--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -78,6 +78,11 @@ rpc = ["tempo-contracts/rpc"]
 name = "storage"
 required-features = ["test-utils"]
 
+[[bin]]
+name = "tempo-zone-verifier-debug"
+path = "src/bin/zone_verifier_debug.rs"
+required-features = ["test-utils"]
+
 [[bench]]
 name = "tempo_precompiles"
 harness = false

--- a/crates/precompiles/src/bin/zone_verifier_debug.rs
+++ b/crates/precompiles/src/bin/zone_verifier_debug.rs
@@ -1,0 +1,59 @@
+use std::{error::Error, fs};
+
+use alloy::{
+    primitives::{Address, U256, hex},
+    sol_types::SolCall,
+};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_contracts::precompiles::IZoneVerifier;
+use tempo_precompiles::{
+    Precompile,
+    storage::{StorageCtx, hashmap::HashMapStorageProvider},
+    zone_verifier::ZoneVerifier,
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut args = std::env::args().skip(1);
+    let portal = args.next().ok_or(USAGE)?.parse::<Address>()?;
+    let chain_id = args.next().ok_or(USAGE)?.parse::<u64>()?;
+    let block_timestamp = args.next().ok_or(USAGE)?.parse::<u64>()?;
+    let calldata_arg = args.next().ok_or(USAGE)?;
+    if args.next().is_some() {
+        return Err(USAGE.into());
+    }
+
+    let calldata = read_calldata(&calldata_arg)?;
+    let call = IZoneVerifier::verifyCall::abi_decode(&calldata)?;
+
+    let mut dispatch_storage = storage(chain_id, block_timestamp);
+    let precompile_result = StorageCtx::enter(&mut dispatch_storage, || {
+        ZoneVerifier::new().call(&calldata, portal)
+    })?;
+    let valid = IZoneVerifier::verifyCall::abi_decode_returns(&precompile_result.bytes)?;
+
+    let mut diagnostic_storage = storage(chain_id, block_timestamp);
+    let diagnostic = StorageCtx::enter(&mut diagnostic_storage, || {
+        ZoneVerifier::new().diagnose(portal, call)
+    })?;
+
+    println!("precompile result: {valid}");
+    println!("diagnostic: {diagnostic:#?}");
+    Ok(())
+}
+
+fn storage(chain_id: u64, timestamp: u64) -> HashMapStorageProvider {
+    let mut storage = HashMapStorageProvider::new_with_spec(chain_id, TempoHardfork::T11);
+    storage.set_timestamp(U256::from(timestamp));
+    storage
+}
+
+fn read_calldata(argument: &str) -> Result<Vec<u8>, Box<dyn Error>> {
+    let value = if argument.starts_with("0x") {
+        argument.to_owned()
+    } else {
+        fs::read_to_string(argument)?.trim().to_owned()
+    };
+    Ok(hex::decode(value.strip_prefix("0x").unwrap_or(&value))?)
+}
+
+const USAGE: &str = "usage: tempo-zone-verifier-debug <portal> <chain-id> <block-timestamp-seconds> <calldata-hex-or-file>";

--- a/crates/precompiles/src/zone_verifier/attestation.rs
+++ b/crates/precompiles/src/zone_verifier/attestation.rs
@@ -7,8 +7,9 @@ use aws_lc_rs::{
     },
 };
 use tempo_nitro_attestation::{
-    MAX_DOCUMENT_SIZE, NitroAttestation, P384_FIXED_SIGNATURE_SIZE, P384_PUBLIC_KEY_SIZE,
-    P384Verifier, SHA384_SIZE, Sha384Hasher, parse_attestation, verify_parsed,
+    Error as NitroAttestationError, FormatError, MAX_DOCUMENT_SIZE, NitroAttestation,
+    P384_FIXED_SIGNATURE_SIZE, P384_PUBLIC_KEY_SIZE, P384Verifier, SHA384_SIZE, Sha384Hasher,
+    parse_attestation, verify_parsed,
 };
 
 use crate::storage::StorageCtx;
@@ -26,7 +27,7 @@ pub(super) const AWS_NITRO_ROOT_DER: &[u8; 533] = &alloy::primitives::hex!(
 
 #[derive(Debug, PartialEq, Eq)]
 pub(super) enum AttestationError {
-    Validation,
+    Validation(NitroAttestationError),
     OutOfGas,
 }
 
@@ -37,13 +38,15 @@ pub(super) fn verify_attestation_with_root(
     root_der: &[u8],
 ) -> Result<NitroAttestation, AttestationError> {
     if document.len() > MAX_DOCUMENT_SIZE {
-        return Err(AttestationError::Validation);
+        return Err(AttestationError::Validation(
+            FormatError::DocumentTooLarge.into(),
+        ));
     }
     storage
         .deduct_gas(BASE_GAS)
         .map_err(|_| AttestationError::OutOfGas)?;
 
-    let parsed = parse_attestation(document).map_err(|_| AttestationError::Validation)?;
+    let parsed = parse_attestation(document).map_err(AttestationError::Validation)?;
     let verification_gas = u64::try_from(parsed.signature_count())
         .unwrap_or(u64::MAX)
         .saturating_mul(SIGNATURE_GAS);
@@ -52,7 +55,7 @@ pub(super) fn verify_attestation_with_root(
         .map_err(|_| AttestationError::OutOfGas)?;
 
     verify_parsed(parsed, block_timestamp, root_der, &AwsLcP384)
-        .map_err(|_| AttestationError::Validation)
+        .map_err(AttestationError::Validation)
 }
 
 struct AwsLcP384;
@@ -156,6 +159,10 @@ pub(super) mod tests {
                 AWS_NITRO_ROOT_DER,
             )
         })
+    }
+
+    fn assert_validation_error(result: Result<NitroAttestation, AttestationError>) {
+        assert!(matches!(result, Err(AttestationError::Validation(_))));
     }
 
     fn replace_unique(haystack: &mut [u8], needle: &[u8], replacement: &[u8]) {
@@ -359,10 +366,7 @@ pub(super) mod tests {
             verify_production_document_at(&document, timestamp).unwrap();
         }
         for timestamp in [not_before - 1, not_after + 1] {
-            assert_eq!(
-                verify_production_document_at(&document, timestamp).unwrap_err(),
-                AttestationError::Validation
-            );
+            assert_validation_error(verify_production_document_at(&document, timestamp));
         }
     }
 
@@ -384,10 +388,10 @@ pub(super) mod tests {
             mutate_leaf_certificate(&mut document, |leaf| {
                 replace_unique(leaf, needle, replacement);
             });
-            assert_eq!(
-                verify_production_document_at(&document, PRODUCTION_FIXTURE_TIME).unwrap_err(),
-                AttestationError::Validation
-            );
+            assert_validation_error(verify_production_document_at(
+                &document,
+                PRODUCTION_FIXTURE_TIME,
+            ));
         }
     }
 
@@ -412,10 +416,10 @@ pub(super) mod tests {
             };
             replace_unique(leaf, &issuer, &changed);
         });
-        assert_eq!(
-            verify_production_document_at(&broken_issuer, PRODUCTION_FIXTURE_TIME).unwrap_err(),
-            AttestationError::Validation
-        );
+        assert_validation_error(verify_production_document_at(
+            &broken_issuer,
+            PRODUCTION_FIXTURE_TIME,
+        ));
 
         let mut unknown_critical = production_fixture();
         mutate_leaf_certificate(&mut unknown_critical, |leaf| {
@@ -425,10 +429,10 @@ pub(super) mod tests {
                 &CRITICAL_UNKNOWN_EXTENSION,
             );
         });
-        assert_eq!(
-            verify_production_document_at(&unknown_critical, PRODUCTION_FIXTURE_TIME).unwrap_err(),
-            AttestationError::Validation
-        );
+        assert_validation_error(verify_production_document_at(
+            &unknown_critical,
+            PRODUCTION_FIXTURE_TIME,
+        ));
     }
 
     #[test]
@@ -438,25 +442,25 @@ pub(super) mod tests {
         let mut replacement = root.clone();
         *replacement.last_mut().unwrap() ^= 1;
         replace_unique(&mut wrong_root, &root, &replacement);
-        assert_eq!(
-            verify_production_document_at(&wrong_root, PRODUCTION_FIXTURE_TIME).unwrap_err(),
-            AttestationError::Validation
-        );
+        assert_validation_error(verify_production_document_at(
+            &wrong_root,
+            PRODUCTION_FIXTURE_TIME,
+        ));
 
         let mut corrupt_document = production_fixture();
         *corrupt_document.last_mut().unwrap() ^= 1;
-        assert_eq!(
-            verify_production_document_at(&corrupt_document, PRODUCTION_FIXTURE_TIME).unwrap_err(),
-            AttestationError::Validation
-        );
+        assert_validation_error(verify_production_document_at(
+            &corrupt_document,
+            PRODUCTION_FIXTURE_TIME,
+        ));
 
         let mut corrupt_leaf = production_fixture();
         mutate_leaf_certificate(&mut corrupt_leaf, |leaf| {
             *leaf.last_mut().unwrap() ^= 1;
         });
-        assert_eq!(
-            verify_production_document_at(&corrupt_leaf, PRODUCTION_FIXTURE_TIME).unwrap_err(),
-            AttestationError::Validation
-        );
+        assert_validation_error(verify_production_document_at(
+            &corrupt_leaf,
+            PRODUCTION_FIXTURE_TIME,
+        ));
     }
 }

--- a/crates/precompiles/src/zone_verifier/mod.rs
+++ b/crates/precompiles/src/zone_verifier/mod.rs
@@ -4,7 +4,7 @@ mod attestation;
 pub mod dispatch;
 
 use alloy::{
-    primitives::{Address, B256, U256, keccak256},
+    primitives::{Address, B256, Bytes, U256, keccak256},
     sol_types::SolValue,
 };
 use tempo_contracts::precompiles::{IZoneVerifier, ZONE_VERIFIER_ADDRESS};
@@ -33,12 +33,58 @@ const APPROVED_PCRS: Option<[[u8; 48]; 3]> = Some([
 
 const BATCH_ATTESTATION_TYPE: &str = "NitroBatchAttestation(uint256 parentChainId,address verifier,address portal,uint32 zoneId,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,uint64 expectedWithdrawalBatchIndex,bytes32 prevBlockHash,bytes32 nextBlockHash,bytes32 prevProcessedHash,bytes32 nextProcessedHash,uint64 prevDepositNumber,uint64 nextDepositNumber,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)";
 
+/// Detailed result of evaluating a Zone verifier call.
+///
+/// The ABI deliberately collapses every policy rejection to `false`. This type is for offline
+/// diagnostics and is not returned by the consensus precompile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ZoneVerifierDiagnostic {
+    Valid,
+    InvalidConfiguration {
+        actual: Bytes,
+    },
+    EmptyProof,
+    InvalidAttestation(tempo_nitro_attestation::Error),
+    MissingApprovedPcrs,
+    PcrMismatch {
+        index: usize,
+        expected: [u8; 48],
+        actual: Option<Vec<u8>>,
+    },
+    FutureAttestation {
+        timestamp: u64,
+        maximum_timestamp: u64,
+    },
+    InvalidUserDataLength {
+        actual: usize,
+    },
+    CommitmentMismatch {
+        expected: B256,
+        actual: Bytes,
+    },
+}
+
+impl ZoneVerifierDiagnostic {
+    pub const fn is_valid(&self) -> bool {
+        matches!(self, Self::Valid)
+    }
+}
+
 #[contract(addr = ZONE_VERIFIER_ADDRESS)]
 pub struct ZoneVerifier {}
 
 impl ZoneVerifier {
     pub fn verify(&mut self, portal: Address, call: IZoneVerifier::verifyCall) -> Result<bool> {
         self.verify_with_policy(portal, call, AWS_NITRO_ROOT_DER, APPROVED_PCRS)
+    }
+
+    /// Runs the production verifier policy while retaining its rejection reason.
+    pub fn diagnose(
+        &mut self,
+        portal: Address,
+        call: IZoneVerifier::verifyCall,
+    ) -> Result<ZoneVerifierDiagnostic> {
+        self.diagnose_with_policy(portal, call, AWS_NITRO_ROOT_DER, APPROVED_PCRS)
     }
 
     fn verify_with_policy(
@@ -55,7 +101,7 @@ impl ZoneVerifier {
         let block_timestamp = self.storage.timestamp().saturating_to::<u64>();
         let attestation = match verify_attestation_with_root(
             &mut self.storage,
-            call.proof.as_ref(),
+            &call.proof,
             block_timestamp,
             root_der,
         ) {
@@ -91,6 +137,85 @@ impl ZoneVerifier {
 
         let commitment = batch_commitment(self.storage.chain_id(), portal, &call);
         Ok(attestation.user_data.as_slice() == commitment.as_slice())
+    }
+
+    fn diagnose_with_policy(
+        &mut self,
+        portal: Address,
+        call: IZoneVerifier::verifyCall,
+        root_der: &[u8],
+        approved_pcrs: Option<[[u8; 48]; 3]>,
+    ) -> Result<ZoneVerifierDiagnostic> {
+        if call.verifierConfig.as_ref() != CONFIG_V1 {
+            return Ok(ZoneVerifierDiagnostic::InvalidConfiguration {
+                actual: call.verifierConfig,
+            });
+        }
+        if call.proof.is_empty() {
+            return Ok(ZoneVerifierDiagnostic::EmptyProof);
+        }
+
+        let block_timestamp = self.storage.timestamp().saturating_to::<u64>();
+        let attestation = match verify_attestation_with_root(
+            &mut self.storage,
+            call.proof.as_ref(),
+            block_timestamp,
+            root_der,
+        ) {
+            Ok(attestation) => attestation,
+            Err(AttestationError::OutOfGas) => {
+                return Err(crate::error::TempoPrecompileError::OutOfGas);
+            }
+            Err(AttestationError::Validation(error)) => {
+                return Ok(ZoneVerifierDiagnostic::InvalidAttestation(error));
+            }
+        };
+
+        let Some(approved_pcrs) = approved_pcrs else {
+            return Ok(ZoneVerifierDiagnostic::MissingApprovedPcrs);
+        };
+        for (index, expected) in approved_pcrs.iter().enumerate() {
+            let actual = attestation
+                .pcrs
+                .iter()
+                .find(|pcr| usize::from(pcr.index) == index)
+                .map(|pcr| pcr.value.clone());
+            if actual.as_deref() != Some(expected.as_slice()) {
+                return Ok(ZoneVerifierDiagnostic::PcrMismatch {
+                    index,
+                    expected: *expected,
+                    actual,
+                });
+            }
+        }
+
+        let max_timestamp = self
+            .storage
+            .timestamp()
+            .saturating_to::<u64>()
+            .saturating_mul(1_000)
+            .saturating_add(MAX_FUTURE_SKEW_MILLIS);
+        if attestation.timestamp > max_timestamp {
+            return Ok(ZoneVerifierDiagnostic::FutureAttestation {
+                timestamp: attestation.timestamp,
+                maximum_timestamp: max_timestamp,
+            });
+        }
+        if attestation.user_data.len() != 32 {
+            return Ok(ZoneVerifierDiagnostic::InvalidUserDataLength {
+                actual: attestation.user_data.len(),
+            });
+        }
+
+        let commitment = batch_commitment(self.storage.chain_id(), portal, &call);
+        if attestation.user_data.as_slice() != commitment.as_slice() {
+            return Ok(ZoneVerifierDiagnostic::CommitmentMismatch {
+                expected: commitment,
+                actual: attestation.user_data.into(),
+            });
+        }
+
+        Ok(ZoneVerifierDiagnostic::Valid)
     }
 }
 
@@ -219,18 +344,36 @@ mod tests {
                     .verify_with_policy(portal, call.clone(), &root, Some(pcrs))
                     .unwrap()
             );
+            assert_eq!(
+                verifier
+                    .diagnose_with_policy(portal, call.clone(), &root, Some(pcrs))
+                    .unwrap(),
+                ZoneVerifierDiagnostic::Valid
+            );
 
             let mut altered = call.clone();
             altered.anchorBlockNumber += 1;
             assert!(
                 !verifier
-                    .verify_with_policy(portal, altered, &root, Some(pcrs))
+                    .verify_with_policy(portal, altered.clone(), &root, Some(pcrs))
                     .unwrap()
             );
+            assert!(matches!(
+                verifier
+                    .diagnose_with_policy(portal, altered, &root, Some(pcrs))
+                    .unwrap(),
+                ZoneVerifierDiagnostic::CommitmentMismatch { .. }
+            ));
             assert!(
                 !verifier
-                    .verify_with_policy(portal, call, &root, None)
+                    .verify_with_policy(portal, call.clone(), &root, None)
                     .unwrap()
+            );
+            assert_eq!(
+                verifier
+                    .diagnose_with_policy(portal, call, &root, None)
+                    .unwrap(),
+                ZoneVerifierDiagnostic::MissingApprovedPcrs
             );
         });
     }
@@ -255,10 +398,20 @@ mod tests {
                 candidate.proof = proof.into();
                 assert_eq!(
                     ZoneVerifier::new()
-                        .verify_with_policy(portal, candidate, &root, Some(pcrs))
+                        .verify_with_policy(portal, candidate.clone(), &root, Some(pcrs))
                         .unwrap(),
                     expected
                 );
+                let diagnostic = ZoneVerifier::new()
+                    .diagnose_with_policy(portal, candidate, &root, Some(pcrs))
+                    .unwrap();
+                assert_eq!(diagnostic.is_valid(), expected);
+                if !expected {
+                    assert!(matches!(
+                        diagnostic,
+                        ZoneVerifierDiagnostic::FutureAttestation { .. }
+                    ));
+                }
             }
         });
     }


### PR DESCRIPTION
Adds an offline CLI that invokes the exact Zone verifier precompile and then runs a detailed diagnostic pass without changing the consensus boolean path. It reports attestation parsing/signature, PCR, freshness, user-data, and commitment mismatch failures.

Validated with focused Zone verifier tests and nightly clippy.

Prompted by: @rkrasiuk