### PR TITLE
docs(tip-1098): retarget activation from T11 to T13

### DIFF
--- a/tips/tip-1098.md
+++ b/tips/tip-1098.md
@@ -1,11 +1,11 @@
 ---
 id: TIP-1098
 title: Nitro-Backed Zone Batch Verification
-description: Defines the T11 verifier policy for Nitro-attested Zone batch proofs.
+description: Defines the T13 verifier policy for Nitro-attested Zone batch proofs.
 authors: Roman Krasiuk
 status: Draft
 related: TIP-1090, TIP-1091, [Tempo Zones spec](https://github.com/tempoxyz/zones/blob/main/specs/spec.md), [AWS Nitro Attestation Process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
-protocolVersion: T11
+protocolVersion: T13
 ---
 
 # TIP-1098: Nitro-Backed Zone Batch Verification
@@ -13,7 +13,7 @@ protocolVersion: T11
 ## Abstract
 
 The Zone portal activates at T10 with a permissive verifier placeholder. This TIP activates the
-production verifier at T11, accepting only batches executed by the approved Zone stateless proof
+production verifier at T13, accepting only batches executed by the approved Zone stateless proof
 function inside AWS Nitro Enclaves. The verifier uses TIP-1090 to authenticate the Nitro document,
 pins the measured enclave image, and requires the document's signed `user_data` to commit to every
 public input used by `IVerifier`.
@@ -31,7 +31,7 @@ exact commitment that connects a valid Nitro document to one portal batch.
 
 ## Assumptions
 
-- TIP-1090 is active at T11 and authenticates Nitro documents to the pinned AWS root, including
+- TIP-1090 is active at T13 and authenticates Nitro documents to the pinned AWS root, including
   certificate validity at the current Tempo block timestamp.
 - TIP-1091's verifier remains at `0x5a56000000000000000000000000000000000000` and its runtime can
   be replaced only by a hardfork.
@@ -59,9 +59,9 @@ exact commitment that connects a valid Nitro document to one portal batch.
 
 ## Activation
 
-At the T11 boundary, Tempo MUST replace the permissive verifier runtime used by the T10 portal at
+At the T13 boundary, Tempo MUST replace the permissive verifier runtime used by the T10 portal at
 `0x5a56000000000000000000000000000000000000` with the verifier defined by this TIP. The
-replacement applies to every existing and future Zone portal. Before T11, the T10 permissive
+replacement applies to every existing and future Zone portal. Before T13, the T10 permissive
 placeholder remains unchanged.
 
 ## Interface and Encoding
@@ -98,9 +98,9 @@ The returned document MUST contain the following 48-byte SHA-384 measurements:
 
 | Register | Required value |
 |---|---|
-| PCR0 | `<T11_PCR0_SHA384>` |
-| PCR1 | `<T11_PCR1_SHA384>` |
-| PCR2 | `<T11_PCR2_SHA384>` |
+| PCR0 | `<T13_PCR0_SHA384>` |
+| PCR1 | `<T13_PCR1_SHA384>` |
+| PCR2 | `<T13_PCR2_SHA384>` |
 
 PCR0, PCR1, and PCR2 MUST each be present and equal their required value. Other locked PCRs do not
 change this policy and MAY be present.
@@ -158,7 +158,7 @@ bundle.
 
 - The prover protocol distinguishes output-only `verify` requests from production `attest`
   requests. A successful `attest` response contains configuration `0x01` and the raw Nitro document.
-- Production T11 sequencers MUST use an attesting Nitro prover. In-process SPF execution is useful
+- Production T13 sequencers MUST use an attesting Nitro prover. In-process SPF execution is useful
   for diagnostics but cannot produce a settlement proof.
 - The reproducible EIF workflow MUST publish its EIF hash and raw PCR0/PCR1/PCR2 values. Release
   tooling MUST verify that those values match this TIP and the deployed verifier constants.


### PR DESCRIPTION
Retargets TIP-1098 activation from T11 to T13, per the current upgrade plan. The Nitro-backed verifier work moved out of T11 alongside TIP-1090 and TIP-1096.

Replaces every T11 reference in the spec: frontmatter `protocolVersion` and `description`, the abstract, the TIP-1090 activation assumption, the Activation section, the PCR placeholder names, and the Tooling note on production sequencers. No other content changes.

Opened against `tip/1098` rather than `main` so it can merge into the open spec PR (#7215).