### PR TITLE
docs(tip-1061): add CREATE2 recovery derivation

### DIFF
--- a/.changelog/native-multisig.md
+++ b/.changelog/native-multisig.md
@@ -8,4 +8,4 @@ tempo-revm: minor
 tempo-node: minor
 ---
 
-Activates counterfactual native multisig accounts at T12, including a new multisig precompile, signature-carried configuration witnesses, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Owner updates persist one configuration commitment slot.
+Activates counterfactual native multisig accounts at T12, including a new multisig precompile, signature-carried configuration witnesses, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Initial account identity uses a canonical CREATE2 recovery address, while owner updates persist one configuration commitment slot.

--- a/.changelog/native-multisig.md
+++ b/.changelog/native-multisig.md
@@ -8,4 +8,4 @@ tempo-revm: minor
 tempo-node: minor
 ---
 
-Activates counterfactual native multisig accounts at T12, including a new multisig precompile, signature-carried configuration witnesses, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Initial account identity uses a canonical CREATE2 recovery address, while owner updates persist one configuration commitment slot.
+Activates counterfactual native multisig accounts at T12, including a new multisig precompile, signature-carried configuration witnesses, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Initial account identity uses a dedicated cross-chain CREATE2 recovery factory that is reserved on Tempo, while owner updates persist one configuration commitment slot.

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -9,6 +9,7 @@ on:
       - "Cargo.lock"
       - "Cargo.toml"
       - "crates/**/Cargo.toml"
+      - "tips/tip-1061.md"
       - "tips/verify/**"
       - "crates/contracts/**"
       - "crates/precompiles/**"
@@ -43,6 +44,7 @@ jobs:
         with:
           filters: |
             specs:
+              - 'tips/tip-1061.md'
               - 'tips/verify/**'
               - 'crates/contracts/**'
               - '!crates/contracts/CHANGELOG.md'

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -181,7 +181,10 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          version: nightly
+          version: nightly-423ac0d4080830fd2ec6ea52175b323a095973e9
+
+      - name: Verify TIP-1061 recovery artifacts
+        run: tips/verify/gen_recovery_init_code_hash.sh --check
 
       - name: Run Forge build
         working-directory: tips/verify

--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -160,7 +160,7 @@ macro_rules! tempo_hardfork {
 // -------------------------------------------------------------------------------------
 // Tempo hardfork definitions — append new variants here.
 // -------------------------------------------------------------------------------------
-tempo_hardfork! (
+tempo_hardfork!(
     /// Tempo-specific hardforks for network upgrades.
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     #[derive(Default)]

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -28,6 +28,7 @@ Today, these needs typically require a contract wallet or external account abstr
 - The existing Tempo transaction, key authorization, and sponsorship digests bind the fields documented by their respective TIPs. Multisig authorization inherits those digest guarantees and adds the account and configuration version bindings defined below.
 - Only the native multisig precompile can modify multisig configuration commitments.
 - Account keychain validation continues to enforce access-key expiry, scope, spending limits, and admin permissions. Multisig authorization does not weaken those restrictions.
+- Cross-chain recovery is an asset-recovery mechanism controlled by the initial owner configuration. It does not synchronize later Tempo configuration updates or make the address a general-purpose multisig identity on other chains.
 
 ## Threat Model
 
@@ -36,6 +37,7 @@ Today, these needs typically require a contract wallet or external account abstr
 - Nested multisig owners are untrusted authorization principals. Nesting depth, ordering, membership, cycle, and per-node threshold checks prevent them from bypassing the parent configuration.
 - Access keys and fee payers are untrusted delegates, not owners. Access keys remain subject to account keychain restrictions and cannot update the owner configuration; fee sponsorship grants no account authority.
 - Attackers may choose salts, owner sets, and primitive keys while searching for address collisions. Reserved namespace outputs are rejected. Finding an EOA key and multisig input with the same 160-bit address, with generic work of approximately 2^80, is outside this TIP's security scope.
+- Initial owners may later be removed or compromised. They permanently retain baseline recovery authority on non-Tempo chains, so applications MUST NOT treat the recovery wallet as proof of the account's current Tempo owners or allow it to stand in for current Tempo governance.
 - RPC simulators and transaction pools may use stale or incomplete configuration data. Their results are advisory; consensus validation MUST compare each witness with the commitment at the transaction's block position.
 
 ---
@@ -48,8 +50,16 @@ Today, these needs typically require a contract wallet or external account abstr
 /// Tempo signature type byte for multisig account signatures.
 pub const SIGNATURE_TYPE_MULTISIG: u8 = 0x05;
 
-/// Domain prefix for multisig account address derivation.
+/// Domain prefix for multisig account CREATE2 salt derivation.
 pub const MULTISIG_ACCOUNT_DOMAIN: &[u8] = b"tempo:multisig:account";
+
+/// Canonical CREATE2 factory for recovery wallets on non-Tempo EVM chains.
+pub const MULTISIG_RECOVERY_FACTORY: Address =
+    address!("0000000000FFe8B47B3e2130213B802212439497");
+
+/// Keccak-256 of the canonical recovery wallet creation code.
+pub const MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH: B256 =
+    b256!("656fd041814ae97ba0328872d17e7bde9b65e41ec63e6d88d66ae5af9b41dbb0");
 
 /// Domain prefix for multisig account owner signatures.
 pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
@@ -143,16 +153,27 @@ Rules:
 
 ## Account Identity
 
-The initial owner configuration and salt establish an account identity that remains stable across later owner changes. The salt lets identical owner configurations derive distinct accounts:
+The initial owner configuration and salt establish an account identity that remains stable across later owner changes. First, hash that identity into a CREATE2 salt:
 
 ```text
-multisig_address = address(keccak256(
+account_salt = keccak256(
   "tempo:multisig:account" ||
   salt ||
   uint8(threshold) ||
   uint8(owners.len()) ||
   owners[0].owner || uint8(owners[0].weight) ||
   ...
+)
+```
+
+Then derive the account with the canonical recovery factory and wallet creation code:
+
+```text
+multisig_address = address(keccak256(
+  0xff ||
+  MULTISIG_RECOVERY_FACTORY ||
+  account_salt ||
+  MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH
 )[12:32])
 ```
 
@@ -172,7 +193,9 @@ config_commitment = keccak256(
 
 Rules:
 
-- Derivation MUST use the formula exactly: ASCII domain, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
+- `account_salt` MUST use the formula exactly: ASCII domain, raw 32-byte salt, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
+- Account derivation MUST use the EIP-1014 CREATE2 formula exactly, with the canonical recovery factory, `account_salt`, and recovery wallet init-code hash above.
+- The same version-0 configuration MUST derive the same account on every Tempo chain and every EVM chain with the canonical factory and recovery wallet.
 - Configuration commitments MUST use the formula exactly: ASCII domain, raw 32-byte salt, eight-byte big-endian version, one-byte integers, raw concatenation, and no chain ID, RLP, or ABI encoding.
 - The derived address MUST be nonzero and outside virtual, active-precompile, TIP-20, and ZonePortal namespaces.
 - Configuration updates MUST preserve the salt and replace the current threshold and owners without changing the account address.
@@ -316,6 +339,27 @@ Rules:
 - Address derivation MUST return `InvalidAccount` when the derived address is zero or reserved.
 - `updateConfig` MUST return `UnauthorizedMultisigCaller` for an indirect call, `msg.sender != tx.origin`, a nonzero keychain transaction key, or a transaction not directly authorized by the applicable initial or current owner quorum.
 
+## Cross-chain Recovery
+
+The CREATE2 derivation lets the initial owners materialize a recovery wallet at the multisig account address on another EVM chain. Tempo does not deploy EVM bytecode at the account and does not depend on the recovery contracts for transaction validation.
+
+The canonical recovery artifacts are `TempoMultisigRecoveryFactory` and `TempoMultisigRecoveryWallet` in `tips/verify/src/TempoMultisigRecovery.sol`. Their build MUST use Solidity 0.8.34, optimizer enabled with 200 runs, via-IR enabled, Cancun EVM version, and no compiler metadata (`bytecode_hash = "none"`, `cbor_metadata = false`). The resulting recovery wallet creation-code hash MUST equal `MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH`.
+
+Rules:
+
+- The canonical factory MUST be deployed at `MULTISIG_RECOVERY_FACTORY` at the identical address on each supported EVM chain. Deployment MUST be deterministic and MUST verify the factory runtime bytecode. If the factory is absent or different at that address, this TIP provides no recovery guarantee on that chain.
+- The factory MUST deploy the canonical wallet with `CREATE2`, using `account_salt`, and bind that salt to the wallet before the deployment transaction returns. The deployed wallet MUST equal `multisig_address`.
+- The wallet MUST accept initialization only from the factory that created it and exactly once.
+- Recovery MUST carry the initial configuration fields `(salt, threshold, owners)`; version is implicitly zero. The wallet MUST recompute `account_salt` and reject a configuration that does not match the salt bound at deployment.
+- Recovery signatures MUST commit to the recovery domain, destination chain ID, wallet address, `account_salt`, wallet nonce, and the complete requested transfer set.
+- The baseline wallet MUST accept only canonical secp256k1 signatures from the initial owners. P256, WebAuthn, and nested multisig recovery require chain-specific verifier support and are outside the baseline mechanism.
+- Recovery MUST enforce the initial configuration's owner ordering, weights, threshold, 48-owner limit, eight-signature limit, low-`s` secp256k1 form, and no-signatures-after-quorum rule.
+- Recovery execution MUST be limited to nonzero native-value transfers with empty calldata and calls carrying the standard ERC-20 `transfer`, ERC-721 `safeTransferFrom`, or ERC-1155 `safeTransferFrom` / `safeBatchTransferFrom` selectors. Approvals and other selectors MUST be rejected.
+- An ERC-20 `transfer` MUST return ABI-encoded `true`; a revert, malformed return, or `false` return MUST revert recovery.
+- Selector restriction bounds the wallet interface but cannot prove a target contract's semantics. Cross-chain applications MUST NOT treat a call from the recovery wallet as current Tempo authorization, governance authority, or a synchronized cross-chain identity.
+- Owner updates on Tempo MUST NOT change `account_salt`, `multisig_address`, or baseline recovery authority. Removed initial owners retain recovery authority, while replacement owners do not gain it; loss of the initial quorum makes baseline recovery unavailable.
+- A stronger recovery system MAY prove the current Tempo commitment through a checkpoint, oracle, or light client, but that system is outside this TIP and MUST use a distinct authorization domain.
+
 ## Account Keychain
 
 ### Access Keys on Multisig Accounts
@@ -390,7 +434,8 @@ keccak_cost(byte_len) =
   30 + 6 * ceil(byte_len / 32)
 
 account_derivation_hash_cost(config) =
-  keccak_cost(account_derivation_preimage(config).len())
+  keccak_cost(account_salt_preimage(config).len())
+  + keccak_cost(85)
 
 config_commitment_hash_cost(config) =
   keccak_cost(config_commitment_preimage(config).len())
@@ -463,6 +508,7 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 Rules:
 
 - Tooling MUST support the T12 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
+- Recovery tooling MUST verify the canonical factory runtime and wallet init-code hash before presenting a chain as supported.
 
 ## Observability
 
@@ -960,7 +1006,7 @@ Rules:
 
 Rules:
 
-- **Stable identity.** Initial authorization MUST satisfy `tx.from == multisig_address`. `updateConfig` MUST NOT change the address.
+- **Stable identity.** Initial authorization MUST satisfy `tx.from == multisig_address`, where `multisig_address` is the canonical CREATE2 recovery address. `updateConfig` MUST NOT change the address.
 - **Witness selection.** A zero commitment MUST accept only the derived initial witness; a nonzero commitment MUST accept only a matching current witness.
 - **Configuration validity.** Configurations MUST satisfy all owner, weight, total-weight, and threshold limits above, and MUST NOT include their own account as an owner.
 - **Single-slot state.** Multisig configuration storage MUST contain only the current commitment and MUST NOT persist owner rows.
@@ -977,3 +1023,5 @@ Rules:
 - **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
 - **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
 - **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.
+- **Recovery binding.** A canonical recovery wallet MUST deploy at `multisig_address` and accept only an initial configuration that re-derives its bound `account_salt`.
+- **Recovery authority.** Baseline cross-chain recovery MUST remain bound to the initial owner configuration and MUST NOT be represented as current Tempo authorization after an owner update.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -53,13 +53,32 @@ pub const SIGNATURE_TYPE_MULTISIG: u8 = 0x05;
 /// Domain prefix for multisig account CREATE2 salt derivation.
 pub const MULTISIG_ACCOUNT_DOMAIN: &[u8] = b"tempo:multisig:account";
 
-/// Canonical CREATE2 factory for recovery wallets on non-Tempo EVM chains.
+/// Safe Singleton Factory used only to deploy the dedicated recovery factory.
+pub const MULTISIG_RECOVERY_SINGLETON_FACTORY: Address =
+    address!("914d7Fec6aaC8cd542e72Bca78B30650d45643d7");
+
+/// Expected runtime-code hash of the Safe Singleton Factory.
+pub const MULTISIG_RECOVERY_SINGLETON_FACTORY_RUNTIME_HASH: B256 =
+    b256!("2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989");
+
+/// Permissionless salt used to deploy the dedicated factory through the bootstrap factory.
+pub const MULTISIG_RECOVERY_FACTORY_DEPLOYMENT_SALT: B256 = B256::ZERO;
+
+/// Dedicated CREATE2 factory for recovery wallets on non-Tempo EVM chains.
 pub const MULTISIG_RECOVERY_FACTORY: Address =
-    address!("0000000000FFe8B47B3e2130213B802212439497");
+    address!("08919882768F959FCFd64aD86097368f76BC9808");
+
+/// Keccak-256 of the dedicated recovery factory creation code.
+pub const MULTISIG_RECOVERY_FACTORY_INIT_CODE_HASH: B256 =
+    b256!("595a7ee10fa3bf56214edcd947fd963571fccbfe80f013d4739c93b2c9ea287c");
+
+/// Keccak-256 of the dedicated recovery factory runtime code.
+pub const MULTISIG_RECOVERY_FACTORY_RUNTIME_HASH: B256 =
+    b256!("a44ed7004678d01a23f6a04f77d453f0fc6e2e8bc51af79f7d32193f30215f46");
 
 /// Keccak-256 of the canonical recovery wallet creation code.
 pub const MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH: B256 =
-    b256!("656fd041814ae97ba0328872d17e7bde9b65e41ec63e6d88d66ae5af9b41dbb0");
+    b256!("5bda203056c9735495be335da97e26667ba119894dd0d447587c1378ed897c4c");
 
 /// Domain prefix for multisig account owner signatures.
 pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
@@ -343,19 +362,23 @@ Rules:
 
 The CREATE2 derivation lets the initial owners materialize a recovery wallet at the multisig account address on another EVM chain. Tempo does not deploy EVM bytecode at the account and does not depend on the recovery contracts for transaction validation.
 
-The canonical recovery artifacts are `TempoMultisigRecoveryFactory` and `TempoMultisigRecoveryWallet` in `tips/verify/src/TempoMultisigRecovery.sol`. Their build MUST use Solidity 0.8.34, optimizer enabled with 200 runs, via-IR enabled, Cancun EVM version, and no compiler metadata (`bytecode_hash = "none"`, `cbor_metadata = false`). The resulting recovery wallet creation-code hash MUST equal `MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH`.
+The canonical recovery artifacts are `TempoMultisigRecoveryFactory` and `TempoMultisigRecoveryWallet` in `tips/verify/src/TempoMultisigRecovery.sol`. Their build MUST use Solidity 0.8.34, optimizer enabled with 200 runs, via-IR enabled, Paris EVM version, and no compiler metadata (`bytecode_hash = "none"`, `cbor_metadata = false`). Paris bytecode avoids requiring PUSH0, MCOPY, or another post-Paris opcode on a recovery chain. The build and hash check MUST use Foundry commit `423ac0d4080830fd2ec6ea52175b323a095973e9`. The resulting hashes MUST equal the factory and wallet constants above.
 
 Rules:
 
-- The canonical factory MUST be deployed at `MULTISIG_RECOVERY_FACTORY` at the identical address on each supported EVM chain. Deployment MUST be deterministic and MUST verify the factory runtime bytecode. If the factory is absent or different at that address, this TIP provides no recovery guarantee on that chain.
+- On a supported non-Tempo EVM chain, tooling MUST first verify that `MULTISIG_RECOVERY_SINGLETON_FACTORY` contains code with hash `MULTISIG_RECOVERY_SINGLETON_FACTORY_RUNTIME_HASH`. This is Safe's Singleton Factory; it is the deterministic deployer, not the recovery factory.
+- The dedicated recovery factory MUST be deployed by sending `MULTISIG_RECOVERY_FACTORY_DEPLOYMENT_SALT || TempoMultisigRecoveryFactory.creationCode` as raw calldata to the Safe Singleton Factory. Its EIP-1014 address MUST equal `MULTISIG_RECOVERY_FACTORY`, and its runtime-code hash MUST equal `MULTISIG_RECOVERY_FACTORY_RUNTIME_HASH`. A missing singleton or dedicated factory, or any hash mismatch, means this TIP provides no recovery guarantee on that chain.
+- On every Tempo chain, the T12 state transition MUST reserve `MULTISIG_RECOVERY_FACTORY` with the one-byte `0xEF` marker and a nonce of at least one before native multisig authorization is accepted. The transition MUST replace any code already present at that address while preserving its balance, storage, and any higher nonce. The canonical recovery-factory runtime MUST NOT be installed on Tempo. The Safe Singleton Factory MAY remain available for unrelated deployments.
 - The factory MUST deploy the canonical wallet with `CREATE2`, using `account_salt`, and bind that salt to the wallet before the deployment transaction returns. The deployed wallet MUST equal `multisig_address`.
 - The wallet MUST accept initialization only from the factory that created it and exactly once.
 - Recovery MUST carry the initial configuration fields `(salt, threshold, owners)`; version is implicitly zero. The wallet MUST recompute `account_salt` and reject a configuration that does not match the salt bound at deployment.
 - Recovery signatures MUST commit to the recovery domain, destination chain ID, wallet address, `account_salt`, wallet nonce, and the complete requested transfer set.
-- The baseline wallet MUST accept only canonical secp256k1 signatures from the initial owners. P256, WebAuthn, and nested multisig recovery require chain-specific verifier support and are outside the baseline mechanism.
+- The baseline wallet MUST accept only canonical secp256k1 signatures from direct initial owners. P256, WebAuthn, and nested multisig owners contribute no baseline recovery weight; configurations that cannot reach threshold without them intentionally have no baseline cross-chain recovery. Tooling MUST calculate and disclose whether direct secp256k1 owners can reach the threshold and MUST NOT present baseline recovery as available otherwise.
 - Recovery MUST enforce the initial configuration's owner ordering, weights, threshold, 48-owner limit, eight-signature limit, low-`s` secp256k1 form, and no-signatures-after-quorum rule.
-- Recovery execution MUST be limited to nonzero native-value transfers with empty calldata and calls carrying the standard ERC-20 `transfer`, ERC-721 `safeTransferFrom`, or ERC-1155 `safeTransferFrom` / `safeBatchTransferFrom` selectors. Approvals and other selectors MUST be rejected.
-- An ERC-20 `transfer` MUST return ABI-encoded `true`; a revert, malformed return, or `false` return MUST revert recovery.
+- Recovery execution MUST be limited to nonzero native-value transfers with empty calldata and calls carrying the standard ERC-20 `transfer`, ERC-721 `transferFrom` / `safeTransferFrom`, or ERC-1155 `safeTransferFrom` / `safeBatchTransferFrom` selectors. Token calls MUST target deployed code. Approvals and other selectors MUST be rejected.
+- Every NFT call MUST be valid canonical ABI for its selector, MUST name the recovery wallet as `from`, and MUST reject mismatched ERC-1155 ID and amount array lengths. This prevents an initial quorum from using a third party's operator approval through the recovery wallet.
+- An ERC-20 `transfer` MAY return no data or exactly ABI-encoded `true`; a revert, malformed return, or `false` return MUST revert recovery.
+- The deployed wallet MUST implement ERC-165 and the ERC-721 and ERC-1155 receiver callbacks so safe transfers and mints to the materialized recovery address succeed.
 - Selector restriction bounds the wallet interface but cannot prove a target contract's semantics. Cross-chain applications MUST NOT treat a call from the recovery wallet as current Tempo authorization, governance authority, or a synchronized cross-chain identity.
 - Owner updates on Tempo MUST NOT change `account_salt`, `multisig_address`, or baseline recovery authority. Removed initial owners retain recovery authority, while replacement owners do not gain it; loss of the initial quorum makes baseline recovery unavailable.
 - A stronger recovery system MAY prove the current Tempo commitment through a checkpoint, oracle, or light client, but that system is outside this TIP and MUST use a distinct authorization domain.
@@ -508,7 +531,7 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 Rules:
 
 - Tooling MUST support the T12 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
-- Recovery tooling MUST verify the canonical factory runtime and wallet init-code hash before presenting a chain as supported.
+- Recovery tooling MUST verify the Safe Singleton Factory runtime, dedicated factory runtime, and wallet init-code hash before presenting a chain as supported, and MUST report whether the initial configuration has a direct secp256k1 recovery quorum.
 
 ## Observability
 

--- a/tips/verify/gen_recovery_init_code_hash.sh
+++ b/tips/verify/gen_recovery_init_code_hash.sh
@@ -95,22 +95,26 @@ printf 'factory_init_code_hash=%s\n' "$factory_init_code_hash"
 printf 'factory_runtime_hash=%s\n' "$factory_runtime_hash"
 printf 'wallet_init_code_hash=%s\n' "$wallet_init_code_hash"
 
+check_tip_constant() {
+  local name="$1"
+  local value="${2#0x}"
+  sed -n "/^pub const ${name}:/,/;$/p" "$repo/tips/tip-1061.md" | grep -Fqi "$value"
+}
+
 if [[ "${1:-}" == "--check" ]]; then
   [[ "$factory" == "$EXPECTED_FACTORY" ]]
   [[ "$factory_init_code_hash" == "$EXPECTED_FACTORY_INIT_CODE_HASH" ]]
   [[ "$factory_runtime_hash" == "$EXPECTED_FACTORY_RUNTIME_HASH" ]]
   [[ "$wallet_init_code_hash" == "$EXPECTED_WALLET_INIT_CODE_HASH" ]]
+  [[ "$FACTORY_DEPLOYMENT_SALT" == "0x$(printf '%064d' 0)" ]]
 
-  for value in \
-    "$SINGLETON_FACTORY" \
-    "$SINGLETON_FACTORY_RUNTIME_HASH" \
-    "$EXPECTED_FACTORY" \
-    "$EXPECTED_FACTORY_INIT_CODE_HASH" \
-    "$EXPECTED_FACTORY_RUNTIME_HASH" \
-    "$EXPECTED_WALLET_INIT_CODE_HASH"
-  do
-    grep -Fqi "${value#0x}" "$repo/tips/tip-1061.md"
-  done
+  check_tip_constant MULTISIG_RECOVERY_SINGLETON_FACTORY "$SINGLETON_FACTORY"
+  check_tip_constant MULTISIG_RECOVERY_SINGLETON_FACTORY_RUNTIME_HASH "$SINGLETON_FACTORY_RUNTIME_HASH"
+  check_tip_constant MULTISIG_RECOVERY_FACTORY_DEPLOYMENT_SALT B256::ZERO
+  check_tip_constant MULTISIG_RECOVERY_FACTORY "$EXPECTED_FACTORY"
+  check_tip_constant MULTISIG_RECOVERY_FACTORY_INIT_CODE_HASH "$EXPECTED_FACTORY_INIT_CODE_HASH"
+  check_tip_constant MULTISIG_RECOVERY_FACTORY_RUNTIME_HASH "$EXPECTED_FACTORY_RUNTIME_HASH"
+  check_tip_constant MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH "$EXPECTED_WALLET_INIT_CODE_HASH"
 elif [[ $# -ne 0 ]]; then
   printf 'usage: %s [--check]\n' "$0" >&2
   exit 2

--- a/tips/verify/gen_recovery_init_code_hash.sh
+++ b/tips/verify/gen_recovery_init_code_hash.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Regenerates MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH in tip-1061.md from the canonical
+# standard-EVM build of TempoMultisigRecoveryWallet. The recovery contracts must build under
+# standard Cancun (not the Tempo hardfork the rest of tips/verify uses), so this uses an isolated
+# Foundry config.
+#
+# Usage: tips/verify/gen_recovery_init_code_hash.sh
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/src"
+cp "$here/src/TempoMultisigRecovery.sol" "$tmp/src/"
+cat > "$tmp/foundry.toml" <<'TOML'
+[profile.default]
+solc = "0.8.34"
+evm_version = "cancun"
+optimizer = true
+optimizer_runs = 200
+via_ir = true
+bytecode_hash = "none"
+cbor_metadata = false
+TOML
+forge inspect --root "$tmp" src/TempoMultisigRecovery.sol:TempoMultisigRecoveryWallet bytecode \
+  | cast keccak

--- a/tips/verify/gen_recovery_init_code_hash.sh
+++ b/tips/verify/gen_recovery_init_code_hash.sh
@@ -1,25 +1,117 @@
 #!/usr/bin/env bash
-# Regenerates MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH in tip-1061.md from the canonical
-# standard-EVM build of TempoMultisigRecoveryWallet. The recovery contracts must build under
-# standard Cancun (not the Tempo hardfork the rest of tips/verify uses), so this uses an isolated
-# Foundry config.
+# Regenerates and optionally checks the canonical TIP-1061 cross-chain recovery artifacts.
 #
-# Usage: tips/verify/gen_recovery_init_code_hash.sh
+# Usage:
+#   tips/verify/gen_recovery_init_code_hash.sh
+#   tips/verify/gen_recovery_init_code_hash.sh --check
 set -euo pipefail
+
+readonly FOUNDRY_COMMIT="423ac0d4080830fd2ec6ea52175b323a095973e9"
+readonly SINGLETON_FACTORY="0x914d7fec6aac8cd542e72bca78b30650d45643d7"
+readonly SINGLETON_FACTORY_RUNTIME_HASH="0x2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989"
+readonly FACTORY_DEPLOYMENT_SALT="0x0000000000000000000000000000000000000000000000000000000000000000"
+readonly EXPECTED_FACTORY="0x08919882768f959fcfd64ad86097368f76bc9808"
+readonly EXPECTED_FACTORY_INIT_CODE_HASH="0x595a7ee10fa3bf56214edcd947fd963571fccbfe80f013d4739c93b2c9ea287c"
+readonly EXPECTED_FACTORY_RUNTIME_HASH="0xa44ed7004678d01a23f6a04f77d453f0fc6e2e8bc51af79f7d32193f30215f46"
+readonly EXPECTED_WALLET_INIT_CODE_HASH="0x5bda203056c9735495be335da97e26667ba119894dd0d447587c1378ed897c4c"
+
 here="$(cd "$(dirname "$0")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 mkdir -p "$tmp/src"
 cp "$here/src/TempoMultisigRecovery.sol" "$tmp/src/"
 cat > "$tmp/foundry.toml" <<'TOML'
 [profile.default]
+src = "src"
+out = "out"
 solc = "0.8.34"
-evm_version = "cancun"
+evm_version = "paris"
 optimizer = true
 optimizer_runs = 200
 via_ir = true
 bytecode_hash = "none"
 cbor_metadata = false
 TOML
-forge inspect --root "$tmp" src/TempoMultisigRecovery.sol:TempoMultisigRecoveryWallet bytecode \
-  | cast keccak
+
+# Keep canonical compilation independent of ambient Foundry profiles and overrides.
+task_path="$PATH"
+task_home="$HOME"
+run_forge() {
+  env -i HOME="$task_home" PATH="$task_path" FOUNDRY_DISABLE_NIGHTLY_WARNING=1 forge "$@"
+}
+run_cast() {
+  env -i HOME="$task_home" PATH="$task_path" FOUNDRY_DISABLE_NIGHTLY_WARNING=1 cast "$@"
+}
+
+forge_version="$(run_forge --version)"
+if [[ "$forge_version" != *"$FOUNDRY_COMMIT"* ]]; then
+  printf 'error: canonical recovery artifacts require Foundry commit %s\n' "$FOUNDRY_COMMIT" >&2
+  printf '%s\n' "$forge_version" >&2
+  exit 1
+fi
+
+config="$(run_forge config --root "$tmp" --json)"
+jq -e '
+  .solc == "0.8.34" and
+  .evm_version == "paris" and
+  .optimizer == true and
+  .optimizer_runs == 200 and
+  .via_ir == true and
+  .bytecode_hash == "none" and
+  .cbor_metadata == false
+' >/dev/null <<<"$config"
+
+wallet_bytecode="$(
+  run_forge inspect --root "$tmp" \
+    src/TempoMultisigRecovery.sol:TempoMultisigRecoveryWallet bytecode
+)"
+factory_bytecode="$(
+  run_forge inspect --root "$tmp" \
+    src/TempoMultisigRecovery.sol:TempoMultisigRecoveryFactory bytecode
+)"
+factory_runtime="$(
+  run_forge inspect --root "$tmp" \
+    src/TempoMultisigRecovery.sol:TempoMultisigRecoveryFactory deployedBytecode
+)"
+
+wallet_init_code_hash="$(printf '%s' "$wallet_bytecode" | run_cast keccak)"
+factory_init_code_hash="$(printf '%s' "$factory_bytecode" | run_cast keccak)"
+factory_runtime_hash="$(printf '%s' "$factory_runtime" | run_cast keccak)"
+factory_digest="$(
+  printf '0xff%s%s%s' \
+    "${SINGLETON_FACTORY#0x}" \
+    "${FACTORY_DEPLOYMENT_SALT#0x}" \
+    "${factory_init_code_hash#0x}" \
+    | run_cast keccak
+)"
+factory="0x${factory_digest: -40}"
+
+printf 'singleton_factory=%s\n' "$SINGLETON_FACTORY"
+printf 'singleton_factory_runtime_hash=%s\n' "$SINGLETON_FACTORY_RUNTIME_HASH"
+printf 'factory_deployment_salt=%s\n' "$FACTORY_DEPLOYMENT_SALT"
+printf 'factory=%s\n' "$factory"
+printf 'factory_init_code_hash=%s\n' "$factory_init_code_hash"
+printf 'factory_runtime_hash=%s\n' "$factory_runtime_hash"
+printf 'wallet_init_code_hash=%s\n' "$wallet_init_code_hash"
+
+if [[ "${1:-}" == "--check" ]]; then
+  [[ "$factory" == "$EXPECTED_FACTORY" ]]
+  [[ "$factory_init_code_hash" == "$EXPECTED_FACTORY_INIT_CODE_HASH" ]]
+  [[ "$factory_runtime_hash" == "$EXPECTED_FACTORY_RUNTIME_HASH" ]]
+  [[ "$wallet_init_code_hash" == "$EXPECTED_WALLET_INIT_CODE_HASH" ]]
+
+  for value in \
+    "$SINGLETON_FACTORY" \
+    "$SINGLETON_FACTORY_RUNTIME_HASH" \
+    "$EXPECTED_FACTORY" \
+    "$EXPECTED_FACTORY_INIT_CODE_HASH" \
+    "$EXPECTED_FACTORY_RUNTIME_HASH" \
+    "$EXPECTED_WALLET_INIT_CODE_HASH"
+  do
+    grep -Fqi "${value#0x}" "$repo/tips/tip-1061.md"
+  done
+elif [[ $# -ne 0 ]]; then
+  printf 'usage: %s [--check]\n' "$0" >&2
+  exit 2
+fi

--- a/tips/verify/src/TempoMultisigRecovery.sol
+++ b/tips/verify/src/TempoMultisigRecovery.sol
@@ -73,6 +73,7 @@ contract TempoMultisigRecoveryWallet {
     // so a compromised or malicious initial owner set cannot use the cross-chain address for
     // governance, bridging, approvals, or any other arbitrary call — only asset recovery.
     bytes4 internal constant ERC20_TRANSFER = 0xa9059cbb; // transfer(address,uint256)
+    bytes4 internal constant ERC721_TRANSFER_FROM = 0x23b872dd; // transferFrom(a,a,u256)
     bytes4 internal constant ERC721_SAFE_TRANSFER_FROM = 0x42842e0e; // safeTransferFrom(a,a,u256)
     bytes4 internal constant ERC721_SAFE_TRANSFER_FROM_DATA = 0xb88d4fde; // safeTransferFrom(a,a,u,b)
     bytes4 internal constant ERC1155_SAFE_TRANSFER_FROM = 0xf242432a; // safeTransferFrom(a,a,u,u,b)
@@ -96,6 +97,57 @@ contract TempoMultisigRecoveryWallet {
         0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
 
     receive() external payable { }
+
+    /// @notice Accepts safe ERC-721 transfers and mints before and after recovery deployment.
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    )
+        external
+        pure
+        returns (bytes4)
+    {
+        return this.onERC721Received.selector;
+    }
+
+    /// @notice Accepts safe ERC-1155 single-token transfers and mints.
+    function onERC1155Received(
+        address,
+        address,
+        uint256,
+        uint256,
+        bytes calldata
+    )
+        external
+        pure
+        returns (bytes4)
+    {
+        return this.onERC1155Received.selector;
+    }
+
+    /// @notice Accepts safe ERC-1155 batch transfers and mints.
+    function onERC1155BatchReceived(
+        address,
+        address,
+        uint256[] calldata,
+        uint256[] calldata,
+        bytes calldata
+    )
+        external
+        pure
+        returns (bytes4)
+    {
+        return this.onERC1155BatchReceived.selector;
+    }
+
+    /// @notice Reports the receiver interfaces implemented by the recovery wallet.
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7 // ERC-165
+            || interfaceId == 0x150b7a02 // ERC-721 receiver
+            || interfaceId == 0x4e2312e0; // ERC-1155 receiver
+    }
 
     /// @notice Binds this wallet to the config committed to by `salt`. Callable once.
     /// @dev Permissionless but safe: only the factory can CREATE2 a wallet at this address, and it
@@ -143,11 +195,15 @@ contract TempoMultisigRecoveryWallet {
             if (!ok) {
                 revert CallFailed(i, returndata);
             }
-            if (
-                calls[i].data.length >= 4 && bytes4(calls[i].data[:4]) == ERC20_TRANSFER
-                    && (returndata.length != 32 || !abi.decode(returndata, (bool)))
-            ) {
-                revert CallFailed(i, returndata);
+            if (calls[i].data.length >= 4 && bytes4(calls[i].data[:4]) == ERC20_TRANSFER) {
+                // Match SafeERC20's optional-return convention: deployed token contracts may
+                // return no data, but an explicit result must be exactly ABI-encoded `true`.
+                if (
+                    returndata.length != 0
+                        && (returndata.length != 32 || !abi.decode(returndata, (bool)))
+                ) {
+                    revert CallFailed(i, returndata);
+                }
             }
         }
     }
@@ -156,17 +212,51 @@ contract TempoMultisigRecoveryWallet {
     /// @dev A data-carrying call must target a standard transfer selector and send no value; an
     /// empty-calldata call is a native-value sweep. Everything else (approvals, governance,
     /// bridging, arbitrary calls) is rejected.
-    function _isAllowedRecoveryCall(Call calldata call_) internal pure returns (bool) {
+    function _isAllowedRecoveryCall(Call calldata call_) internal view returns (bool) {
         if (call_.data.length == 0) {
             return call_.value != 0;
         }
-        if (call_.value != 0 || call_.data.length < 4) {
+        if (call_.value != 0 || call_.data.length < 4 || call_.target.code.length == 0) {
             return false;
         }
         bytes4 selector = bytes4(call_.data[:4]);
-        return selector == ERC20_TRANSFER || selector == ERC721_SAFE_TRANSFER_FROM
-            || selector == ERC721_SAFE_TRANSFER_FROM_DATA || selector == ERC1155_SAFE_TRANSFER_FROM
-            || selector == ERC1155_SAFE_BATCH_TRANSFER_FROM;
+        if (selector == ERC20_TRANSFER) {
+            return call_.data.length == 4 + 32 * 2;
+        }
+        if (selector == ERC721_TRANSFER_FROM || selector == ERC721_SAFE_TRANSFER_FROM) {
+            (address from, address to, uint256 tokenId) =
+                abi.decode(call_.data[4:], (address, address, uint256));
+            return from == address(this)
+                && keccak256(call_.data)
+                    == keccak256(abi.encodeWithSelector(selector, from, to, tokenId));
+        }
+        if (selector == ERC721_SAFE_TRANSFER_FROM_DATA) {
+            (address from, address to, uint256 tokenId, bytes memory data) =
+                abi.decode(call_.data[4:], (address, address, uint256, bytes));
+            return from == address(this)
+                && keccak256(call_.data)
+                    == keccak256(abi.encodeWithSelector(selector, from, to, tokenId, data));
+        }
+        if (selector == ERC1155_SAFE_TRANSFER_FROM) {
+            (address from, address to, uint256 id, uint256 amount, bytes memory data) =
+                abi.decode(call_.data[4:], (address, address, uint256, uint256, bytes));
+            return from == address(this)
+                && keccak256(call_.data)
+                    == keccak256(abi.encodeWithSelector(selector, from, to, id, amount, data));
+        }
+        if (selector == ERC1155_SAFE_BATCH_TRANSFER_FROM) {
+            (
+                address from,
+                address to,
+                uint256[] memory ids,
+                uint256[] memory amounts,
+                bytes memory data
+            ) = abi.decode(call_.data[4:], (address, address, uint256[], uint256[], bytes));
+            return from == address(this) && ids.length == amounts.length
+                && keccak256(call_.data)
+                    == keccak256(abi.encodeWithSelector(selector, from, to, ids, amounts, data));
+        }
+        return false;
     }
 
     function deriveAccountSalt(InitMultisig calldata init) public pure returns (bytes32) {

--- a/tips/verify/src/TempoMultisigRecovery.sol
+++ b/tips/verify/src/TempoMultisigRecovery.sol
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.34;
+
+/// @notice CREATE2 factory for native multisig recovery wallets on non-Tempo EVM chains.
+contract TempoMultisigRecoveryFactory {
+
+    error DeploymentFailed();
+
+    event RecoveryWalletDeployed(bytes32 indexed accountSalt, address indexed wallet);
+
+    bytes32 public constant WALLET_INIT_CODE_HASH =
+        keccak256(type(TempoMultisigRecoveryWallet).creationCode);
+
+    function walletAddress(bytes32 accountSalt) public view returns (address) {
+        bytes32 digest = keccak256(
+            abi.encodePacked(bytes1(0xff), address(this), accountSalt, WALLET_INIT_CODE_HASH)
+        );
+        return address(uint160(uint256(digest)));
+    }
+
+    function deploy(bytes32 accountSalt) public returns (address wallet) {
+        wallet = walletAddress(accountSalt);
+        if (wallet.code.length != 0) {
+            return wallet;
+        }
+
+        bytes memory creationCode = type(TempoMultisigRecoveryWallet).creationCode;
+        assembly {
+            wallet := create2(0, add(creationCode, 0x20), mload(creationCode), accountSalt)
+        }
+        if (wallet == address(0)) {
+            revert DeploymentFailed();
+        }
+        // Bind the freshly deployed wallet to the config committed to by `accountSalt`. Only this
+        // factory can CREATE2 a wallet at this address, and it always initializes in the same
+        // transaction, so `recover` can trust the stored salt as the wallet's true config.
+        TempoMultisigRecoveryWallet(payable(wallet)).initialize(accountSalt);
+        emit RecoveryWalletDeployed(accountSalt, wallet);
+    }
+
+}
+
+/// @notice Minimal recovery wallet for assets sent to a native multisig address on EVM chains.
+contract TempoMultisigRecoveryWallet {
+
+    struct Owner {
+        address owner;
+        uint8 weight;
+    }
+
+    struct InitMultisig {
+        bytes32 salt;
+        uint8 threshold;
+        Owner[] owners;
+    }
+
+    struct Call {
+        address target;
+        uint256 value;
+        bytes data;
+    }
+
+    error InvalidConfig();
+    error InvalidSignature();
+    error InvalidThreshold();
+    error InvalidOwner();
+    error UnauthorizedFactory();
+    error CallFailed(uint256 index, bytes returndata);
+    error AlreadyInitialized();
+    error UnsupportedCall(uint256 index);
+
+    // Standard token transfer selectors. Recovery is limited to these (plus native-value sweeps)
+    // so a compromised or malicious initial owner set cannot use the cross-chain address for
+    // governance, bridging, approvals, or any other arbitrary call — only asset recovery.
+    bytes4 internal constant ERC20_TRANSFER = 0xa9059cbb; // transfer(address,uint256)
+    bytes4 internal constant ERC721_SAFE_TRANSFER_FROM = 0x42842e0e; // safeTransferFrom(a,a,u256)
+    bytes4 internal constant ERC721_SAFE_TRANSFER_FROM_DATA = 0xb88d4fde; // safeTransferFrom(a,a,u,b)
+    bytes4 internal constant ERC1155_SAFE_TRANSFER_FROM = 0xf242432a; // safeTransferFrom(a,a,u,u,b)
+    bytes4 internal constant ERC1155_SAFE_BATCH_TRANSFER_FROM = 0x2eb2c2d6; // safeBatchTransferFrom
+
+    uint256 public nonce;
+
+    address private immutable FACTORY = msg.sender;
+
+    /// @notice CREATE2 salt committing to the immutable initial config this wallet recovers for.
+    /// @dev Set once by the factory in the same transaction as deployment. `recover` requires the
+    /// supplied config to re-derive this salt, so a caller cannot recover with an arbitrary config.
+    bytes32 public accountSalt;
+    bool private initialized;
+
+    bytes internal constant ACCOUNT_DOMAIN = "tempo:multisig:account";
+    bytes internal constant RECOVERY_DOMAIN = "tempo:multisig:recovery";
+    uint256 internal constant MAX_OWNERS = 48;
+    uint256 internal constant MAX_SIGNATURES = 8;
+    uint256 internal constant SECP256K1_HALF_ORDER =
+        0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
+    receive() external payable { }
+
+    /// @notice Binds this wallet to the config committed to by `salt`. Callable once.
+    /// @dev Permissionless but safe: only the factory can CREATE2 a wallet at this address, and it
+    /// always calls this in the same transaction as deployment, so the wallet is never observable
+    /// in a deployed-but-uninitialized state.
+    function initialize(bytes32 salt) external {
+        if (msg.sender != FACTORY) {
+            revert UnauthorizedFactory();
+        }
+        if (initialized) {
+            revert AlreadyInitialized();
+        }
+        accountSalt = salt;
+        initialized = true;
+    }
+
+    function recover(
+        InitMultisig calldata init,
+        bytes[] calldata signatures,
+        Call[] calldata calls
+    )
+        external
+        payable
+    {
+        if (!initialized) {
+            revert InvalidConfig();
+        }
+        // Bind the supplied config to the one this wallet was deployed for. Without this check any
+        // caller could pass their own owner set + signatures and drain the wallet.
+        if (deriveAccountSalt(init) != accountSalt) {
+            revert InvalidConfig();
+        }
+        bytes32 digest = recoveryDigest(accountSalt, calls);
+        verifyOwnerSignatures(init, digest, signatures);
+        unchecked {
+            ++nonce;
+        }
+
+        for (uint256 i = 0; i < calls.length; ++i) {
+            if (!_isAllowedRecoveryCall(calls[i])) {
+                revert UnsupportedCall(i);
+            }
+            (bool ok, bytes memory returndata) =
+                calls[i].target.call{ value: calls[i].value }(calls[i].data);
+            if (!ok) {
+                revert CallFailed(i, returndata);
+            }
+            if (
+                calls[i].data.length >= 4 && bytes4(calls[i].data[:4]) == ERC20_TRANSFER
+                    && (returndata.length != 32 || !abi.decode(returndata, (bool)))
+            ) {
+                revert CallFailed(i, returndata);
+            }
+        }
+    }
+
+    /// @notice Restricts recovery to native-value sweeps and standard ERC-20/721/1155 transfers.
+    /// @dev A data-carrying call must target a standard transfer selector and send no value; an
+    /// empty-calldata call is a native-value sweep. Everything else (approvals, governance,
+    /// bridging, arbitrary calls) is rejected.
+    function _isAllowedRecoveryCall(Call calldata call_) internal pure returns (bool) {
+        if (call_.data.length == 0) {
+            return call_.value != 0;
+        }
+        if (call_.value != 0 || call_.data.length < 4) {
+            return false;
+        }
+        bytes4 selector = bytes4(call_.data[:4]);
+        return selector == ERC20_TRANSFER || selector == ERC721_SAFE_TRANSFER_FROM
+            || selector == ERC721_SAFE_TRANSFER_FROM_DATA || selector == ERC1155_SAFE_TRANSFER_FROM
+            || selector == ERC1155_SAFE_BATCH_TRANSFER_FROM;
+    }
+
+    function deriveAccountSalt(InitMultisig calldata init) public pure returns (bytes32) {
+        validateConfig(init);
+
+        bytes memory input =
+            abi.encodePacked(ACCOUNT_DOMAIN, init.salt, init.threshold, uint8(init.owners.length));
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            input = abi.encodePacked(input, init.owners[i].owner, init.owners[i].weight);
+        }
+
+        return keccak256(input);
+    }
+
+    function recoveryDigest(
+        bytes32 boundAccountSalt,
+        Call[] calldata calls
+    )
+        public
+        view
+        returns (bytes32)
+    {
+        return keccak256(
+            abi.encodePacked(
+                RECOVERY_DOMAIN,
+                block.chainid,
+                address(this),
+                boundAccountSalt,
+                nonce,
+                hashCalls(calls)
+            )
+        );
+    }
+
+    function hashCalls(Call[] calldata calls) public pure returns (bytes32) {
+        bytes32[] memory callHashes = new bytes32[](calls.length);
+        for (uint256 i = 0; i < calls.length; ++i) {
+            callHashes[i] =
+                keccak256(abi.encode(calls[i].target, calls[i].value, keccak256(calls[i].data)));
+        }
+        return keccak256(abi.encodePacked(callHashes));
+    }
+
+    function validateConfig(InitMultisig calldata init) internal pure {
+        if (init.threshold == 0 || init.owners.length == 0 || init.owners.length > MAX_OWNERS) {
+            revert InvalidThreshold();
+        }
+
+        uint256 totalWeight;
+        address previousOwner;
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            Owner calldata owner = init.owners[i];
+            if (owner.owner == address(0) || owner.owner <= previousOwner || owner.weight == 0) {
+                revert InvalidOwner();
+            }
+            previousOwner = owner.owner;
+            totalWeight += owner.weight;
+        }
+        if (totalWeight > type(uint8).max || init.threshold > _maxReachableWeight(init.owners)) {
+            revert InvalidThreshold();
+        }
+    }
+
+    function _maxReachableWeight(Owner[] calldata owners) internal pure returns (uint256 total) {
+        uint8[MAX_SIGNATURES] memory highest;
+        for (uint256 i = 0; i < owners.length; ++i) {
+            uint8 weight = owners[i].weight;
+            for (uint256 j = 0; j < MAX_SIGNATURES; ++j) {
+                if (weight > highest[j]) {
+                    for (uint256 k = MAX_SIGNATURES - 1; k > j; --k) {
+                        highest[k] = highest[k - 1];
+                    }
+                    highest[j] = weight;
+                    break;
+                }
+            }
+        }
+        for (uint256 i = 0; i < MAX_SIGNATURES; ++i) {
+            total += highest[i];
+        }
+    }
+
+    function verifyOwnerSignatures(
+        InitMultisig calldata init,
+        bytes32 digest,
+        bytes[] calldata signatures
+    )
+        internal
+        pure
+    {
+        if (signatures.length == 0 || signatures.length > MAX_SIGNATURES) {
+            revert InvalidSignature();
+        }
+
+        uint256 recoveredWeight;
+        address previousSigner;
+        for (uint256 i = 0; i < signatures.length; ++i) {
+            address signer = recoverSigner(digest, signatures[i]);
+            if (signer <= previousSigner) {
+                revert InvalidSignature();
+            }
+            previousSigner = signer;
+
+            uint256 ownerIndex = findOwner(init.owners, signer);
+            recoveredWeight += init.owners[ownerIndex].weight;
+            if (recoveredWeight >= init.threshold && i + 1 != signatures.length) {
+                revert InvalidSignature();
+            }
+        }
+
+        if (recoveredWeight < init.threshold) {
+            revert InvalidThreshold();
+        }
+    }
+
+    function findOwner(Owner[] calldata owners, address signer) internal pure returns (uint256) {
+        for (uint256 i = 0; i < owners.length; ++i) {
+            if (owners[i].owner == signer) {
+                return i;
+            }
+        }
+        revert InvalidOwner();
+    }
+
+    function recoverSigner(
+        bytes32 digest,
+        bytes calldata signature
+    )
+        internal
+        pure
+        returns (address)
+    {
+        if (signature.length != 65) {
+            revert InvalidSignature();
+        }
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+        assembly {
+            r := calldataload(signature.offset)
+            s := calldataload(add(signature.offset, 0x20))
+            v := byte(0, calldataload(add(signature.offset, 0x40)))
+        }
+        if (v < 27) {
+            v += 27;
+        }
+        if ((v != 27 && v != 28) || uint256(s) > SECP256K1_HALF_ORDER) {
+            revert InvalidSignature();
+        }
+        address signer = ecrecover(digest, v, r, s);
+        if (signer == address(0)) {
+            revert InvalidSignature();
+        }
+        return signer;
+    }
+
+}

--- a/tips/verify/test/TempoMultisigRecovery.t.sol
+++ b/tips/verify/test/TempoMultisigRecovery.t.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.13 <0.9.0;
+
+import {
+    TempoMultisigRecoveryFactory,
+    TempoMultisigRecoveryWallet
+} from "../src/TempoMultisigRecovery.sol";
+import { Test } from "forge-std/Test.sol";
+
+contract TempoMultisigRecoveryTest is Test {
+
+    TempoMultisigRecoveryFactory factory;
+
+    uint256 ownerAKey = 0xA11CE;
+    uint256 ownerBKey = 0xB0B;
+    uint256 ownerCKey = 0xCA11;
+
+    function setUp() public {
+        factory = new TempoMultisigRecoveryFactory();
+    }
+
+    function testDeploysAtCreate2AddressAndSweepsPrefundedEth() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address predicted = factory.walletAddress(accountSalt);
+        address recipient = address(0xBEEF);
+
+        vm.deal(predicted, 1 ether);
+        assertEq(predicted.balance, 1 ether);
+
+        address deployed = factory.deploy(accountSalt);
+        assertEq(deployed, predicted);
+
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(deployed));
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({ target: recipient, value: 1 ether, data: "" });
+
+        bytes32 digest = wallet.recoveryDigest(accountSalt, calls);
+        bytes[] memory signatures = _sortedSignatures(ownerAKey, ownerBKey, digest);
+
+        wallet.recover(init, signatures, calls);
+
+        assertEq(recipient.balance, 1 ether);
+        assertEq(predicted.balance, 0);
+        assertEq(wallet.nonce(), 1);
+    }
+
+    function testRejectsBelowThresholdRecovery() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](0);
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = _sign(ownerAKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(TempoMultisigRecoveryWallet.InvalidThreshold.selector);
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testRejectsSignatureAfterQuorum() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        init.threshold = 1;
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](0);
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(TempoMultisigRecoveryWallet.InvalidSignature.selector);
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testRejectsZeroValueEmptyCalldataCall() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({ target: address(0xBEEF), value: 0, data: "" });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TempoMultisigRecoveryWallet.UnsupportedCall.selector, uint256(0))
+        );
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testRejectsInitializationByNonFactory() public {
+        TempoMultisigRecoveryWallet wallet = new TempoMultisigRecoveryWallet();
+
+        vm.prank(address(0xBAD));
+        vm.expectRevert(TempoMultisigRecoveryWallet.UnauthorizedFactory.selector);
+        wallet.initialize(bytes32("salt"));
+    }
+
+    function testRejectsRecoveryWithMismatchedConfig() public {
+        // Deploy the legitimate wallet (bound to `victim`'s config) and fund it.
+        TempoMultisigRecoveryWallet.InitMultisig memory victim = _initConfig();
+        bytes32 victimSalt = _deriveAccountSalt(victim);
+        address walletAddr = factory.deploy(victimSalt);
+        vm.deal(walletAddr, 1 ether);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+
+        // Attacker supplies their own single-owner config and signs the wallet's real digest.
+        uint256 attackerKey = 0xBAD;
+        TempoMultisigRecoveryWallet.InitMultisig memory attacker;
+        attacker.salt = bytes32("attacker");
+        attacker.threshold = 1;
+        attacker.owners = new TempoMultisigRecoveryWallet.Owner[](1);
+        attacker.owners[0] =
+            TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(attackerKey), weight: 1 });
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] =
+            TempoMultisigRecoveryWallet.Call({ target: address(0xBEEF), value: 1 ether, data: "" });
+
+        bytes[] memory signatures = new bytes[](1);
+        signatures[0] = _sign(attackerKey, wallet.recoveryDigest(wallet.accountSalt(), calls));
+
+        // The config does not re-derive this wallet's deployment salt, so recovery is rejected and
+        // the funds are untouched.
+        vm.expectRevert(TempoMultisigRecoveryWallet.InvalidConfig.selector);
+        wallet.recover(attacker, signatures, calls);
+        assertEq(walletAddr.balance, 1 ether);
+    }
+
+    function testRejectsNonTransferCall() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+
+        // A non-transfer call (here ERC-20 approve) is rejected even with a valid quorum, so a
+        // compromised owner set cannot use the cross-chain address for approvals, governance, or
+        // bridging — only asset transfers.
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(0xDEAD),
+            value: 0,
+            data: abi.encodeWithSignature("approve(address,uint256)", address(0xBEEF), 1)
+        });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TempoMultisigRecoveryWallet.UnsupportedCall.selector, uint256(0))
+        );
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testSweepsErc20ViaTransfer() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+
+        MockERC20 token = new MockERC20();
+        token.mint(walletAddr, 1000);
+        address recipient = address(0xBEEF);
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(token),
+            value: 0,
+            data: abi.encodeWithSignature("transfer(address,uint256)", recipient, 1000)
+        });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+        wallet.recover(init, signatures, calls);
+
+        assertEq(token.balanceOf(recipient), 1000);
+        assertEq(token.balanceOf(walletAddr), 0);
+    }
+
+    function testRejectsErc20FalseReturn() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+        MockFalseERC20 token = new MockFalseERC20();
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(token),
+            value: 0,
+            data: abi.encodeWithSignature("transfer(address,uint256)", address(0xBEEF), 1)
+        });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                TempoMultisigRecoveryWallet.CallFailed.selector, uint256(0), abi.encode(false)
+            )
+        );
+        wallet.recover(init, signatures, calls);
+    }
+
+    function _initConfig()
+        internal
+        view
+        returns (TempoMultisigRecoveryWallet.InitMultisig memory init)
+    {
+        init.salt = bytes32("native-multisig");
+        init.threshold = 2;
+        init.owners = new TempoMultisigRecoveryWallet.Owner[](3);
+        init.owners[0] = TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(ownerAKey), weight: 1 });
+        init.owners[1] = TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(ownerBKey), weight: 1 });
+        init.owners[2] = TempoMultisigRecoveryWallet.Owner({ owner: vm.addr(ownerCKey), weight: 1 });
+
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            for (uint256 j = i + 1; j < init.owners.length; ++j) {
+                if (init.owners[j].owner < init.owners[i].owner) {
+                    TempoMultisigRecoveryWallet.Owner memory owner = init.owners[i];
+                    init.owners[i] = init.owners[j];
+                    init.owners[j] = owner;
+                }
+            }
+        }
+
+        for (uint256 i = 1; i < init.owners.length; ++i) {
+            assertLt(uint160(init.owners[i - 1].owner), uint160(init.owners[i].owner));
+        }
+    }
+
+    function _deriveAccountSalt(TempoMultisigRecoveryWallet.InitMultisig memory init)
+        internal
+        pure
+        returns (bytes32)
+    {
+        bytes memory input = abi.encodePacked(
+            "tempo:multisig:account", init.salt, init.threshold, uint8(init.owners.length)
+        );
+        for (uint256 i = 0; i < init.owners.length; ++i) {
+            input = abi.encodePacked(input, init.owners[i].owner, init.owners[i].weight);
+        }
+        return keccak256(input);
+    }
+
+    function _sign(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory) {
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _sortedSignatures(
+        uint256 leftKey,
+        uint256 rightKey,
+        bytes32 digest
+    )
+        internal
+        pure
+        returns (bytes[] memory signatures)
+    {
+        signatures = new bytes[](2);
+        if (vm.addr(leftKey) < vm.addr(rightKey)) {
+            signatures[0] = _sign(leftKey, digest);
+            signatures[1] = _sign(rightKey, digest);
+        } else {
+            signatures[0] = _sign(rightKey, digest);
+            signatures[1] = _sign(leftKey, digest);
+        }
+    }
+
+}
+
+contract MockERC20 {
+
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+}
+
+contract MockFalseERC20 {
+
+    function transfer(address, uint256) external pure returns (bool) {
+        return false;
+    }
+
+}

--- a/tips/verify/test/TempoMultisigRecovery.t.sol
+++ b/tips/verify/test/TempoMultisigRecovery.t.sol
@@ -180,6 +180,202 @@ contract TempoMultisigRecoveryTest is Test {
         assertEq(token.balanceOf(walletAddr), 0);
     }
 
+    function testSweepsErc20WithNoReturnData() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+        MockNoReturnERC20 token = new MockNoReturnERC20();
+        token.mint(walletAddr, 1000);
+        address recipient = address(0xBEEF);
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(token),
+            value: 0,
+            data: abi.encodeWithSignature("transfer(address,uint256)", recipient, 1000)
+        });
+
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+        wallet.recover(init, signatures, calls);
+
+        assertEq(token.balanceOf(recipient), 1000);
+        assertEq(token.balanceOf(walletAddr), 0);
+    }
+
+    function testRejectsErc20TransferToNonContract() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(0xDEAD),
+            value: 0,
+            data: abi.encodeWithSignature("transfer(address,uint256)", address(0xBEEF), 1)
+        });
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TempoMultisigRecoveryWallet.UnsupportedCall.selector, uint256(0))
+        );
+        wallet.recover(init, signatures, calls);
+    }
+
+    function testAcceptsSafeNftMintsAndReportsReceiverInterfaces() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        address walletAddr = factory.deploy(_deriveAccountSalt(init));
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+        MockERC721 nft = new MockERC721();
+        MockERC1155 multiToken = new MockERC1155();
+
+        nft.safeMint(walletAddr, 1);
+        multiToken.safeMint(walletAddr, 2, 3, "");
+
+        assertEq(nft.ownerOf(1), walletAddr);
+        assertEq(multiToken.balanceOf(2, walletAddr), 3);
+        assertTrue(wallet.supportsInterface(0x01ffc9a7));
+        assertTrue(wallet.supportsInterface(0x150b7a02));
+        assertTrue(wallet.supportsInterface(0x4e2312e0));
+        assertFalse(wallet.supportsInterface(0xffffffff));
+    }
+
+    function testRejectsRecoveryTransferFromThirdParty() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+        MockERC721 nft = new MockERC721();
+        address victim = address(0xCAFE);
+        nft.mint(victim, 1);
+        vm.prank(victim);
+        nft.approve(walletAddr, 1);
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(nft),
+            value: 0,
+            data: abi.encodeWithSignature(
+                "transferFrom(address,address,uint256)", victim, address(0xBEEF), 1
+            )
+        });
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TempoMultisigRecoveryWallet.UnsupportedCall.selector, uint256(0))
+        );
+        wallet.recover(init, signatures, calls);
+        assertEq(nft.ownerOf(1), victim);
+    }
+
+    function testRejectsThirdPartyFromForEverySafeNftSelector() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        TempoMultisigRecoveryWallet wallet =
+            TempoMultisigRecoveryWallet(payable(factory.deploy(accountSalt)));
+        MockERC721 target = new MockERC721();
+        address victim = address(0xCAFE);
+        address recipient = address(0xBEEF);
+
+        _assertUnsupported(
+            wallet,
+            init,
+            accountSalt,
+            address(target),
+            abi.encodeWithSignature(
+                "safeTransferFrom(address,address,uint256)", victim, recipient, 1
+            )
+        );
+        _assertUnsupported(
+            wallet,
+            init,
+            accountSalt,
+            address(target),
+            abi.encodeWithSignature(
+                "safeTransferFrom(address,address,uint256,bytes)", victim, recipient, 1, bytes("x")
+            )
+        );
+        _assertUnsupported(
+            wallet,
+            init,
+            accountSalt,
+            address(target),
+            abi.encodeWithSignature(
+                "safeTransferFrom(address,address,uint256,uint256,bytes)",
+                victim,
+                recipient,
+                1,
+                2,
+                bytes("x")
+            )
+        );
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 1;
+        uint256[] memory amounts = new uint256[](1);
+        amounts[0] = 2;
+        _assertUnsupported(
+            wallet,
+            init,
+            accountSalt,
+            address(target),
+            abi.encodeWithSignature(
+                "safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)",
+                victim,
+                recipient,
+                ids,
+                amounts,
+                bytes("x")
+            )
+        );
+    }
+
+    function testSweepsOwnedErc721ViaTransferFrom() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+        MockERC721 nft = new MockERC721();
+        nft.mint(walletAddr, 1);
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(nft),
+            value: 0,
+            data: abi.encodeWithSignature(
+                "transferFrom(address,address,uint256)", walletAddr, address(0xBEEF), 1
+            )
+        });
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        wallet.recover(init, signatures, calls);
+        assertEq(nft.ownerOf(1), address(0xBEEF));
+    }
+
+    function testRejectsMalformedNftTransfer() public {
+        TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
+        bytes32 accountSalt = _deriveAccountSalt(init);
+        address walletAddr = factory.deploy(accountSalt);
+        TempoMultisigRecoveryWallet wallet = TempoMultisigRecoveryWallet(payable(walletAddr));
+        MockERC721 nft = new MockERC721();
+
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({
+            target: address(nft),
+            value: 0,
+            data: abi.encodePacked(bytes4(0x23b872dd), bytes32(uint256(uint160(walletAddr))))
+        });
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+
+        vm.expectRevert();
+        wallet.recover(init, signatures, calls);
+    }
+
     function testRejectsErc20FalseReturn() public {
         TempoMultisigRecoveryWallet.InitMultisig memory init = _initConfig();
         bytes32 accountSalt = _deriveAccountSalt(init);
@@ -246,6 +442,25 @@ contract TempoMultisigRecoveryTest is Test {
         return keccak256(input);
     }
 
+    function _assertUnsupported(
+        TempoMultisigRecoveryWallet wallet,
+        TempoMultisigRecoveryWallet.InitMultisig memory init,
+        bytes32 accountSalt,
+        address target,
+        bytes memory data
+    )
+        internal
+    {
+        TempoMultisigRecoveryWallet.Call[] memory calls = new TempoMultisigRecoveryWallet.Call[](1);
+        calls[0] = TempoMultisigRecoveryWallet.Call({ target: target, value: 0, data: data });
+        bytes[] memory signatures =
+            _sortedSignatures(ownerAKey, ownerBKey, wallet.recoveryDigest(accountSalt, calls));
+        vm.expectRevert(
+            abi.encodeWithSelector(TempoMultisigRecoveryWallet.UnsupportedCall.selector, uint256(0))
+        );
+        wallet.recover(init, signatures, calls);
+    }
+
     function _sign(uint256 privateKey, bytes32 digest) internal pure returns (bytes memory) {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         return abi.encodePacked(r, s, v);
@@ -292,6 +507,68 @@ contract MockFalseERC20 {
 
     function transfer(address, uint256) external pure returns (bool) {
         return false;
+    }
+
+}
+
+contract MockNoReturnERC20 {
+
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external {
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+    }
+
+}
+
+contract MockERC721 {
+
+    mapping(uint256 => address) public ownerOf;
+    mapping(uint256 => address) public getApproved;
+
+    function mint(address to, uint256 tokenId) external {
+        ownerOf[tokenId] = to;
+    }
+
+    function safeMint(address to, uint256 tokenId) external {
+        ownerOf[tokenId] = to;
+        if (to.code.length != 0) {
+            bytes4 result = TempoMultisigRecoveryWallet(payable(to))
+                .onERC721Received(msg.sender, address(0), tokenId, "");
+            require(result == TempoMultisigRecoveryWallet.onERC721Received.selector);
+        }
+    }
+
+    function approve(address spender, uint256 tokenId) external {
+        require(ownerOf[tokenId] == msg.sender);
+        getApproved[tokenId] = spender;
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) external {
+        require(ownerOf[tokenId] == from);
+        require(msg.sender == from || getApproved[tokenId] == msg.sender);
+        ownerOf[tokenId] = to;
+        delete getApproved[tokenId];
+    }
+
+}
+
+contract MockERC1155 {
+
+    mapping(uint256 => mapping(address => uint256)) public balanceOf;
+
+    function safeMint(address to, uint256 id, uint256 amount, bytes calldata data) external {
+        balanceOf[id][to] += amount;
+        if (to.code.length != 0) {
+            bytes4 result = TempoMultisigRecoveryWallet(payable(to))
+                .onERC1155Received(msg.sender, address(0), id, amount, data);
+            require(result == TempoMultisigRecoveryWallet.onERC1155Received.selector);
+        }
     }
 
 }


### PR DESCRIPTION
Reopens #6640 against #7242.

Anchors initial multisig identity to a canonical CREATE2 recovery wallet while preserving stateless versioned commitments. The baseline recovery path remains bound to the initial owners and is restricted to asset-transfer call shapes, with a reproducible init-code hash and focused Foundry tests.