### PR TITLE
fix(consensus): revert back to allow(dead_code)

### DIFF
--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -492,11 +492,14 @@ mod tests {
         // gate on `--consensus.signing-key`. These args live in the outer
         // binary's CLI struct; we re-declare them here just so clap can
         // resolve the references during parse-time validation.
+        //
+        // NOTE(re #[allow(dead_code)]): those are explicitly allow(dead_code) due to the fact that
+        // those trigger rust-analyzer warnings otherwise.
         #[arg(long = "follow")]
-        #[expect(dead_code)]
+        #[allow(dead_code)]
         follow: Option<String>,
         #[arg(long = "dev")]
-        #[expect(dead_code)]
+        #[allow(dead_code)]
         dev: bool,
 
         #[command(flatten)]


### PR DESCRIPTION
At some point before, we mass migrated from allow(dead_code) to expect(dead_code) to be able to remove redundant/unnecessary annotations. However, this particular case causes some false- positives when using rust-analyzer. Therefore, we turn them back into allow(dead_code). The expectation is still to use expect(dead_code), just this is an exceptional case.