### PR TITLE
fix(evm): align Zone verifier PCR measurements

### DIFF
--- a/crates/precompiles/src/zone_verifier/mod.rs
+++ b/crates/precompiles/src/zone_verifier/mod.rs
@@ -17,17 +17,17 @@ use self::attestation::{AWS_NITRO_ROOT_DER, AttestationError, verify_attestation
 const CONFIG_V1: &[u8] = &[1];
 const MAX_FUTURE_SKEW_MILLIS: u64 = 300_000;
 
-/// Measurements for the T11 EIF built from `tempoxyz/zones` PR 1258 at merge commit
-/// `4e58b924224b89e705c74aa41ad2b9d33b63b2f4`.
+/// Measurements for the deployed T11 EIF built from `tempoxyz/zones` PR 1258 at head commit
+/// `594e3f6b9ca79f8d8ed55a50ab8d1023a84fb954`.
 const APPROVED_PCRS: Option<[[u8; 48]; 3]> = Some([
     alloy::primitives::hex!(
-        "aacfa461849093d9b9eb1a652787352eb5ebe2e24b9efc4a605fc3699aab5e5503cd2e23c5f0ba01781fa361f3e97d27"
+        "57c7a22a732e90c94ddca71b9a3e88d33d603f700c99bfeb32c6936d4b4b86fe7a261f1e658f922372fbdc4a9a5de779"
     ),
     alloy::primitives::hex!(
         "4b4d5b3661b3efc12920900c80e126e4ce783c522de6c02a2a5bf7af3a2b9327b86776f188e4be1c1c404a129dbda493"
     ),
     alloy::primitives::hex!(
-        "00a45c0d7641c9bf4c90369f03034a3d71ed47f2e115985315f962a52a00bcd46f1b8b14b6dcef58904c3109aedfa444"
+        "e627e49d32d0caac54703b2ae650c30c130a36a293ac4ae0d685a0fde663868e4483dd14a0ff84ad4e1ceb2179e959fd"
     ),
 ]);
 

--- a/tips/tip-1098.md
+++ b/tips/tip-1098.md
@@ -111,12 +111,12 @@ The attestation MUST contain the following 48-byte SHA-384 measurements:
 
 | Register | Required value |
 |---|---|
-| PCR0 | `aacfa461849093d9b9eb1a652787352eb5ebe2e24b9efc4a605fc3699aab5e5503cd2e23c5f0ba01781fa361f3e97d27` |
+| PCR0 | `57c7a22a732e90c94ddca71b9a3e88d33d603f700c99bfeb32c6936d4b4b86fe7a261f1e658f922372fbdc4a9a5de779` |
 | PCR1 | `4b4d5b3661b3efc12920900c80e126e4ce783c522de6c02a2a5bf7af3a2b9327b86776f188e4be1c1c404a129dbda493` |
-| PCR2 | `00a45c0d7641c9bf4c90369f03034a3d71ed47f2e115985315f962a52a00bcd46f1b8b14b6dcef58904c3109aedfa444` |
+| PCR2 | `e627e49d32d0caac54703b2ae650c30c130a36a293ac4ae0d685a0fde663868e4483dd14a0ff84ad4e1ceb2179e959fd` |
 
-These measurements identify the T11 EIF built from `tempoxyz/zones` PR 1258 at merge commit
-`4e58b924224b89e705c74aa41ad2b9d33b63b2f4`. The tuple is a hardfork constant and is not
+These measurements identify the deployed T11 EIF built from `tempoxyz/zones` PR 1258 at head
+commit `594e3f6b9ca79f8d8ed55a50ab8d1023a84fb954`. The tuple is a hardfork constant and is not
 runtime-configurable. Other locked PCRs MAY be present.
 
 The document timestamp MUST NOT exceed `block.timestamp * 1000 + 300_000`; no additional maximum


### PR DESCRIPTION
Updates PCR0 and PCR2 to the measurements produced by the deployed `tempoxyz/zones` `sha-594e3f6` image build, and keeps TIP-1098 in sync. This fixes native verifier rejection of otherwise valid enclave attestations.

Build evidence: https://github.com/tempoxyz/zones/actions/runs/32767946443

Prompted by: @rkrasiuk