### PR TITLE
test(node): reduce Alloy polling interval for keychain refund

### DIFF
--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -112,6 +112,10 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
     let provider = ProviderBuilder::new()
         .wallet(root.clone())
         .connect_http(setup.http_url);
+    // Keep Alloy's pending-transaction heartbeat ahead of the 100ms dev block interval.
+    provider
+        .client()
+        .set_poll_interval(std::time::Duration::from_millis(10));
     let access_key = PrivateKeySigner::random();
 
     let gas_limit = 500_000u64;


### PR DESCRIPTION
Reduces Alloy’s HTTP polling interval only in the TIP-1060 keychain refund regression test, preventing its heartbeat from skipping transaction inclusion while the local dev chain advances every 100ms. Verified with `cargo +nightly fmt --check` and the targeted `tempo-node` test.

Prompted by: @shekhirin