### PR TITLE
fix(ci): match sync workflow via OIDC claim

### DIFF
--- a/.github/sts/sync-from-upstream.sts.yaml
+++ b/.github/sts/sync-from-upstream.sts.yaml
@@ -1,10 +1,13 @@
 # Allow only the sync-from-upstream workflows on the main branches of the
 # tempo-private-fork and tempo-firedrill repositories to mint a short-lived
-# token. `workflows: write` is required because synced commits can touch
-# .github/workflows files.
+# token. The subject pins the repositories and refs; the claim pattern pins
+# the workflow files. `workflows: write` is required because synced commits
+# can touch .github/workflows files.
 subject:
-  - repo:tempoxyz@211589300/tempo-private-fork@1160043351:job_workflow_ref:tempoxyz/tempo-private-fork/.github/workflows/sync-from-upstream.yml@refs/heads/main
-  - repo:tempoxyz@211589300/tempo-firedrill@1167619511:job_workflow_ref:tempoxyz/tempo-firedrill/.github/workflows/sync-from-upstream.yml@refs/heads/main
+  - repo:tempoxyz@211589300/tempo-private-fork@1160043351:ref:refs/heads/main
+  - repo:tempoxyz@211589300/tempo-firedrill@1167619511:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: tempoxyz/(tempo-private-fork|tempo-firedrill)/\.github/workflows/sync-from-upstream\.yml@refs/heads/main
 permissions:
   contents: write
   workflows: write


### PR DESCRIPTION
Restores the immutable main-branch subjects for fork syncs and matches job_workflow_ref separately through claim_pattern.

This fixes the STS subject mismatch seen in https://github.com/tempoxyz/tempo-private-fork/actions/runs/33340728343/job/99335782164 because the copy repositories use the default OIDC subject template.