### PR TITLE
chore(ci): authenticate container registries via OIDC

### DIFF
--- a/.github/sts/ghcr-publish.sts.yaml
+++ b/.github/sts/ghcr-publish.sts.yaml
@@ -1,0 +1,11 @@
+# Allow the container publishing workflows in Tempo and its private copy to
+# mint short-lived GitHub App tokens for GHCR. Workflow and event claims keep
+# package writes limited to the four workflows that publish or promote images.
+subject_pattern:
+  - repo:tempoxyz@211589300/tempo@994992847:ref:refs/(heads|tags)/.+
+  - repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/(heads|tags)/.+
+claim_pattern:
+  event_name: (merge_group|push|schedule|workflow_call|workflow_dispatch)
+  workflow_ref: tempoxyz/(tempo|tempo-private-fork)/\.github/workflows/(build-reth-bump-image|docker|docker-profiling|promote-canary)\.yml@refs/(heads|tags)/.+
+permissions:
+  packages: write

--- a/.github/workflows/build-reth-bump-image.yml
+++ b/.github/workflows/build-reth-bump-image.yml
@@ -22,7 +22,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
       id-token: write
     uses: ./.github/workflows/docker.yml
     # docker.yml does not declare a workflow_call secret interface.
@@ -131,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write
     steps:
       - name: Check current branch head
         id: branch-head
@@ -151,13 +150,20 @@ jobs:
 
           echo "current=true" >> "$GITHUB_OUTPUT"
 
+      - name: Fetch GHCR token via GitHub STS
+        if: steps.branch-head.outputs.current == 'true'
+        id: ghcr-token
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        with:
+          policy: ghcr-publish
+
       - name: Log in to GitHub Container Registry
         if: steps.branch-head.outputs.current == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.ghcr-token.outputs.token }}
 
       - name: Set up Docker Buildx
         if: steps.branch-head.outputs.current == 'true'

--- a/.github/workflows/build-reth-bump-image.yml
+++ b/.github/workflows/build-reth-bump-image.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: steps.branch-head.outputs.current == 'true'
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -40,7 +40,7 @@ jobs:
             type=sha,prefix=${{ github.event.inputs.tag }}-sha-
 
       - name: Log in to Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docker-profiling.yml
+++ b/.github/workflows/docker-profiling.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: depot-ubuntu-latest-16
     permissions:
       contents: read
-      packages: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -39,12 +38,18 @@ jobs:
             type=raw,value=${{ github.event.inputs.tag }}
             type=sha,prefix=${{ github.event.inputs.tag }}-sha-
 
+      - name: Fetch GHCR token via GitHub STS
+        id: ghcr-token
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        with:
+          policy: ghcr-publish
+
       - name: Log in to Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.ghcr-token.outputs.token }}
 
       - id: shortsha
         run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -158,9 +158,6 @@ jobs:
           password: ${{ steps.ghcr-token.outputs.token }}
 
       - name: Log in to Docker Hub via OIDC (read/write)
-        if: >-
-          github.repository == 'tempoxyz/tempo' ||
-          github.repository == 'tempoxyz/tempo-private-fork'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         env:
           DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo
-            docker.io/tempoxyz/tempo
+            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo' || '' }}
           bake-target: tempo
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -88,7 +88,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo-localnet
-            docker.io/tempoxyz/tempo-localnet
+            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo-localnet' || '' }}
           bake-target: tempo-localnet
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -109,7 +109,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo-sidecar
-            docker.io/tempoxyz/tempo-sidecar
+            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo-sidecar' || '' }}
           bake-target: tempo-sidecar
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -130,7 +130,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo-xtask
-            docker.io/tempoxyz/tempo-xtask
+            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo-xtask' || '' }}
           bake-target: tempo-xtask
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -152,11 +152,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      - name: Require Docker Hub write OIDC configuration
+        if: github.repository == 'tempoxyz/tempo' && vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE == ''
+        run: |
+          echo "::error::The DOCKERHUB_OIDC_CONNECTIONID_WRITE repository variable is not set."
+          exit 1
+
+      - name: Log in to Docker Hub via OIDC (read/write)
+        if: github.repository == 'tempoxyz/tempo'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE }}
         with:
-          username: ${{ vars.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          username: tempoxyz
+
+      - name: Require Docker Hub read OIDC configuration
+        if: github.repository == 'tempoxyz/tempo-private-fork' && vars.DOCKERHUB_OIDC_CONNECTIONID_READ == ''
+        run: |
+          echo "::error::The DOCKERHUB_OIDC_CONNECTIONID_READ repository variable is not set."
+          exit 1
+
+      # Private-fork builds publish only to GHCR. Docker Hub authentication is
+      # read-only and used for authenticated base-image pulls.
+      - name: Log in to Docker Hub via OIDC (read-only)
+        if: github.repository == 'tempoxyz/tempo-private-fork'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        env:
+          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID_READ }}
+        with:
+          username: tempoxyz
 
       - id: shortsha
         run: echo "shortsha=$(echo ${{ github.sha }} | cut -c1-7)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -146,20 +146,11 @@ jobs:
             type=ref,event=pr
 
       - name: Log in to Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Require Docker Hub write OIDC configuration
-        if: >-
-          (github.repository == 'tempoxyz/tempo' ||
-          github.repository == 'tempoxyz/tempo-private-fork') &&
-          vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE == ''
-        run: |
-          echo "::error::The DOCKERHUB_OIDC_CONNECTIONID_WRITE repository variable is not set."
-          exit 1
 
       - name: Log in to Docker Hub via OIDC (read/write)
         if: >-

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo
-            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo' || '' }}
+            docker.io/tempoxyz/tempo
           bake-target: tempo
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -88,7 +88,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo-localnet
-            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo-localnet' || '' }}
+            docker.io/tempoxyz/tempo-localnet
           bake-target: tempo-localnet
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -109,7 +109,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo-sidecar
-            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo-sidecar' || '' }}
+            docker.io/tempoxyz/tempo-sidecar
           bake-target: tempo-sidecar
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -130,7 +130,7 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/tempo-xtask
-            ${{ github.repository == 'tempoxyz/tempo' && 'docker.io/tempoxyz/tempo-xtask' || '' }}
+            docker.io/tempoxyz/tempo-xtask
           bake-target: tempo-xtask
           labels: ${{ steps.docker-labels.outputs.value }}
           tags: |
@@ -153,32 +153,21 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Require Docker Hub write OIDC configuration
-        if: github.repository == 'tempoxyz/tempo' && vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE == ''
+        if: >-
+          (github.repository == 'tempoxyz/tempo' ||
+          github.repository == 'tempoxyz/tempo-private-fork') &&
+          vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE == ''
         run: |
           echo "::error::The DOCKERHUB_OIDC_CONNECTIONID_WRITE repository variable is not set."
           exit 1
 
       - name: Log in to Docker Hub via OIDC (read/write)
-        if: github.repository == 'tempoxyz/tempo'
+        if: >-
+          github.repository == 'tempoxyz/tempo' ||
+          github.repository == 'tempoxyz/tempo-private-fork'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         env:
           DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID_WRITE }}
-        with:
-          username: tempoxyz
-
-      - name: Require Docker Hub read OIDC configuration
-        if: github.repository == 'tempoxyz/tempo-private-fork' && vars.DOCKERHUB_OIDC_CONNECTIONID_READ == ''
-        run: |
-          echo "::error::The DOCKERHUB_OIDC_CONNECTIONID_READ repository variable is not set."
-          exit 1
-
-      # Private-fork builds publish only to GHCR. Docker Hub authentication is
-      # read-only and used for authenticated base-image pulls.
-      - name: Log in to Docker Hub via OIDC (read-only)
-        if: github.repository == 'tempoxyz/tempo-private-fork'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        env:
-          DOCKERHUB_OIDC_CONNECTIONID: ${{ vars.DOCKERHUB_OIDC_CONNECTIONID_READ }}
         with:
           username: tempoxyz
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      packages: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -145,12 +144,18 @@ jobs:
             type=sha,prefix=sha-
             type=ref,event=pr
 
+      - name: Fetch GHCR token via GitHub STS
+        id: ghcr-token
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        with:
+          policy: ghcr-publish
+
       - name: Log in to Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.ghcr-token.outputs.token }}
 
       - name: Log in to Docker Hub via OIDC (read/write)
         if: >-

--- a/.github/workflows/promote-canary.yml
+++ b/.github/workflows/promote-canary.yml
@@ -35,7 +35,7 @@ jobs:
       packages: write
     steps:
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/promote-canary.yml
+++ b/.github/workflows/promote-canary.yml
@@ -32,14 +32,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      packages: write
+      id-token: write
     steps:
+      - name: Fetch GHCR token via GitHub STS
+        id: ghcr-token
+        uses: tempoxyz/gh-actions/actions/github-sts@183a02178c660ce295e9a262edc5857cb7135f06
+        with:
+          policy: ghcr-publish
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ steps.ghcr-token.outputs.token }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0


### PR DESCRIPTION
Replaces Docker Hub credentials with Docker Hub OIDC, replaces GHCR `GITHUB_TOKEN` logins with package-write tokens minted through GitHub STS, adds the dedicated `ghcr-publish` STS policy, removes built-in `packages: write` grants, preserves publishing from both repositories, and updates every `docker/login-action` use to v4.6.0.

In Docker Hub, add four rulesets to the existing read/write connection with subjects `repo:tempoxyz@211589300/tempo@994992847:ref:refs/heads/*`, `repo:tempoxyz@211589300/tempo@994992847:ref:refs/tags/v*.*.*`, `repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/heads/*`, and `repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/tags/v*.*.*`, granting read/write only to `tempoxyz/tempo`, `tempoxyz/tempo-localnet`, `tempoxyz/tempo-sidecar`, and `tempoxyz/tempo-xtask`.

The Docker Hub connection ID is already stored as `DOCKERHUB_OIDC_CONNECTIONID_WRITE` in both GitHub repositories; these workflows have no pull-only Docker Hub context, so the READ connection is not used here, and `DOCKER_HUB_TOKEN` plus `DOCKER_HUB_USER` can be deleted from both repositories after OIDC-backed runs succeed.