### PR TITLE
fix(ci): remove obsolete partial persistence image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -124,19 +124,6 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=pr
 
-      - name: Docker metadata for tempo partial persistence
-        id: meta-tempo-partial-persistence
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.nightly == 'true' }}
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
-        with:
-          images: |
-            ${{ env.REGISTRY }}/tempo
-            docker.io/tempoxyz/tempo
-          bake-target: tempo-partial-persistence
-          labels: ${{ steps.docker-labels.outputs.value }}
-          tags: |
-            type=raw,value=nightly-partial-persistence
-
       - name: Docker metadata for tempo-xtask
         id: meta-tempo-xtask
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
@@ -184,7 +171,6 @@ jobs:
             ${{ steps.meta-tempo-localnet.outputs.bake-file }}
             ${{ steps.meta-tempo-sidecar.outputs.bake-file }}
             ${{ steps.meta-tempo-xtask.outputs.bake-file }}
-            ${{ steps.meta-tempo-partial-persistence.outputs.bake-file }}
           targets: ${{ (github.event_name == 'schedule' || github.event.inputs.nightly == 'true') && 'nightly' || 'default' }}
           project: 0c6tg19qsp
           push: true
@@ -205,7 +191,6 @@ jobs:
           TEMPO_LOCALNET_TAGS: ${{ steps.meta-tempo-localnet.outputs.tags }}
           TEMPO_SIDECAR_TAGS: ${{ steps.meta-tempo-sidecar.outputs.tags }}
           TEMPO_XTASK_TAGS: ${{ steps.meta-tempo-xtask.outputs.tags }}
-          TEMPO_PARTIAL_PERSISTENCE_TAGS: ${{ steps.meta-tempo-partial-persistence.outputs.tags }}
         run: |
           set -euo pipefail
           sign_image() {
@@ -233,7 +218,6 @@ jobs:
             "$TEMPO_LOCALNET_TAGS"
             "$TEMPO_SIDECAR_TAGS"
             "$TEMPO_XTASK_TAGS"
-            "$TEMPO_PARTIAL_PERSISTENCE_TAGS"
           )
           sign_failures=0
           for tags in "${images[@]}"; do
@@ -331,7 +315,6 @@ jobs:
           TEMPO_LOCALNET_TAGS: ${{ steps.meta-tempo-localnet.outputs.tags }}
           TEMPO_SIDECAR_TAGS: ${{ steps.meta-tempo-sidecar.outputs.tags }}
           TEMPO_XTASK_TAGS: ${{ steps.meta-tempo-xtask.outputs.tags }}
-          TEMPO_PARTIAL_PERSISTENCE_TAGS: ${{ steps.meta-tempo-partial-persistence.outputs.tags }}
           SHORT_SHA: ${{ steps.shortsha.outputs.shortsha }}
           BUILD_OUTCOME: ${{ steps.build-and-push.outcome }}
           SIGN_OUTCOME: ${{ steps.sign-images.outcome }}
@@ -401,7 +384,6 @@ jobs:
           summarize_image "tempo-localnet" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo-localnet" "$TEMPO_LOCALNET_TAGS" "tempo-localnet"
           summarize_image "tempo-sidecar" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo-sidecar" "$TEMPO_SIDECAR_TAGS" "tempo-sidecar"
           summarize_image "tempo-xtask" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo-xtask" "$TEMPO_XTASK_TAGS" "tempo-xtask"
-          summarize_image "tempo partial persistence" "${{ github.server_url }}/orgs/tempoxyz/packages/container/package/tempo" "$TEMPO_PARTIAL_PERSISTENCE_TAGS" "tempo-partial-persistence"
 
           {
             echo

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,7 +11,7 @@ group "default" {
 }
 
 group "nightly" {
-  targets = ["tempo", "tempo-localnet", "tempo-sidecar", "tempo-xtask", "tempo-partial-persistence"]
+  targets = ["tempo", "tempo-localnet", "tempo-sidecar", "tempo-xtask"]
 }
 
 target "docker-metadata" {}
@@ -51,14 +51,6 @@ target "tempo" {
 target "tempo-localnet" {
   inherits = ["_common", "docker-metadata"]
   target = "tempo-localnet"
-}
-
-target "tempo-partial-persistence" {
-  inherits = ["_common", "docker-metadata"]
-  target = "tempo"
-  args = {
-    RUST_FEATURES = "asm-keccak,jemalloc,otlp,partial-persistence"
-  }
 }
 
 target "tempo-sidecar" {


### PR DESCRIPTION
## Summary

- remove the obsolete partial-persistence target from the nightly Docker bake
- remove its metadata, signing, and job-summary wiring
- keep the remaining nightly images unchanged

## Context

The partial-persistence Cargo feature was removed in #7314, but the nightly workflow still requested it. This caused [Docker Build run 33085063056](https://github.com/tempoxyz/tempo/actions/runs/33085063056) to fail before publishing the new nightly image.

## Validation

- parsed `.github/workflows/docker.yml` as YAML
- parsed `docker-bake.hcl` and verified the nightly targets
- confirmed no remaining partial-persistence image references in Tempo repositories
- `git diff --check`

Prompted by: @shekhirin
