### PR TITLE
chore(ci): authorize GHCR publishing via STS

### DIFF
--- a/.github/sts/ghcr-publish.sts.yaml
+++ b/.github/sts/ghcr-publish.sts.yaml
@@ -1,0 +1,11 @@
+# Allow the container publishing workflows in Tempo and its private copy to
+# mint short-lived GitHub App tokens for GHCR. Workflow and event claims keep
+# package writes limited to the four workflows that publish or promote images.
+subject_pattern:
+  - repo:tempoxyz@211589300/tempo@994992847:ref:refs/(heads|tags)/.+
+  - repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/(heads|tags)/.+
+claim_pattern:
+  event_name: (merge_group|push|schedule|workflow_call|workflow_dispatch)
+  workflow_ref: tempoxyz/(tempo|tempo-private-fork)/\.github/workflows/(build-reth-bump-image|docker|docker-profiling|promote-canary)\.yml@refs/(heads|tags)/.+
+permissions:
+  packages: write


### PR DESCRIPTION
Adds the package-write GitHub STS policy for the four workflows that publish or promote GHCR images in `tempo` and `tempo-private-fork`.

This must land before #7342 because STS reads policies from the target repository's default branch, so the workflow migration cannot authorize its merge-queue run until this policy is present on `main`.