### PR TITLE
fix(node): warm KZG settings in pool builder

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -737,6 +737,15 @@ where
                 .no_eip4844()
                 .build_with_tasks(ctx.task_executor().clone(), blob_store.clone());
 
+        // EIP-4844 remains disabled in the pool, but KZG settings are also used by the
+        // point-evaluation precompile. Initialize them in the background so the one-time setup
+        // cost does not affect block execution.
+        let kzg_settings = ctx.kzg_settings()?;
+        ctx.task_executor().spawn_blocking_task(async move {
+            let _ = kzg_settings.get();
+            debug!(target: "reth::cli", "Initialized KZG settings");
+        });
+
         let aa_2d_config = AA2dPoolConfig {
             price_bump_config: pool_config.price_bumps,
             pending_limit: pool_config.pending_limit,


### PR DESCRIPTION
Initializes KZG settings from `TempoPoolBuilder` using the same background task pattern as reth while retaining `.no_eip4844()`. This keeps the one-time setup cost out of point-evaluation precompile execution without enabling blob transaction pool support.

Prompted by: @mattsse

supersedes https://github.com/tempoxyz/tempo/pull/7304