### PR TITLE
chore: ignore root .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export AMP_TOOLBOX=".amp/tools"

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ profile.json.gz
 .vscode
 **/.env
 **/.envrc
-!.envrc
 localnet/**
 
 .claude/


### PR DESCRIPTION
## Summary

- stop tracking the repository-root `.envrc`
- allow the existing `**/.envrc` rule to ignore it

Prompted by: @shekhirin
