### PR TITLE
deps: update reth from main (2026-09-01)

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,7 +112,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          # Foundry's revm 43 migration (https://github.com/foundry-rs/foundry/pull/16409).
+          # Keep this pinned until the migration lands on master.
+          ref: 1e46c603f85368b82ed78bc2e90969b60bda8f17
           path: foundry
           persist-credentials: false
 
@@ -260,7 +262,9 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          ref: master
+          # Foundry's revm 43 migration (https://github.com/foundry-rs/foundry/pull/16409).
+          # Keep this pinned until the migration lands on master.
+          ref: 1e46c603f85368b82ed78bc2e90969b60bda8f17
           path: foundry
           persist-credentials: false
 

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -112,9 +112,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          # Foundry's revm 43 migration (https://github.com/foundry-rs/foundry/pull/16409).
-          # Keep this pinned until the migration lands on master.
-          ref: 1e46c603f85368b82ed78bc2e90969b60bda8f17
+          # Keep Foundry on revm 42 to match the version used by reth and Tempo.
+          ref: 8811c408fe72c244317a508e5343fc460447be1a
           path: foundry
           persist-credentials: false
 
@@ -262,9 +261,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: foundry-rs/foundry
-          # Foundry's revm 43 migration (https://github.com/foundry-rs/foundry/pull/16409).
-          # Keep this pinned until the migration lands on master.
-          ref: 1e46c603f85368b82ed78bc2e90969b60bda8f17
+          # Keep Foundry on revm 42 to match the version used by reth and Tempo.
+          ref: 8811c408fe72c244317a508e5343fc460447be1a
           path: foundry
           persist-credentials: false
 

--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -537,8 +537,9 @@ jobs:
                 break
               fi
 
-              # All done with no failures = success
-              PENDING=$(echo "$STATUS" | jq -r '[.[] | select((.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS") and .name != "Review")] | length')
+              # External reviews run after this loop posts their commands, so they must not
+              # block the pre-audit CI gate. Failed reviews are still handled above.
+              PENDING=$(echo "$STATUS" | jq -r '[.[] | select((.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS") and .name != "Review" and .name != "Cyclops audit run")] | length')
               if [ "$PENDING" = "0" ] 2>/dev/null; then
                 echo "All CI checks passed!"
                 PR_NUMBER=$(gh pr view "$PR_BRANCH" --json number --jq '.number')
@@ -565,7 +566,7 @@ jobs:
               ELAPSED=$(( (SECONDS - WAIT_START) / 60 ))
               if [ "$ELAPSED" -ge "$CI_TIMEOUT_MINUTES" ]; then
                 echo "CI checks stuck for ${ELAPSED}m — investigating with Amp..."
-                STUCK_NAMES=$(echo "$STATUS" | jq -r '[.[] | select((.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS") and .name != "Review")] | map(.name) | join(", ")')
+                STUCK_NAMES=$(echo "$STATUS" | jq -r '[.[] | select((.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS") and .name != "Review" and .name != "Cyclops audit run")] | map(.name) | join(", ")')
 
                 # Fetch logs from in-progress runs for the current HEAD commit
                 HEAD_SHA=$(gh pr view "$PR_BRANCH" --json headRefOid --jq '.headRefOid')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9190,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9211,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,12 +9240,11 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
  "alloy-primitives",
- "alloy-rlp",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -9255,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9268,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9293,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9322,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9348,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9378,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9393,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9418,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9442,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9466,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9503,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9560,7 +9559,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9587,7 +9586,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9610,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9637,7 +9636,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9723,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9741,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9757,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9781,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9792,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9820,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9843,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9884,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9907,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9939,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9952,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9982,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9996,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10032,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10052,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10070,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10083,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10140,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10154,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10164,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10190,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10210,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10227,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10236,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10250,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10273,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10357,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10381,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10396,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10410,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10428,7 +10427,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10452,7 +10451,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10520,7 +10519,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10575,7 +10574,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10624,7 +10623,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10648,7 +10647,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10672,7 +10671,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "bytes",
  "eyre",
@@ -10701,7 +10700,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10713,7 +10712,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10737,7 +10736,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10749,7 +10748,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10772,7 +10771,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10781,9 +10780,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10815,7 +10814,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10865,7 +10864,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10892,7 +10891,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10908,7 +10907,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10923,7 +10922,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10999,7 +10998,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11029,7 +11028,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11072,7 +11071,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11092,7 +11091,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11123,7 +11122,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11170,7 +11169,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11206,7 +11205,6 @@ dependencies = [
  "reth-storage-api",
  "reth-tasks",
  "reth-transaction-pool",
- "reth-trie",
  "revm",
  "revm-inspectors",
  "schnellru",
@@ -11221,7 +11219,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11237,7 +11235,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11252,9 +11250,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
+checksum = "f410d6bff1fd059ebaec2edeff1326f103f61162158411325d78158f94b2b4a9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11268,7 +11266,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11320,7 +11318,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11348,7 +11346,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11362,7 +11360,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11382,7 +11380,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11397,7 +11395,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11423,7 +11421,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11440,7 +11438,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11467,7 +11465,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11488,7 +11486,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11504,7 +11502,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11514,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "clap",
  "eyre",
@@ -11534,7 +11532,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11553,7 +11551,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11596,7 +11594,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11622,7 +11620,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11650,7 +11648,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11666,7 +11664,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11691,7 +11689,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=23305f9#23305f9d98e2424da527fdd8a46f762a18d9de3f"
+source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11712,18 +11710,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
+checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11740,9 +11738,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf 0.14.0",
@@ -11752,9 +11750,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
+checksum = "67822069c254eb83e95fa5912a0d1324dd176f6ea05e8f110671ad242e27d61b"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11769,9 +11767,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
+checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11785,9 +11783,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11801,9 +11799,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -11815,9 +11813,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
+checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11834,9 +11832,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
+checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
 dependencies = [
  "auto_impl",
  "either",
@@ -11852,9 +11850,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c136a072540987ee442e9824631835520b13e5756f20780a637ba2e11f9c28"
+checksum = "79b609cb78fcb3a8c10f3190847c9bb0223423cf46e2de30a61ea9e37a3e6736"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11872,9 +11870,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
+checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11885,9 +11883,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
+checksum = "d85f7a8906482f8d18f2a2c793bc4daf254b29465af4285268384505ce6ee308"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11911,9 +11909,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11922,9 +11920,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9783,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9886,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "clap",
  "eyre",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10008,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "serde",
  "serde_json",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10192,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "bytes",
  "futures",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "bindgen",
  "cc",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "futures",
  "libc",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10359,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "bytes",
  "eyre",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10750,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10893,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10909,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10924,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11000,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11030,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11124,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11237,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11320,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11382,7 +11382,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11397,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11440,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11489,7 +11489,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11515,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "clap",
  "eyre",
@@ -11535,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11554,7 +11554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11651,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
+source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9783,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9886,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "clap",
  "eyre",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10008,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "serde",
  "serde_json",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10192,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "bytes",
  "futures",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "bindgen",
  "cc",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "futures",
  "libc",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10359,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "bytes",
  "eyre",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10750,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10893,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10909,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10924,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11000,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11030,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11124,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11237,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11320,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11382,7 +11382,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11397,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11440,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11489,7 +11489,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11515,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "clap",
  "eyre",
@@ -11535,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11554,7 +11554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11651,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=f0166c3#f0166c32e235bc1e94667c7760818e345f2e1189"
+source = "git+https://github.com/paradigmxyz/reth?rev=3a1cc31#3a1cc31f02060e8689f06b5247eeaac296a55aeb"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.39.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
+checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9190,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
+checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9211,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
+checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9547,6 +9547,8 @@ dependencies = [
  "reth-tasks",
  "reth-tokio-util",
  "reth-tracing",
+ "reth-trie",
+ "reth-trie-db",
  "revm",
  "serde_json",
  "tempfile",
@@ -9559,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9586,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9609,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9636,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9693,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9723,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9741,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9757,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9781,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9792,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9820,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9843,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9884,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "clap",
  "eyre",
@@ -9907,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9923,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9939,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9952,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9982,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9996,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10006,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10032,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10052,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10070,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10083,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10102,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10140,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10154,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "serde",
  "serde_json",
@@ -10164,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10190,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "bytes",
  "futures",
@@ -10210,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10227,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "bindgen",
  "cc",
@@ -10236,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "futures",
  "libc",
@@ -10250,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10259,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10273,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10332,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10357,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10381,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10396,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10410,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10427,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10451,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10519,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10574,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10623,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10647,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10671,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "bytes",
  "eyre",
@@ -10700,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10712,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10736,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10748,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10771,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10780,9 +10782,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
+checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10814,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10864,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10891,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10907,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10922,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10998,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11028,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11071,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11091,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11122,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11169,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11219,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11235,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11250,9 +11252,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f410d6bff1fd059ebaec2edeff1326f103f61162158411325d78158f94b2b4a9"
+checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11266,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11318,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11346,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11360,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11380,7 +11382,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11395,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11421,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11438,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11459,13 +11461,14 @@ dependencies = [
  "reth-trie",
  "reth-trie-common",
  "reth-trie-db",
+ "revm",
  "tracing",
 ]
 
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11486,7 +11489,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11502,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11512,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "clap",
  "eyre",
@@ -11532,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11551,7 +11554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11594,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11620,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11648,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11664,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11689,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=701b5a1#701b5a175a1aada7acb2f914327f481f8ab90a48"
+source = "git+https://github.com/paradigmxyz/reth?rev=3bc71d4#3bc71d43f7101f772bbb4f9e15d3cdd58f60e958"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11710,18 +11713,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.7.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
+checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "43.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
+checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11738,9 +11741,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
+checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
 dependencies = [
  "bitvec",
  "phf 0.14.0",
@@ -11750,9 +11753,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67822069c254eb83e95fa5912a0d1324dd176f6ea05e8f110671ad242e27d61b"
+checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11767,9 +11770,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
+checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11783,9 +11786,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
+checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11799,9 +11802,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
+checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
 dependencies = [
  "auto_impl",
  "either",
@@ -11813,9 +11816,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "43.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
+checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11832,9 +11835,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "43.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
+checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
 dependencies = [
  "auto_impl",
  "either",
@@ -11850,9 +11853,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.43.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b609cb78fcb3a8c10f3190847c9bb0223423cf46e2de30a61ea9e37a3e6736"
+checksum = "90c136a072540987ee442e9824631835520b13e5756f20780a637ba2e11f9c28"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11870,9 +11873,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
+checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11883,9 +11886,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "43.0.0"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f7a8906482f8d18f2a2c793bc4daf254b29465af4285268384505ce6ee308"
+checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11909,9 +11912,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
+checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11920,9 +11923,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "43.0.0"
+version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
+checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "23305f9", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3a1cc31", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f0166c3", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-codecs = { version = "0.6.0", default-features = false }
+reth-codecs = { version = "0.7.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
@@ -185,7 +185,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "701b5
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
-reth-primitives-traits = { version = "0.6.0", default-features = false }
+reth-primitives-traits = { version = "0.7.0", default-features = false }
 reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1" }
@@ -212,8 +212,8 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "701b5a1", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "0.42.2"
+revm = { version = "43.0.0", features = ["optional_fee_charge"], default-features = false }
+revm-inspectors = "0.43.0"
 
 alloy-json-abi = { version = "1.7.1", default-features = false }
 alloy-primitives = { version = "1.7.1", default-features = false }
@@ -224,7 +224,7 @@ alloy-consensus = { version = "2.4.1", default-features = false }
 alloy-contract = { version = "2.4.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.4.1", default-features = false }
-alloy-evm = { version = "0.38.0", default-features = false }
+alloy-evm = { version = "0.39.0", default-features = false }
 alloy-genesis = { version = "2.4.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-rpc = "2.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-codecs = { version = "0.7.0", default-features = false }
+reth-codecs = { version = "0.6.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
@@ -185,7 +185,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
-reth-primitives-traits = { version = "0.7.0", default-features = false }
+reth-primitives-traits = { version = "0.6.0", default-features = false }
 reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4" }
@@ -212,8 +212,8 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "3bc71d4", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "43.0.0", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "0.43.0"
+revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
+revm-inspectors = "0.42.2"
 
 alloy-json-abi = { version = "1.7.1", default-features = false }
 alloy-primitives = { version = "1.7.1", default-features = false }
@@ -224,7 +224,7 @@ alloy-consensus = { version = "2.4.1", default-features = false }
 alloy-contract = { version = "2.4.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.4.1", default-features = false }
-alloy-evm = { version = "0.39.0", default-features = false }
+alloy-evm = { version = "0.38.0", default-features = false }
 alloy-genesis = { version = "2.4.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-rpc = "2.4.1"

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -384,7 +384,7 @@ impl<'evm> StorageCtx {
         journal: &'evm mut J,
         block_env: &'evm TempoBlockEnv,
         cfg: &CfgEnv<TempoHardfork>,
-        tx_env: &'evm impl Transaction,
+        tx_env: &'evm (impl Transaction + 'static),
         actions: StorageActions,
         f: impl FnOnce() -> R,
     ) -> R
@@ -408,7 +408,7 @@ impl<'evm> StorageCtx {
         journal: &'evm mut J,
         block_env: &'evm TempoBlockEnv,
         cfg: &CfgEnv<TempoHardfork>,
-        tx_env: &'evm impl Transaction,
+        tx_env: &'evm (impl Transaction + 'static),
         actions: StorageActions,
         f: impl FnOnce() -> R,
     ) -> R
@@ -433,6 +433,7 @@ impl<'evm> StorageCtx {
                 Journal: Debug,
                 Db: Database,
             >,
+        C::Tx: 'static,
     {
         let (tx, block, cfg, journal) = ctx.tx_block_cfg_journal_mut();
         Self::enter_evm(journal, block, cfg, tx, actions, f)
@@ -454,6 +455,7 @@ impl<'evm> StorageCtx {
                 Journal: Debug,
                 Db: Database,
             >,
+        C::Tx: 'static,
     {
         let (tx, block, cfg, journal) = ctx.tx_block_cfg_journal_mut();
         let internals = EvmInternals::new(journal, block, cfg, tx);
@@ -470,7 +472,7 @@ impl<'evm> StorageCtx {
         journal: &'evm mut J,
         block_env: &'evm TempoBlockEnv,
         cfg: &CfgEnv<TempoHardfork>,
-        tx_env: &'evm impl Transaction,
+        tx_env: &'evm (impl Transaction + 'static),
         actions: StorageActions,
         f: impl FnOnce(P) -> R,
     ) -> R


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`23305f9...3a1cc31`](https://github.com/paradigmxyz/reth/compare/23305f9...3a1cc31)

🔗 Amp thread: https://ampcode.com/threads/T-01a05af4-1a71-70d5-8f8e-b689a4264557
- **Engine**
  - Base persistence thresholds on the in-memory chain and classify malformed inputs—including invalid BALs—separately from fatal errors ([#26827](https://github.com/paradigmxyz/reth/pull/26827), [#26829](https://github.com/paradigmxyz/reth/pull/26829), [#26844](https://github.com/paradigmxyz/reth/pull/26844)).

- **Downloader**
  - Add authenticated snap storage ranges and select storage-bearing accounts for requests ([#26814](https://github.com/paradigmxyz/reth/pull/26814), [#26852](https://github.com/paradigmxyz/reth/pull/26852)).

- **RPC**
  - Improve BAL-backed transaction replay, align BAL getter semantics, and guard replay ([#26835](https://github.com/paradigmxyz/reth/pull/26835), [#26882](https://github.com/paradigmxyz/reth/pull/26882), [#26895](https://github.com/paradigmxyz/reth/pull/26895)).
  - Fix batch call accounting, `eth_getLogs` validation, and basic-transfer gas estimation ([#26866](https://github.com/paradigmxyz/reth/pull/26866), [#26891](https://github.com/paradigmxyz/reth/pull/26891), [#26875](https://github.com/paradigmxyz/reth/pull/26875)).
  - Remove the dead header cache and state-provider wrapper ([#26836](https://github.com/paradigmxyz/reth/pull/26836), [#26837](https://github.com/paradigmxyz/reth/pull/26837)).

- **Overlay**
  - Build, cache, and broadly adopt execution overlays and overlay state providers on hot paths ([#26838](https://github.com/paradigmxyz/reth/pull/26838), [#26834](https://github.com/paradigmxyz/reth/pull/26834), [#26862](https://github.com/paradigmxyz/reth/pull/26862), [#26616](https://github.com/paradigmxyz/reth/pull/26616)).
  - Preserve storage wipes and run overlay computations on dedicated workers ([#26872](https://github.com/paradigmxyz/reth/pull/26872), [#26871](https://github.com/paradigmxyz/reth/pull/26871)).

- **TxPool**
  - Enforce minimum priority fees for local transactions ([#26861](https://github.com/paradigmxyz/reth/pull/26861)).

- **Testing**
  - Add cross-hardfork end-to-end coverage for post-Cancun `SELFDESTRUCT` behavior ([#26865](https://github.com/paradigmxyz/reth/pull/26865)).

- **Operations**
  - Configure nightly Docker persistence thresholds ([#26888](https://github.com/paradigmxyz/reth/pull/26888)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-01a05af4-4706-770e-94a9-8bd653512cc2
- Upgraded all Reth Git dependencies from revision `23305f9` to `3a1cc31`.
- Added `'static` bounds to transaction environments and `C::Tx` to satisfy the updated Reth transaction API requirements.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/33465019691)
