### PR TITLE
fix(ci): update deny workflow pin

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -160,7 +160,7 @@ jobs:
   deny:
     permissions:
       contents: read
-    uses: tempoxyz/ci/.github/workflows/deny.yml@f7b868401133161610784f840fbf8ba5c45fdd4e # main
+    uses: tempoxyz/ci/.github/workflows/deny.yml@09f481293feb726bcd5c94853063b224a9b2ff24 # main
 
   zepter:
     name: zepter


### PR DESCRIPTION
Updates Tempo’s deny reusable workflow to the revision that pins all nested GitHub Actions to full commit SHAs. This restores the job under the SHA-only Actions policy.

Prompted by: @klkvr