### PR TITLE
fix(txpool): separate expiry eviction metrics

### DIFF
--- a/crates/transaction-pool/src/maintain.rs
+++ b/crates/transaction-pool/src/maintain.rs
@@ -625,7 +625,7 @@ where
             whitelist_removals = updates.whitelist_removals.len(),
             "Processing transaction invalidation events"
         );
-        let evicted = {
+        let (evicted, expired_count) = {
             let all_txs = all_txs.get_or_insert_with(|| pool.all_transactions());
             pool.evict_invalidated_transactions_from(
                 &updates,
@@ -635,9 +635,13 @@ where
                 Some(tip_timestamp.saturating_add(EVICTION_BUFFER_SECS)),
             )
         };
+        let invalidated_count = evicted.len().saturating_sub(expired_count);
         metrics
             .transactions_invalidated
-            .increment(evicted.len() as u64);
+            .increment(invalidated_count as u64);
+        metrics
+            .expired_transactions_evicted
+            .increment(expired_count as u64);
         removed_txs.push(evicted);
         metrics
             .invalidation_eviction_duration_seconds

--- a/crates/transaction-pool/src/metrics.rs
+++ b/crates/transaction-pool/src/metrics.rs
@@ -96,6 +96,9 @@ pub struct TempoPoolMaintenanceMetrics {
     /// Number of transactions evicted due to invalidation events.
     pub transactions_invalidated: Counter,
 
+    /// Number of expired transactions evicted.
+    pub expired_transactions_evicted: Counter,
+
     /// Number of transactions re-validated due to transfer policy updates.
     pub transfer_policy_revalidated: Counter,
 

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -142,18 +142,22 @@ where
 
         let all_txs = self.all_transactions();
         self.evict_invalidated_transactions_from(updates, all_txs.iter(), None)
+            .0
     }
 
-    /// See [`Self::evict_invalidated_transactions`]; returns the removed transactions so
-    /// the caller controls when they are dropped.
+    /// See [`Self::evict_invalidated_transactions`]; returns the removed transactions and the
+    /// subset removed due to expiry so the caller can account for both causes separately.
     pub(crate) fn evict_invalidated_transactions_from<'a>(
         &self,
         updates: &crate::maintain::TempoPoolUpdates,
         transactions: impl IntoIterator<Item = &'a Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
         expiry_cutoff: Option<u64>,
-    ) -> Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
+    ) -> (
+        Vec<Arc<ValidPoolTransaction<TempoPooledTransaction>>>,
+        usize,
+    ) {
         if !updates.has_invalidation_events() && expiry_cutoff.is_none() {
-            return Vec::new();
+            return (Vec::new(), 0);
         }
 
         // Fetch state provider if any check needs on-chain reads:
@@ -507,7 +511,7 @@ where
         }
 
         if to_remove.is_empty() {
-            return Vec::new();
+            return (Vec::new(), 0);
         }
 
         tracing::debug!(
@@ -526,7 +530,14 @@ where
             paused_token_count,
             "Evicting invalidated or expired transactions"
         );
-        self.remove_transactions(to_remove)
+        let evicted = self.remove_transactions(to_remove);
+        let expired_count = expiry_cutoff.map_or(0, |cutoff| {
+            evicted
+                .iter()
+                .filter(|tx| tx.transaction.is_expired_by(cutoff))
+                .count()
+        });
+        (evicted, expired_count)
     }
 
     /// Adds a validated transaction to the subpool derived from its type and nonce key.
@@ -1772,6 +1783,40 @@ mod tests {
         let evicted = pool.evict_invalidated_transactions(&updates);
         assert_eq!(tx_hashes(&evicted), vec![*pooled.hash()]);
         assert!(pool.get(pooled.hash()).is_none());
+    }
+
+    #[tokio::test]
+    async fn separates_expired_transactions_from_invalidated_transactions() {
+        let expired_sender = Address::random();
+        let invalidated_sender = Address::random();
+        let expired = crate::test_utils::TxBuilder::aa(expired_sender)
+            .valid_before(100)
+            .build();
+        let invalidated = crate::test_utils::TxBuilder::aa(invalidated_sender).build();
+
+        let provider = create_provider_with_tip();
+        provider.add_account(
+            expired_sender,
+            ExtendedAccount::new(expired.nonce(), *expired.cost()),
+        );
+        provider.add_account(
+            invalidated_sender,
+            ExtendedAccount::new(invalidated.nonce(), *invalidated.cost()),
+        );
+        let pool = create_test_pool(provider);
+        add_validated(&pool, expired.clone());
+        add_validated(&pool, invalidated.clone());
+
+        let mut updates = crate::maintain::TempoPoolUpdates::new();
+        updates.user_token_changes.insert(invalidated_sender);
+        let all_txs = pool.all_transactions();
+        let (evicted, expired_count) =
+            pool.evict_invalidated_transactions_from(&updates, all_txs.iter(), Some(100));
+
+        assert_eq!(evicted.len(), 2);
+        assert_eq!(expired_count, 1);
+        assert!(pool.get(expired.hash()).is_none());
+        assert!(pool.get(invalidated.hash()).is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Restores separate counters for expired and genuinely invalidated pool transactions while preserving the single-pass scan.
- Classifies only transactions actually removed from the pool.

## Profile
- [Bench run 33161030059](https://github.com/tempoxyz/tempo/actions/runs/33161030059) reported 129,646 expiries as invalidations because the combined eviction result fed one counter.
- No branch benchmark was run; this is metric-accounting correctness with unchanged eviction behavior.

## Verification
- `cargo test -p tempo-transaction-pool` (263 passed)
- `cargo +nightly clippy -p tempo-transaction-pool --tests -- -D warnings`
- `cargo +nightly fmt --all -- --check`

Prompted by: @onbjerg