### PR TITLE
chore(release): bump workspace version to v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13286,7 +13286,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13449,7 +13449,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13518,7 +13518,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13548,7 +13548,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13562,7 +13562,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13614,7 +13614,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13666,7 +13666,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13685,7 +13685,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "eyre",
  "indenter",
@@ -13693,7 +13693,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13718,7 +13718,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13796,7 +13796,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13834,7 +13834,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13854,7 +13854,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13890,7 +13890,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13939,7 +13939,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13972,7 +13972,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "clap",
@@ -13997,7 +13997,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "eyre",
  "jiff",
@@ -14006,7 +14006,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14049,7 +14049,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14061,7 +14061,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.13.1"
+version = "0.2.1"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.13.1"
+version = "0.2.1"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Sets the workspace package version to v0.2.1 and refreshes the lockfile entries.

Prompted by: @grandizzy