### PR TITLE
feat(consensus): make equal timestamps configurable

### DIFF
--- a/crates/evm/src/consensus/mod.rs
+++ b/crates/evm/src/consensus/mod.rs
@@ -38,6 +38,8 @@ pub const TEMPO_MAXIMUM_EXTRA_DATA_SIZE: usize = 10 * 1_024; // 10KiB
 pub struct TempoConsensus<C = TempoChainSpec> {
     /// Inner Ethereum consensus.
     inner: EthBeaconConsensus<C>,
+    /// Whether child headers may use the same millisecond timestamp as their parent.
+    allow_equal_timestamps: bool,
 }
 
 impl<C> TempoConsensus<C>
@@ -55,7 +57,16 @@ where
             inner: EthBeaconConsensus::new(chain_spec)
                 .with_max_extra_data_size(TEMPO_MAXIMUM_EXTRA_DATA_SIZE)
                 .with_allow_bal_hashes(allow_bal_hashes),
+            allow_equal_timestamps: false,
         }
+    }
+
+    /// Configures whether child headers may use the same millisecond timestamp as their parent.
+    ///
+    /// Equal timestamps are rejected by default. Timestamp regressions are always rejected.
+    pub fn with_allow_equal_timestamps(mut self, allow_equal_timestamps: bool) -> Self {
+        self.allow_equal_timestamps = allow_equal_timestamps;
+        self
     }
 
     /// Validates the given header against common consensus rules and the given millisecond timestamp.
@@ -147,10 +158,18 @@ where
             validate_against_parent_4844(header.header(), parent.header(), blob_params)?;
         }
 
-        if header.timestamp_millis() <= parent.timestamp_millis() {
+        let timestamp = header.timestamp_millis();
+        let parent_timestamp = parent.timestamp_millis();
+        let timestamp_is_invalid = if self.allow_equal_timestamps {
+            timestamp < parent_timestamp
+        } else {
+            timestamp <= parent_timestamp
+        };
+
+        if timestamp_is_invalid {
             return Err(ConsensusError::TimestampIsInPast {
-                parent_timestamp: parent.timestamp_millis(),
-                timestamp: header.timestamp_millis(),
+                parent_timestamp,
+                timestamp,
             });
         }
 
@@ -720,10 +739,48 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_header_against_parent_equal_timestamp_is_configurable() {
+        use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
+
+        let parent_ts = TempoHardfork::T6.moderato_activation_timestamp().unwrap();
+        let parent = TestHeaderBuilder::default()
+            .gas_limit(30_000_000)
+            .timestamp(parent_ts)
+            .number(1)
+            .timestamp_millis_part(500)
+            .base_fee(TEMPO_T1_BASE_FEE)
+            .build();
+        let parent_sealed = SealedHeader::seal_slow(parent);
+
+        let child = TestHeaderBuilder::default()
+            .gas_limit(30_000_000)
+            .timestamp(parent_ts)
+            .timestamp_millis_part(500)
+            .number(2)
+            .base_fee(TEMPO_T1_BASE_FEE)
+            .parent_hash(parent_sealed.hash())
+            .build();
+        let child_sealed = SealedHeader::seal_slow(child);
+
+        let strict_consensus = TempoConsensus::new(MODERATO.clone());
+        let result = strict_consensus.validate_header_against_parent(&child_sealed, &parent_sealed);
+        assert!(matches!(
+            result,
+            Err(ConsensusError::TimestampIsInPast { .. })
+        ));
+
+        let permissive_consensus =
+            TempoConsensus::new(MODERATO.clone()).with_allow_equal_timestamps(true);
+        let result =
+            permissive_consensus.validate_header_against_parent(&child_sealed, &parent_sealed);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_validate_header_against_parent_timestamp_not_increasing() {
         use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 
-        let consensus = TempoConsensus::new(MODERATO.clone());
+        let consensus = TempoConsensus::new(MODERATO.clone()).with_allow_equal_timestamps(true);
         let parent_ts = TempoHardfork::T6.moderato_activation_timestamp().unwrap();
         let parent = TestHeaderBuilder::default()
             .gas_limit(30_000_000)


### PR DESCRIPTION
Adds an opt-in `TempoConsensus::with_allow_equal_timestamps` configuration so consumers can accept nondecreasing millisecond timestamps while Tempo remains strict by default. Timestamp regressions remain invalid in either mode, allowing Zones to replace catch-up pacing without changing Tempo defaults.

Related: https://github.com/tempoxyz/zones/pull/1302