### PR TITLE
Fix hardcoded RPC credentials in fee-amm test script

### DIFF
--- a/scripts/fee-amm-predeployed.sh
+++ b/scripts/fee-amm-predeployed.sh
@@ -5,7 +5,9 @@
 
 set -e
 
-ETH_RPC_URL="https://eng:zealous-mayer@rpc-adagietto.tempoxyz.dev"
+if [ -z "$ETH_RPC_URL" ]; then
+  export ETH_RPC_URL="http://localhost:8545"
+fi
 
 echo "Testing fee-amm with predeployed tokens..."
 


### PR DESCRIPTION
## Summary

Fix `ETH_RPC_URL` handling in `scripts/fee-amm-predeployed.sh`.

[The script documented](https://github.com/tempoxyz/tempo/blob/main/scripts/fee-amm-predeployed.sh#L3) that it uses an existing `ETH_RPC_URL` or defaults to `localhost:8545`, but the previous implementation unconditionally overwrote the variable with a remote RPC URL containing credentials.

The fix:

* preserves an existing `ETH_RPC_URL`;
* defaults to `http://localhost:8545` when it is not set;
* removes the hardcoded RPC credentials from the script.

No other script behavior was changed.