### PR TITLE
fix(ci): isolate txgen from benchmark nodes

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -12,8 +12,11 @@ const E2E_B_MOUNT = "/reth-bench-b"
 const BENCH_SCHELK_SCRIPT = "bench-schelk.nu"
 const E2E_VALIDATORS = "127.0.0.2:8000,127.0.0.3:8100"
 const E2E_SEED = 42
-const E2E_A_CPUS = "0-7,16-23"
-const E2E_B_CPUS = "8-15,24-31"
+# Keep each validator on seven complete physical cores within one CCD and
+# reserve one physical core per CCD (including its SMT sibling) for txgen.
+const E2E_A_CPUS = "0-6,16-22"
+const E2E_B_CPUS = "8-14,24-30"
+const E2E_TXGEN_CPUS = "7,15,23,31"
 const E2E_A_MEMORY = "60G"
 const E2E_B_MEMORY = "60G"
 const E2E_GAS_LIMIT = "1000000000000"
@@ -1154,6 +1157,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --duration $ctx.duration
                 --accounts $ctx.accounts
                 --max-concurrent-requests $ctx.max_concurrent_requests
+                --txgen-cpus $E2E_TXGEN_CPUS
                 --bench-args $ctx.bench_args
                 --bench-env $ctx.bench_env
                 --git-ref $run.ref

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -610,6 +610,7 @@ def txgen-run-preset-pipeline [
     --duration: int
     --accounts: int
     --max-concurrent-requests: int
+    --txgen-cpus: string = ""
     --bench-args: string = ""
     --bench-env: string = ""
     --git-ref: string = ""
@@ -738,7 +739,12 @@ def txgen-run-preset-pipeline [
         let setup_pipeline = $"set -euo pipefail; ($bench_env_export)ulimit -Sn unlimited && ($txgen_setup_cmd_str) | ($bench_setup_cmd_str)"
 
         print "  Streaming keychain setup transactions into bench send..."
-        let setup_result = (bash -lc $setup_pipeline | complete)
+        let setup_command = if $txgen_cpus != "" {
+            ["taskset" "-c" $txgen_cpus "bash" "-lc" $setup_pipeline]
+        } else {
+            ["bash" "-lc" $setup_pipeline]
+        }
+        let setup_result = (run-external ($setup_command | first) ...($setup_command | skip 1) | complete)
         if $setup_result.stdout != "" { print $setup_result.stdout }
         if $setup_result.stderr != "" { print $setup_result.stderr }
 
@@ -748,7 +754,12 @@ def txgen-run-preset-pipeline [
     }
 
     print $"  Streaming up to ($tx_count) txgen transaction\(s\) over ($txgen_duration) into bench send..."
-    let result = (bash -lc $pipeline | complete)
+    let command = if $txgen_cpus != "" {
+        ["taskset" "-c" $txgen_cpus "bash" "-lc" $pipeline]
+    } else {
+        ["bash" "-lc" $pipeline]
+    }
+    let result = (run-external ($command | first) ...($command | skip 1) | complete)
     if $result.stdout != "" { print $result.stdout }
     if $result.stderr != "" { print $result.stderr }
 


### PR DESCRIPTION
Reserve one physical core and its SMT sibling on each CCD for the local txgen pipeline. Each Tempo validator remains isolated to a single CCD while avoiding contention with load generation.

Prompted by: @onbjerg