### PR TITLE
test(tip-1015): match PolicyNotFound revert data

### DIFF
--- a/tips/verify/test/TIP1015.t.sol
+++ b/tips/verify/test/TIP1015.t.sol
@@ -162,19 +162,13 @@ contract TIP1015Test is TempoTest {
 
         vm.startPrank(admin);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(ITIP403Registry.PolicyNotFound.selector, nonExistentPolicy)
-        );
+        vm.expectRevert(ITIP403Registry.PolicyNotFound.selector);
         this.createCompoundPolicyExternal(nonExistentPolicy, whitelistPolicy, whitelistPolicy);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(ITIP403Registry.PolicyNotFound.selector, nonExistentPolicy)
-        );
+        vm.expectRevert(ITIP403Registry.PolicyNotFound.selector);
         this.createCompoundPolicyExternal(whitelistPolicy, nonExistentPolicy, whitelistPolicy);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(ITIP403Registry.PolicyNotFound.selector, nonExistentPolicy)
-        );
+        vm.expectRevert(ITIP403Registry.PolicyNotFound.selector);
         this.createCompoundPolicyExternal(whitelistPolicy, whitelistPolicy, nonExistentPolicy);
 
         vm.stopPrank();


### PR DESCRIPTION
Updates the TIP-1015 test to expect the zero-argument `PolicyNotFound()` payload. This restores compatibility with Foundry's exact revert-data matching.

Prompted by: @grandizzy

Testing:
- `FOUNDRY_HARDFORK=tempo:T10 ... forge test --match-contract TIP1015Test --match-test test_invariant3_revertsOnNonExistentPolicy`
- `FOUNDRY_HARDFORK=tempo:T11 ... forge test --match-contract TIP1015Test --match-test test_invariant3_revertsOnNonExistentPolicy`
