### PR TITLE
perf: warm KZG setup in background

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13844,6 +13844,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "bitflags 2.11.1",
+ "c-kzg",
  "codspeed-criterion-compat",
  "commonware-codec",
  "commonware-cryptography",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,6 +266,7 @@ axum = "0.8.8"
 base64 = { version = "0.22", features = ["alloc"], default-features = false }
 blake3 = "1.8.5"
 bytes = "1.11.1"
+c-kzg = { version = "2.1.8", default-features = false, features = ["ethereum_kzg_settings"] }
 clap = { version = "4.5.57", features = ["derive", "env"] }
 coins-bip32 = "0.12"
 const-hex = { version = "1.17.0" }

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -255,6 +255,9 @@ impl TempoNode {
     where
         Node: FullNodeTypes<Types = Self>,
     {
+        let _ = std::thread::Builder::new()
+            .name("kzg-warmup".to_string())
+            .spawn(tempo_precompiles::warmup_kzg_settings);
         ComponentsBuilder::default()
             .node_types::<Node>()
             .pool(pool_builder)

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -29,6 +29,7 @@ alloy-primitives = { workspace = true, features = ["map-foldhash"] }
 revm.workspace = true
 paste.workspace = true
 bitflags.workspace = true
+c-kzg.workspace = true
 
 commonware-cryptography.workspace = true
 commonware-codec.workspace = true

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -162,6 +162,15 @@ pub fn tempo_precompiles(
     precompiles
 }
 
+/// Initializes the KZG trusted setup used by the EIP-4844 point-evaluation precompile.
+///
+/// Revm calls `c_kzg::ethereum_kzg_settings(8)` when the point-evaluation precompile is first
+/// executed. Calling the same initializer from node startup warmup keeps that one-time cost out
+/// of transaction execution when the warmup finishes first.
+pub fn warmup_kzg_settings() {
+    let _ = c_kzg::ethereum_kzg_settings(8);
+}
+
 /// Registers Tempo-specific precompiles into an existing [`PrecompilesMap`] by installing a
 /// lookup function that matches addresses to their precompile: TIP-20 tokens (by prefix),
 /// TIP20Factory, TIP403Registry, TipFeeManager, StablecoinDEX, NonceManager, ValidatorConfig,


### PR DESCRIPTION
Starts KZG trusted setup initialization in a background thread during node component setup. This keeps the one-time c-kzg initialization cost out of the first KZG precompile execution when warmup completes first.