### PR TITLE
refactor(consensus): remove executor pacing

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -44,7 +44,7 @@ use commonware_consensus::{
 };
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{
-    Clock, ContextCell, FutureExt, Handle, Metrics as RuntimeMetrics, Pacer, Spawner, spawn_cell,
+    Clock, ContextCell, Handle, Metrics as RuntimeMetrics, Spawner, spawn_cell,
 };
 use commonware_utils::{Acknowledgement, acknowledgement::Exact};
 use eyre::{OptionExt as _, Report, WrapErr as _, bail, ensure, eyre};
@@ -218,7 +218,7 @@ impl Metrics {
 
 impl<TContext, TExecutionLayer, TMarshal> Actor<TContext, TExecutionLayer, TMarshal>
 where
-    TContext: Clock + RuntimeMetrics + Pacer + Spawner,
+    TContext: Clock + RuntimeMetrics + Spawner,
     TExecutionLayer: ExecutionLayer,
     TMarshal: Marshal,
 {
@@ -444,14 +444,8 @@ where
                     self.notarized_tree.set_local_state(canonicalized);
                 }
                 if let Some(job) = payload_job {
-                    self.payload_jobs.push(
-                        run_payload_job(
-                            self.context.child("payload_job"),
-                            self.execution_node.clone(),
-                            job,
-                        )
-                        .boxed(),
-                    );
+                    self.payload_jobs
+                        .push(run_payload_job(self.execution_node.clone(), job).boxed());
                 }
             }
             ExecutionTaskOutcome::NotarizedBlockRejected { digest, .. } => {
@@ -572,12 +566,7 @@ where
         }
 
         let on_top_of = self.notarized_tree.local_state();
-        let fut = execute_heartbeat(
-            self.context.child("heartbeat"),
-            self.execution_node.clone(),
-            on_top_of,
-            Span::current(),
-        );
+        let fut = execute_heartbeat(self.execution_node.clone(), on_top_of, Span::current());
         self.set_execution_task(ExecutionTask::new(
             ExecutionTaskType::Heartbeat,
             on_top_of,
@@ -766,11 +755,7 @@ where
                     || !self.is_convergence_target(request.block.parent_digest())
                 {
                     let on_top_of = self.notarized_tree.local_state();
-                    let fut = execute_validation(
-                        self.context.child("validate"),
-                        self.execution_node.clone(),
-                        request,
-                    );
+                    let fut = execute_validation(self.execution_node.clone(), request);
                     self.set_execution_task(ExecutionTask::new(
                         ExecutionTaskType::Verify,
                         on_top_of,
@@ -792,13 +777,7 @@ where
                 // notarized-chain convergence.
                 if self.notarized_tree.is_local_head(build.digest) {
                     let on_top_of = self.notarized_tree.local_state();
-                    let fut = execute_build(
-                        self.context.child("build"),
-                        self.execution_node.clone(),
-                        on_top_of,
-                        cause,
-                        build,
-                    );
+                    let fut = execute_build(self.execution_node.clone(), on_top_of, cause, build);
                     self.set_execution_task(ExecutionTask::new(
                         ExecutionTaskType::Build,
                         on_top_of,
@@ -827,13 +806,7 @@ where
 
         if let Some(step) = self.notarized_tree.next_to_forward(self.context.current()) {
             let on_top_of = self.notarized_tree.local_state();
-            let fut = execute_notarization(
-                self.context.child("notarize"),
-                self.execution_node.clone(),
-                on_top_of,
-                step,
-                None,
-            );
+            let fut = execute_notarization(self.execution_node.clone(), on_top_of, step, None);
             self.set_execution_task(ExecutionTask::new(
                 ExecutionTaskType::Notarize,
                 on_top_of,
@@ -1133,18 +1106,13 @@ struct StartPayloadJob {
         finalized_block_height = %canonicalized.finalized.0,
     ),
 )]
-async fn execute_heartbeat<TContext>(
-    context: TContext,
+async fn execute_heartbeat(
     execution_node: impl ExecutionLayer,
     canonicalized: LocalState,
     cause: Span,
-) -> ExecutionTaskOutcome
-where
-    TContext: Pacer,
-{
+) -> ExecutionTaskOutcome {
     if let Err(error) = submit_forkchoice_update(
         &execution_node,
-        &context,
         cause,
         canonicalized,
         None,
@@ -1175,8 +1143,7 @@ where
     parent = &cause,
     fields(%digest),
 )]
-async fn execute_build<TContext>(
-    context: TContext,
+async fn execute_build(
     execution_node: impl ExecutionLayer,
     canonicalized: LocalState,
     cause: Span,
@@ -1186,10 +1153,7 @@ async fn execute_build<TContext>(
         attributes,
         response,
     }: Build,
-) -> ExecutionTaskOutcome
-where
-    TContext: Pacer,
-{
+) -> ExecutionTaskOutcome {
     let mut build_attributes = Some((*attributes, response));
     if build_attributes
         .as_ref()
@@ -1206,7 +1170,6 @@ where
     // heartbeat relies on this).
     match submit_forkchoice_update(
         &execution_node,
-        &context,
         cause.clone(),
         canonicalized,
         attributes,
@@ -1263,7 +1226,7 @@ async fn execute_finalization<TContext>(
     request: FinalizedBlockRequest,
 ) -> ExecutionTaskOutcome
 where
-    TContext: Pacer + Clock,
+    TContext: Clock,
 {
     let target = match finalization_target(&execution_node, canonicalized, request.block.as_ref()) {
         Ok(target) => target,
@@ -1297,29 +1260,16 @@ where
         block.height = %step.height(),
     ),
 )]
-async fn execute_notarization<TContext>(
-    context: TContext,
+async fn execute_notarization(
     execution_node: impl ExecutionLayer,
     on_top_of: LocalState,
     step: NextToForward,
     validator_set: Option<Vec<B256>>,
-) -> ExecutionTaskOutcome
-where
-    TContext: Pacer,
-{
+) -> ExecutionTaskOutcome {
     let digest = step.digest();
     let is_repoint = matches!(step, NextToForward::Repoint(..));
     let target = on_top_of.update_head(step.height(), digest);
-    match forward_notarized(
-        &context,
-        execution_node,
-        on_top_of,
-        target,
-        step,
-        validator_set,
-    )
-    .await
-    {
+    match forward_notarized(execution_node, on_top_of, target, step, validator_set).await {
         Ok(canonicalized) => ExecutionTaskOutcome::Completed {
             canonicalized: Some(canonicalized),
             payload_job: None,
@@ -1359,14 +1309,10 @@ where
         block.parent_digest = %request.block.parent_digest(),
     ),
 )]
-async fn execute_validation<TContext>(
-    context: TContext,
+async fn execute_validation(
     execution_node: impl ExecutionLayer,
     request: VerifyBlockRequest,
-) -> ExecutionTaskOutcome
-where
-    TContext: Pacer,
-{
+) -> ExecutionTaskOutcome {
     let VerifyBlockRequest {
         cause: _,
         block,
@@ -1374,7 +1320,7 @@ where
         mut response,
     } = request;
 
-    let work = validate_block(&context, &execution_node, block, validator_set);
+    let work = validate_block(&execution_node, block, validator_set);
     futures::pin_mut!(work);
 
     let result = select! {
@@ -1424,15 +1370,11 @@ where
 /// Returns the validation duration when the block is valid, `None` when the
 /// execution layer rejected it, and an error when validation was not
 /// possible.
-async fn validate_block<TContext>(
-    context: &TContext,
+async fn validate_block(
     execution_node: &impl ExecutionLayer,
     block: Arc<Block>,
     validator_set: Option<Vec<B256>>,
-) -> eyre::Result<Option<Duration>>
-where
-    TContext: Pacer,
-{
+) -> eyre::Result<Option<Duration>> {
     use alloy_rpc_types_engine::PayloadStatusEnum;
 
     let (block, block_access_list) = Arc::unwrap_or_clone(block).into_parts();
@@ -1443,7 +1385,6 @@ where
             block_access_list,
             validator_set,
         })
-        .pace(context, Duration::from_millis(20))
         .await
         .wrap_err("failed sending new-payload request to execution layer to validate block")?;
     match payload_status.status {
@@ -1485,8 +1426,7 @@ where
     parent = &cause,
     fields(%payload_id),
 )]
-async fn run_payload_job<TContext: Pacer>(
-    context: TContext,
+async fn run_payload_job(
     execution_node: impl ExecutionLayer,
     StartPayloadJob {
         cause,
@@ -1497,7 +1437,6 @@ async fn run_payload_job<TContext: Pacer>(
     let payload = select! {
         payload = execution_node
             .resolve_payload(payload_id)
-            .pace(&context, Duration::from_millis(20))
         => payload,
 
         // Drops the in-flight payload-resolution, killing payload build.
@@ -1552,9 +1491,8 @@ async fn run_payload_job<TContext: Pacer>(
         ?kind,
     ),
 )]
-async fn submit_forkchoice_update<TContext: Pacer>(
+async fn submit_forkchoice_update(
     execution_node: &impl ExecutionLayer,
-    context: &TContext,
     cause: Span,
     canonicalized: LocalState,
     attrs: Option<TempoPayloadAttributes>,
@@ -1617,7 +1555,6 @@ async fn submit_forkchoice_update<TContext: Pacer>(
 
     let fcu_response = execution_node
         .fork_choice_updated(canonicalized.to_forkchoice_state(), attrs)
-        .pace(context, Duration::from_millis(20))
         .await
         .wrap_err("failed requesting execution layer to update forkchoice state")?;
 
@@ -1710,7 +1647,7 @@ fn finalization_target(
     err(level = Level::WARN),
     ret,
 )]
-async fn forward_finalized<TContext: Pacer + Clock>(
+async fn forward_finalized<TContext: Clock>(
     context: &TContext,
     execution_node: impl ExecutionLayer,
     public_key: Option<PublicKey>,
@@ -1734,7 +1671,6 @@ async fn forward_finalized<TContext: Pacer + Clock>(
             // can be omitted for finalized blocks
             validator_set: None,
         })
-        .pace(context, Duration::from_millis(20))
         .await
         .wrap_err(
             "failed sending new-payload request to execution engine to \
@@ -1776,7 +1712,6 @@ async fn forward_finalized<TContext: Pacer + Clock>(
 
     submit_forkchoice_update(
         &execution_node,
-        context,
         cause.clone(),
         target,
         None,
@@ -1832,8 +1767,7 @@ impl std::fmt::Debug for ForwardFinalized {
     ),
     err(level = Level::WARN),
 )]
-async fn forward_notarized<TContext: Pacer>(
-    context: &TContext,
+async fn forward_notarized(
     execution_node: impl ExecutionLayer,
     on_top_of: LocalState,
     target: LocalState,
@@ -1848,7 +1782,6 @@ async fn forward_notarized<TContext: Pacer>(
                 block_access_list,
                 validator_set,
             })
-            .pace(context, Duration::from_millis(20))
             .await
             .wrap_err(
                 "failed sending new-payload request to execution engine to \
@@ -1869,7 +1802,6 @@ async fn forward_notarized<TContext: Pacer>(
     }
     submit_forkchoice_update(
         &execution_node,
-        context,
         Span::current(),
         target,
         None,

--- a/crates/consensus/src/executor/actor/tests/arbitration.rs
+++ b/crates/consensus/src/executor/actor/tests/arbitration.rs
@@ -4,6 +4,7 @@
 
 use std::time::Duration;
 
+use alloy_rpc_types_engine::PayloadStatusEnum;
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 use futures::future::Either;
@@ -16,11 +17,13 @@ fn build_supersedes_queued_verification_while_another_request_executes() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
-        // Start a validation and stop polling its subscriber before the
-        // execution layer's paced result is delivered. Its new-payload call
-        // proves that it currently owns the execution-task slot.
+        // Hold a validation open in the execution layer so it owns the
+        // execution-task slot while later requests arbitrate behind it.
         let active_block = make_block(1, 1, GENESIS);
         let active_digest = active_block.digest();
+        let release_active = h
+            .execution
+            .script_delayed_new_payload(active_digest, Ok(PayloadStatusEnum::Valid));
         let active = h.verify(round(1), active_block);
         futures::pin_mut!(active);
         let deadline = h.run_for(Duration::from_millis(1));
@@ -54,6 +57,9 @@ fn build_supersedes_queued_verification_while_another_request_executes() {
         let _ = superseded
             .await
             .expect_err("the newer build must supersede the queued verification");
+        release_active
+            .send(())
+            .expect("active validation should still be gated");
         assert!(
             active
                 .await

--- a/crates/consensus/src/executor/actor/tests/backfill.rs
+++ b/crates/consensus/src/executor/actor/tests/backfill.rs
@@ -349,9 +349,9 @@ fn invalid_payload_fails_startup_backfill() {
         let execution = FakeExecution::new();
         execution.script_new_payload(
             d1,
-            [Ok(PayloadStatusEnum::Invalid {
+            Ok(PayloadStatusEnum::Invalid {
                 validation_error: "bad backfill block".into(),
-            })],
+            }),
         );
 
         let h = Harness::builder()
@@ -419,10 +419,8 @@ fn syncing_execution_layer_stalls_the_backfill_until_it_recovers() {
         let execution = FakeExecution::new();
         // The execution layer is not ready once (e.g. rebuilding indices),
         // then accepts the explicit retry.
-        execution.script_new_payload(
-            d1,
-            [Ok(PayloadStatusEnum::Syncing), Ok(PayloadStatusEnum::Valid)],
-        );
+        execution.script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
+        execution.script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
 
         let h = Harness::builder()
             .execution(execution)
@@ -453,7 +451,7 @@ fn new_payload_transport_error_fails_startup() {
         let marshal = FakeMarshal::new();
         marshal.add_block(b1);
         let execution = FakeExecution::new();
-        execution.script_new_payload(d1, [Err("connection closed")]);
+        execution.script_new_payload(d1, Err("connection closed"));
 
         let h = Harness::builder()
             .execution(execution)

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -153,13 +153,12 @@ fn rejected_notarized_block_is_withheld_then_retried() {
         let d1 = b1.digest();
         h.execution.script_new_payload(
             d1,
-            [
-                Ok(PayloadStatusEnum::Invalid {
-                    validation_error: "transient".into(),
-                }),
-                Ok(PayloadStatusEnum::Valid),
-            ],
+            Ok(PayloadStatusEnum::Invalid {
+                validation_error: "transient".into(),
+            }),
         );
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
 
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
@@ -195,8 +194,9 @@ fn new_payload_transport_error_is_withheld_then_retried() {
 
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
+        h.execution.script_new_payload(d1, Err("connection closed"));
         h.execution
-            .script_new_payload(d1, [Err("connection closed"), Ok(PayloadStatusEnum::Valid)]);
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
 
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
@@ -319,7 +319,7 @@ fn syncing_notarized_payload_is_rejected_without_updating_forkchoice() {
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution
-            .script_new_payload(d1, [Ok(PayloadStatusEnum::Syncing)]);
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
 
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
@@ -349,7 +349,7 @@ fn accepted_notarized_payload_is_rejected_without_updating_forkchoice() {
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution
-            .script_new_payload(d1, [Ok(PayloadStatusEnum::Accepted)]);
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Accepted));
 
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -84,10 +84,10 @@ fn syncing_finalized_block_is_postponed_and_retried_in_order() {
         // The execution layer reports SYNCING once (e.g. while rebuilding
         // indices); the block must be retried, and the block queued behind
         // it must stay behind it.
-        h.execution.script_new_payload(
-            d1,
-            [Ok(PayloadStatusEnum::Syncing), Ok(PayloadStatusEnum::Valid)],
-        );
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
 
         h.deliver_tip(round(2), 2, d2);
         let w1 = h.deliver_finalized(b1);
@@ -113,9 +113,9 @@ fn invalid_finalized_block_is_fatal() {
         let b1 = make_block(1, 1, GENESIS);
         h.execution.script_new_payload(
             b1.digest(),
-            [Ok(PayloadStatusEnum::Invalid {
+            Ok(PayloadStatusEnum::Invalid {
                 validation_error: "bad block".into(),
-            })],
+            }),
         );
 
         h.deliver_tip(round(1), 1, b1.digest());
@@ -142,7 +142,7 @@ fn accepted_finalized_block_is_fatal() {
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution
-            .script_new_payload(d1, [Ok(PayloadStatusEnum::Accepted)]);
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Accepted));
 
         h.deliver_tip(round(1), 1, d1);
         h.deliver_finalized(b1)
@@ -167,7 +167,7 @@ fn new_payload_transport_error_is_fatal() {
 
         let b1 = make_block(1, 1, GENESIS);
         h.execution
-            .script_new_payload(b1.digest(), [Err("connection closed")]);
+            .script_new_payload(b1.digest(), Err("connection closed"));
 
         h.deliver_tip(round(1), 1, b1.digest());
         h.deliver_finalized(b1)

--- a/crates/consensus/src/executor/actor/tests/harness.rs
+++ b/crates/consensus/src/executor/actor/tests/harness.rs
@@ -31,7 +31,7 @@ use commonware_consensus::{
     simplex::types::Context,
     types::{Epoch, Height, Round, View},
 };
-use commonware_runtime::{Clock, Handle, Metrics, Pacer, Spawner, deterministic};
+use commonware_runtime::{Clock, Handle, Metrics, Spawner, deterministic};
 use commonware_utils::{Acknowledgement as _, acknowledgement::Exact};
 use eyre::{Report, WrapErr as _};
 use parking_lot::Mutex;
@@ -156,14 +156,31 @@ struct ElState {
     finalized: Option<BlockNumHash>,
 }
 
-type ScriptedResult<T> = Result<T, &'static str>;
-type ScriptedSequence<T> = VecDeque<ScriptedResult<T>>;
+enum ScriptedResult<T> {
+    Immediate(Result<T, &'static str>),
+    Delayed {
+        response: Result<T, &'static str>,
+        release: oneshot::Receiver<()>,
+    },
+}
 
-struct ScriptedResults<K, T>(Mutex<Vec<(K, ScriptedSequence<T>)>>);
+impl<T> ScriptedResult<T> {
+    async fn resolve(self) -> Result<T, &'static str> {
+        match self {
+            Self::Immediate(result) => result,
+            Self::Delayed { response, release } => match release.await {
+                Ok(()) => response,
+                Err(_) => Err("delayed scripted result sender was dropped"),
+            },
+        }
+    }
+}
+
+struct ScriptedResults<K, T>(Mutex<Vec<(K, VecDeque<T>)>>);
 
 enum NextScriptedResult<T> {
     Unscripted,
-    Scripted(Result<T, &'static str>),
+    Scripted(T),
     Exhausted,
 }
 
@@ -175,7 +192,7 @@ where
         Self(Mutex::new(Vec::new()))
     }
 
-    fn push(&self, key: K, result: Result<T, &'static str>) {
+    fn push(&self, key: K, result: T) {
         let mut scripts = self.0.lock();
         if let Some((_, results)) = scripts.iter_mut().find(|(existing, _)| existing == &key) {
             results.push_back(result);
@@ -184,7 +201,7 @@ where
         }
     }
 
-    fn script(&self, key: K, results: impl IntoIterator<Item = Result<T, &'static str>>) {
+    fn script(&self, key: K, results: impl IntoIterator<Item = T>) {
         let results = results.into_iter().collect::<VecDeque<_>>();
         assert!(!results.is_empty(), "a scripted sequence must not be empty");
         let mut scripts = self.0.lock();
@@ -195,7 +212,7 @@ where
         scripts.push((key, results));
     }
 
-    fn pop(&self, key: &K) -> Option<Result<T, &'static str>> {
+    fn pop(&self, key: &K) -> Option<T> {
         self.0
             .lock()
             .iter_mut()
@@ -223,7 +240,7 @@ struct FakeExecutionInner {
     /// absent from this map uses the fake's stateful default behavior; a
     /// digest present in it must not receive more calls than scripted.
     /// A scripted `Ok(Valid)` still marks the block as known to the execution layer.
-    payload_overrides: ScriptedResults<B256, PayloadStatusEnum>,
+    payload_overrides: ScriptedResults<B256, ScriptedResult<PayloadStatusEnum>>,
     /// Validator sets received with new-payload requests, keyed by block hash.
     payload_validator_sets: Mutex<Vec<(Digest, Option<Vec<B256>>)>>,
     /// Payload attributes received with forkchoice-update requests.
@@ -231,11 +248,11 @@ struct FakeExecutionInner {
     /// Complete FCU outcome sequences keyed by forkchoice state. An absent
     /// state uses the fake's stateful default; a present state must not receive
     /// more calls than scripted.
-    fcu_overrides: ScriptedResults<ForkchoiceState, PayloadStatusEnum>,
+    fcu_overrides: ScriptedResults<ForkchoiceState, Result<PayloadStatusEnum, &'static str>>,
     /// Scripted canonical-hash lookup outcomes keyed by height.
-    canonical_hash_overrides: ScriptedResults<u64, Option<B256>>,
+    canonical_hash_overrides: ScriptedResults<u64, Result<Option<B256>, &'static str>>,
     /// Scripted block lookup outcomes keyed by digest.
-    block_overrides: ScriptedResults<B256, Option<Block>>,
+    block_overrides: ScriptedResults<B256, Result<Option<Block>, &'static str>>,
     /// Rejects every FCU while set.
     reject_all_fcus: AtomicBool,
     /// Accepts attribute-carrying FCUs without registering a payload build.
@@ -342,10 +359,9 @@ impl FakeExecution {
 
     // ---- fault injection ----
 
-    /// Scripts the complete sequence of new-payload outcomes for `digest`.
-    /// Each request consumes one outcome in FIFO order; a request beyond the
-    /// supplied sequence fails the test instead of falling back to default
-    /// behavior. The whole sequence must be installed in one call.
+    /// Appends a new-payload response for `digest` to its scripted sequence.
+    /// Requests consume responses in FIFO order; a request beyond the supplied
+    /// responses fails the test instead of falling back to default behavior.
     ///
     /// A digest without a script uses the stateful default: `Valid` if its
     /// parent is known to the fake execution layer, otherwise `Syncing`.
@@ -355,9 +371,25 @@ impl FakeExecution {
     pub(super) fn script_new_payload(
         &self,
         digest: Digest,
-        outcomes: impl IntoIterator<Item = Result<PayloadStatusEnum, &'static str>>,
+        response: Result<PayloadStatusEnum, &'static str>,
     ) {
-        self.inner.payload_overrides.script(digest.0, outcomes);
+        self.inner
+            .payload_overrides
+            .push(digest.0, ScriptedResult::Immediate(response));
+    }
+
+    /// Appends a delayed new-payload response for `digest` and returns the
+    /// sender that releases it.
+    pub(super) fn script_delayed_new_payload(
+        &self,
+        digest: Digest,
+        response: Result<PayloadStatusEnum, &'static str>,
+    ) -> oneshot::Sender<()> {
+        let (sender, release) = oneshot::channel();
+        self.inner
+            .payload_overrides
+            .push(digest.0, ScriptedResult::Delayed { response, release });
+        sender
     }
 
     /// Scripts the complete sequence of outcomes for `state`.
@@ -415,15 +447,6 @@ impl FakeExecution {
     pub(super) fn omit_payload_job(&self, omit: bool) {
         self.inner.omit_payload_job.store(omit, Ordering::SeqCst);
     }
-
-    // NOTE: the fake deliberately offers no way to hold a new-payload or
-    // FCU response open. The actor paces those futures
-    // (`Pacer::pace`), and the deterministic runtime *blocks* when a paced
-    // future is still pending at its pace deadline - a test-side gate can
-    // then never be released, deadlocking the test. To keep the execution
-    // task slot occupied over a stretch of virtual time, script a SYNCING
-    // payload status instead: the actor's own postpone-retry pause holds
-    // the slot without a pending execution-layer future.
 
     // ---- payload builds ----
 
@@ -603,42 +626,36 @@ impl ExecutionLayer for FakeExecution {
             .payload_validator_sets
             .lock()
             .push((Digest(digest), validator_set));
-
-        let outcome = match self.inner.payload_overrides.next_scripted(&digest) {
-            NextScriptedResult::Scripted(outcome) => outcome,
-            NextScriptedResult::Unscripted => {
-                Ok(if self.inner.state.lock().blocks.contains_key(&parent) {
-                    PayloadStatusEnum::Valid
-                } else {
-                    PayloadStatusEnum::Syncing
-                })
-            }
+        let scripted_result = match self.inner.payload_overrides.next_scripted(&digest) {
+            NextScriptedResult::Scripted(result) => Some(result),
+            NextScriptedResult::Unscripted => None,
             NextScriptedResult::Exhausted => panic!(
                 "new-payload request for `{}` exceeded its scripted outcome sequence",
                 Digest(digest),
             ),
         };
-        let outcome = outcome.map_err(Report::msg).wrap_err_with(|| {
-            format!(
-                "scripted new-payload request failed for `{}`",
-                Digest(digest)
-            )
-        });
-        let result = match outcome {
-            Ok(status) => {
-                if status == PayloadStatusEnum::Valid {
-                    self.inner
-                        .state
-                        .lock()
-                        .blocks
-                        .insert(digest, (height, parent));
-                }
-                Ok(PayloadStatus::from_status(status))
-            }
-            Err(error) => Err(error),
-        };
+        let inner = self.inner.clone();
 
-        async move { result }
+        async move {
+            let outcome = match scripted_result {
+                Some(result) => result.resolve().await,
+                None => Ok(if inner.state.lock().blocks.contains_key(&parent) {
+                    PayloadStatusEnum::Valid
+                } else {
+                    PayloadStatusEnum::Syncing
+                }),
+            };
+            let status = outcome.map_err(Report::msg).wrap_err_with(|| {
+                format!(
+                    "scripted new-payload request failed for `{}`",
+                    Digest(digest)
+                )
+            })?;
+            if status == PayloadStatusEnum::Valid {
+                inner.state.lock().blocks.insert(digest, (height, parent));
+            }
+            Ok(PayloadStatus::from_status(status))
+        }
     }
 
     fn fork_choice_updated(
@@ -960,7 +977,7 @@ impl HarnessBuilder {
 
     pub(super) fn start<TContext>(self, context: &TContext) -> Harness<TContext>
     where
-        TContext: Clock + Metrics + Pacer + Spawner,
+        TContext: Clock + Metrics + Spawner,
     {
         self.try_start(context)
             .expect("executor actor should initialize")
@@ -968,7 +985,7 @@ impl HarnessBuilder {
 
     pub(super) fn try_start<TContext>(self, context: &TContext) -> eyre::Result<Harness<TContext>>
     where
-        TContext: Clock + Metrics + Pacer + Spawner,
+        TContext: Clock + Metrics + Spawner,
     {
         let Self {
             execution,
@@ -1018,7 +1035,7 @@ impl Harness {
 
 impl<TContext> Harness<TContext>
 where
-    TContext: Clock + Metrics + Pacer + Spawner,
+    TContext: Clock + Metrics + Spawner,
 {
     /// Starts the actor on a genesis-only chain: empty fakes, floor and tip
     /// at genesis.
@@ -1136,7 +1153,7 @@ mod scripted_results_tests {
 
     #[test]
     fn absent_and_exhausted_scripts_are_distinct() {
-        let results = ScriptedResults::<u8, u8>::new();
+        let results = ScriptedResults::<u8, Result<u8, &'static str>>::new();
 
         assert!(matches!(
             results.next_scripted(&1),

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -6,9 +6,7 @@ use std::time::Duration;
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
 use commonware_macros::test_traced;
-use commonware_runtime::{
-    Runner as _, Spawner as _, Supervisor as _, deterministic, tokio as commonware_tokio,
-};
+use commonware_runtime::{Runner as _, Spawner as _, Supervisor as _, deterministic};
 use futures::future::Either;
 
 use super::harness::{
@@ -134,7 +132,7 @@ fn payload_resolution_does_not_occupy_the_execution_task_slot() {
         assert_eq!(h.execution.pending_payload_jobs(), vec![payload_id]);
 
         // Release the fake payload builder so both in-flight operations can
-        // pass their deterministic pacing boundaries and finish normally.
+        // finish normally.
         h.execution
             .deliver_payload(payload_id, built_payload(&proposal));
         let verdict = verify
@@ -150,10 +148,7 @@ fn payload_resolution_does_not_occupy_the_execution_task_slot() {
 
 #[test_traced]
 fn multiple_payload_jobs_can_complete_out_of_order() {
-    // Payload resolutions are externally driven futures. The Tokio runtime
-    // lets both remain pending concurrently; deterministic pacing would
-    // intentionally block at the first unresolved external-call boundary.
-    commonware_tokio::Runner::default().start(|context| async move {
+    deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
         let first_proposal = make_block(1, 1, GENESIS);
@@ -245,10 +240,10 @@ fn one_execution_task_at_a_time_and_consensus_requests_win_the_next_slot() {
         // A SYNCING status parks the finalization of b1 in its postpone
         // pause (1s), keeping the single execution-task slot occupied over
         // a long stretch of virtual time.
-        h.execution.script_new_payload(
-            d1,
-            [Ok(PayloadStatusEnum::Syncing), Ok(PayloadStatusEnum::Valid)],
-        );
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
         h.deliver_tip(round(1), 1, d1);
         let w1 = h.deliver_finalized(b1);
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
@@ -316,10 +311,10 @@ fn consensus_work_takes_priority_over_ready_convergence() {
         // execution-task slot with a postponed finalization of b1.
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
-        h.execution.script_new_payload(
-            d1,
-            [Ok(PayloadStatusEnum::Syncing), Ok(PayloadStatusEnum::Valid)],
-        );
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
         h.deliver_tip(round(1), 1, d1);
         let finalized = h.deliver_finalized(b1);
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
@@ -393,14 +388,12 @@ fn convergence_takes_priority_over_queued_finalization() {
         // returns its postponed outcome, retaining the execution-task slot
         // while both kinds of work are queued. Replace this setup once that
         // retry relinquishes the slot before waiting.
-        h.execution.script_new_payload(
-            d1,
-            [
-                Ok(PayloadStatusEnum::Syncing),
-                Ok(PayloadStatusEnum::Valid),
-                Ok(PayloadStatusEnum::Valid),
-            ],
-        );
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
         h.deliver_tip(round(1), 1, d1);
         let first_finalization = h.deliver_finalized(b1.clone());
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
@@ -467,10 +460,10 @@ fn heartbeats_are_disarmed_while_work_is_active_or_queued() {
         let d1 = b1.digest();
         // Temporarily exploit finalization retaining the execution slot while
         // it stalls internally before returning its postponed SYNCING outcome.
-        h.execution.script_new_payload(
-            d1,
-            [Ok(PayloadStatusEnum::Syncing), Ok(PayloadStatusEnum::Valid)],
-        );
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
         h.deliver_tip(round(1), 1, d1);
         let finalized = h.deliver_finalized(b1);
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
@@ -620,7 +613,7 @@ fn actor_exits_when_its_mailbox_closes_during_an_execution_task() {
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution
-            .script_new_payload(d1, [Ok(PayloadStatusEnum::Syncing)]);
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
         h.deliver_tip(round(1), 1, d1);
         let acknowledgement = h.deliver_finalized(b1);
         h.wait_until(|| h.execution.new_payloads() == vec![d1])

--- a/crates/consensus/src/executor/actor/tests/verify.rs
+++ b/crates/consensus/src/executor/actor/tests/verify.rs
@@ -57,9 +57,9 @@ fn invalid_block_resolves_with_a_rejection() {
         let b1 = make_block(1, 1, GENESIS);
         h.execution.script_new_payload(
             b1.digest(),
-            [Ok(PayloadStatusEnum::Invalid {
+            Ok(PayloadStatusEnum::Invalid {
                 validation_error: "bad state root".into(),
-            })],
+            }),
         );
 
         let verdict = h
@@ -144,13 +144,10 @@ fn accepted_payload_status_fails_the_validation() {
         let h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
-        h.execution.script_new_payload(
-            b1.digest(),
-            [
-                Ok(PayloadStatusEnum::Accepted),
-                Ok(PayloadStatusEnum::Valid),
-            ],
-        );
+        h.execution
+            .script_new_payload(b1.digest(), Ok(PayloadStatusEnum::Accepted));
+        h.execution
+            .script_new_payload(b1.digest(), Ok(PayloadStatusEnum::Valid));
         let _ = h
             .verify(round(1), b1)
             .await
@@ -172,10 +169,10 @@ fn new_payload_transport_error_fails_validation_but_is_not_fatal() {
         let h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
-        h.execution.script_new_payload(
-            b1.digest(),
-            [Err("connection closed"), Ok(PayloadStatusEnum::Valid)],
-        );
+        h.execution
+            .script_new_payload(b1.digest(), Err("connection closed"));
+        h.execution
+            .script_new_payload(b1.digest(), Ok(PayloadStatusEnum::Valid));
         let _ = h
             .verify(round(1), b1.clone())
             .await
@@ -243,9 +240,14 @@ fn cancellation_before_verification_delivery_still_leaves_the_body_for_convergen
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
 
-        // Start validation, then abandon it after newPayload has been issued
-        // but before its paced result is delivered (consensus moved on from
-        // the view). Dropping the future drops the response receiver.
+        // Start validation, then abandon it while newPayload is held open
+        // (consensus moved on from the view). Dropping the future drops the
+        // response receiver.
+        let _release_validation = h
+            .execution
+            .script_delayed_new_payload(d1, Ok(PayloadStatusEnum::Valid));
+        h.execution
+            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
         let verify = Box::pin(h.verify(round(1), b1));
         let sleep = Box::pin(h.run_for(Duration::from_millis(1)));
         let verify = match futures::future::select(verify, sleep).await {

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -8,7 +8,7 @@ use commonware_consensus::{
     types::{Height, Round},
 };
 use commonware_cryptography::ed25519::PublicKey;
-use commonware_runtime::{Clock, Metrics, Pacer, Spawner};
+use commonware_runtime::{Clock, Metrics, Spawner};
 use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
 use reth_node_builder::PayloadKind;
 use reth_provider::{BlockHashReader as _, BlockReader as _, BlockSource};
@@ -188,7 +188,7 @@ pub(crate) fn init<TContext, TExecutionLayer, TMarshal>(
     config: Config<TExecutionLayer, TMarshal>,
 ) -> eyre::Result<(Actor<TContext, TExecutionLayer, TMarshal>, Mailbox)>
 where
-    TContext: Clock + Metrics + Pacer + Spawner,
+    TContext: Clock + Metrics + Spawner,
     TExecutionLayer: ExecutionLayer,
     TMarshal: Marshal,
 {


### PR DESCRIPTION
Remove explicit pacing from executor-layer futures so deterministic tests can control pending operations directly. Replace pacing-dependent test timing with explicit fake execution-layer gates.

We were never able to make use of commonware's pacer API, which was originally intended to make our e2e tests deterministic despite the execution layer running in a non-deterministic runtime.


With this patch all executor unit tests can now run on the deterministic runtime.