### PR TITLE
fix(dex): quote swaps through checkpointed fills

### DIFF
--- a/crates/contracts/src/precompiles/stablecoin_dex.rs
+++ b/crates/contracts/src/precompiles/stablecoin_dex.rs
@@ -61,8 +61,8 @@ crate::sol! {
         // Swap Functions
         function swapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn, uint128 minAmountOut) external returns (uint128 amountOut);
         function swapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut, uint128 maxAmountIn) external returns (uint128 amountIn);
-        function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn) external view returns (uint128 amountOut);
-        function quoteSwapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut) external view returns (uint128 amountIn);
+        function quoteSwapExactAmountIn(address tokenIn, address tokenOut, uint128 amountIn) external returns (uint128 amountOut);
+        function quoteSwapExactAmountOut(address tokenIn, address tokenOut, uint128 amountOut) external returns (uint128 amountIn);
 
         // Balance Management
         function balanceOf(address user, address token) external view returns (uint128);

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -106,6 +106,7 @@ where
         }
 
         let db = self.inner.evm.db_mut();
+        let mut checkpoints = Vec::new();
         for action in actions {
             // Expiring nonces are handled above
             if is_expiring_nonce && action.address() == NONCE_PRECOMPILE_ADDRESS {
@@ -113,6 +114,18 @@ where
             }
 
             match action {
+                StorageAction::Checkpoint(owner) => {
+                    checkpoints.push((owner, self.replay_state.checkpoint()));
+                }
+                StorageAction::CheckpointRevert(owner) => {
+                    let Some((checkpoint_owner, checkpoint)) = checkpoints.pop() else {
+                        return Err(StorageActionReplayError::ActionConflict.into());
+                    };
+                    if checkpoint_owner != owner {
+                        return Err(StorageActionReplayError::ActionConflict.into());
+                    }
+                    self.replay_state.checkpoint_revert(checkpoint);
+                }
                 StorageAction::Sload(address, key, value) => {
                     let _ = self.replay_state.sload_exact(db, address, key, value)?;
                 }
@@ -175,6 +188,10 @@ where
                     }
                 }
             }
+        }
+
+        if !checkpoints.is_empty() {
+            return Err(StorageActionReplayError::ActionConflict.into());
         }
 
         let mut state = EvmState::default();
@@ -373,7 +390,7 @@ impl From<StorageActionReplayError> for BlockExecutionError {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct StorageActionReplayState {
     /// Changes for the current transaction.
     tx_changes: AddressMap<U256Map<SlotChange>>,
@@ -382,6 +399,16 @@ pub struct StorageActionReplayState {
 }
 
 impl StorageActionReplayState {
+    /// Snapshots transaction-local replay state for a recorded action checkpoint.
+    fn checkpoint(&self) -> Self {
+        self.clone()
+    }
+
+    /// Restores transaction-local replay state at a recorded action checkpoint.
+    fn checkpoint_revert(&mut self, checkpoint: Self) {
+        *self = checkpoint;
+    }
+
     /// Clears cached expiring-nonce state after execution that did not go through action replay.
     pub fn invalidate_expiring_nonce_cache(&mut self) {
         self.expiring_nonce.invalidate_cache();
@@ -546,14 +573,14 @@ impl StorageActionReplayState {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct SlotChange {
     original: U256,
     current: U256,
     written: bool,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 struct ExpiringNonceReplayState {
     /// Current cached ring pointer.
     ring_ptr: Option<U256>,
@@ -800,5 +827,31 @@ mod tests {
         assert_eq!(change.original, U256::from(11));
         assert_eq!(change.current, U256::from(14));
         assert!(change.written);
+    }
+
+    #[test]
+    fn checkpoint_revert_restores_transaction_view() {
+        let address = Address::repeat_byte(0x42);
+        let slot = U256::from(7);
+        let mut db = state_with_storage(address, slot, U256::from(10));
+        let mut replay_state = StorageActionReplayState::default();
+
+        replay_state
+            .sload_exact(&mut db, address, slot, U256::from(10))
+            .expect("load slot before checkpoint");
+        let checkpoint = replay_state.checkpoint();
+        replay_state
+            .sstore(address, slot, U256::from(11))
+            .expect("apply speculative store");
+        replay_state.checkpoint_revert(checkpoint);
+
+        let change = replay_state
+            .tx_changes
+            .get(&address)
+            .and_then(|slots| slots.get(&slot))
+            .expect("pre-checkpoint slot view restored");
+        assert_eq!(change.original, U256::from(10));
+        assert_eq!(change.current, U256::from(10));
+        assert!(!change.written);
     }
 }

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -16,7 +16,7 @@ use reth_revm::{
     state::{Account, EvmState, EvmStorageSlot, TransactionId},
 };
 use tempo_precompiles::{
-    NONCE_PRECOMPILE_ADDRESS,
+    NONCE_PRECOMPILE_ADDRESS, TIP_FEE_MANAGER_ADDRESS,
     nonce::NonceManager,
     storage::StorageAction,
     tip_fee_manager::amm::{Pool, compute_amount_out},
@@ -111,12 +111,16 @@ where
                 return Err(StorageActionReplayError::ActionConflict.into());
             }
 
-            let action_address = action
-                .address()
-                .expect("checkpoint revert handled before storage action replay");
-
             // Expiring nonces are handled above
-            if is_expiring_nonce && action_address == NONCE_PRECOMPILE_ADDRESS {
+            if is_expiring_nonce
+                && match action {
+                    StorageAction::Sload(address, ..)
+                    | StorageAction::Sstore(address, ..)
+                    | StorageAction::Sinc(address, ..)
+                    | StorageAction::Sdec(address, ..) => address == NONCE_PRECOMPILE_ADDRESS,
+                    _ => false,
+                }
+            {
                 continue;
             }
 
@@ -148,9 +152,12 @@ where
                     self.replay_state.sstore(address, key, value)?;
                 }
                 StorageAction::FeeAmmSwap(key, sload_value, amount_in) => {
-                    let pool_slot =
-                        self.replay_state
-                            .sload_current_or(db, action_address, key, sload_value)?;
+                    let pool_slot = self.replay_state.sload_current_or(
+                        db,
+                        TIP_FEE_MANAGER_ADDRESS,
+                        key,
+                        sload_value,
+                    )?;
                     let mut pool = Pool::decode_from_slot(pool_slot);
                     pool.apply_swap(
                         amount_in,
@@ -161,7 +168,8 @@ where
                     let value = pool
                         .encode_to_slot()
                         .map_err(|_| StorageActionReplayError::ActionConflict)?;
-                    self.replay_state.sstore(action_address, key, value)?;
+                    self.replay_state
+                        .sstore(TIP_FEE_MANAGER_ADDRESS, key, value)?;
                 }
                 StorageAction::FeeAmmLiquidityCheck(
                     key,
@@ -169,9 +177,12 @@ where
                     amount_out,
                     has_enough_liquidity,
                 ) => {
-                    let pool_slot =
-                        self.replay_state
-                            .sload_current_or(db, action_address, key, sload_value)?;
+                    let pool_slot = self.replay_state.sload_current_or(
+                        db,
+                        TIP_FEE_MANAGER_ADDRESS,
+                        key,
+                        sload_value,
+                    )?;
                     let pool = Pool::decode_from_slot(pool_slot);
                     if pool.has_enough_reserve_validator_token(amount_out) != has_enough_liquidity {
                         return Err(StorageActionReplayError::ActionConflict.into());

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -107,17 +107,21 @@ where
 
         let db = self.inner.evm.db_mut();
         for action in actions {
-            if matches!(action, StorageAction::CheckpointRevert(_)) {
+            if matches!(action, StorageAction::CheckpointRevert) {
                 return Err(StorageActionReplayError::ActionConflict.into());
             }
 
+            let action_address = action
+                .address()
+                .expect("checkpoint revert handled before storage action replay");
+
             // Expiring nonces are handled above
-            if is_expiring_nonce && action.address() == NONCE_PRECOMPILE_ADDRESS {
+            if is_expiring_nonce && action_address == NONCE_PRECOMPILE_ADDRESS {
                 continue;
             }
 
             match action {
-                StorageAction::CheckpointRevert(_) => unreachable!(),
+                StorageAction::CheckpointRevert => unreachable!(),
                 StorageAction::Sload(address, key, value) => {
                     let _ = self.replay_state.sload_exact(db, address, key, value)?;
                 }
@@ -144,12 +148,9 @@ where
                     self.replay_state.sstore(address, key, value)?;
                 }
                 StorageAction::FeeAmmSwap(key, sload_value, amount_in) => {
-                    let pool_slot = self.replay_state.sload_current_or(
-                        db,
-                        action.address(),
-                        key,
-                        sload_value,
-                    )?;
+                    let pool_slot =
+                        self.replay_state
+                            .sload_current_or(db, action_address, key, sload_value)?;
                     let mut pool = Pool::decode_from_slot(pool_slot);
                     pool.apply_swap(
                         amount_in,
@@ -160,7 +161,7 @@ where
                     let value = pool
                         .encode_to_slot()
                         .map_err(|_| StorageActionReplayError::ActionConflict)?;
-                    self.replay_state.sstore(action.address(), key, value)?;
+                    self.replay_state.sstore(action_address, key, value)?;
                 }
                 StorageAction::FeeAmmLiquidityCheck(
                     key,
@@ -168,12 +169,9 @@ where
                     amount_out,
                     has_enough_liquidity,
                 ) => {
-                    let pool_slot = self.replay_state.sload_current_or(
-                        db,
-                        action.address(),
-                        key,
-                        sload_value,
-                    )?;
+                    let pool_slot =
+                        self.replay_state
+                            .sload_current_or(db, action_address, key, sload_value)?;
                     let pool = Pool::decode_from_slot(pool_slot);
                     if pool.has_enough_reserve_validator_token(amount_out) != has_enough_liquidity {
                         return Err(StorageActionReplayError::ActionConflict.into());

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -106,26 +106,18 @@ where
         }
 
         let db = self.inner.evm.db_mut();
-        let mut checkpoints = Vec::new();
         for action in actions {
+            if matches!(action, StorageAction::CheckpointRevert(_)) {
+                return Err(StorageActionReplayError::ActionConflict.into());
+            }
+
             // Expiring nonces are handled above
             if is_expiring_nonce && action.address() == NONCE_PRECOMPILE_ADDRESS {
                 continue;
             }
 
             match action {
-                StorageAction::Checkpoint(owner) => {
-                    checkpoints.push((owner, self.replay_state.checkpoint()));
-                }
-                StorageAction::CheckpointRevert(owner) => {
-                    let Some((checkpoint_owner, checkpoint)) = checkpoints.pop() else {
-                        return Err(StorageActionReplayError::ActionConflict.into());
-                    };
-                    if checkpoint_owner != owner {
-                        return Err(StorageActionReplayError::ActionConflict.into());
-                    }
-                    self.replay_state.checkpoint_revert(checkpoint);
-                }
+                StorageAction::CheckpointRevert(_) => unreachable!(),
                 StorageAction::Sload(address, key, value) => {
                     let _ = self.replay_state.sload_exact(db, address, key, value)?;
                 }
@@ -188,10 +180,6 @@ where
                     }
                 }
             }
-        }
-
-        if !checkpoints.is_empty() {
-            return Err(StorageActionReplayError::ActionConflict.into());
         }
 
         let mut state = EvmState::default();
@@ -390,7 +378,7 @@ impl From<StorageActionReplayError> for BlockExecutionError {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct StorageActionReplayState {
     /// Changes for the current transaction.
     tx_changes: AddressMap<U256Map<SlotChange>>,
@@ -399,16 +387,6 @@ pub struct StorageActionReplayState {
 }
 
 impl StorageActionReplayState {
-    /// Snapshots transaction-local replay state for a recorded action checkpoint.
-    fn checkpoint(&self) -> Self {
-        self.clone()
-    }
-
-    /// Restores transaction-local replay state at a recorded action checkpoint.
-    fn checkpoint_revert(&mut self, checkpoint: Self) {
-        *self = checkpoint;
-    }
-
     /// Clears cached expiring-nonce state after execution that did not go through action replay.
     pub fn invalidate_expiring_nonce_cache(&mut self) {
         self.expiring_nonce.invalidate_cache();
@@ -573,14 +551,14 @@ impl StorageActionReplayState {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct SlotChange {
     original: U256,
     current: U256,
     written: bool,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 struct ExpiringNonceReplayState {
     /// Current cached ring pointer.
     ring_ptr: Option<U256>,
@@ -827,31 +805,5 @@ mod tests {
         assert_eq!(change.original, U256::from(11));
         assert_eq!(change.current, U256::from(14));
         assert!(change.written);
-    }
-
-    #[test]
-    fn checkpoint_revert_restores_transaction_view() {
-        let address = Address::repeat_byte(0x42);
-        let slot = U256::from(7);
-        let mut db = state_with_storage(address, slot, U256::from(10));
-        let mut replay_state = StorageActionReplayState::default();
-
-        replay_state
-            .sload_exact(&mut db, address, slot, U256::from(10))
-            .expect("load slot before checkpoint");
-        let checkpoint = replay_state.checkpoint();
-        replay_state
-            .sstore(address, slot, U256::from(11))
-            .expect("apply speculative store");
-        replay_state.checkpoint_revert(checkpoint);
-
-        let change = replay_state
-            .tx_changes
-            .get(&address)
-            .and_then(|slots| slots.get(&slot))
-            .expect("pre-checkpoint slot view restored");
-        assert_eq!(change.original, U256::from(10));
-        assert_eq!(change.current, U256::from(10));
-        assert!(!change.written);
     }
 }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -1162,7 +1162,7 @@ mod tests {
         .unwrap();
     }
 
-    #[derive(Clone, Default)]
+    #[derive(Default)]
     struct StorageState {
         reconstructed: BTreeMap<(Address, U256), U256>,
         first_loads: BTreeMap<(Address, U256), U256>,
@@ -1200,18 +1200,11 @@ mod tests {
         hardfork: TempoHardfork,
     ) {
         let mut storage_state = StorageState::default();
-        let mut checkpoints = Vec::new();
 
         for action in actions {
             match *action {
-                StorageAction::Checkpoint(owner) => {
-                    checkpoints.push((owner, storage_state.clone()));
-                }
-                StorageAction::CheckpointRevert(owner) => {
-                    let (checkpoint_owner, checkpoint) =
-                        checkpoints.pop().expect("storage action checkpoint exists");
-                    assert_eq!(checkpoint_owner, owner, "storage action checkpoint owner");
-                    storage_state = checkpoint;
+                StorageAction::CheckpointRevert(_) => {
+                    panic!("checkpoint-reverted action traces are not replayable")
                 }
                 StorageAction::Sload(address, slot, value) => {
                     let key = (address, slot);
@@ -1282,11 +1275,6 @@ mod tests {
                 }
             }
         }
-        assert!(
-            checkpoints.is_empty(),
-            "storage action checkpoints are balanced"
-        );
-
         for (address, account) in state {
             for (slot, storage_slot) in &account.storage {
                 let key = (*address, *slot);
@@ -1328,9 +1316,6 @@ mod tests {
         actions
             .iter()
             .map(|action| match *action {
-                StorageAction::Checkpoint(address) => {
-                    format!("Checkpoint({})", labels.address(address))
-                }
                 StorageAction::CheckpointRevert(address) => {
                     format!("CheckpointRevert({})", labels.address(address))
                 }

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -1234,8 +1234,7 @@ mod tests {
                     storage_state.reconstructed.insert(key, value);
                 }
                 StorageAction::FeeAmmSwap(slot, sload_value, amount_in) => {
-                    let action_address = action.address().expect("FeeAMM action has an address");
-                    let key = (action_address, slot);
+                    let key = (TIP_FEE_MANAGER_ADDRESS, slot);
                     let current =
                         storage_state.apply_sload_value(key, sload_value, "FeeAmmSwap", hardfork);
                     let mut pool = Pool::decode_from_slot(current);
@@ -1245,7 +1244,7 @@ mod tests {
                     )
                     .unwrap_or_else(|err| {
                         panic!(
-                            "FeeAmmSwap invalid for {action_address:?}:{slot:?} on {hardfork:?}: {err}"
+                            "FeeAmmSwap invalid for {TIP_FEE_MANAGER_ADDRESS:?}:{slot:?} on {hardfork:?}: {err}"
                         )
                     });
                     storage_state
@@ -1258,8 +1257,7 @@ mod tests {
                     amount_out,
                     has_enough_liquidity,
                 ) => {
-                    let action_address = action.address().expect("FeeAMM action has an address");
-                    let key = (action_address, slot);
+                    let key = (TIP_FEE_MANAGER_ADDRESS, slot);
                     let current = storage_state.apply_sload_value(
                         key,
                         sload_value,
@@ -1270,7 +1268,7 @@ mod tests {
                     assert_eq!(
                         pool.has_enough_reserve_validator_token(amount_out),
                         has_enough_liquidity,
-                        "FeeAmmLiquidityCheck mismatch for {action_address:?}:{slot:?} on {hardfork:?}",
+                        "FeeAmmLiquidityCheck mismatch for {TIP_FEE_MANAGER_ADDRESS:?}:{slot:?} on {hardfork:?}",
                     );
                 }
             }
@@ -1346,11 +1344,10 @@ mod tests {
                     )
                 }
                 StorageAction::FeeAmmSwap(slot, sload_value, amount_in) => {
-                    let address = action.address().expect("FeeAMM action has an address");
                     format!(
                         "FeeAmmSwap({}, {}, {sload_value}, {amount_in})",
-                        labels.address(address),
-                        labels.slot(address, slot),
+                        labels.address(TIP_FEE_MANAGER_ADDRESS),
+                        labels.slot(TIP_FEE_MANAGER_ADDRESS, slot),
                     )
                 }
                 StorageAction::FeeAmmLiquidityCheck(
@@ -1359,11 +1356,10 @@ mod tests {
                     amount_out,
                     has_enough_liquidity,
                 ) => {
-                    let address = action.address().expect("FeeAMM action has an address");
                     format!(
                         "FeeAmmLiquidityCheck({}, {}, {slot_value}, {amount_out}, {has_enough_liquidity})",
-                        labels.address(address),
-                        labels.slot(address, slot),
+                        labels.address(TIP_FEE_MANAGER_ADDRESS),
+                        labels.slot(TIP_FEE_MANAGER_ADDRESS, slot),
                     )
                 }
             })

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -1203,7 +1203,7 @@ mod tests {
 
         for action in actions {
             match *action {
-                StorageAction::CheckpointRevert(_) => {
+                StorageAction::CheckpointRevert => {
                     panic!("checkpoint-reverted action traces are not replayable")
                 }
                 StorageAction::Sload(address, slot, value) => {
@@ -1234,7 +1234,8 @@ mod tests {
                     storage_state.reconstructed.insert(key, value);
                 }
                 StorageAction::FeeAmmSwap(slot, sload_value, amount_in) => {
-                    let key = (action.address(), slot);
+                    let action_address = action.address().expect("FeeAMM action has an address");
+                    let key = (action_address, slot);
                     let current =
                         storage_state.apply_sload_value(key, sload_value, "FeeAmmSwap", hardfork);
                     let mut pool = Pool::decode_from_slot(current);
@@ -1244,8 +1245,7 @@ mod tests {
                     )
                     .unwrap_or_else(|err| {
                         panic!(
-                            "FeeAmmSwap invalid for {:?}:{slot:?} on {hardfork:?}: {err}",
-                            action.address()
+                            "FeeAmmSwap invalid for {action_address:?}:{slot:?} on {hardfork:?}: {err}"
                         )
                     });
                     storage_state
@@ -1258,7 +1258,8 @@ mod tests {
                     amount_out,
                     has_enough_liquidity,
                 ) => {
-                    let key = (action.address(), slot);
+                    let action_address = action.address().expect("FeeAMM action has an address");
+                    let key = (action_address, slot);
                     let current = storage_state.apply_sload_value(
                         key,
                         sload_value,
@@ -1269,8 +1270,7 @@ mod tests {
                     assert_eq!(
                         pool.has_enough_reserve_validator_token(amount_out),
                         has_enough_liquidity,
-                        "FeeAmmLiquidityCheck mismatch for {:?}:{slot:?} on {hardfork:?}",
-                        action.address(),
+                        "FeeAmmLiquidityCheck mismatch for {action_address:?}:{slot:?} on {hardfork:?}",
                     );
                 }
             }
@@ -1316,9 +1316,7 @@ mod tests {
         actions
             .iter()
             .map(|action| match *action {
-                StorageAction::CheckpointRevert(address) => {
-                    format!("CheckpointRevert({})", labels.address(address))
-                }
+                StorageAction::CheckpointRevert => "CheckpointRevert".to_string(),
                 StorageAction::Sload(address, slot, value) => {
                     format!(
                         "Sload({}, {}, {value})",
@@ -1348,10 +1346,11 @@ mod tests {
                     )
                 }
                 StorageAction::FeeAmmSwap(slot, sload_value, amount_in) => {
+                    let address = action.address().expect("FeeAMM action has an address");
                     format!(
                         "FeeAmmSwap({}, {}, {sload_value}, {amount_in})",
-                        labels.address(action.address()),
-                        labels.slot(action.address(), slot),
+                        labels.address(address),
+                        labels.slot(address, slot),
                     )
                 }
                 StorageAction::FeeAmmLiquidityCheck(
@@ -1360,10 +1359,11 @@ mod tests {
                     amount_out,
                     has_enough_liquidity,
                 ) => {
+                    let address = action.address().expect("FeeAMM action has an address");
                     format!(
                         "FeeAmmLiquidityCheck({}, {}, {slot_value}, {amount_out}, {has_enough_liquidity})",
-                        labels.address(action.address()),
-                        labels.slot(action.address(), slot),
+                        labels.address(address),
+                        labels.slot(address, slot),
                     )
                 }
             })

--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -1162,7 +1162,7 @@ mod tests {
         .unwrap();
     }
 
-    #[derive(Default)]
+    #[derive(Clone, Default)]
     struct StorageState {
         reconstructed: BTreeMap<(Address, U256), U256>,
         first_loads: BTreeMap<(Address, U256), U256>,
@@ -1200,9 +1200,19 @@ mod tests {
         hardfork: TempoHardfork,
     ) {
         let mut storage_state = StorageState::default();
+        let mut checkpoints = Vec::new();
 
         for action in actions {
             match *action {
+                StorageAction::Checkpoint(owner) => {
+                    checkpoints.push((owner, storage_state.clone()));
+                }
+                StorageAction::CheckpointRevert(owner) => {
+                    let (checkpoint_owner, checkpoint) =
+                        checkpoints.pop().expect("storage action checkpoint exists");
+                    assert_eq!(checkpoint_owner, owner, "storage action checkpoint owner");
+                    storage_state = checkpoint;
+                }
                 StorageAction::Sload(address, slot, value) => {
                     let key = (address, slot);
                     storage_state.apply_sload_value(key, value, "SLOAD", hardfork);
@@ -1272,6 +1282,10 @@ mod tests {
                 }
             }
         }
+        assert!(
+            checkpoints.is_empty(),
+            "storage action checkpoints are balanced"
+        );
 
         for (address, account) in state {
             for (slot, storage_slot) in &account.storage {
@@ -1314,6 +1328,12 @@ mod tests {
         actions
             .iter()
             .map(|action| match *action {
+                StorageAction::Checkpoint(address) => {
+                    format!("Checkpoint({})", labels.address(address))
+                }
+                StorageAction::CheckpointRevert(address) => {
+                    format!("CheckpointRevert({})", labels.address(address))
+                }
                 StorageAction::Sload(address, slot, value) => {
                     format!(
                         "Sload({}, {}, {value})",

--- a/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_revert_gas_snapshot_t11.snap
+++ b/crates/node/tests/it/gas/snapshots/it__gas__stablecoin_dex__stablecoin_dex_revert_gas_snapshot_t11.snap
@@ -1,0 +1,10 @@
+---
+source: crates/node/tests/it/gas/stablecoin_dex.rs
+expression: gas
+---
+place_aggregate_overflow:
+  gas: 841969
+  status: true
+swap_exact_out_accumulation_overflow:
+  gas: 845408
+  status: false

--- a/crates/node/tests/it/gas/stablecoin_dex.rs
+++ b/crates/node/tests/it/gas/stablecoin_dex.rs
@@ -494,7 +494,8 @@ async fn test_stablecoin_dex_order_gas_snapshots(hardfork: TempoHardfork) -> eyr
 #[test_case(TempoHardfork::T6 ; "t6_without_tip1060")]
 #[test_case(TempoHardfork::T7 ; "t7_with_tip1060")]
 #[test_case(TempoHardfork::T8 ; "t8_with_packed_order_layout")]
-#[test_case(TempoHardfork::T9 ; "t9_without_aggregate_liquidity")]
+#[test_case(TempoHardfork::T9 ; "t9_before_aggregate_liquidity_removal")]
+#[test_case(TempoHardfork::T11 ; "t11_without_aggregate_liquidity")]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_stablecoin_dex_revert_gas_snapshots(hardfork: TempoHardfork) -> eyre::Result<()> {
     reth_tracing::init_test_tracing();

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -257,7 +257,7 @@ impl BestTransactionsPrewarming {
 fn action_replay_invalidated(actions: &[StorageAction]) -> bool {
     actions
         .iter()
-        .any(|action| matches!(action, StorageAction::CheckpointRevert(_)))
+        .any(|action| matches!(action, StorageAction::CheckpointRevert))
 }
 
 impl Drop for BestTransactionsPrewarming {
@@ -530,7 +530,7 @@ mod tests {
     fn checkpoint_revert_invalidates_action_replay() {
         assert!(!action_replay_invalidated(&[]));
         assert!(action_replay_invalidated(&[
-            StorageAction::CheckpointRevert(Address::ZERO),
+            StorageAction::CheckpointRevert,
         ]));
     }
 

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -14,6 +14,7 @@ use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
 use tempo_evm::{ExpiringNonceReplay, StorageActionReplay, TempoEvmConfig, evm::TempoEvm};
+use tempo_precompiles::storage::StorageAction;
 use tempo_transaction_pool::{StateAwarePoolTransaction, best::BestTransaction};
 use tracing::{instrument, trace};
 
@@ -213,6 +214,13 @@ impl BestTransactionsPrewarming {
             }
 
             let actions = evm.take_actions()?;
+            if action_replay_invalidated(&actions) {
+                trace!(
+                    target: "payload_builder",
+                    "Storage checkpoint revert invalidated transaction replay"
+                );
+                return None;
+            }
             let expiring_nonce = tx
                 .transaction
                 .is_expiring_nonce()
@@ -242,6 +250,14 @@ impl BestTransactionsPrewarming {
 
         PrewarmedTransaction { tx, replay }
     }
+}
+
+/// Returns whether an execution trace contains a state rollback that cannot be represented by
+/// storage-action replay.
+fn action_replay_invalidated(actions: &[StorageAction]) -> bool {
+    actions
+        .iter()
+        .any(|action| matches!(action, StorageAction::CheckpointRevert(_)))
 }
 
 impl Drop for BestTransactionsPrewarming {
@@ -508,6 +524,14 @@ mod tests {
     struct TestBestTransactions {
         txs: VecDeque<BestTransaction>,
         log: Arc<Mutex<TestLog>>,
+    }
+
+    #[test]
+    fn checkpoint_revert_invalidates_action_replay() {
+        assert!(!action_replay_invalidated(&[]));
+        assert!(action_replay_invalidated(&[
+            StorageAction::CheckpointRevert(Address::ZERO),
+        ]));
     }
 
     impl TestBestTransactions {

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -65,12 +65,28 @@ impl Precompile for StablecoinDEX {
                         preserve_storage_credits(self.address)?;
                         self.swap_exact_amount_out(s, c.tokenIn, c.tokenOut, c.amountOut, c.maxAmountIn)
                     }),
-                    quoteSwapExactAmountIn(call) => view(call, |c| {
-                        self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)
-                    }),
-                    quoteSwapExactAmountOut(call) => view(call, |c| {
-                        self.quote_swap_exact_amount_out(c.tokenIn, c.tokenOut, c.amountOut)
-                    }),
+                    quoteSwapExactAmountIn(call) => {
+                        if self.storage.spec().is_t9() {
+                            mutate(call, msg_sender, |_, c| {
+                                self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)
+                            })
+                        } else {
+                            view(call, |c| {
+                                self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)
+                            })
+                        }
+                    },
+                    quoteSwapExactAmountOut(call) => {
+                        if self.storage.spec().is_t9() {
+                            mutate(call, msg_sender, |_, c| {
+                                self.quote_swap_exact_amount_out(c.tokenIn, c.tokenOut, c.amountOut)
+                            })
+                        } else {
+                            view(call, |c| {
+                                self.quote_swap_exact_amount_out(c.tokenIn, c.tokenOut, c.amountOut)
+                            })
+                        }
+                    },
                     MIN_TICK(call) => view(call, |_| Ok(crate::stablecoin_dex::MIN_TICK)),
                     MAX_TICK(call) => view(call, |_| Ok(crate::stablecoin_dex::MAX_TICK)),
                     TICK_SPACING(call) => view(call, |_| Ok(crate::stablecoin_dex::TICK_SPACING)),
@@ -107,13 +123,14 @@ mod tests {
 
     use crate::{
         Precompile,
+        dispatch::StaticCallNotAllowed,
         stablecoin_dex::{IStablecoinDEX, MIN_ORDER_AMOUNT, StablecoinDEX},
         storage::{ContractStorage, StorageCtx, hashmap::HashMapStorageProvider},
         test_util::{TIP20Setup, assert_full_coverage, check_selector_coverage},
     };
     use alloy::{
         primitives::{Address, U256},
-        sol_types::{SolCall, SolValue},
+        sol_types::{SolCall, SolError, SolValue},
     };
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::IStablecoinDEX::IStablecoinDEXCalls;
@@ -460,6 +477,26 @@ mod tests {
             let result = exchange.call(&calldata, sender);
             assert!(result.is_ok());
 
+            Ok(())
+        })
+    }
+
+    #[test]
+    fn test_t9_quote_rejects_static_call() -> eyre::Result<()> {
+        let mut storage =
+            HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9).with_static(true);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            let calldata = IStablecoinDEX::quoteSwapExactAmountInCall {
+                tokenIn: Address::random(),
+                tokenOut: Address::random(),
+                amountIn: 1,
+            }
+            .abi_encode();
+
+            let output = exchange.call(&calldata, Address::random())?;
+            assert!(output.is_revert());
+            assert!(StaticCallNotAllowed::abi_decode(&output.bytes).is_ok());
             Ok(())
         })
     }

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -7,7 +7,7 @@ use tempo_contracts::precompiles::IStablecoinDEX;
 use crate::{
     Precompile, charge_input_cost, dispatch, mutate, mutate_void, preserve_storage_credits,
     stablecoin_dex::{
-        StablecoinDEX,
+        StablecoinDEX, TickLevel,
         orderbook::{BookId, compute_book_key},
     },
     view,
@@ -35,8 +35,9 @@ impl Precompile for StablecoinDEX {
                         self.get_order(c.orderId).map(|order| order.into())
                     }),
                     getTickLevel(call) => view(call, |c| {
-                        let level = self.get_price_level(c.base, c.tick, c.isBid)?;
-                        Ok((level.head, level.tail, level.total_liquidity).into())
+                        let TickLevel { links, total_liquidity } =
+                            self.get_price_level(c.base, c.tick, c.isBid)?;
+                        Ok((links.head, links.tail, total_liquidity).into())
                     }),
                     pairKey(call) => view(call, |c| Ok(compute_book_key(c.tokenA, c.tokenB))),
                     books(call) => view(call, |c| self.books(c.pairKey).map(Into::into)),

--- a/crates/precompiles/src/stablecoin_dex/dispatch.rs
+++ b/crates/precompiles/src/stablecoin_dex/dispatch.rs
@@ -66,7 +66,7 @@ impl Precompile for StablecoinDEX {
                         self.swap_exact_amount_out(s, c.tokenIn, c.tokenOut, c.amountOut, c.maxAmountIn)
                     }),
                     quoteSwapExactAmountIn(call) => {
-                        if self.storage.spec().is_t9() {
+                        if self.storage.spec().is_t11() {
                             mutate(call, msg_sender, |_, c| {
                                 self.quote_swap_exact_amount_in(c.tokenIn, c.tokenOut, c.amountIn)
                             })
@@ -77,7 +77,7 @@ impl Precompile for StablecoinDEX {
                         }
                     },
                     quoteSwapExactAmountOut(call) => {
-                        if self.storage.spec().is_t9() {
+                        if self.storage.spec().is_t11() {
                             mutate(call, msg_sender, |_, c| {
                                 self.quote_swap_exact_amount_out(c.tokenIn, c.tokenOut, c.amountOut)
                             })
@@ -482,9 +482,9 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_quote_rejects_static_call() -> eyre::Result<()> {
+    fn test_t11_quote_rejects_static_call() -> eyre::Result<()> {
         let mut storage =
-            HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9).with_static(true);
+            HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11).with_static(true);
         StorageCtx::enter(&mut storage, || {
             let mut exchange = StablecoinDEX::new();
             let calldata = IStablecoinDEX::quoteSwapExactAmountInCall {

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -22,6 +22,7 @@ pub use tempo_contracts::precompiles::{IStablecoinDEX, StablecoinDEXError, Stabl
 
 use crate::{
     STABLECOIN_DEX_ADDRESS,
+    dispatch::preserve_storage_credits,
     error::{Result, TempoPrecompileError},
     stablecoin_dex::orderbook::{MAX_PRICE, MIN_PRICE, compute_book_key},
     storage::{Handler, Mapping},
@@ -343,13 +344,16 @@ impl StablecoinDEX {
     /// Quotes the input amount required to receive exactly `amount_out` tokens, routing through
     /// one or more orderbooks without executing trades.
     ///
+    /// At T9+, this simulates the swap fill path under a state checkpoint. It is intended for
+    /// offchain calls and consumes gas even though all simulated state changes are reverted.
+    ///
     /// # Errors
     /// - `IdenticalTokens` — `token_in` and `token_out` are the same address
     /// - `InvalidToken` — a token address does not have a valid TIP-20 prefix
     /// - `PairDoesNotExist` — no orderbook exists for one of the hops in the route
     /// - `InsufficientLiquidity` — not enough resting orders to fill `amount_out`
     pub fn quote_swap_exact_amount_out(
-        &self,
+        &mut self,
         token_in: Address,
         token_out: Address,
         amount_out: u128,
@@ -357,17 +361,36 @@ impl StablecoinDEX {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
 
-        // Execute quotes backwards from output to input
-        let mut current_amount = amount_out;
-        for (book_key, base_for_quote) in route.iter().rev() {
-            current_amount = self.quote_exact_out(*book_key, current_amount, *base_for_quote)?;
+        if !self.storage.spec().is_t9() {
+            // Execute quotes backwards from output to input
+            let mut current_amount = amount_out;
+            for (book_key, base_for_quote) in route.iter().rev() {
+                current_amount =
+                    self.quote_exact_out(*book_key, current_amount, *base_for_quote)?;
+            }
+            return Ok(current_amount);
         }
 
-        Ok(current_amount)
+        self.simulate_swap(|dex, storage_credits| {
+            let mut current_amount = amount_out;
+            for (book_key, base_for_quote) in route.iter().rev() {
+                current_amount = dex.fill_orders_exact_out(
+                    storage_credits,
+                    *book_key,
+                    *base_for_quote,
+                    current_amount,
+                    Address::ZERO,
+                )?;
+            }
+            Ok(current_amount)
+        })
     }
 
     /// Quotes the output amount received for exactly `amount_in` input tokens, routing through
     /// one or more orderbooks without executing trades.
+    ///
+    /// At T9+, this simulates the swap fill path under a state checkpoint. It is intended for
+    /// offchain calls and consumes gas even though all simulated state changes are reverted.
     ///
     /// # Errors
     /// - `IdenticalTokens` — `token_in` and `token_out` are the same address
@@ -375,7 +398,7 @@ impl StablecoinDEX {
     /// - `PairDoesNotExist` — no orderbook exists for one of the hops in the route
     /// - `InsufficientLiquidity` — not enough resting orders to fill `amount_in`
     pub fn quote_swap_exact_amount_in(
-        &self,
+        &mut self,
         token_in: Address,
         token_out: Address,
         amount_in: u128,
@@ -383,13 +406,53 @@ impl StablecoinDEX {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
 
-        // Execute quotes for each hop using precomputed book keys and directions
-        let mut current_amount = amount_in;
-        for (book_key, base_for_quote) in route {
-            current_amount = self.quote_exact_in(book_key, current_amount, base_for_quote)?;
+        if !self.storage.spec().is_t9() {
+            // Execute quotes for each hop using precomputed book keys and directions
+            let mut current_amount = amount_in;
+            for (book_key, base_for_quote) in route {
+                current_amount = self.quote_exact_in(book_key, current_amount, base_for_quote)?;
+            }
+            return Ok(current_amount);
         }
 
-        Ok(current_amount)
+        self.simulate_swap(|dex, storage_credits| {
+            let mut current_amount = amount_in;
+            for (book_key, base_for_quote) in route {
+                current_amount = dex.fill_orders_exact_in(
+                    storage_credits,
+                    book_key,
+                    base_for_quote,
+                    current_amount,
+                    Address::ZERO,
+                )?;
+            }
+            Ok(current_amount)
+        })
+    }
+
+    /// Executes the real swap fill path against a temporary state checkpoint.
+    ///
+    /// State, logs, transient storage, storage actions, and speculative SSTORE refunds are
+    /// discarded. Gas consumed while executing the simulation remains charged.
+    fn simulate_swap<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self, &mut StorageCreditDeltas) -> Result<R>,
+    ) -> Result<R> {
+        let actions = self.storage.actions();
+        actions.discarded(|| {
+            let _checkpoint = self.storage.checkpoint();
+            preserve_storage_credits(self.address)?;
+
+            let refunds_before = self.storage.gas_refunded();
+            let mut storage_credits = StorageCreditDeltas::new();
+            let result = f(self, &mut storage_credits);
+
+            // Journal checkpoints do not include the precompile gas tracker. Retain gas charges,
+            // but remove refunds earned by storage clears that are about to be reverted.
+            let simulated_refunds = self.storage.gas_refunded().saturating_sub(refunds_before);
+            self.storage.refund_gas(simulated_refunds.saturating_neg());
+            result
+        })
     }
 
     /// Swaps `amount_in` of `token_in` for `token_out`, routing through
@@ -1899,6 +1962,50 @@ mod tests {
             .apply()?;
 
         Ok((base.address(), quote.address()))
+    }
+
+    fn with_fragmented_book<R>(
+        spec: TempoHardfork,
+        orders: &[(u128, i16)],
+        maker_is_bid: bool,
+        f: impl FnOnce(&mut StablecoinDEX, Address, Address, Address) -> eyre::Result<R>,
+    ) -> eyre::Result<R> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+
+            let admin = Address::random();
+            let taker = Address::random();
+            let makers: Vec<_> = orders.iter().map(|_| Address::random()).collect();
+            let actors: Vec<_> = makers.iter().copied().chain([taker]).collect();
+            let fund = U256::from(1_000_000_000_000_000_000u128);
+
+            let mut base_setup = TIP20Setup::create("BASE", "BASE", admin).with_issuer(admin);
+            let mut quote_setup = TIP20Setup::path_usd(admin).with_issuer(admin);
+            for actor in actors {
+                base_setup = base_setup.with_mint(actor, fund).with_approval(
+                    actor,
+                    exchange.address,
+                    U256::MAX,
+                );
+                quote_setup = quote_setup.with_mint(actor, fund).with_approval(
+                    actor,
+                    exchange.address,
+                    U256::MAX,
+                );
+            }
+
+            let base = base_setup.apply()?;
+            let quote = quote_setup.apply()?;
+            let book_key = exchange.create_pair(base.address())?;
+            for ((amount, tick), maker) in orders.iter().zip(makers) {
+                exchange.place(maker, base.address(), *amount, maker_is_bid, *tick)?;
+            }
+
+            assert_eq!(book_key, compute_book_key(base.address(), quote.address()));
+            f(&mut exchange, base.address(), quote.address(), taker)
+        })
     }
 
     #[test]
@@ -6430,5 +6537,208 @@ mod tests {
             })?;
         }
         Ok(())
+    }
+
+    #[test]
+    fn test_t9_quote_executes_fill_path_and_reverts_state() -> eyre::Result<()> {
+        let orders = [(100_006_000, 10), (100_006_000, 10)];
+        let amount_in = 200_012_000;
+
+        // Before T9, the aggregate tick quote rounds once and differs from the two fills.
+        with_fragmented_book(
+            TempoHardfork::T8,
+            &orders,
+            true,
+            |exchange, base, quote, taker| {
+                let quoted = exchange.quote_swap_exact_amount_in(base, quote, amount_in)?;
+                let executed = exchange.swap_exact_amount_in(taker, base, quote, amount_in, 0)?;
+                assert_eq!(quoted, 200_032_001);
+                assert_eq!(executed, 200_032_000);
+                Ok(())
+            },
+        )?;
+
+        with_fragmented_book(
+            TempoHardfork::T9,
+            &orders,
+            true,
+            |exchange, base, quote, taker| {
+                let book_key = compute_book_key(base, quote);
+                let best_bid_before = exchange.books[book_key].read()?.best_bid_tick;
+                let level_before = exchange.books[book_key]
+                    .tick_level_handler(10, true)
+                    .read()?;
+                let first_before = exchange.get_order(level_before.head)?;
+                let second_before = exchange.get_order(first_before.next())?;
+                let maker_base_before = exchange.balance_of(first_before.maker(), base)?;
+                let maker_credits_before = exchange.storage_credits(first_before.maker())?;
+                let events_before = exchange.emitted_events().len();
+
+                let quoted = exchange.quote_swap_exact_amount_in(base, quote, amount_in)?;
+                assert_eq!(quoted, 200_032_000);
+
+                assert_eq!(
+                    exchange.books[book_key].read()?.best_bid_tick,
+                    best_bid_before
+                );
+                assert_eq!(
+                    exchange.books[book_key]
+                        .tick_level_handler(10, true)
+                        .read()?,
+                    level_before
+                );
+                assert_eq!(exchange.get_order(first_before.order_id())?, first_before);
+                assert_eq!(exchange.get_order(second_before.order_id())?, second_before);
+                assert_eq!(
+                    exchange.balance_of(first_before.maker(), base)?,
+                    maker_base_before
+                );
+                assert_eq!(
+                    exchange.storage_credits(first_before.maker())?,
+                    maker_credits_before
+                );
+                assert_eq!(exchange.emitted_events().len(), events_before);
+
+                let executed =
+                    exchange.swap_exact_amount_in(taker, base, quote, amount_in, quoted)?;
+                assert_eq!(quoted, executed);
+                Ok(())
+            },
+        )
+    }
+
+    #[test]
+    fn test_t9_quote_error_reverts_partial_simulation() -> eyre::Result<()> {
+        let orders = [(100_000_005, 10), (100_000_007, 10)];
+        with_fragmented_book(
+            TempoHardfork::T9,
+            &orders,
+            true,
+            |exchange, base, quote, _| {
+                let book_key = compute_book_key(base, quote);
+                let level_before = exchange.books[book_key]
+                    .tick_level_handler(10, true)
+                    .read()?;
+                let first_before = exchange.get_order(level_before.head)?;
+                let second_before = exchange.get_order(first_before.next())?;
+                let events_before = exchange.emitted_events().len();
+
+                let error = exchange
+                    .quote_swap_exact_amount_in(
+                        base,
+                        quote,
+                        orders.iter().map(|(amount, _)| amount).sum::<u128>() + 1,
+                    )
+                    .unwrap_err();
+                assert_eq!(
+                    error,
+                    TempoPrecompileError::from(StablecoinDEXError::insufficient_liquidity())
+                );
+
+                assert_eq!(
+                    exchange.books[book_key]
+                        .tick_level_handler(10, true)
+                        .read()?,
+                    level_before
+                );
+                assert_eq!(exchange.get_order(first_before.order_id())?, first_before);
+                assert_eq!(exchange.get_order(second_before.order_id())?, second_before);
+                assert_eq!(exchange.emitted_events().len(), events_before);
+                Ok(())
+            },
+        )
+    }
+
+    #[test]
+    fn test_t9_multi_hop_quote_matches_swap() -> eyre::Result<()> {
+        fn run(exact_in: bool) -> eyre::Result<()> {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+            StorageCtx::enter(&mut storage, || {
+                let mut exchange = StablecoinDEX::new();
+                exchange.initialize()?;
+
+                let admin = Address::random();
+                let taker = Address::random();
+                let makers = [
+                    Address::random(),
+                    Address::random(),
+                    Address::random(),
+                    Address::random(),
+                ];
+                let actors: Vec<_> = makers.iter().copied().chain([taker]).collect();
+                let fund = U256::from(1_000_000_000_000_000_000u128);
+
+                let mut path_setup = TIP20Setup::path_usd(admin).with_issuer(admin);
+                let mut token_a_setup =
+                    TIP20Setup::create("TOKEN_A", "TOKEN_A", admin).with_issuer(admin);
+                let mut token_b_setup =
+                    TIP20Setup::create("TOKEN_B", "TOKEN_B", admin).with_issuer(admin);
+                for actor in actors {
+                    path_setup = path_setup.with_mint(actor, fund).with_approval(
+                        actor,
+                        exchange.address,
+                        U256::MAX,
+                    );
+                    token_a_setup = token_a_setup.with_mint(actor, fund).with_approval(
+                        actor,
+                        exchange.address,
+                        U256::MAX,
+                    );
+                    token_b_setup = token_b_setup.with_mint(actor, fund).with_approval(
+                        actor,
+                        exchange.address,
+                        U256::MAX,
+                    );
+                }
+
+                path_setup.apply()?;
+                let token_a = token_a_setup.apply()?;
+                let token_b = token_b_setup.apply()?;
+                exchange.create_pair(token_a.address())?;
+                exchange.create_pair(token_b.address())?;
+
+                exchange.place(makers[0], token_a.address(), 100_006_000, true, 10)?;
+                exchange.place(makers[1], token_a.address(), 100_006_000, true, 10)?;
+                exchange.place(makers[2], token_b.address(), 100_000_003, false, 20)?;
+                exchange.place(makers[3], token_b.address(), 150_000_009, false, 20)?;
+
+                if exact_in {
+                    let amount_in = 200_012_000;
+                    let quoted = exchange.quote_swap_exact_amount_in(
+                        token_a.address(),
+                        token_b.address(),
+                        amount_in,
+                    )?;
+                    let executed = exchange.swap_exact_amount_in(
+                        taker,
+                        token_a.address(),
+                        token_b.address(),
+                        amount_in,
+                        quoted,
+                    )?;
+                    assert_eq!(quoted, executed);
+                } else {
+                    let amount_out = 150_000_000;
+                    let quoted = exchange.quote_swap_exact_amount_out(
+                        token_a.address(),
+                        token_b.address(),
+                        amount_out,
+                    )?;
+                    let executed = exchange.swap_exact_amount_out(
+                        taker,
+                        token_a.address(),
+                        token_b.address(),
+                        amount_out,
+                        quoted,
+                    )?;
+                    assert_eq!(quoted, executed);
+                }
+
+                Ok(())
+            })
+        }
+
+        run(true)?;
+        run(false)
     }
 }

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -360,27 +360,22 @@ impl StablecoinDEX {
     ) -> Result<u128> {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
+        let simulate_fills = self.storage.spec().is_t9();
 
-        if !self.storage.spec().is_t9() {
-            // Execute quotes backwards from output to input
+        self.with_quote_execution(|dex, storage_credits| {
             let mut current_amount = amount_out;
-            for (book_key, base_for_quote) in route.iter().rev() {
-                current_amount =
-                    self.quote_exact_out(*book_key, current_amount, *base_for_quote)?;
-            }
-            return Ok(current_amount);
-        }
-
-        self.simulate_swap(|dex, storage_credits| {
-            let mut current_amount = amount_out;
-            for (book_key, base_for_quote) in route.iter().rev() {
-                current_amount = dex.fill_orders_exact_out(
-                    storage_credits,
-                    *book_key,
-                    *base_for_quote,
-                    current_amount,
-                    Address::ZERO,
-                )?;
+            for (book_key, base_for_quote) in route.into_iter().rev() {
+                current_amount = if simulate_fills {
+                    dex.fill_orders_exact_out(
+                        storage_credits,
+                        book_key,
+                        base_for_quote,
+                        current_amount,
+                        Address::ZERO,
+                    )?
+                } else {
+                    dex.quote_exact_out(book_key, current_amount, base_for_quote)?
+                };
             }
             Ok(current_amount)
         })
@@ -405,26 +400,22 @@ impl StablecoinDEX {
     ) -> Result<u128> {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
+        let simulate_fills = self.storage.spec().is_t9();
 
-        if !self.storage.spec().is_t9() {
-            // Execute quotes for each hop using precomputed book keys and directions
+        self.with_quote_execution(|dex, storage_credits| {
             let mut current_amount = amount_in;
             for (book_key, base_for_quote) in route {
-                current_amount = self.quote_exact_in(book_key, current_amount, base_for_quote)?;
-            }
-            return Ok(current_amount);
-        }
-
-        self.simulate_swap(|dex, storage_credits| {
-            let mut current_amount = amount_in;
-            for (book_key, base_for_quote) in route {
-                current_amount = dex.fill_orders_exact_in(
-                    storage_credits,
-                    book_key,
-                    base_for_quote,
-                    current_amount,
-                    Address::ZERO,
-                )?;
+                current_amount = if simulate_fills {
+                    dex.fill_orders_exact_in(
+                        storage_credits,
+                        book_key,
+                        base_for_quote,
+                        current_amount,
+                        Address::ZERO,
+                    )?
+                } else {
+                    dex.quote_exact_in(book_key, current_amount, base_for_quote)?
+                };
             }
             Ok(current_amount)
         })
@@ -432,19 +423,24 @@ impl StablecoinDEX {
 
     /// Executes the real swap fill path against a temporary state checkpoint.
     ///
-    /// State, logs, transient storage, storage actions, and speculative SSTORE refunds are
-    /// discarded. Gas consumed while executing the simulation remains charged.
-    fn simulate_swap<R>(
+    /// State, logs, transient storage, and speculative SSTORE refunds are discarded. Storage
+    /// actions remain recorded inside matching checkpoint markers so replay validates every
+    /// access without committing simulated writes. Gas consumed by the simulation remains charged.
+    fn with_quote_execution<R>(
         &mut self,
         f: impl FnOnce(&mut Self, &mut StorageCreditDeltas) -> Result<R>,
     ) -> Result<R> {
+        let mut storage_credits = StorageCreditDeltas::new();
+        if !self.storage.spec().is_t9() {
+            return f(self, &mut storage_credits);
+        }
+
         let actions = self.storage.actions();
-        actions.discarded(|| {
+        actions.reverted(self.address, || {
             let _checkpoint = self.storage.checkpoint();
             preserve_storage_credits(self.address)?;
 
             let refunds_before = self.storage.gas_refunded();
-            let mut storage_credits = StorageCreditDeltas::new();
             let result = f(self, &mut storage_credits);
 
             // Journal checkpoints do not include the precompile gas tracker. Retain gas charges,

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -22,7 +22,6 @@ pub use tempo_contracts::precompiles::{IStablecoinDEX, StablecoinDEXError, Stabl
 
 use crate::{
     STABLECOIN_DEX_ADDRESS,
-    dispatch::preserve_storage_credits,
     error::{Result, TempoPrecompileError},
     stablecoin_dex::orderbook::{MAX_PRICE, MIN_PRICE, compute_book_key},
     storage::{Handler, Mapping},
@@ -438,8 +437,6 @@ impl StablecoinDEX {
         let actions = self.storage.actions();
         actions.reverted(self.address, || {
             let _checkpoint = self.storage.checkpoint();
-            preserve_storage_credits(self.address)?;
-
             let refunds_before = self.storage.gas_refunded();
             let result = f(self, &mut storage_credits);
 

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -435,7 +435,7 @@ impl StablecoinDEX {
         }
 
         let actions = self.storage.actions();
-        actions.reverted(self.address, || {
+        actions.reverted(|| {
             let _checkpoint = self.storage.checkpoint();
             let refunds_before = self.storage.gas_refunded();
             let result = f(self, &mut storage_credits);

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -547,11 +547,25 @@ impl StablecoinDEX {
     pub fn get_price_level(&self, base: Address, tick: i16, is_bid: bool) -> Result<TickLevel> {
         let quote = TIP20Token::from_address(base)?.quote_token()?;
         let book_key = compute_book_key(base, quote);
-        if is_bid {
-            self.books[book_key].bids[tick].read()
+        let mut level = if is_bid {
+            self.books[book_key].bids[tick].read()?
         } else {
-            self.books[book_key].asks[tick].read()
+            self.books[book_key].asks[tick].read()?
+        };
+
+        if self.storage.spec().is_t11() {
+            let mut order_id = level.links.head;
+            while order_id != 0 {
+                let order = self.orders[order_id].read_in_book(book_key)?;
+                level.total_liquidity = level
+                    .total_liquidity
+                    .checked_add(order.remaining())
+                    .ok_or(TempoPrecompileError::under_overflow())?;
+                order_id = order.next();
+            }
         }
+
+        Ok(level)
     }
 
     /// Returns the [`Orderbook`] for a given pair key.
@@ -761,10 +775,10 @@ impl StablecoinDEX {
             .tick_level_handler(order.tick(), order.is_bid())
             .read()?;
 
-        let prev_tail = level.tail;
+        let prev_tail = level.links.tail;
         if prev_tail == 0 {
-            level.head = order.order_id();
-            level.tail = order.order_id();
+            level.links.head = order.order_id();
+            level.links.tail = order.order_id();
 
             self.books[order.book_key()].set_tick_bit(order.tick(), order.is_bid())?;
 
@@ -791,14 +805,15 @@ impl StablecoinDEX {
 
             // Set current order's prev pointer
             order.prev = prev_tail;
-            level.tail = order.order_id();
+            level.links.tail = order.order_id();
         }
 
-        let new_liquidity = level
-            .total_liquidity
-            .checked_add(order.remaining())
-            .ok_or(TempoPrecompileError::under_overflow())?;
-        level.total_liquidity = new_liquidity;
+        if !self.storage.spec().is_t11() {
+            level.total_liquidity = level
+                .total_liquidity
+                .checked_add(order.remaining())
+                .ok_or(TempoPrecompileError::under_overflow())?;
+        }
 
         self.books[order.book_key()]
             .tick_level_handler_mut(order.tick(), order.is_bid())
@@ -1080,16 +1095,16 @@ impl StablecoinDEX {
             fill_amount
         };
 
-        // Update price level total liquidity
-        let new_liquidity = level
-            .total_liquidity
-            .checked_sub(fill_amount)
-            .ok_or(TempoPrecompileError::under_overflow())?;
-        level.total_liquidity = new_liquidity;
+        if !self.storage.spec().is_t11() {
+            level.total_liquidity = level
+                .total_liquidity
+                .checked_sub(fill_amount)
+                .ok_or(TempoPrecompileError::under_overflow())?;
 
-        self.books[order.book_key()]
-            .tick_level_handler_mut(order.tick(), order.is_bid())
-            .write(*level)?;
+            self.books[order.book_key()]
+                .tick_level_handler_mut(order.tick(), order.is_bid())
+                .write(*level)?;
+        }
 
         // Emit OrderFilled event for partial fill
         self.emit_order_filled(order.order_id(), order.maker(), taker, fill_amount, true)?;
@@ -1212,22 +1227,23 @@ impl StablecoinDEX {
                 let new_level = self.books[book_key]
                     .tick_level_handler(tick, order.is_bid())
                     .read()?;
-                let new_order = self.orders[new_level.head].read_in_book(book_key)?;
+                let new_order = self.orders[new_level.links.head].read_in_book(book_key)?;
 
                 Some((new_level, new_order))
             }
         } else {
             // If there are subsequent orders at tick, advance to next order
-            level.head = order.next();
+            level.links.head = order.next();
             let (_, credits) = StorageCredits::new().track_minted_credits(self.address, || {
                 self.orders[order.next()].prev()?.delete()
             })?;
 
-            let new_liquidity = level
-                .total_liquidity
-                .checked_sub(fill_amount)
-                .ok_or(TempoPrecompileError::under_overflow())?;
-            level.total_liquidity = new_liquidity;
+            if !self.storage.spec().is_t11() {
+                level.total_liquidity = level
+                    .total_liquidity
+                    .checked_sub(fill_amount)
+                    .ok_or(TempoPrecompileError::under_overflow())?;
+            }
 
             self.books[book_key]
                 .tick_level_handler_mut(order.tick(), order.is_bid())
@@ -1252,7 +1268,7 @@ impl StablecoinDEX {
         taker: Address,
     ) -> Result<u128> {
         let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read_in_book(book_key)?;
+        let mut order = self.orders[level.links.head].read_in_book(book_key)?;
 
         let mut total_amount_in: u128 = 0;
 
@@ -1333,7 +1349,7 @@ impl StablecoinDEX {
         taker: Address,
     ) -> Result<u128> {
         let mut level = self.get_best_price_level(book_key, bid)?;
-        let mut order = self.orders[level.head].read_in_book(book_key)?;
+        let mut order = self.orders[level.links.head].read_in_book(book_key)?;
 
         let mut total_amount_out: u128 = 0;
 
@@ -1463,7 +1479,7 @@ impl StablecoinDEX {
                 s.orders[order.prev()].next()?.write(order.next())
             })?;
         } else {
-            level.head = order.next();
+            level.links.head = order.next();
         }
 
         if order.next() != 0 {
@@ -1471,18 +1487,21 @@ impl StablecoinDEX {
                 s.orders[order.next()].prev()?.write(order.prev())
             })?;
         } else {
-            level.tail = order.prev();
+            level.links.tail = order.prev();
         }
 
-        // Update level liquidity
-        let new_liquidity = level
-            .total_liquidity
-            .checked_sub(order.remaining())
-            .ok_or(TempoPrecompileError::under_overflow())?;
-        level.total_liquidity = new_liquidity;
+        let has_level_changed = if self.storage.spec().is_t11() {
+            order.prev() == 0 || order.next() == 0
+        } else {
+            level.total_liquidity = level
+                .total_liquidity
+                .checked_sub(order.remaining())
+                .ok_or(TempoPrecompileError::under_overflow())?;
+            true
+        };
 
         // If this was the last order at this tick, clear the bitmap bit
-        if level.head == 0 {
+        if level.links.head == 0 {
             self.books[order.book_key()].delete_tick_bit(order.tick(), order.is_bid())?;
 
             // If this was the best tick, update it
@@ -1507,9 +1526,11 @@ impl StablecoinDEX {
             }
         }
 
-        self.books[order.book_key()]
-            .tick_level_handler_mut(order.tick(), order.is_bid())
-            .write(level)?;
+        if has_level_changed {
+            self.books[order.book_key()]
+                .tick_level_handler_mut(order.tick(), order.is_bid())
+                .write(level)?;
+        }
 
         // Refund tokens to maker - must match the escrow amount
         let orderbook = self.books[order.book_key()].read()?;
@@ -2016,6 +2037,123 @@ mod tests {
             assert_eq!(exchange.book_key_index(book_key)?, Some(0));
 
             Ok(())
+        })
+    }
+
+    #[test]
+    fn test_get_price_level_across_t11() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T10);
+        let maker = Address::random();
+        let admin = Address::random();
+        let tick = 10;
+        let amount = MIN_ORDER_AMOUNT;
+
+        let (base, quote, book_key, first_order) = StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+            exchange.initialize()?;
+            let (base, quote) = setup_test_tokens(admin, maker, exchange.address, amount * 4)?;
+            let book_key = exchange.create_pair(base)?;
+            let first_order = exchange.place(maker, base, amount, true, tick)?;
+            exchange.place(maker, base, amount, true, tick)?;
+
+            assert_eq!(
+                exchange.get_price_level(base, tick, true)?.total_liquidity,
+                amount * 2,
+                "pre-T11 must return the maintained aggregate"
+            );
+
+            Ok::<_, eyre::Report>((base, quote, book_key, first_order))
+        })?;
+
+        let mut storage = storage.with_spec(TempoHardfork::T11);
+        StorageCtx::enter(&mut storage, || {
+            let mut exchange = StablecoinDEX::new();
+
+            assert_eq!(
+                exchange.get_price_level(base, tick, true)?.total_liquidity,
+                amount * 2,
+                "T11 must derive the same liquidity at the fork boundary"
+            );
+
+            exchange.cancel(maker, first_order)?;
+            let stored = Handler::<TickLevel>::read(
+                exchange.books[book_key].tick_level_handler(tick, true),
+            )?;
+            assert_eq!(
+                stored.total_liquidity,
+                amount * 2,
+                "T11 must leave the legacy aggregate stale"
+            );
+            assert_eq!(
+                exchange.get_price_level(base, tick, true)?.total_liquidity,
+                amount
+            );
+
+            exchange.place(maker, base, amount * 2, true, tick)?;
+            let stored = Handler::<TickLevel>::read(
+                exchange.books[book_key].tick_level_handler(tick, true),
+            )?;
+            assert_eq!(stored.total_liquidity, amount * 2);
+            assert_eq!(
+                exchange.get_price_level(base, tick, true)?.total_liquidity,
+                amount * 3
+            );
+
+            exchange.swap_exact_amount_in(maker, base, quote, amount * 3, 0)?;
+            let stored = Handler::<TickLevel>::read(
+                exchange.books[book_key].tick_level_handler(tick, true),
+            )?;
+            assert_eq!(stored.links.head, 0);
+            assert_eq!(stored.links.tail, 0);
+            assert_eq!(stored.total_liquidity, amount * 2);
+            assert_eq!(
+                exchange.get_price_level(base, tick, true)?.total_liquidity,
+                0
+            );
+
+            let maker_1 = Address::random();
+            let maker_2 = Address::random();
+            let overflow_amount = u128::MAX / 2 + 1;
+            let escrow = base_to_quote(overflow_amount, MIN_TICK, RoundingDirection::Up).unwrap();
+            let mut quote_token = TIP20Token::from_address(quote)?;
+            for maker in [maker_1, maker_2] {
+                quote_token.mint(
+                    admin,
+                    ITIP20::mintCall {
+                        to: maker,
+                        amount: U256::from(escrow),
+                    },
+                )?;
+                quote_token.approve(
+                    maker,
+                    ITIP20::approveCall {
+                        spender: exchange.address,
+                        amount: U256::MAX,
+                    },
+                )?;
+            }
+            let head = exchange.place(maker_1, base, overflow_amount, true, MIN_TICK)?;
+            let tail = exchange.place(maker_2, base, overflow_amount, true, MIN_TICK)?;
+
+            let links_before = exchange.books[book_key]
+                .tick_level_handler(MIN_TICK, true)
+                .read()?
+                .links;
+            assert_eq!(links_before.head, head);
+            assert_eq!(links_before.tail, tail);
+            assert_eq!(
+                exchange.get_price_level(base, MIN_TICK, true),
+                Err(TempoPrecompileError::under_overflow())
+            );
+            assert_eq!(
+                exchange.books[book_key]
+                    .tick_level_handler(MIN_TICK, true)
+                    .read()?
+                    .links,
+                links_before
+            );
+
+            Ok::<_, eyre::Report>(())
         })
     }
 
@@ -2534,8 +2672,8 @@ mod tests {
             let book_key = compute_book_key(base_token, quote_token);
             let book_handler = &exchange.books[book_key];
             let level = book_handler.tick_level_handler(tick, true).read()?;
-            assert_eq!(level.head, order_id);
-            assert_eq!(level.tail, order_id);
+            assert_eq!(level.links.head, order_id);
+            assert_eq!(level.links.tail, order_id);
             assert_eq!(level.total_liquidity, min_order_amount);
 
             // Verify balance was reduced by the escrow amount
@@ -2594,8 +2732,8 @@ mod tests {
             let book_key = compute_book_key(base_token, quote_token);
             let book_handler = &exchange.books[book_key];
             let level = book_handler.tick_level_handler(tick, false).read()?;
-            assert_eq!(level.head, order_id);
-            assert_eq!(level.tail, order_id);
+            assert_eq!(level.links.head, order_id);
+            assert_eq!(level.links.tail, order_id);
             assert_eq!(level.total_liquidity, min_order_amount);
 
             // Verify balance was reduced by the escrow amount
@@ -2762,8 +2900,8 @@ mod tests {
             let book_key = compute_book_key(base_token, quote_token);
             let book_handler = &exchange.books[book_key];
             let level = book_handler.tick_level_handler(tick, true).read()?;
-            assert_eq!(level.head, order_id);
-            assert_eq!(level.tail, order_id);
+            assert_eq!(level.links.head, order_id);
+            assert_eq!(level.links.tail, order_id);
             assert_eq!(level.total_liquidity, min_order_amount);
 
             // Verify balance was reduced by the escrow amount
@@ -2979,15 +3117,15 @@ mod tests {
             let bid_level = exchange.books[book_key]
                 .tick_level_handler(tick, true)
                 .read()?;
-            assert_eq!(bid_level.head, resting_bid_id);
-            assert_eq!(bid_level.tail, resting_bid_id);
+            assert_eq!(bid_level.links.head, resting_bid_id);
+            assert_eq!(bid_level.links.tail, resting_bid_id);
             assert_eq!(bid_level.total_liquidity, amount);
 
             let ask_level = exchange.books[book_key]
                 .tick_level_handler(tick, false)
                 .read()?;
-            assert_eq!(ask_level.head, new_ask_id);
-            assert_eq!(ask_level.tail, new_ask_id);
+            assert_eq!(ask_level.links.head, new_ask_id);
+            assert_eq!(ask_level.links.tail, new_ask_id);
             assert_eq!(ask_level.total_liquidity, amount);
 
             let book = exchange.books[book_key].read()?;
@@ -3029,8 +3167,8 @@ mod tests {
             let bid_level_after = exchange.books[book_key]
                 .tick_level_handler(tick, true)
                 .read()?;
-            assert_eq!(bid_level_after.head, resting_bid_id);
-            assert_eq!(bid_level_after.tail, flipped_back_id);
+            assert_eq!(bid_level_after.links.head, resting_bid_id);
+            assert_eq!(bid_level_after.links.tail, flipped_back_id);
             assert_eq!(bid_level_after.total_liquidity, amount * 2);
 
             Ok(())
@@ -3566,8 +3704,8 @@ mod tests {
             let ask_level = exchange.books[book_key]
                 .tick_level_handler(flip_tick, false)
                 .read()?;
-            assert_eq!(ask_level.head, 0);
-            assert_eq!(ask_level.tail, 0);
+            assert_eq!(ask_level.links.head, 0);
+            assert_eq!(ask_level.links.tail, 0);
             assert_eq!(ask_level.total_liquidity, 0);
 
             Ok(())
@@ -4909,8 +5047,14 @@ mod tests {
             let book_key = compute_book_key(base_token, quote_token);
             let book_handler = &exchange.books[book_key];
             let level = book_handler.tick_level_handler(tick, true).read()?;
-            assert_eq!(level.head, order_id, "Order should be head of tick level");
-            assert_eq!(level.tail, order_id, "Order should be tail of tick level");
+            assert_eq!(
+                level.links.head, order_id,
+                "Order should be head of tick level"
+            );
+            assert_eq!(
+                level.links.tail, order_id,
+                "Order should be tail of tick level"
+            );
             assert_eq!(
                 level.total_liquidity, min_order_amount,
                 "Tick level should have order's liquidity"
@@ -4970,8 +5114,14 @@ mod tests {
             let book_key = compute_book_key(base_token, quote_token);
             let book_handler = &exchange.books[book_key];
             let level = book_handler.tick_level_handler(tick, true).read()?;
-            assert_eq!(level.head, order_id, "Order should be head of tick level");
-            assert_eq!(level.tail, order_id, "Order should be tail of tick level");
+            assert_eq!(
+                level.links.head, order_id,
+                "Order should be head of tick level"
+            );
+            assert_eq!(
+                level.links.tail, order_id,
+                "Order should be tail of tick level"
+            );
             assert_eq!(
                 level.total_liquidity, min_order_amount,
                 "Tick level should have order's liquidity"
@@ -5035,8 +5185,8 @@ mod tests {
             let level = exchange.books[book_key]
                 .tick_level_handler(tick, true)
                 .read()?;
-            assert_eq!(level.head, order_id);
-            assert_eq!(level.tail, order_id);
+            assert_eq!(level.links.head, order_id);
+            assert_eq!(level.links.tail, order_id);
             assert_eq!(level.total_liquidity, min_order_amount);
 
             let book = exchange.books[book_key].read()?;
@@ -5998,8 +6148,14 @@ mod tests {
             let bid_level = exchange.books[book_key]
                 .tick_level_handler(tick, true)
                 .read()?;
-            assert_eq!(bid_level.head, 0, "bid level head must be 0 after drain");
-            assert_eq!(bid_level.tail, 0, "bid level tail must be 0 after drain");
+            assert_eq!(
+                bid_level.links.head, 0,
+                "bid level head must be 0 after drain"
+            );
+            assert_eq!(
+                bid_level.links.tail, 0,
+                "bid level tail must be 0 after drain"
+            );
             assert_eq!(
                 bid_level.total_liquidity, 0,
                 "bid level liquidity must be 0 after drain"
@@ -6008,8 +6164,14 @@ mod tests {
             let ask_level = exchange.books[book_key]
                 .tick_level_handler(tick, false)
                 .read()?;
-            assert_eq!(ask_level.head, 0, "ask level head must be 0 after drain");
-            assert_eq!(ask_level.tail, 0, "ask level tail must be 0 after drain");
+            assert_eq!(
+                ask_level.links.head, 0,
+                "ask level head must be 0 after drain"
+            );
+            assert_eq!(
+                ask_level.links.tail, 0,
+                "ask level tail must be 0 after drain"
+            );
             assert_eq!(
                 ask_level.total_liquidity, 0,
                 "ask level liquidity must be 0 after drain"
@@ -6100,15 +6262,15 @@ mod tests {
             let bid_level = exchange.books[book_key]
                 .tick_level_handler(tick, true)
                 .read()?;
-            assert_eq!(bid_level.head, 0, "bid level head must be 0");
-            assert_eq!(bid_level.tail, 0, "bid level tail must be 0");
+            assert_eq!(bid_level.links.head, 0, "bid level head must be 0");
+            assert_eq!(bid_level.links.tail, 0, "bid level tail must be 0");
             assert_eq!(bid_level.total_liquidity, 0, "bid liquidity must be 0");
 
             let ask_level = exchange.books[book_key]
                 .tick_level_handler(tick, false)
                 .read()?;
-            assert_eq!(ask_level.head, 0, "ask level head must be 0");
-            assert_eq!(ask_level.tail, 0, "ask level tail must be 0");
+            assert_eq!(ask_level.links.head, 0, "ask level head must be 0");
+            assert_eq!(ask_level.links.tail, 0, "ask level tail must be 0");
             assert_eq!(ask_level.total_liquidity, 0, "ask liquidity must be 0");
 
             // Verify swap against drained book fails
@@ -6555,7 +6717,7 @@ mod tests {
                 let level_before = exchange.books[book_key]
                     .tick_level_handler(10, true)
                     .read()?;
-                let first_before = exchange.get_order(level_before.head)?;
+                let first_before = exchange.get_order(level_before.links.head)?;
                 let second_before = exchange.get_order(first_before.next())?;
                 let maker_base_before = exchange.balance_of(first_before.maker(), base)?;
                 let maker_credits_before = exchange.storage_credits(first_before.maker())?;
@@ -6606,7 +6768,7 @@ mod tests {
                 let level_before = exchange.books[book_key]
                     .tick_level_handler(10, true)
                     .read()?;
-                let first_before = exchange.get_order(level_before.head)?;
+                let first_before = exchange.get_order(level_before.links.head)?;
                 let second_before = exchange.get_order(first_before.next())?;
                 let events_before = exchange.emitted_events().len();
 

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -423,8 +423,8 @@ impl StablecoinDEX {
     /// Executes the real swap fill path against a temporary state checkpoint.
     ///
     /// State, logs, transient storage, and speculative SSTORE refunds are discarded. Storage
-    /// actions remain recorded inside matching checkpoint markers so replay validates every
-    /// access without committing simulated writes. Gas consumed by the simulation remains charged.
+    /// actions remain recorded, and a checkpoint-revert action invalidates precomputed replay for
+    /// the enclosing transaction. Gas consumed by the simulation remains charged.
     fn with_quote_execution<R>(
         &mut self,
         f: impl FnOnce(&mut Self, &mut StorageCreditDeltas) -> Result<R>,

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -343,7 +343,7 @@ impl StablecoinDEX {
     /// Quotes the input amount required to receive exactly `amount_out` tokens, routing through
     /// one or more orderbooks without executing trades.
     ///
-    /// At T9+, this simulates the swap fill path under a state checkpoint. It is intended for
+    /// At T11+, this simulates the swap fill path under a state checkpoint. It is intended for
     /// offchain calls and consumes gas even though all simulated state changes are reverted.
     ///
     /// # Errors
@@ -359,32 +359,32 @@ impl StablecoinDEX {
     ) -> Result<u128> {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
-        let simulate_fills = self.storage.spec().is_t9();
+        let simulate_fills = self.storage.spec().is_t11();
         let mut storage_credits = StorageCreditDeltas::new();
 
-        self.with_quote_execution(|dex| {
-            let mut current_amount = amount_out;
-            for (book_key, base_for_quote) in route.into_iter().rev() {
-                current_amount = if simulate_fills {
+        let mut current_amount = amount_out;
+        for (book_key, base_for_quote) in route.into_iter().rev() {
+            current_amount = if simulate_fills {
+                self.with_quote_execution(|dex| {
                     dex.fill_orders_exact_out(
                         &mut storage_credits,
                         book_key,
                         base_for_quote,
                         current_amount,
                         Address::ZERO,
-                    )?
-                } else {
-                    dex.quote_exact_out(book_key, current_amount, base_for_quote)?
-                };
-            }
-            Ok(current_amount)
-        })
+                    )
+                })?
+            } else {
+                self.quote_exact_out(book_key, current_amount, base_for_quote)?
+            };
+        }
+        Ok(current_amount)
     }
 
     /// Quotes the output amount received for exactly `amount_in` input tokens, routing through
     /// one or more orderbooks without executing trades.
     ///
-    /// At T9+, this simulates the swap fill path under a state checkpoint. It is intended for
+    /// At T11+, this simulates the swap fill path under a state checkpoint. It is intended for
     /// offchain calls and consumes gas even though all simulated state changes are reverted.
     ///
     /// # Errors
@@ -400,26 +400,26 @@ impl StablecoinDEX {
     ) -> Result<u128> {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
-        let simulate_fills = self.storage.spec().is_t9();
+        let simulate_fills = self.storage.spec().is_t11();
         let mut storage_credits = StorageCreditDeltas::new();
 
-        self.with_quote_execution(|dex| {
-            let mut current_amount = amount_in;
-            for (book_key, base_for_quote) in route {
-                current_amount = if simulate_fills {
+        let mut current_amount = amount_in;
+        for (book_key, base_for_quote) in route {
+            current_amount = if simulate_fills {
+                self.with_quote_execution(|dex| {
                     dex.fill_orders_exact_in(
                         &mut storage_credits,
                         book_key,
                         base_for_quote,
                         current_amount,
                         Address::ZERO,
-                    )?
-                } else {
-                    dex.quote_exact_in(book_key, current_amount, base_for_quote)?
-                };
-            }
-            Ok(current_amount)
-        })
+                    )
+                })?
+            } else {
+                self.quote_exact_in(book_key, current_amount, base_for_quote)?
+            };
+        }
+        Ok(current_amount)
     }
 
     /// Executes the real swap fill path against a temporary state checkpoint.
@@ -428,10 +428,6 @@ impl StablecoinDEX {
     /// actions remain recorded, and a checkpoint-revert action invalidates precomputed replay for
     /// the enclosing transaction. Gas consumed by the simulation remains charged.
     fn with_quote_execution<R>(&mut self, f: impl FnOnce(&mut Self) -> Result<R>) -> Result<R> {
-        if !self.storage.spec().is_t9() {
-            return f(self);
-        }
-
         let actions = self.storage.actions();
         actions.reverted(|| {
             let _checkpoint = self.storage.checkpoint();
@@ -6531,13 +6527,13 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_quote_executes_fill_path_and_reverts_state() -> eyre::Result<()> {
+    fn test_t11_quote_executes_fill_path_and_reverts_state() -> eyre::Result<()> {
         let orders = [(100_006_000, 10), (100_006_000, 10)];
         let amount_in = 200_012_000;
 
-        // Before T9, the aggregate tick quote rounds once and differs from the two fills.
+        // Before T11, the aggregate tick quote rounds once and differs from the two fills.
         with_fragmented_book(
-            TempoHardfork::T8,
+            TempoHardfork::T10,
             &orders,
             true,
             |exchange, base, quote, taker| {
@@ -6550,7 +6546,7 @@ mod tests {
         )?;
 
         with_fragmented_book(
-            TempoHardfork::T9,
+            TempoHardfork::T11,
             &orders,
             true,
             |exchange, base, quote, taker| {
@@ -6599,10 +6595,10 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_quote_error_reverts_partial_simulation() -> eyre::Result<()> {
+    fn test_t11_quote_error_reverts_partial_simulation() -> eyre::Result<()> {
         let orders = [(100_000_005, 10), (100_000_007, 10)];
         with_fragmented_book(
-            TempoHardfork::T9,
+            TempoHardfork::T11,
             &orders,
             true,
             |exchange, base, quote, _| {
@@ -6641,9 +6637,9 @@ mod tests {
     }
 
     #[test]
-    fn test_t9_multi_hop_quote_matches_swap() -> eyre::Result<()> {
+    fn test_t11_multi_hop_quote_matches_swap() -> eyre::Result<()> {
         fn run(exact_in: bool) -> eyre::Result<()> {
-            let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T9);
+            let mut storage = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
             StorageCtx::enter(&mut storage, || {
                 let mut exchange = StablecoinDEX::new();
                 exchange.initialize()?;

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -362,7 +362,7 @@ impl StablecoinDEX {
         let simulate_fills = self.storage.spec().is_t9();
         let mut storage_credits = StorageCreditDeltas::new();
 
-        let result = self.with_quote_execution(|dex| {
+        self.with_quote_execution(|dex| {
             let mut current_amount = amount_out;
             for (book_key, base_for_quote) in route.into_iter().rev() {
                 current_amount = if simulate_fills {
@@ -378,11 +378,7 @@ impl StablecoinDEX {
                 };
             }
             Ok(current_amount)
-        });
-
-        // Quotes never flush maker storage credits; discard the simulated deltas with the fill.
-        drop(storage_credits);
-        result
+        })
     }
 
     /// Quotes the output amount received for exactly `amount_in` input tokens, routing through
@@ -407,7 +403,7 @@ impl StablecoinDEX {
         let simulate_fills = self.storage.spec().is_t9();
         let mut storage_credits = StorageCreditDeltas::new();
 
-        let result = self.with_quote_execution(|dex| {
+        self.with_quote_execution(|dex| {
             let mut current_amount = amount_in;
             for (book_key, base_for_quote) in route {
                 current_amount = if simulate_fills {
@@ -423,11 +419,7 @@ impl StablecoinDEX {
                 };
             }
             Ok(current_amount)
-        });
-
-        // Quotes never flush maker storage credits; discard the simulated deltas with the fill.
-        drop(storage_credits);
-        result
+        })
     }
 
     /// Executes the real swap fill path against a temporary state checkpoint.

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -360,13 +360,14 @@ impl StablecoinDEX {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
         let simulate_fills = self.storage.spec().is_t9();
+        let mut storage_credits = StorageCreditDeltas::new();
 
-        self.with_quote_execution(|dex, storage_credits| {
+        let result = self.with_quote_execution(|dex| {
             let mut current_amount = amount_out;
             for (book_key, base_for_quote) in route.into_iter().rev() {
                 current_amount = if simulate_fills {
                     dex.fill_orders_exact_out(
-                        storage_credits,
+                        &mut storage_credits,
                         book_key,
                         base_for_quote,
                         current_amount,
@@ -377,7 +378,11 @@ impl StablecoinDEX {
                 };
             }
             Ok(current_amount)
-        })
+        });
+
+        // Quotes never flush maker storage credits; discard the simulated deltas with the fill.
+        drop(storage_credits);
+        result
     }
 
     /// Quotes the output amount received for exactly `amount_in` input tokens, routing through
@@ -400,13 +405,14 @@ impl StablecoinDEX {
         // Find and validate the trade route (book keys + direction for each hop)
         let route = self.find_trade_path(token_in, token_out)?;
         let simulate_fills = self.storage.spec().is_t9();
+        let mut storage_credits = StorageCreditDeltas::new();
 
-        self.with_quote_execution(|dex, storage_credits| {
+        let result = self.with_quote_execution(|dex| {
             let mut current_amount = amount_in;
             for (book_key, base_for_quote) in route {
                 current_amount = if simulate_fills {
                     dex.fill_orders_exact_in(
-                        storage_credits,
+                        &mut storage_credits,
                         book_key,
                         base_for_quote,
                         current_amount,
@@ -417,7 +423,11 @@ impl StablecoinDEX {
                 };
             }
             Ok(current_amount)
-        })
+        });
+
+        // Quotes never flush maker storage credits; discard the simulated deltas with the fill.
+        drop(storage_credits);
+        result
     }
 
     /// Executes the real swap fill path against a temporary state checkpoint.
@@ -425,20 +435,16 @@ impl StablecoinDEX {
     /// State, logs, transient storage, and speculative SSTORE refunds are discarded. Storage
     /// actions remain recorded, and a checkpoint-revert action invalidates precomputed replay for
     /// the enclosing transaction. Gas consumed by the simulation remains charged.
-    fn with_quote_execution<R>(
-        &mut self,
-        f: impl FnOnce(&mut Self, &mut StorageCreditDeltas) -> Result<R>,
-    ) -> Result<R> {
-        let mut storage_credits = StorageCreditDeltas::new();
+    fn with_quote_execution<R>(&mut self, f: impl FnOnce(&mut Self) -> Result<R>) -> Result<R> {
         if !self.storage.spec().is_t9() {
-            return f(self, &mut storage_credits);
+            return f(self);
         }
 
         let actions = self.storage.actions();
         actions.reverted(|| {
             let _checkpoint = self.storage.checkpoint();
             let refunds_before = self.storage.gas_refunded();
-            let result = f(self, &mut storage_credits);
+            let result = f(self);
 
             // Journal checkpoints do not include the precompile gas tracker. Retain gas charges,
             // but remove refunds earned by storage clears that are about to be reverted.

--- a/crates/precompiles/src/stablecoin_dex/order/storage.rs
+++ b/crates/precompiles/src/stablecoin_dex/order/storage.rs
@@ -1084,15 +1084,15 @@ mod tests {
                 let bid_level = exchange.books[book_key]
                     .tick_level_handler(tick, true)
                     .read()?;
-                assert_eq!(bid_level.head, resting_id);
-                assert_eq!(bid_level.tail, resting_id);
+                assert_eq!(bid_level.links.head, resting_id);
+                assert_eq!(bid_level.links.tail, resting_id);
                 assert_eq!(bid_level.total_liquidity, amount);
 
                 let ask_level = exchange.books[book_key]
                     .tick_level_handler(tick, false)
                     .read()?;
-                assert_eq!(ask_level.head, flip_id);
-                assert_eq!(ask_level.tail, flip_id);
+                assert_eq!(ask_level.links.head, flip_id);
+                assert_eq!(ask_level.links.tail, flip_id);
                 assert_eq!(ask_level.total_liquidity, amount);
 
                 Ok::<_, TempoPrecompileError>(())
@@ -1175,15 +1175,15 @@ mod tests {
                 let source_level = exchange.books[book_key]
                     .tick_level_handler(tick, true)
                     .read()?;
-                assert_eq!(source_level.head, source_next_id);
-                assert_eq!(source_level.tail, source_next_id);
+                assert_eq!(source_level.links.head, source_next_id);
+                assert_eq!(source_level.links.tail, source_next_id);
                 assert_eq!(source_level.total_liquidity, amount);
 
                 let destination_level = exchange.books[book_key]
                     .tick_level_handler(flip_tick, false)
                     .read()?;
-                assert_eq!(destination_level.head, destination_tail_id);
-                assert_eq!(destination_level.tail, flip_id);
+                assert_eq!(destination_level.links.head, destination_tail_id);
+                assert_eq!(destination_level.links.tail, flip_id);
                 assert_eq!(destination_level.total_liquidity, amount * 2);
 
                 let destination_tail = exchange.get_order(destination_tail_id)?;
@@ -1233,15 +1233,15 @@ mod tests {
                 let source_level = exchange.books[book_key]
                     .tick_level_handler(tick, true)
                     .read()?;
-                assert_eq!(source_level.head, source_next_id);
-                assert_eq!(source_level.tail, source_next_id);
+                assert_eq!(source_level.links.head, source_next_id);
+                assert_eq!(source_level.links.tail, source_next_id);
                 assert_eq!(source_level.total_liquidity, amount);
 
                 let destination_level = exchange.books[book_key]
                     .tick_level_handler(flip_tick, false)
                     .read()?;
-                assert_eq!(destination_level.head, destination_tail_id);
-                assert_eq!(destination_level.tail, destination_tail_id);
+                assert_eq!(destination_level.links.head, destination_tail_id);
+                assert_eq!(destination_level.links.tail, destination_tail_id);
                 assert_eq!(destination_level.total_liquidity, amount);
 
                 let destination_tail = exchange.get_order(destination_tail_id)?;
@@ -1309,15 +1309,15 @@ mod tests {
                 let source_level = exchange.books[book_key]
                     .tick_level_handler(tick, true)
                     .read()?;
-                assert_eq!(source_level.head, source_next_id);
-                assert_eq!(source_level.tail, source_next_id);
+                assert_eq!(source_level.links.head, source_next_id);
+                assert_eq!(source_level.links.tail, source_next_id);
                 assert_eq!(source_level.total_liquidity, amount);
 
                 let destination_level = exchange.books[book_key]
                     .tick_level_handler(flip_tick, false)
                     .read()?;
-                assert_eq!(destination_level.head, destination_tail_id);
-                assert_eq!(destination_level.tail, destination_tail_id);
+                assert_eq!(destination_level.links.head, destination_tail_id);
+                assert_eq!(destination_level.links.tail, destination_tail_id);
                 assert_eq!(destination_level.total_liquidity, amount);
 
                 let destination_tail = exchange.get_order(destination_tail_id)?;
@@ -1386,15 +1386,15 @@ mod tests {
                 let bid_level = exchange.books[book_key]
                     .tick_level_handler(tick, true)
                     .read()?;
-                assert_eq!(bid_level.head, flip_id);
-                assert_eq!(bid_level.tail, flip_id);
+                assert_eq!(bid_level.links.head, flip_id);
+                assert_eq!(bid_level.links.tail, flip_id);
                 assert_eq!(bid_level.total_liquidity, amount);
 
                 let ask_level = exchange.books[book_key]
                     .tick_level_handler(tick, false)
                     .read()?;
-                assert_eq!(ask_level.head, 0);
-                assert_eq!(ask_level.tail, 0);
+                assert_eq!(ask_level.links.head, 0);
+                assert_eq!(ask_level.links.tail, 0);
                 assert_eq!(ask_level.total_liquidity, 0);
 
                 Ok(())
@@ -1443,8 +1443,8 @@ mod tests {
                 let ask_level = exchange.books[book_key]
                     .tick_level_handler(tick, false)
                     .read()?;
-                assert_eq!(ask_level.head, new_tail_id);
-                assert_eq!(ask_level.tail, new_tail_id);
+                assert_eq!(ask_level.links.head, new_tail_id);
+                assert_eq!(ask_level.links.tail, new_tail_id);
                 assert_eq!(ask_level.total_liquidity, amount);
 
                 Ok::<_, TempoPrecompileError>(())
@@ -1520,15 +1520,15 @@ mod tests {
                 let bid_level = exchange.books[book_key]
                     .tick_level_handler(tick, true)
                     .read()?;
-                assert_eq!(bid_level.head, source_next_id);
-                assert_eq!(bid_level.tail, source_next_id);
+                assert_eq!(bid_level.links.head, source_next_id);
+                assert_eq!(bid_level.links.tail, source_next_id);
                 assert_eq!(bid_level.total_liquidity, amount);
 
                 let ask_level = exchange.books[book_key]
                     .tick_level_handler(flip_tick, false)
                     .read()?;
-                assert_eq!(ask_level.head, 0);
-                assert_eq!(ask_level.tail, 0);
+                assert_eq!(ask_level.links.head, 0);
+                assert_eq!(ask_level.links.tail, 0);
                 assert_eq!(ask_level.total_liquidity, 0);
 
                 Ok(())

--- a/crates/precompiles/src/stablecoin_dex/orderbook.rs
+++ b/crates/precompiles/src/stablecoin_dex/orderbook.rs
@@ -3,7 +3,7 @@
 use crate::{
     error::Result,
     stablecoin_dex::{IStablecoinDEX, TICK_SPACING},
-    storage::{Handler, Mapping},
+    storage::{Handler, Mapping, StorageCtx},
 };
 use alloy::primitives::{Address, B256, U256, keccak256};
 use std::ops::Deref;
@@ -91,15 +91,22 @@ pub(crate) const MIN_PRICE: u32 = 98_000;
 /// Highest representable scaled price (`PRICE_SCALE + MAX_TICK`).
 pub(crate) const MAX_PRICE: u32 = 102_000;
 
-/// Represents a price level in the orderbook with a doubly-linked list of orders
-/// Orders are maintained in FIFO order at each tick level
+/// The packed linked-list fields in the first storage slot of [`TickLevel`].
+#[derive(Debug, Storable, Default, Clone, Copy, PartialEq, Eq)]
+pub struct TickLevelLinks {
+    /// Order ID of the first order at this tick (0 if empty).
+    pub head: u128,
+    /// Order ID of the last order at this tick (0 if empty).
+    pub tail: u128,
+}
+
+/// Represents a price level in the orderbook with a doubly-linked list of orders.
+/// Orders are maintained in FIFO order at each tick level.
 #[derive(Debug, Storable, Default, Clone, Copy, PartialEq, Eq)]
 pub struct TickLevel {
-    /// Order ID of the first order at this tick (0 if empty)
-    pub head: u128,
-    /// Order ID of the last order at this tick (0 if empty)
-    pub tail: u128,
-    /// Total liquidity available at this tick level
+    /// Live order links packed into the first storage slot.
+    pub links: TickLevelLinks,
+    /// Legacy aggregate, maintained only before T11 and derived on demand at T11.
     pub total_liquidity: u128,
 }
 
@@ -138,8 +145,7 @@ impl TickLevel {
     /// Creates a new empty tick level
     pub fn new() -> Self {
         Self {
-            head: 0,
-            tail: 0,
+            links: TickLevelLinks::default(),
             total_liquidity: 0,
         }
     }
@@ -147,15 +153,14 @@ impl TickLevel {
     /// Creates a tick level with specific values
     pub fn with_values(head: u128, tail: u128, total_liquidity: u128) -> Self {
         Self {
-            head,
-            tail,
+            links: TickLevelLinks { head, tail },
             total_liquidity,
         }
     }
 
     /// Returns true if this tick level has no orders
     pub fn is_empty(&self) -> bool {
-        self.head == 0 && self.tail == 0
+        self.links.head == 0 && self.links.tail == 0
     }
 
     /// Returns true if this tick level has orders
@@ -164,11 +169,49 @@ impl TickLevel {
     }
 }
 
+// `Storable` also generates `Handler<TickLevel>` for raw two-slot access. These
+// inherent methods intentionally take precedence so normal T11 access touches
+// only the live links; tests can use UFCS to inspect the stale aggregate slot.
+impl TickLevelHandler {
+    /// Reads only the live linked-list slot at T11, preserving legacy behavior before T11.
+    #[inline]
+    pub(crate) fn read(&self) -> Result<TickLevel> {
+        if StorageCtx.spec().is_t11() {
+            Ok(TickLevel {
+                links: self.links.read()?,
+                total_liquidity: 0,
+            })
+        } else {
+            <Self as Handler<TickLevel>>::read(self)
+        }
+    }
+
+    /// Writes only the live linked-list slot at T11, preserving legacy behavior before T11.
+    #[inline]
+    pub(crate) fn write(&mut self, level: TickLevel) -> Result<()> {
+        if StorageCtx.spec().is_t11() {
+            self.links.write(level.links)
+        } else {
+            <Self as Handler<TickLevel>>::write(self, level)
+        }
+    }
+
+    /// Deletes only the live linked-list slot at T11, leaving the legacy aggregate stale.
+    #[inline]
+    pub(crate) fn delete(&mut self) -> Result<()> {
+        if StorageCtx.spec().is_t11() {
+            self.links.delete()
+        } else {
+            <Self as Handler<TickLevel>>::delete(self)
+        }
+    }
+}
+
 impl From<TickLevel> for IStablecoinDEX::PriceLevel {
     fn from(value: TickLevel) -> Self {
         Self {
-            head: value.head,
-            tail: value.tail,
+            head: value.links.head,
+            tail: value.links.tail,
             totalLiquidity: value.total_liquidity,
         }
     }
@@ -519,19 +562,74 @@ pub fn validate_tick_spacing(tick: i16) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::TempoPrecompileError;
+    use crate::{
+        error::TempoPrecompileError,
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+    };
     use rand_08::Rng;
+    use tempo_chainspec::hardfork::TempoHardfork;
 
     use alloy::primitives::address;
 
     #[test]
     fn test_tick_level_creation() {
         let level = TickLevel::new();
-        assert_eq!(level.head, 0);
-        assert_eq!(level.tail, 0);
+        assert_eq!(level.links.head, 0);
+        assert_eq!(level.links.tail, 0);
         assert_eq!(level.total_liquidity, 0);
         assert!(level.is_empty());
         assert!(!level.has_liquidity());
+    }
+
+    #[test]
+    fn test_tick_level_handler_io() -> eyre::Result<()> {
+        let slot = U256::from(7);
+        let address = Address::random();
+        let legacy = TickLevel::with_values(11, 22, 33);
+        let updated = TickLevel::with_values(44, 55, 0);
+
+        for spec in [
+            TempoHardfork::T0,
+            TempoHardfork::T3,
+            TempoHardfork::T10,
+            TempoHardfork::T11,
+        ] {
+            let is_t11 = spec.is_t11();
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            StorageCtx::enter(&mut storage, || {
+                Handler::<TickLevel>::write(&mut TickLevelHandler::new(slot, address), legacy)
+            })?;
+
+            storage.reset_counters();
+            let level =
+                StorageCtx::enter(&mut storage, || TickLevelHandler::new(slot, address).read())?;
+            assert_eq!(level.links, legacy.links);
+            assert_eq!(level.total_liquidity, if is_t11 { 0 } else { 33 });
+            assert_eq!(storage.counter_sload(), if is_t11 { 1 } else { 2 });
+            assert_eq!(storage.counter_sstore(), 0);
+
+            storage.reset_counters();
+            StorageCtx::enter(&mut storage, || {
+                TickLevelHandler::new(slot, address).write(updated)
+            })?;
+            assert_eq!(storage.counter_sload(), if spec.is_t4() { 0 } else { 2 });
+            assert_eq!(storage.counter_sstore(), if is_t11 { 1 } else { 2 });
+
+            storage.reset_counters();
+            StorageCtx::enter(&mut storage, || {
+                TickLevelHandler::new(slot, address).delete()
+            })?;
+            assert_eq!(storage.counter_sload(), 0);
+            assert_eq!(storage.counter_sstore(), if is_t11 { 1 } else { 2 });
+
+            let stored = StorageCtx::enter(&mut storage, || {
+                Handler::<TickLevel>::read(&TickLevelHandler::new(slot, address))
+            })?;
+            assert_eq!(stored.links, TickLevelLinks::default());
+            assert_eq!(stored.total_liquidity, if is_t11 { 33 } else { 0 });
+        }
+
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -146,6 +146,19 @@ impl StorageActions {
         f()
     }
 
+    /// Runs a closure with an isolated actions buffer and discards actions recorded within it.
+    ///
+    /// Unlike [`Self::unrecorded`], this also discards [`Self::record_always`] calls. Actions
+    /// recorded before entering the scope are restored on exit, including when the closure
+    /// returns early or panics.
+    pub fn discarded<R>(&self, f: impl FnOnce() -> R) -> R {
+        let _guard = DiscardedStorageActionsGuard {
+            actions: self.clone(),
+            previous_actions: self.take(),
+        };
+        f()
+    }
+
     /// Enters a scope where [`Self::record`] calls are suppressed.
     fn unrecorded_guard(&self) -> Option<UnrecordedStorageActionsGuard> {
         if let Self::Enabled(state) = self {
@@ -210,6 +223,21 @@ impl Drop for UnrecordedStorageActionsGuard {
 struct RecordedStorageActionsGuard {
     actions: StorageActions,
     previous_unrecorded_depth: usize,
+}
+
+/// Isolated storage-actions scope guard that restores the previous buffer on drop.
+#[derive(Debug)]
+struct DiscardedStorageActionsGuard {
+    actions: StorageActions,
+    previous_actions: Option<Vec<StorageAction>>,
+}
+
+impl Drop for DiscardedStorageActionsGuard {
+    fn drop(&mut self) {
+        if let Some(previous_actions) = self.previous_actions.take() {
+            self.actions.replace(previous_actions);
+        }
+    }
 }
 
 impl Drop for RecordedStorageActionsGuard {
@@ -327,5 +355,35 @@ mod tests {
                 StorageAction::Sstore(address, key, U256::from(1), U256::from(8)),
             ])
         );
+    }
+
+    #[test]
+    fn test_discarded_scope_restores_previous_actions() {
+        let actions = StorageActions::enabled();
+        let address = Address::repeat_byte(0x42);
+        let key = U256::from(7);
+        let before = StorageAction::Sload(address, key, U256::from(1));
+
+        actions.record(before);
+        actions.discarded(|| {
+            actions.record(StorageAction::Sstore(
+                address,
+                key,
+                U256::from(1),
+                U256::from(2),
+            ));
+            actions.record_always(StorageAction::FeeAmmSwap(key, U256::from(3), U256::from(4)));
+
+            actions.discarded(|| {
+                actions.record_always(StorageAction::FeeAmmLiquidityCheck(
+                    key,
+                    U256::from(5),
+                    U256::from(6),
+                    true,
+                ));
+            });
+        });
+
+        assert_eq!(actions.take(), Some(vec![before]));
     }
 }

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -1,7 +1,6 @@
 use std::{cell::RefCell, rc::Rc};
 
 use alloy_primitives::{Address, U256};
-use tempo_contracts::precompiles::TIP_FEE_MANAGER_ADDRESS;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StorageAction {
@@ -54,20 +53,6 @@ pub enum StorageAction {
     /// `amount_out` - Amount of tokens to swap out.
     /// `has_enough_liquidity` - Whether the pool has enough liquidity.
     FeeAmmLiquidityCheck(U256, U256, U256, bool),
-}
-
-impl StorageAction {
-    /// Returns the address targeted by the storage action, or `None` for a replay marker.
-    pub fn address(&self) -> Option<Address> {
-        match self {
-            Self::CheckpointRevert => None,
-            Self::Sload(address, ..)
-            | Self::Sstore(address, ..)
-            | Self::Sinc(address, ..)
-            | Self::Sdec(address, ..) => Some(*address),
-            Self::FeeAmmSwap(..) | Self::FeeAmmLiquidityCheck(..) => Some(TIP_FEE_MANAGER_ADDRESS),
-        }
-    }
 }
 
 /// Buffer for recording EVM [storage actions](StorageAction).

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -152,15 +152,14 @@ impl StorageActions {
         f()
     }
 
-    /// Runs a closure whose underlying storage checkpoint is reverted on exit.
+    /// Runs a closure and marks its underlying storage checkpoint as reverted after it returns.
     ///
     /// All actions remain in the trace, followed by a [`StorageAction::CheckpointRevert`] marker
     /// that invalidates precomputed action replay for the enclosing transaction.
     pub fn reverted<R>(&self, f: impl FnOnce() -> R) -> R {
-        let _guard = RevertedStorageActionsGuard {
-            actions: self.clone(),
-        };
-        f()
+        let result = f();
+        self.record_always(StorageAction::CheckpointRevert);
+        result
     }
 
     /// Enters a scope where [`Self::record`] calls are suppressed.
@@ -227,18 +226,6 @@ impl Drop for UnrecordedStorageActionsGuard {
 struct RecordedStorageActionsGuard {
     actions: StorageActions,
     previous_unrecorded_depth: usize,
-}
-
-/// Recorded storage-actions checkpoint guard that appends a revert marker on drop.
-#[derive(Debug)]
-struct RevertedStorageActionsGuard {
-    actions: StorageActions,
-}
-
-impl Drop for RevertedStorageActionsGuard {
-    fn drop(&mut self) {
-        self.actions.record_always(StorageAction::CheckpointRevert);
-    }
 }
 
 impl Drop for RecordedStorageActionsGuard {

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -9,7 +9,7 @@ pub enum StorageAction {
     ///
     /// Traces containing this action cannot be applied to a precomputed replay target and must be
     /// executed normally instead.
-    CheckpointRevert(Address),
+    CheckpointRevert,
     /// Records an SLOAD opcode.
     Sload(Address, U256, U256),
     /// Records an SSTORE opcode.
@@ -57,15 +57,15 @@ pub enum StorageAction {
 }
 
 impl StorageAction {
-    /// Returns the address of the storage action.
-    pub fn address(&self) -> Address {
+    /// Returns the address targeted by the storage action, or `None` for a replay marker.
+    pub fn address(&self) -> Option<Address> {
         match self {
-            Self::CheckpointRevert(address)
-            | Self::Sload(address, ..)
+            Self::CheckpointRevert => None,
+            Self::Sload(address, ..)
             | Self::Sstore(address, ..)
             | Self::Sinc(address, ..)
-            | Self::Sdec(address, ..) => *address,
-            Self::FeeAmmSwap(..) | Self::FeeAmmLiquidityCheck(..) => TIP_FEE_MANAGER_ADDRESS,
+            | Self::Sdec(address, ..) => Some(*address),
+            Self::FeeAmmSwap(..) | Self::FeeAmmLiquidityCheck(..) => Some(TIP_FEE_MANAGER_ADDRESS),
         }
     }
 }
@@ -156,10 +156,9 @@ impl StorageActions {
     ///
     /// All actions remain in the trace, followed by a [`StorageAction::CheckpointRevert`] marker
     /// that invalidates precomputed action replay for the enclosing transaction.
-    pub fn reverted<R>(&self, owner: Address, f: impl FnOnce() -> R) -> R {
+    pub fn reverted<R>(&self, f: impl FnOnce() -> R) -> R {
         let _guard = RevertedStorageActionsGuard {
             actions: self.clone(),
-            owner,
         };
         f()
     }
@@ -234,13 +233,11 @@ struct RecordedStorageActionsGuard {
 #[derive(Debug)]
 struct RevertedStorageActionsGuard {
     actions: StorageActions,
-    owner: Address,
 }
 
 impl Drop for RevertedStorageActionsGuard {
     fn drop(&mut self) {
-        self.actions
-            .record_always(StorageAction::CheckpointRevert(self.owner));
+        self.actions.record_always(StorageAction::CheckpointRevert);
     }
 }
 
@@ -369,7 +366,7 @@ mod tests {
         let before = StorageAction::Sload(address, key, U256::from(1));
 
         actions.record(before);
-        actions.reverted(address, || {
+        actions.reverted(|| {
             actions.record(StorageAction::Sstore(
                 address,
                 key,
@@ -378,7 +375,7 @@ mod tests {
             ));
             actions.record_always(StorageAction::FeeAmmSwap(key, U256::from(3), U256::from(4)));
 
-            actions.reverted(address, || {
+            actions.reverted(|| {
                 actions.record_always(StorageAction::FeeAmmLiquidityCheck(
                     key,
                     U256::from(5),
@@ -395,8 +392,8 @@ mod tests {
                 StorageAction::Sstore(address, key, U256::from(1), U256::from(2)),
                 StorageAction::FeeAmmSwap(key, U256::from(3), U256::from(4)),
                 StorageAction::FeeAmmLiquidityCheck(key, U256::from(5), U256::from(6), true,),
-                StorageAction::CheckpointRevert(address),
-                StorageAction::CheckpointRevert(address),
+                StorageAction::CheckpointRevert,
+                StorageAction::CheckpointRevert,
             ])
         );
     }

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -5,10 +5,10 @@ use tempo_contracts::precompiles::TIP_FEE_MANAGER_ADDRESS;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StorageAction {
-    /// Begins a temporary storage-action scope whose effects are reverted by
-    /// [`Self::CheckpointRevert`].
-    Checkpoint(Address),
-    /// Reverts storage actions to the matching [`Self::Checkpoint`].
+    /// Marks that execution reverted a storage checkpoint.
+    ///
+    /// Traces containing this action cannot be applied to a precomputed replay target and must be
+    /// executed normally instead.
     CheckpointRevert(Address),
     /// Records an SLOAD opcode.
     Sload(Address, U256, U256),
@@ -60,8 +60,7 @@ impl StorageAction {
     /// Returns the address of the storage action.
     pub fn address(&self) -> Address {
         match self {
-            Self::Checkpoint(address)
-            | Self::CheckpointRevert(address)
+            Self::CheckpointRevert(address)
             | Self::Sload(address, ..)
             | Self::Sstore(address, ..)
             | Self::Sinc(address, ..)
@@ -153,13 +152,11 @@ impl StorageActions {
         f()
     }
 
-    /// Runs a closure in a recorded action checkpoint that is reverted on exit.
+    /// Runs a closure whose underlying storage checkpoint is reverted on exit.
     ///
-    /// All actions remain in the trace so replay can validate the storage accesses that affected
-    /// execution, while the checkpoint markers prevent speculative writes from becoming part of
-    /// the replayed final state.
+    /// All actions remain in the trace, followed by a [`StorageAction::CheckpointRevert`] marker
+    /// that invalidates precomputed action replay for the enclosing transaction.
     pub fn reverted<R>(&self, owner: Address, f: impl FnOnce() -> R) -> R {
-        self.record_always(StorageAction::Checkpoint(owner));
         let _guard = RevertedStorageActionsGuard {
             actions: self.clone(),
             owner,
@@ -365,7 +362,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reverted_scope_preserves_checkpointed_actions() {
+    fn test_reverted_scope_preserves_actions_and_marks_revert() {
         let actions = StorageActions::enabled();
         let address = Address::repeat_byte(0x42);
         let key = U256::from(7);
@@ -395,10 +392,8 @@ mod tests {
             actions.take(),
             Some(vec![
                 before,
-                StorageAction::Checkpoint(address),
                 StorageAction::Sstore(address, key, U256::from(1), U256::from(2)),
                 StorageAction::FeeAmmSwap(key, U256::from(3), U256::from(4)),
-                StorageAction::Checkpoint(address),
                 StorageAction::FeeAmmLiquidityCheck(key, U256::from(5), U256::from(6), true,),
                 StorageAction::CheckpointRevert(address),
                 StorageAction::CheckpointRevert(address),

--- a/crates/precompiles/src/storage/actions.rs
+++ b/crates/precompiles/src/storage/actions.rs
@@ -5,6 +5,11 @@ use tempo_contracts::precompiles::TIP_FEE_MANAGER_ADDRESS;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum StorageAction {
+    /// Begins a temporary storage-action scope whose effects are reverted by
+    /// [`Self::CheckpointRevert`].
+    Checkpoint(Address),
+    /// Reverts storage actions to the matching [`Self::Checkpoint`].
+    CheckpointRevert(Address),
     /// Records an SLOAD opcode.
     Sload(Address, U256, U256),
     /// Records an SSTORE opcode.
@@ -55,7 +60,9 @@ impl StorageAction {
     /// Returns the address of the storage action.
     pub fn address(&self) -> Address {
         match self {
-            Self::Sload(address, ..)
+            Self::Checkpoint(address)
+            | Self::CheckpointRevert(address)
+            | Self::Sload(address, ..)
             | Self::Sstore(address, ..)
             | Self::Sinc(address, ..)
             | Self::Sdec(address, ..) => *address,
@@ -146,15 +153,16 @@ impl StorageActions {
         f()
     }
 
-    /// Runs a closure with an isolated actions buffer and discards actions recorded within it.
+    /// Runs a closure in a recorded action checkpoint that is reverted on exit.
     ///
-    /// Unlike [`Self::unrecorded`], this also discards [`Self::record_always`] calls. Actions
-    /// recorded before entering the scope are restored on exit, including when the closure
-    /// returns early or panics.
-    pub fn discarded<R>(&self, f: impl FnOnce() -> R) -> R {
-        let _guard = DiscardedStorageActionsGuard {
+    /// All actions remain in the trace so replay can validate the storage accesses that affected
+    /// execution, while the checkpoint markers prevent speculative writes from becoming part of
+    /// the replayed final state.
+    pub fn reverted<R>(&self, owner: Address, f: impl FnOnce() -> R) -> R {
+        self.record_always(StorageAction::Checkpoint(owner));
+        let _guard = RevertedStorageActionsGuard {
             actions: self.clone(),
-            previous_actions: self.take(),
+            owner,
         };
         f()
     }
@@ -225,18 +233,17 @@ struct RecordedStorageActionsGuard {
     previous_unrecorded_depth: usize,
 }
 
-/// Isolated storage-actions scope guard that restores the previous buffer on drop.
+/// Recorded storage-actions checkpoint guard that appends a revert marker on drop.
 #[derive(Debug)]
-struct DiscardedStorageActionsGuard {
+struct RevertedStorageActionsGuard {
     actions: StorageActions,
-    previous_actions: Option<Vec<StorageAction>>,
+    owner: Address,
 }
 
-impl Drop for DiscardedStorageActionsGuard {
+impl Drop for RevertedStorageActionsGuard {
     fn drop(&mut self) {
-        if let Some(previous_actions) = self.previous_actions.take() {
-            self.actions.replace(previous_actions);
-        }
+        self.actions
+            .record_always(StorageAction::CheckpointRevert(self.owner));
     }
 }
 
@@ -358,14 +365,14 @@ mod tests {
     }
 
     #[test]
-    fn test_discarded_scope_restores_previous_actions() {
+    fn test_reverted_scope_preserves_checkpointed_actions() {
         let actions = StorageActions::enabled();
         let address = Address::repeat_byte(0x42);
         let key = U256::from(7);
         let before = StorageAction::Sload(address, key, U256::from(1));
 
         actions.record(before);
-        actions.discarded(|| {
+        actions.reverted(address, || {
             actions.record(StorageAction::Sstore(
                 address,
                 key,
@@ -374,7 +381,7 @@ mod tests {
             ));
             actions.record_always(StorageAction::FeeAmmSwap(key, U256::from(3), U256::from(4)));
 
-            actions.discarded(|| {
+            actions.reverted(address, || {
                 actions.record_always(StorageAction::FeeAmmLiquidityCheck(
                     key,
                     U256::from(5),
@@ -384,6 +391,18 @@ mod tests {
             });
         });
 
-        assert_eq!(actions.take(), Some(vec![before]));
+        assert_eq!(
+            actions.take(),
+            Some(vec![
+                before,
+                StorageAction::Checkpoint(address),
+                StorageAction::Sstore(address, key, U256::from(1), U256::from(2)),
+                StorageAction::FeeAmmSwap(key, U256::from(3), U256::from(4)),
+                StorageAction::Checkpoint(address),
+                StorageAction::FeeAmmLiquidityCheck(key, U256::from(5), U256::from(6), true,),
+                StorageAction::CheckpointRevert(address),
+                StorageAction::CheckpointRevert(address),
+            ])
+        );
     }
 }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -898,6 +898,49 @@ mod tests {
     }
 
     #[test]
+    fn test_checkpoint_revert_preserves_gas_charges() -> eyre::Result<()> {
+        // T4 has both journal checkpoints and the opt-in state-gas split, without the
+        // currently unsupported TIP-1060 + EIP-8037 combination used by later forks.
+        let mut evm = TestEvm::new_with_tip1016(TempoHardfork::T4);
+        let mut provider = evm.provider_with_reservoir(460_000);
+        let address = Address::random();
+        let existing_key = U256::from(1);
+        let new_key = U256::from(2);
+
+        provider.sstore(address, existing_key, U256::from(7))?;
+        let gas_before_simulation = provider.gas_used();
+        let state_gas_before_simulation = provider.state_gas_used();
+        let refunds_before_simulation = provider.gas_refunded();
+
+        let checkpoint = provider.checkpoint();
+        provider.sstore(address, new_key, U256::from(42))?;
+        provider.sstore(address, existing_key, U256::ZERO)?;
+        let gas_after_simulation = provider.gas_used();
+        let state_gas_after_simulation = provider.state_gas_used();
+        let reservoir_after_simulation = provider.reservoir();
+        let refunds_after_simulation = provider.gas_refunded();
+        provider.checkpoint_revert(checkpoint);
+
+        let simulated_refunds = refunds_after_simulation - refunds_before_simulation;
+        provider.refund_gas(-simulated_refunds);
+
+        assert!(gas_after_simulation > gas_before_simulation);
+        assert_eq!(
+            state_gas_after_simulation - state_gas_before_simulation,
+            230_000
+        );
+        assert_eq!(reservoir_after_simulation, 0);
+        assert!(simulated_refunds > 0);
+        assert_eq!(provider.gas_used(), gas_after_simulation);
+        assert_eq!(provider.state_gas_used(), state_gas_after_simulation);
+        assert_eq!(provider.reservoir(), reservoir_after_simulation);
+        assert_eq!(provider.gas_refunded(), refunds_before_simulation);
+        assert_eq!(provider.sload(address, existing_key)?, U256::from(7));
+        assert_eq!(provider.sload(address, new_key)?, U256::ZERO);
+        Ok(())
+    }
+
+    #[test]
     fn test_set_code() -> eyre::Result<()> {
         let mut evm = TestEvm::default();
         let mut provider = evm.provider_max_gas();

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -104,6 +104,12 @@ impl HashMapStorageProvider {
         self.gas_params = GasParams::new_spec(self.spec.into());
         self
     }
+
+    /// Returns self with the static-call flag overridden (builder pattern).
+    pub fn with_static(mut self, is_static: bool) -> Self {
+        self.is_static = is_static;
+        self
+    }
 }
 
 impl PrecompileStorageProvider for HashMapStorageProvider {


### PR DESCRIPTION
Implements the quote-execution portion of #6700 by running the existing fill path inside per-book checkpoints at T11 while sharing route loops with the legacy quote path.

The storage-action trace retains simulated accesses and appends `CheckpointRevert`, so prewarming discards the replay target; state, logs, transient storage, and speculative refunds revert while gas charges remain. At T11, tick storage also stops maintaining the legacy aggregate-liquidity slot and `getTickLevel` derives liquidity from live orders.