### PR TITLE
fix(ci): add upload-binaries environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,6 +382,7 @@ jobs:
   upload-cloudflare:
     name: Upload to R2 bucket
     needs: [get-version, build-release]
+    environment: upload-binaries
     if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
     runs-on: depot-ubuntu-latest
     permissions:


### PR DESCRIPTION
Ensures variables related to binary upload are gated behind an environment.
