### PR TITLE
fix(follower): handle syncing semantics in the executor

### DIFF
--- a/crates/consensus/src/follow/executor/actor.rs
+++ b/crates/consensus/src/follow/executor/actor.rs
@@ -28,7 +28,7 @@ use super::{
 };
 use crate::{consensus::block::Block, utils::OptionFuture};
 
-const FINALIZED_BLOCK_POSTPONE_DELAY: Duration = Duration::from_secs(1);
+const SYNCING_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub(crate) struct Actor<TContext, P, E, M = crate::alias::marshal::Mailbox> {
     context: ContextCell<TContext>,
@@ -338,7 +338,10 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
         ExecutionRequest::Forkchoice(forkchoice) => {
             match submit_forkchoice_update(&context, &execution_engine, &forkchoice).await {
                 Ok(ForkchoiceOutcome::Valid) => ExecutionTaskResult::Completed(forkchoice),
-                Ok(ForkchoiceOutcome::Syncing) => ExecutionTaskResult::Syncing,
+                Ok(ForkchoiceOutcome::Syncing) => {
+                    context.sleep(SYNCING_RETRY_DELAY).await;
+                    ExecutionTaskResult::Syncing
+                }
                 Err(error) => ExecutionTaskResult::Fatal(error),
             }
         }
@@ -347,7 +350,7 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
                 Ok(NewPayloadOutcome::Valid) => {}
                 Ok(NewPayloadOutcome::Syncing) => {
                     debug!("execution layer is not ready to accept finalized block; postponing");
-                    context.sleep(FINALIZED_BLOCK_POSTPONE_DELAY).await;
+                    context.sleep(SYNCING_RETRY_DELAY).await;
                     return ExecutionTaskResult::BlockPostponed(block, ack);
                 }
                 Err(error) => return ExecutionTaskResult::Fatal(error),
@@ -360,7 +363,7 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
                         debug!(
                             "execution layer is not ready to finalize delivered block; postponing"
                         );
-                        context.sleep(FINALIZED_BLOCK_POSTPONE_DELAY).await;
+                        context.sleep(SYNCING_RETRY_DELAY).await;
                         return ExecutionTaskResult::BlockPostponed(block, ack);
                     }
                     Err(error) => return ExecutionTaskResult::Fatal(error),

--- a/crates/consensus/src/follow/executor/actor.rs
+++ b/crates/consensus/src/follow/executor/actor.rs
@@ -28,7 +28,7 @@ use super::{
 };
 use crate::{consensus::block::Block, utils::OptionFuture};
 
-const SYNCING_RETRY_DELAY: Duration = Duration::from_secs(1);
+const BLOCK_POSTPONED_RETRY_DELAY: Duration = Duration::from_secs(1);
 
 pub(crate) struct Actor<TContext, P, E, M = crate::alias::marshal::Mailbox> {
     context: ContextCell<TContext>,
@@ -41,9 +41,11 @@ pub(crate) struct Actor<TContext, P, E, M = crate::alias::marshal::Mailbox> {
     epoch_strategy: FixedEpocher,
     floor: Height,
 
-    // The last completed FCU
+    // The last non-invalid FCU. A SYNCING response installs its head as Reth's
+    // pipeline target even though its forkchoice markers are not yet applied.
     last_fcu: Forkchoice,
-    // Next FCU to be delivered when it superseded the last
+    // The newest desired forkchoice, including certificate heads received
+    // while Reth is syncing or blocks are queued.
     pending_fcu: Forkchoice,
 
     block_queue: VecDeque<(Block, Exact)>,
@@ -125,15 +127,12 @@ where
                 result = &mut self.execution_task => {
                     self.execution_task = OptionFuture::none();
                     match result {
-                        ExecutionTaskResult::Syncing => {}
                         ExecutionTaskResult::Completed(last_fcu) => {
                             self.last_fcu = last_fcu;
 
                             // Emits an event on error.
                             let _: Result<_, _> = self.try_advance_floor().await;
                         }
-                        // Keep the block unacknowledged until Reth accepts its payload and
-                        // any required FCU. Retry syncing blocks ahead of later blocks.
                         ExecutionTaskResult::BlockPostponed(block, ack) => {
                             self.block_queue.push_front((block, ack));
                         }
@@ -193,9 +192,10 @@ where
 
             let (ack, _waiter) = Exact::handle();
             self.pending_fcu.update_finalized(&block);
-            let forkchoice = (self.pending_fcu.finalized_digest()
-                != self.last_fcu.finalized_digest())
-            .then_some(self.pending_fcu);
+
+            let mut forkchoice = self.last_fcu;
+            let forkchoice = forkchoice.update_finalized(&block).then_some(forkchoice);
+
             let mut request = ExecutionRequest::Block(block, forkchoice, ack);
 
             // Backfill delivers contiguous blocks in order, so SYNCING cannot
@@ -215,13 +215,9 @@ where
                         break;
                     }
                     ExecutionTaskResult::BlockPostponed(block, ack) => {
-                        let forkchoice = (self.pending_fcu.finalized_digest()
-                            != self.last_fcu.finalized_digest())
-                        .then_some(self.pending_fcu);
+                        let mut forkchoice = self.last_fcu;
+                        let forkchoice = forkchoice.update_finalized(&block).then_some(forkchoice);
                         request = ExecutionRequest::Block(block, forkchoice, ack);
-                    }
-                    ExecutionTaskResult::Syncing => {
-                        unreachable!("backfill only executes block requests")
                     }
                     ExecutionTaskResult::Fatal(error) => {
                         return Err(error).wrap_err_with(|| {
@@ -254,9 +250,11 @@ where
         // Prioritize queued blocks so head-only FCUs cannot starve finality.
         let request = if let Some((block, ack)) = self.block_queue.pop_front() {
             self.pending_fcu.update_finalized(&block);
-            let forkchoice = (self.pending_fcu.finalized_digest()
-                != self.last_fcu.finalized_digest())
-            .then_some(self.pending_fcu);
+
+            // Preserve the last head Reth accepted while advancing finality. Newer
+            // certificate heads remain pending until this block has been accepted.
+            let mut forkchoice = self.last_fcu;
+            let forkchoice = forkchoice.update_finalized(&block).then_some(forkchoice);
             ExecutionRequest::Block(block, forkchoice, ack)
         } else if self.should_send_forkchoice() || heartbeat {
             ExecutionRequest::Forkchoice(self.pending_fcu)
@@ -323,7 +321,6 @@ enum ExecutionRequest {
 enum ExecutionTaskResult {
     Completed(Forkchoice),
     BlockPostponed(Block, Exact),
-    Syncing,
     Fatal(Report),
 }
 
@@ -338,10 +335,7 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
         ExecutionRequest::Forkchoice(forkchoice) => {
             match submit_forkchoice_update(&context, &execution_engine, &forkchoice).await {
                 Ok(ForkchoiceOutcome::Valid) => ExecutionTaskResult::Completed(forkchoice),
-                Ok(ForkchoiceOutcome::Syncing) => {
-                    context.sleep(SYNCING_RETRY_DELAY).await;
-                    ExecutionTaskResult::Syncing
-                }
+                Ok(ForkchoiceOutcome::Syncing) => ExecutionTaskResult::Completed(forkchoice),
                 Err(error) => ExecutionTaskResult::Fatal(error),
             }
         }
@@ -350,7 +344,7 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
                 Ok(NewPayloadOutcome::Valid) => {}
                 Ok(NewPayloadOutcome::Syncing) => {
                     debug!("execution layer is not ready to accept finalized block; postponing");
-                    context.sleep(SYNCING_RETRY_DELAY).await;
+                    context.sleep(BLOCK_POSTPONED_RETRY_DELAY).await;
                     return ExecutionTaskResult::BlockPostponed(block, ack);
                 }
                 Err(error) => return ExecutionTaskResult::Fatal(error),
@@ -363,7 +357,7 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
                         debug!(
                             "execution layer is not ready to finalize delivered block; postponing"
                         );
-                        context.sleep(SYNCING_RETRY_DELAY).await;
+                        context.sleep(BLOCK_POSTPONED_RETRY_DELAY).await;
                         return ExecutionTaskResult::BlockPostponed(block, ack);
                     }
                     Err(error) => return ExecutionTaskResult::Fatal(error),

--- a/crates/consensus/src/follow/executor/actor.rs
+++ b/crates/consensus/src/follow/executor/actor.rs
@@ -18,15 +18,17 @@ use commonware_consensus::{
 };
 use commonware_runtime::{Clock, ContextCell, FutureExt as _, Handle, Pacer, Spawner, spawn_cell};
 use commonware_utils::{Acknowledgement as _, acknowledgement::Exact};
-use eyre::{Report, WrapErr as _, ensure, eyre};
+use eyre::{Report, WrapErr as _, eyre};
 use futures::{FutureExt as _, StreamExt as _, channel::mpsc, future::BoxFuture};
 use tempo_node::TempoExecutionData;
-use tracing::{Level, debug, error, instrument};
+use tracing::{Level, debug, error, info, instrument};
 
 use super::{
     Config, ExecutionEngine, FinalizedBlockProvider, Marshal, fcu::Forkchoice, ingress::Message,
 };
 use crate::{consensus::block::Block, utils::OptionFuture};
+
+const FINALIZED_BLOCK_POSTPONE_DELAY: Duration = Duration::from_secs(1);
 
 pub(crate) struct Actor<TContext, P, E, M = crate::alias::marshal::Mailbox> {
     context: ContextCell<TContext>,
@@ -105,6 +107,11 @@ where
     }
 
     async fn run(mut self) {
+        if let Err(error) = self.backfill_to_finalized_floor().await {
+            error!(%error, "executor failed startup backfill");
+            return;
+        }
+
         let mut heartbeat = false;
         loop {
             self.start_execution_task(heartbeat);
@@ -118,11 +125,17 @@ where
                 result = &mut self.execution_task => {
                     self.execution_task = OptionFuture::none();
                     match result {
+                        ExecutionTaskResult::Syncing => {}
                         ExecutionTaskResult::Completed(last_fcu) => {
                             self.last_fcu = last_fcu;
 
                             // Emits an event on error.
                             let _: Result<_, _> = self.try_advance_floor().await;
+                        }
+                        // Keep the block unacknowledged until Reth accepts its payload and
+                        // any required FCU. Retry syncing blocks ahead of later blocks.
+                        ExecutionTaskResult::BlockPostponed(block, ack) => {
+                            self.block_queue.push_front((block, ack));
                         }
                         ExecutionTaskResult::Fatal(error) => {
                             error!(%error, "execution task failed");
@@ -163,6 +176,65 @@ where
             || self.pending_fcu.finalized_digest() != self.last_fcu.finalized_digest()
     }
 
+    async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
+        let start = self.execution_provider.finalized_num_hash()?.number + 1;
+        let end = self.floor.get();
+        if start > end {
+            return Ok(());
+        }
+
+        info!(start, end, "backfilling finalized blocks");
+        for height in start..=end {
+            let block = self
+                .marshal
+                .get_block(Height::new(height))
+                .await
+                .ok_or_else(|| eyre!("marshal missing backfill block at height `{height}`"))?;
+
+            let (ack, _waiter) = Exact::handle();
+            self.pending_fcu.update_finalized(&block);
+            let forkchoice = (self.pending_fcu.finalized_digest()
+                != self.last_fcu.finalized_digest())
+            .then_some(self.pending_fcu);
+            let mut request = ExecutionRequest::Block(block, forkchoice, ack);
+
+            // Backfill delivers contiguous blocks in order, so SYNCING cannot
+            // be repaired by a later block filling a gap. Retry this block until
+            // Reth is ready to accept it.
+            loop {
+                match execute_request(
+                    self.context.child("backfill_on_start"),
+                    self.execution_engine.clone(),
+                    self.last_fcu,
+                    request,
+                )
+                .await
+                {
+                    ExecutionTaskResult::Completed(last_fcu) => {
+                        self.last_fcu = last_fcu;
+                        break;
+                    }
+                    ExecutionTaskResult::BlockPostponed(block, ack) => {
+                        let forkchoice = (self.pending_fcu.finalized_digest()
+                            != self.last_fcu.finalized_digest())
+                        .then_some(self.pending_fcu);
+                        request = ExecutionRequest::Block(block, forkchoice, ack);
+                    }
+                    ExecutionTaskResult::Syncing => {
+                        unreachable!("backfill only executes block requests")
+                    }
+                    ExecutionTaskResult::Fatal(error) => {
+                        return Err(error).wrap_err_with(|| {
+                            format!("failed backfilling block at height `{height}`")
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn update_fcu_heartbeat_timer(&mut self) {
         if self.execution_task.is_none() && self.block_queue.is_empty() {
             if self.fcu_heartbeat_timer.is_none() {
@@ -179,11 +251,12 @@ where
             return;
         }
 
+        // Prioritize queued blocks so head-only FCUs cannot starve finality.
         let request = if let Some((block, ack)) = self.block_queue.pop_front() {
-            let forkchoice = self
-                .pending_fcu
-                .update_finalized(&block)
-                .then_some(self.pending_fcu);
+            self.pending_fcu.update_finalized(&block);
+            let forkchoice = (self.pending_fcu.finalized_digest()
+                != self.last_fcu.finalized_digest())
+            .then_some(self.pending_fcu);
             ExecutionRequest::Block(block, forkchoice, ack)
         } else if self.should_send_forkchoice() || heartbeat {
             ExecutionRequest::Forkchoice(self.pending_fcu)
@@ -200,12 +273,7 @@ where
 
     #[instrument(skip_all, err(level = Level::WARN))]
     async fn try_advance_floor(&mut self) -> eyre::Result<()> {
-        let finalized_height = Height::new(
-            self.execution_provider
-                .finalized_header()?
-                .num_hash()
-                .number,
-        );
+        let finalized_height = Height::new(self.execution_provider.finalized_num_hash()?.number);
         let epoch_length = self
             .epoch_strategy
             .containing(finalized_height)
@@ -254,9 +322,12 @@ enum ExecutionRequest {
 
 enum ExecutionTaskResult {
     Completed(Forkchoice),
+    BlockPostponed(Block, Exact),
+    Syncing,
     Fatal(Report),
 }
 
+#[instrument(skip_all)]
 async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
     context: TContext,
     execution_engine: E,
@@ -266,20 +337,33 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
     match request {
         ExecutionRequest::Forkchoice(forkchoice) => {
             match submit_forkchoice_update(&context, &execution_engine, &forkchoice).await {
-                Ok(()) => ExecutionTaskResult::Completed(forkchoice),
+                Ok(ForkchoiceOutcome::Valid) => ExecutionTaskResult::Completed(forkchoice),
+                Ok(ForkchoiceOutcome::Syncing) => ExecutionTaskResult::Syncing,
                 Err(error) => ExecutionTaskResult::Fatal(error),
             }
         }
         ExecutionRequest::Block(block, forkchoice, ack) => {
-            if let Err(error) = submit_new_payload(&context, &execution_engine, block).await {
-                return ExecutionTaskResult::Fatal(error);
+            match submit_new_payload(&context, &execution_engine, &block).await {
+                Ok(NewPayloadOutcome::Valid) => {}
+                Ok(NewPayloadOutcome::Syncing) => {
+                    debug!("execution layer is not ready to accept finalized block; postponing");
+                    context.sleep(FINALIZED_BLOCK_POSTPONE_DELAY).await;
+                    return ExecutionTaskResult::BlockPostponed(block, ack);
+                }
+                Err(error) => return ExecutionTaskResult::Fatal(error),
             }
 
             let last_fcu = if let Some(forkchoice) = forkchoice {
-                if let Err(error) =
-                    submit_forkchoice_update(&context, &execution_engine, &forkchoice).await
-                {
-                    return ExecutionTaskResult::Fatal(error);
+                match submit_forkchoice_update(&context, &execution_engine, &forkchoice).await {
+                    Ok(ForkchoiceOutcome::Valid) => {}
+                    Ok(ForkchoiceOutcome::Syncing) => {
+                        debug!(
+                            "execution layer is not ready to finalize delivered block; postponing"
+                        );
+                        context.sleep(FINALIZED_BLOCK_POSTPONE_DELAY).await;
+                        return ExecutionTaskResult::BlockPostponed(block, ack);
+                    }
+                    Err(error) => return ExecutionTaskResult::Fatal(error),
                 }
                 forkchoice
             } else {
@@ -292,6 +376,16 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
     }
 }
 
+enum NewPayloadOutcome {
+    Valid,
+    Syncing,
+}
+
+enum ForkchoiceOutcome {
+    Valid,
+    Syncing,
+}
+
 #[instrument(
     skip_all,
     fields(block.height = %block.height(), block.digest = %block.digest()),
@@ -300,9 +394,9 @@ async fn execute_request<TContext: Pacer, E: ExecutionEngine + 'static>(
 async fn submit_new_payload<TContext: Pacer, E: ExecutionEngine + ?Sized>(
     context: &TContext,
     execution_engine: &E,
-    block: Block,
-) -> eyre::Result<()> {
-    let (block, block_access_list) = block.into_parts();
+    block: &Block,
+) -> eyre::Result<NewPayloadOutcome> {
+    let (block, block_access_list) = block.clone().into_parts();
     let payload_status = execution_engine
         .new_payload(TempoExecutionData {
             block,
@@ -314,13 +408,15 @@ async fn submit_new_payload<TContext: Pacer, E: ExecutionEngine + ?Sized>(
         .await
         .wrap_err("failed sending finalized payload")?;
 
-    ensure!(
-        payload_status.is_valid() || payload_status.is_syncing(),
-        "payload status of finalized block was neither valid nor syncing: \
-         `{payload_status}`"
-    );
+    if payload_status.is_valid() {
+        return Ok(NewPayloadOutcome::Valid);
+    }
 
-    Ok(())
+    if payload_status.is_syncing() {
+        return Ok(NewPayloadOutcome::Syncing);
+    }
+
+    Err(Report::msg(payload_status).wrap_err("execution layer rejected finalized payload"))
 }
 
 #[instrument(
@@ -334,7 +430,7 @@ async fn submit_forkchoice_update<TContext: Pacer, E: ExecutionEngine + ?Sized>(
     context: &TContext,
     execution_engine: &E,
     forkchoice: &Forkchoice,
-) -> eyre::Result<()> {
+) -> eyre::Result<ForkchoiceOutcome> {
     let forkchoice = (*forkchoice).into();
 
     let response = execution_engine
@@ -345,10 +441,13 @@ async fn submit_forkchoice_update<TContext: Pacer, E: ExecutionEngine + ?Sized>(
 
     debug!(payload_status = %response.payload_status, "execution layer reported FCU status");
 
-    ensure!(
-        !response.is_invalid(),
-        Report::msg(response.payload_status).wrap_err("execution layer rejected fcu")
-    );
+    if response.is_valid() {
+        return Ok(ForkchoiceOutcome::Valid);
+    }
 
-    Ok(())
+    if response.payload_status.is_syncing() {
+        return Ok(ForkchoiceOutcome::Syncing);
+    }
+
+    Err(Report::msg(response.payload_status).wrap_err("forkchoice update was not valid"))
 }

--- a/crates/consensus/src/follow/executor/mod.rs
+++ b/crates/consensus/src/follow/executor/mod.rs
@@ -19,7 +19,7 @@ use commonware_runtime::{Clock, Pacer, Spawner};
 use eyre::OptionExt as _;
 use futures::channel::mpsc;
 use reth_engine_primitives::ConsensusEngineHandle;
-use reth_ethereum::chainspec::EthChainSpec as _;
+use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
 use reth_primitives_traits::{NodePrimitives, SealedHeader};
 use reth_provider::{
     BlockHashReader, BlockIdReader, ChainSpecProvider as _, DatabaseProviderFactory as _,
@@ -30,7 +30,7 @@ use tempo_node::{TempoExecutionData, TempoPayloadTypes};
 use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::TempoHeader;
 
-use crate::consensus::Digest;
+use crate::consensus::{Digest, block::Block};
 
 mod actor;
 mod fcu;
@@ -67,6 +67,10 @@ where
 
 /// Finalized block state needed to initialize and advance the follower.
 pub(crate) trait FinalizedBlockProvider: Send + Sync {
+    /// Execution layer's finalized block, falling back to genesis if no
+    /// block has been explicitly finalized yet.
+    fn finalized_num_hash(&self) -> eyre::Result<BlockNumHash>;
+
     /// Execution layer's effective finalized header. Returns genesis when no
     /// explicit finalized marker exists on a fresh chain.
     fn finalized_header(&self) -> eyre::Result<SealedHeader<TempoHeader>>;
@@ -95,6 +99,8 @@ pub(crate) trait ExecutionEngine: Send + Sync {
 pub(crate) trait Marshal: Clone + Send + Sync {
     type Finalization: Send;
 
+    fn get_block(&self, height: Height) -> impl Future<Output = Option<Block>> + Send;
+
     fn get_finalization(
         &self,
         height: Height,
@@ -108,11 +114,13 @@ where
     N: ProviderNodeTypes,
     N::Primitives: NodePrimitives<BlockHeader = TempoHeader>,
 {
+    fn finalized_num_hash(&self) -> eyre::Result<BlockNumHash> {
+        Ok(BlockIdReader::finalized_block_num_hash(self)?
+            .unwrap_or_else(|| BlockNumHash::new(0, self.chain_spec().genesis_hash())))
+    }
+
     fn finalized_header(&self) -> eyre::Result<SealedHeader<TempoHeader>> {
-        let hash = BlockIdReader::finalized_block_num_hash(self)?
-            .map(|tip| tip.hash)
-            .unwrap_or_else(|| self.chain_spec().genesis_hash());
-        HeaderProvider::sealed_header_by_hash(self, hash)
+        HeaderProvider::sealed_header_by_hash(self, self.finalized_num_hash()?.hash)
             .map_err(eyre::Report::new)?
             .ok_or_eyre("finalized execution block is missing its header")
     }
@@ -151,6 +159,11 @@ impl ExecutionEngine for ConsensusEngineHandle<TempoPayloadTypes> {
 
 impl Marshal for crate::alias::marshal::Mailbox {
     type Finalization = SimplexFinalization<Scheme<PublicKey, MinSig>, Digest>;
+
+    fn get_block(&self, height: Height) -> impl Future<Output = Option<Block>> + Send {
+        let mailbox = self.clone();
+        async move { mailbox.get_block(height).await }
+    }
 
     fn get_finalization(
         &self,

--- a/crates/consensus/src/follow/executor/test/mod.rs
+++ b/crates/consensus/src/follow/executor/test/mod.rs
@@ -170,7 +170,6 @@ fn block_queue_preempts_a_syncing_head_and_flushes_before_the_latest_head() {
     deterministic::Runner::default().start(|context| async move {
         let provider = StubExecutionProvider::default();
         provider.sync_forkchoices(1);
-        let release_forkchoice = provider.pause_next_forkchoice();
 
         let (actor, mut mailbox) = init(
             context.child("follower_executor"),
@@ -188,6 +187,7 @@ fn block_queue_preempts_a_syncing_head_and_flushes_before_the_latest_head() {
         let first_head = digest(2);
         mailbox.finalization(round(2), first_head);
         wait_until(&context, || provider.forkchoices().len() == 1).await;
+        context.sleep(Duration::from_millis(21)).await;
 
         let block = make_block_at_round(1, B256::ZERO, round(1));
         let block_hash = block.block_hash();
@@ -196,10 +196,6 @@ fn block_queue_preempts_a_syncing_head_and_flushes_before_the_latest_head() {
 
         let latest_head = digest(3);
         mailbox.finalization(round(3), latest_head);
-        context.sleep(Duration::from_millis(1)).await;
-        release_forkchoice
-            .send(())
-            .expect("the syncing forkchoice should still be in flight");
 
         waiter.await.expect("queued block should be acknowledged");
         wait_until(&context, || provider.forkchoices().len() == 3).await;

--- a/crates/consensus/src/follow/executor/test/mod.rs
+++ b/crates/consensus/src/follow/executor/test/mod.rs
@@ -166,7 +166,7 @@ fn syncing_block_is_requeued_ahead_of_later_blocks() {
 }
 
 #[test_traced]
-fn block_queue_preempts_a_syncing_head_and_flushes_before_the_latest_head() {
+fn block_queue_preserves_the_sync_target_before_sending_the_latest_head() {
     deterministic::Runner::default().start(|context| async move {
         let provider = StubExecutionProvider::default();
         provider.sync_forkchoices(1);
@@ -200,10 +200,14 @@ fn block_queue_preempts_a_syncing_head_and_flushes_before_the_latest_head() {
         waiter.await.expect("queued block should be acknowledged");
         wait_until(&context, || provider.forkchoices().len() == 3).await;
 
-        let forkchoices = provider.forkchoices();
-        assert_eq!(forkchoices[0].head_block_hash, first_head.0);
-        assert_eq!(forkchoices[1].head_block_hash, block_hash);
-        assert_eq!(forkchoices[2].head_block_hash, latest_head.0);
+        assert_eq!(
+            provider.forkchoices(),
+            vec![
+                forkchoice(first_head.0, B256::ZERO),
+                forkchoice(first_head.0, block_hash),
+                forkchoice(latest_head.0, block_hash),
+            ]
+        );
     });
 }
 

--- a/crates/consensus/src/follow/executor/test/mod.rs
+++ b/crates/consensus/src/follow/executor/test/mod.rs
@@ -113,6 +113,105 @@ fn block_is_executed_canonicalized_acknowledged_and_advances_floor_to_deep_candi
 }
 
 #[test_traced]
+fn syncing_block_is_requeued_ahead_of_later_blocks() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        provider.sync_payloads(1);
+        provider.sync_forkchoices(1);
+
+        let (actor, mut mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        let first = make_block_at_round(1, B256::ZERO, round(1));
+        let first_hash = first.block_hash();
+        let second = make_block_at_round(2, first_hash, round(2));
+        let second_hash = second.block_hash();
+        let (first_ack, first_waiter) = Exact::handle();
+        let (second_ack, second_waiter) = Exact::handle();
+        assert!(
+            mailbox
+                .report(Update::Block(first.into(), first_ack))
+                .accepted()
+        );
+        assert!(
+            mailbox
+                .report(Update::Block(second.into(), second_ack))
+                .accepted()
+        );
+
+        context.sleep(Duration::from_secs(1)).await;
+        first_waiter
+            .await
+            .expect("postponed block should be acknowledged");
+        second_waiter
+            .await
+            .expect("later block should be acknowledged");
+
+        assert_eq!(provider.payload_count(), 4);
+        let forkchoices = provider.forkchoices();
+        assert_eq!(forkchoices[0].head_block_hash, first_hash);
+        assert_eq!(forkchoices[1].head_block_hash, first_hash);
+        assert_eq!(forkchoices[2].head_block_hash, second_hash);
+    });
+}
+
+#[test_traced]
+fn block_queue_preempts_a_syncing_head_and_flushes_before_the_latest_head() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        provider.sync_forkchoices(1);
+        let release_forkchoice = provider.pause_next_forkchoice();
+
+        let (actor, mut mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal: StubMarshal::default(),
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::zero(),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        let first_head = digest(2);
+        mailbox.finalization(round(2), first_head);
+        wait_until(&context, || provider.forkchoices().len() == 1).await;
+
+        let block = make_block_at_round(1, B256::ZERO, round(1));
+        let block_hash = block.block_hash();
+        let (ack, waiter) = Exact::handle();
+        assert!(mailbox.report(Update::Block(block.into(), ack)).accepted());
+
+        let latest_head = digest(3);
+        mailbox.finalization(round(3), latest_head);
+        context.sleep(Duration::from_millis(1)).await;
+        release_forkchoice
+            .send(())
+            .expect("the syncing forkchoice should still be in flight");
+
+        waiter.await.expect("queued block should be acknowledged");
+        wait_until(&context, || provider.forkchoices().len() == 3).await;
+
+        let forkchoices = provider.forkchoices();
+        assert_eq!(forkchoices[0].head_block_hash, first_head.0);
+        assert_eq!(forkchoices[1].head_block_hash, block_hash);
+        assert_eq!(forkchoices[2].head_block_hash, latest_head.0);
+    });
+}
+
+#[test_traced]
 fn floor_candidate_uses_execution_depth_and_next_tip_starts_new_cycle() {
     deterministic::Runner::default().start(|context| async move {
         let provider = StubExecutionProvider::default();
@@ -758,6 +857,75 @@ fn durable_block_read_failure_does_not_exit_actor() {
         assert_eq!(provider.payload_count(), 2);
         assert_eq!(provider.forkchoices().len(), 2);
         assert_eq!(marshal.floor(), Height::zero());
+    });
+}
+
+#[test_traced]
+fn startup_backfills_when_marshal_floor_is_ahead_of_execution() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        provider.sync_payloads(1);
+        let marshal = StubMarshal::default();
+        let first = make_block_at_round(1, B256::ZERO, round(1));
+        let first_hash = first.block_hash();
+        let second = make_block_at_round(2, first_hash, round(2));
+        let second_hash = second.block_hash();
+        marshal.set_block(first);
+        marshal.set_block(second);
+
+        let (actor, _mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal,
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::new(2),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        context.sleep(Duration::from_secs(2)).await;
+        wait_until(&context, || provider.forkchoices().len() == 2).await;
+
+        assert_eq!(provider.payload_count(), 3);
+        let forkchoices = provider.forkchoices();
+        assert_eq!(forkchoices[0].head_block_hash, first_hash);
+        assert_eq!(forkchoices[0].finalized_block_hash, first_hash);
+        assert_eq!(forkchoices[1].head_block_hash, second_hash);
+        assert_eq!(forkchoices[1].finalized_block_hash, second_hash);
+    });
+}
+
+#[test_traced]
+fn startup_backfills_when_only_the_floor_block_is_missing() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        let execution_hash = B256::with_last_byte(1);
+        provider.set_finalized(1, execution_hash, round(1));
+        let marshal = StubMarshal::default();
+        let block = make_block_at_round(2, execution_hash, round(2));
+        let block_hash = block.block_hash();
+        marshal.set_block(block);
+
+        let (actor, _mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal,
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::new(2),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        wait_until(&context, || provider.forkchoices().len() == 1).await;
+
+        assert_eq!(provider.payload_count(), 1);
+        assert_eq!(provider.forkchoices()[0].finalized_block_hash, block_hash);
     });
 }
 

--- a/crates/consensus/src/follow/executor/test/mod.rs
+++ b/crates/consensus/src/follow/executor/test/mod.rs
@@ -864,7 +864,6 @@ fn durable_block_read_failure_does_not_exit_actor() {
 fn startup_backfills_when_marshal_floor_is_ahead_of_execution() {
     deterministic::Runner::default().start(|context| async move {
         let provider = StubExecutionProvider::default();
-        provider.sync_payloads(1);
         let marshal = StubMarshal::default();
         let first = make_block_at_round(1, B256::ZERO, round(1));
         let first_hash = first.block_hash();
@@ -886,15 +885,45 @@ fn startup_backfills_when_marshal_floor_is_ahead_of_execution() {
         );
         actor.start();
 
-        context.sleep(Duration::from_secs(2)).await;
         wait_until(&context, || provider.forkchoices().len() == 2).await;
 
-        assert_eq!(provider.payload_count(), 3);
+        assert_eq!(provider.payload_count(), 2);
         let forkchoices = provider.forkchoices();
         assert_eq!(forkchoices[0].head_block_hash, first_hash);
         assert_eq!(forkchoices[0].finalized_block_hash, first_hash);
         assert_eq!(forkchoices[1].head_block_hash, second_hash);
         assert_eq!(forkchoices[1].finalized_block_hash, second_hash);
+    });
+}
+
+#[test_traced]
+fn startup_backfill_retries_a_syncing_block() {
+    deterministic::Runner::default().start(|context| async move {
+        let provider = StubExecutionProvider::default();
+        provider.sync_payloads(1);
+        let marshal = StubMarshal::default();
+        let block = make_block_at_round(1, B256::ZERO, round(1));
+        let block_hash = block.block_hash();
+        marshal.set_block(block);
+
+        let (actor, _mailbox) = init(
+            context.child("follower_executor"),
+            Config {
+                execution_provider: provider.clone(),
+                execution_engine: provider.clone(),
+                marshal,
+                epoch_strategy: FixedEpocher::new(EPOCH_LENGTH),
+                floor: Height::new(1),
+                fcu_heartbeat_interval: Duration::from_secs(60),
+            },
+        );
+        actor.start();
+
+        context.sleep(Duration::from_secs(2)).await;
+        wait_until(&context, || provider.forkchoices().len() == 1).await;
+
+        assert_eq!(provider.payload_count(), 2);
+        assert_eq!(provider.forkchoices()[0].finalized_block_hash, block_hash);
     });
 }
 

--- a/crates/consensus/src/follow/executor/test/utils.rs
+++ b/crates/consensus/src/follow/executor/test/utils.rs
@@ -14,7 +14,10 @@ use alloy_primitives::B256;
 use alloy_rpc_types_engine::{
     ForkchoiceState, ForkchoiceUpdated, PayloadStatus, PayloadStatusEnum,
 };
-use commonware_consensus::types::{Height, Round};
+use commonware_consensus::{
+    Heightable as _,
+    types::{Height, Round},
+};
 use futures::channel::oneshot;
 use parking_lot::Mutex;
 use reth_ethereum::rpc::eth::primitives::BlockNumHash;
@@ -75,6 +78,8 @@ struct StubExecutionProviderInner {
     durable: Mutex<HashMap<u64, B256>>,
     fail_durable_reads: AtomicBool,
     payloads: AtomicUsize,
+    syncing_payloads: AtomicUsize,
+    syncing_forkchoices: AtomicUsize,
     forkchoices: Mutex<Vec<ForkchoiceState>>,
     reject_payloads: AtomicBool,
     reject_forkchoices: AtomicBool,
@@ -106,6 +111,16 @@ impl StubExecutionProvider {
         self.inner.reject_payloads.store(true, Ordering::SeqCst);
     }
 
+    pub(super) fn sync_payloads(&self, count: usize) {
+        self.inner.syncing_payloads.store(count, Ordering::SeqCst);
+    }
+
+    pub(super) fn sync_forkchoices(&self, count: usize) {
+        self.inner
+            .syncing_forkchoices
+            .store(count, Ordering::SeqCst);
+    }
+
     pub(super) fn reject_forkchoices(&self) {
         self.inner.reject_forkchoices.store(true, Ordering::SeqCst);
     }
@@ -126,6 +141,10 @@ impl StubExecutionProvider {
 }
 
 impl FinalizedBlockProvider for StubExecutionProvider {
+    fn finalized_num_hash(&self) -> eyre::Result<BlockNumHash> {
+        Ok(*self.inner.finalized.lock())
+    }
+
     fn finalized_header(&self) -> eyre::Result<SealedHeader<TempoHeader>> {
         let tip = *self.inner.finalized.lock();
         let consensus_context =
@@ -166,11 +185,20 @@ impl ExecutionEngine for StubExecutionProvider {
     ) -> impl Future<Output = eyre::Result<PayloadStatus>> + Send + 'static {
         self.inner.payloads.fetch_add(1, Ordering::SeqCst);
         let rejected = self.inner.reject_payloads.load(Ordering::SeqCst);
+        let syncing = self
+            .inner
+            .syncing_payloads
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok();
         async move {
             let status = if rejected {
                 PayloadStatusEnum::Invalid {
                     validation_error: "rejected by test provider".into(),
                 }
+            } else if syncing {
+                PayloadStatusEnum::Syncing
             } else {
                 PayloadStatusEnum::Valid
             };
@@ -186,6 +214,13 @@ impl ExecutionEngine for StubExecutionProvider {
         self.inner.forkchoices.lock().push(state);
         let gate = self.inner.forkchoice_gate.lock().take();
         let rejected = self.inner.reject_forkchoices.load(Ordering::SeqCst);
+        let syncing = self
+            .inner
+            .syncing_forkchoices
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_ok();
         async move {
             if let Some(gate) = gate {
                 let _ = gate.await;
@@ -194,6 +229,8 @@ impl ExecutionEngine for StubExecutionProvider {
                 PayloadStatusEnum::Invalid {
                     validation_error: "rejected by test engine".into(),
                 }
+            } else if syncing {
+                PayloadStatusEnum::Syncing
             } else {
                 PayloadStatusEnum::Valid
             };
@@ -205,16 +242,25 @@ impl ExecutionEngine for StubExecutionProvider {
 #[derive(Clone, Default)]
 pub(super) struct StubMarshal {
     floor: Arc<AtomicU64>,
+    blocks: Arc<Mutex<HashMap<u64, Block>>>,
 }
 
 impl StubMarshal {
     pub(super) fn floor(&self) -> Height {
         Height::new(self.floor.load(Ordering::SeqCst))
     }
+
+    pub(super) fn set_block(&self, block: Block) {
+        self.blocks.lock().insert(block.height().get(), block);
+    }
 }
 
 impl Marshal for StubMarshal {
     type Finalization = Height;
+
+    async fn get_block(&self, height: Height) -> Option<Block> {
+        self.blocks.lock().get(&height.get()).cloned()
+    }
 
     async fn get_finalization(&self, height: Height) -> Option<Self::Finalization> {
         Some(height)

--- a/crates/consensus/src/follow/executor/test/utils.rs
+++ b/crates/consensus/src/follow/executor/test/utils.rs
@@ -188,7 +188,7 @@ impl ExecutionEngine for StubExecutionProvider {
         let syncing = self
             .inner
             .syncing_payloads
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+            .try_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
                 remaining.checked_sub(1)
             })
             .is_ok();
@@ -217,7 +217,7 @@ impl ExecutionEngine for StubExecutionProvider {
         let syncing = self
             .inner
             .syncing_forkchoices
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+            .try_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
                 remaining.checked_sub(1)
             })
             .is_ok();


### PR DESCRIPTION
- If Reth report SYNCING, hold back from acknowledging any blocks. These blocks remain in the queue and will be flushed once the sync is complete
- When syncing, additional FCUs are blocked when there are pending finalized blocks to flush. This prevents starving progressing finalized state. However the actor loop is not blocked and the pending target can continually update while the node is syncing
- Backfill blocks from CL to EL on startup as Reth may not have persisted state