### PR TITLE
fix(tip-1095): use compatibility fallback for legacy captures

### DIFF
--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -931,6 +931,28 @@ impl TIP20Token {
         amount: U256,
         receive_policy_sender: Address,
     ) -> Result<()> {
+        self.channel_reserve_transfer_with_receive_policy_fallback(
+            from,
+            to,
+            amount,
+            receive_policy_sender,
+            None,
+        )
+    }
+
+    /// Moves channel-reserve custody while allowing a temporary legacy sender for TIP-1028.
+    ///
+    /// The fallback is evaluated only when the primary sender is rejected by the receive policy;
+    /// all other errors are returned immediately. The physical transfer is performed once after
+    /// the policy check succeeds.
+    pub(crate) fn channel_reserve_transfer_with_receive_policy_fallback(
+        &mut self,
+        from: Address,
+        to: Recipient,
+        amount: U256,
+        receive_policy_sender: Address,
+        fallback_receive_policy_sender: Option<Address>,
+    ) -> Result<()> {
         if from != TIP20_CHANNEL_RESERVE_ADDRESS
             && to.original_address() != TIP20_CHANNEL_RESERVE_ADDRESS
         {
@@ -944,7 +966,11 @@ impl TIP20Token {
         if to.target == RECEIVE_POLICY_GUARD_ADDRESS {
             return Err(ReceivePolicyGuardError::address_reserved().into());
         }
-        self.ensure_receive_policy_authorized(receive_policy_sender, to.target)?;
+        self.ensure_receive_policy_authorized_with_fallback(
+            receive_policy_sender,
+            fallback_receive_policy_sender,
+            to.target,
+        )?;
 
         self._transfer(from, &to, amount)?;
         if let Some(hop) = to.build_virtual_transfer_event(amount) {
@@ -1221,6 +1247,28 @@ impl TIP20Token {
         }
 
         Ok(())
+    }
+
+    /// Ensures that at least one sender is accepted by the receiver's TIP-1028 policy.
+    fn ensure_receive_policy_authorized_with_fallback(
+        &self,
+        sender: Address,
+        fallback_sender: Option<Address>,
+        receiver: Address,
+    ) -> Result<()> {
+        if TIP403Registry::new()
+            .validate_receive_policy(self.address, sender, receiver)?
+            .is_none()
+        {
+            return Ok(());
+        }
+
+        match fallback_sender {
+            Some(fallback_sender) => {
+                self.ensure_receive_policy_authorized(fallback_sender, receiver)
+            }
+            None => Err(TIP20Error::policy_forbids().into()),
+        }
     }
 
     /// Check whether users are authorized by the token's [`TIP403Registry`] policy for the given

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -245,11 +245,12 @@ impl TIP20ChannelReserve {
         if self.storage.spec().is_t11() {
             let payee = Recipient::resolve(call.descriptor.payee)?;
             token.ensure_transfer_authorized(call.descriptor.payer, payee.target)?;
-            token.channel_reserve_transfer(
+            token.channel_reserve_transfer_with_receive_policy_fallback(
                 self.address,
                 payee,
                 U256::from(delta),
                 call.descriptor.payer,
+                self.legacy_capture_receive_policy_sender(),
             )?;
 
             state.settled = cumulative;
@@ -446,11 +447,12 @@ impl TIP20ChannelReserve {
             if !delta.is_zero() {
                 let payee = Recipient::resolve(call.descriptor.payee)?;
                 token.ensure_transfer_authorized(call.descriptor.payer, payee.target)?;
-                token.channel_reserve_transfer(
+                token.channel_reserve_transfer_with_receive_policy_fallback(
                     self.address,
                     payee,
                     U256::from(delta),
                     call.descriptor.payer,
+                    self.legacy_capture_receive_policy_sender(),
                 )?;
             }
             if !refund.is_zero() {
@@ -713,6 +715,18 @@ impl TIP20ChannelReserve {
     /// Returns the current block timestamp as `u64`.
     fn now(&self) -> u64 {
         self.storage.timestamp().saturating_to::<u64>()
+    }
+
+    /// Returns the TIP-1095 legacy receive-policy sender retained during T11-T12 backwards compatibility.
+    ///
+    /// If this returns `None`, capture checks only the payer against the payee's TIP-1028 policy.
+    /// If this returns `Some`, capture checks the payer first and then the returned sender if the
+    /// payer is rejected.
+    fn legacy_capture_receive_policy_sender(&self) -> Option<Address> {
+        let spec = self.storage.spec();
+        // TODO(T12): return `None` here to disable the legacy fallback. `is_t11()` is cumulative,
+        // so it remains true for later hardforks unless the compatibility window is gated off.
+        spec.is_t11().then_some(TIP20_CHANNEL_RESERVE_ADDRESS)
     }
 
     /// Returns the current block timestamp as the packed close-request representation.
@@ -1363,6 +1377,10 @@ mod tests {
                 },
             )?;
 
+            // During T11, captures retain the legacy reserve sender as a compatibility fallback.
+            // The payer is blocked after funding, while the reserve remains accepted.
+            install_receive_sender_blacklist(payee, payer)?;
+
             let digest =
                 reserve.get_voucher_digest(ITIP20ChannelReserve::getVoucherDigestCall {
                     channelId: channel_id,
@@ -1559,9 +1577,16 @@ mod tests {
                 expiring_nonce_hash,
             );
 
-            // Receive policies remain mutable after funding. The payee now rejects only the
-            // logical payer, while the physical reserve sender remains authorized.
+            // Receive policies remain mutable after funding. The payee now rejects both the
+            // logical payer and the legacy reserve sender.
             let (mut registry, sender_policy) = install_receive_sender_blacklist(payee, payer)?;
+            set_blacklisted(
+                &mut registry,
+                payee,
+                sender_policy,
+                TIP20_CHANNEL_RESERVE_ADDRESS,
+                true,
+            )?;
 
             let cumulative = U96::from(40);
             let digest =

--- a/tips/tip-1095.md
+++ b/tips/tip-1095.md
@@ -113,9 +113,13 @@ physical `Transfer` events as ordinary TIP-20 movements.
 This behavior activates at T11 and applies to both new and existing channels. Before T11, TIP-1034
 keeps its original physical transfer-policy checks.
 
+Compatibility note: between T11 and T12, the legacy reserve-based receive-policy authorization
+remains accepted for channel capture. After T12, only the payer-based behavior specified by TIP-1095
+is accepted.
+
 No on-chain channel migration is required. Existing channels continue to work, but a payee that
-previously allowed the channel reserve in its TIP-1028 policy may need to allow the channel payer
-after T11. Otherwise, future settlements or captures can revert until the policy is updated.
+previously allowed the channel reserve in its TIP-1028 policy must allow the channel payer before
+T12. Otherwise, future settlements or captures can revert until the policy is updated.
 This TIP changes no public ABI, channel ID, voucher, event, or storage layout, and does not change
 TIP-403 behavior outside the channel reserve.
 


### PR DESCRIPTION
Stacks on #6957.

Alternative to https://github.com/tempoxyz/tempo/pull/7271.

PR #7271 uses a per-channel `PackedChannelState` marker, `uses_logical_receive_policy_sender: bool`.

This alternative removes that marker and keeps capture policy authorization in the existing transfer path. The payer is checked first; during the T11-T12 compatibility window, capture retries with the channel reserve only when the payer is rejected by the payee receive policy. The fallback is limited to `settle` and capture in `close`; funding and refunds remain unchanged.

The compatibility switch is centralized in `legacy_capture_receive_policy_sender()`. At T12, it can return `None`. After that, only the payer is checked. No `PackedChannelState` marker or migration is required.

Validation:

```text
cargo test -p tempo-precompiles --features test-utils --lib tip20_channel_reserve
cargo +nightly fmt --all
git diff --check
```