### PR TITLE
feat(txpool): add configurable address checks

### DIFF
--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -678,12 +678,12 @@ mod tests {
     }
 
     #[test]
-    fn txpool_filter_defaults_empty_and_parses_address_list() {
+    fn txpool_filter_defaults_empty_and_parses_address_list_or_file() {
         let cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
-        assert!(node_cmd.ext.node_args.txpool_filter.is_empty());
+        assert!(node_cmd.ext.node_args.txpool_filter.is_none());
 
         let cli = TempoCli::try_parse_from([
             "tempo",
@@ -696,13 +696,59 @@ mod tests {
         let Commands::Node(node_cmd) = cli.command else {
             panic!("expected node command");
         };
-        assert_eq!(
-            node_cmd.ext.node_args.txpool_filter,
-            vec![
-                address!("0000000000000000000000000000000000000001"),
-                address!("0000000000000000000000000000000000000002"),
-            ]
-        );
+        let filter = node_cmd.ext.node_args.txpool_filter.as_ref().unwrap();
+        assert_eq!(filter.len(), 2);
+        assert!(filter.contains(&address!("0000000000000000000000000000000000000001")));
+        assert!(filter.contains(&address!("0000000000000000000000000000000000000002")));
+
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            "0x0000000000000000000000000000000000000003\n\n\
+             0x0000000000000000000000000000000000000004, \
+             0x0000000000000000000000000000000000000005,\
+             0x0000000000000000000000000000000000000003\n",
+        )
+        .unwrap();
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--txpool.filter",
+            file.path().to_str().unwrap(),
+        ])
+        .unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        let filter = node_cmd.ext.node_args.txpool_filter.as_ref().unwrap();
+        assert_eq!(filter.len(), 3);
+        assert!(filter.contains(&address!("0000000000000000000000000000000000000003")));
+        assert!(filter.contains(&address!("0000000000000000000000000000000000000004")));
+        assert!(filter.contains(&address!("0000000000000000000000000000000000000005")));
+    }
+
+    #[test]
+    fn txpool_filter_reports_invalid_file_entry() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            "0x0000000000000000000000000000000000000001\nnot-an-address\n",
+        )
+        .unwrap();
+
+        let error = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--txpool.filter",
+            file.path().to_str().unwrap(),
+        ])
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains(file.path().to_str().unwrap()));
+        assert!(error.contains("invalid address `not-an-address` on line 2"));
     }
 
     fn parse_follow(args: &[&str]) -> Option<FollowMode> {

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -70,8 +70,8 @@ use tempo_contracts::precompiles::{ZONE_FACTORY_ADDRESS, initial_zone_factory_co
 use tempo_evm::{TempoEvmConfig, consensus::TempoConsensus};
 use tempo_faucet::faucet::{TempoFaucetExt, TempoFaucetExtApiServer};
 pub use tempo_node::{
-    AccountInfoReader, InvalidPoolTransactionError, PoolTransaction, PoolTransactionError,
-    StatefulValidationFn, StatelessValidationFn, TempoNode, TempoNodeArgs,
+    AccountInfoReader, AddressFilter, InvalidPoolTransactionError, PoolTransaction,
+    PoolTransactionError, StatefulValidationFn, StatelessValidationFn, TempoNode, TempoNodeArgs,
     TempoPayloadBuilderBuilder, TempoPoolBuilder, TempoPoolTransactionError,
     TempoPooledTransaction, TransactionOrigin,
 };
@@ -675,6 +675,34 @@ mod tests {
     fn init_defaults_once() {
         static INIT: Once = Once::new();
         INIT.call_once(defaults::init_defaults);
+    }
+
+    #[test]
+    fn txpool_filter_defaults_empty_and_parses_address_list() {
+        let cli = TempoCli::try_parse_from(["tempo", "node", "--dev"]).unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert!(node_cmd.ext.node_args.txpool_filter.is_empty());
+
+        let cli = TempoCli::try_parse_from([
+            "tempo",
+            "node",
+            "--dev",
+            "--txpool.filter",
+            "0x0000000000000000000000000000000000000001,0x0000000000000000000000000000000000000002",
+        ])
+        .unwrap();
+        let Commands::Node(node_cmd) = cli.command else {
+            panic!("expected node command");
+        };
+        assert_eq!(
+            node_cmd.ext.node_args.txpool_filter,
+            vec![
+                address!("0000000000000000000000000000000000000001"),
+                address!("0000000000000000000000000000000000000002"),
+            ]
+        );
     }
 
     fn parse_follow(args: &[&str]) -> Option<FollowMode> {

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -18,6 +18,7 @@ pub use reth_transaction_pool::{
     error::{InvalidPoolTransactionError, PoolTransactionError},
 };
 pub use tempo_transaction_pool::{
+    AddressFilter,
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
     validator::DEFAULT_AA_VALID_AFTER_MAX_SECS,
 };

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,7 +9,7 @@ use crate::{
         TempoToken, TempoTokenApiServer,
     },
 };
-use alloy_primitives::B256;
+use alloy_primitives::{Address, B256};
 use reth_chainspec::{ChainKind, EthChainSpec, Hardforks, NamedChain};
 use reth_ethereum::network::{NetworkHandle, PeersInfo as _, primitives::BasicNetworkPrimitives};
 use reth_node_api::{
@@ -50,7 +50,7 @@ use tempo_payload_builder::{
 use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::{TempoHeader, TempoPrimitives, TempoTxEnvelope, TempoTxType};
 use tempo_transaction_pool::{
-    AA2dPool, AA2dPoolConfig, TempoTransactionPool,
+    AA2dPool, AA2dPoolConfig, AddressFilter, TempoTransactionPool,
     amm::AmmLiquidityCache,
     ordering::TempoTipOrdering,
     transaction::TempoPooledTransaction,
@@ -64,7 +64,7 @@ use tempo_transaction_pool::{
 pub const BLOCK_GAS_LIMIT_500M: u64 = 500_000_000;
 
 /// Tempo node CLI arguments.
-#[derive(Debug, Clone, Copy, PartialEq, clap::Args)]
+#[derive(Debug, Clone, PartialEq, clap::Args)]
 pub struct TempoNodeArgs {
     /// Maximum allowed `valid_after` offset for AA txs.
     #[arg(long = "txpool.aa-valid-after-max-secs", default_value_t = DEFAULT_AA_VALID_AFTER_MAX_SECS)]
@@ -73,6 +73,10 @@ pub struct TempoNodeArgs {
     /// Maximum number of authorizations allowed in an AA transaction.
     #[arg(long = "txpool.max-tempo-authorizations", default_value_t = DEFAULT_MAX_TEMPO_AUTHORIZATIONS)]
     pub max_tempo_authorizations: usize,
+
+    /// Addresses checked against transaction senders and direct call targets during pool admission.
+    #[arg(long = "txpool.filter", value_name = "ADDRESS", value_delimiter = ',')]
+    pub txpool_filter: Vec<Address>,
 
     /// Enable state provider metrics for the payload builder.
     #[arg(long = "builder.state-provider-metrics", default_value_t = false)]
@@ -114,6 +118,7 @@ impl Default for TempoNodeArgs {
         Self {
             aa_valid_after_max_secs: DEFAULT_AA_VALID_AFTER_MAX_SECS,
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+            txpool_filter: Vec::new(),
             builder_state_provider_metrics: false,
             builder_disable_prewarming: false,
             builder_enable_prewarming: true,
@@ -130,6 +135,7 @@ impl TempoNodeArgs {
         TempoPoolBuilder {
             aa_valid_after_max_secs: self.aa_valid_after_max_secs,
             max_tempo_authorizations: self.max_tempo_authorizations,
+            address_filter: AddressFilter::new(self.txpool_filter.iter().copied()),
             ..Default::default()
         }
     }
@@ -583,6 +589,8 @@ pub struct TempoPoolBuilder {
     pub max_tempo_authorizations: usize,
     /// Whether to skip the FeeAMM liquidity check during pool admission.
     pub disable_fee_amm_check: bool,
+    /// Addresses checked against transaction senders and direct call targets.
+    pub address_filter: AddressFilter,
     /// Optional additional stateless validation check forwarded to the inner ETH validator.
     pub additional_stateless_validation: Option<StatelessValidationFn<TempoPooledTransaction>>,
     /// Optional additional stateful validation check forwarded to the inner ETH validator.
@@ -605,6 +613,12 @@ impl TempoPoolBuilder {
     /// Configures whether to disable the FeeAMM liquidity check during pool admission.
     pub const fn with_disable_fee_amm_check(mut self, disable: bool) -> Self {
         self.disable_fee_amm_check = disable;
+        self
+    }
+
+    /// Configures transaction sender and direct call target checks.
+    pub fn with_address_filter(mut self, address_filter: AddressFilter) -> Self {
+        self.address_filter = address_filter;
         self
     }
 
@@ -683,6 +697,7 @@ impl core::fmt::Debug for TempoPoolBuilder {
             .field("aa_valid_after_max_secs", &self.aa_valid_after_max_secs)
             .field("max_tempo_authorizations", &self.max_tempo_authorizations)
             .field("disable_fee_amm_check", &self.disable_fee_amm_check)
+            .field("address_filter", &self.address_filter)
             .field(
                 "additional_stateless_validation",
                 &self.additional_stateless_validation.as_ref().map(|_| "..."),
@@ -701,6 +716,7 @@ impl Default for TempoPoolBuilder {
             aa_valid_after_max_secs: DEFAULT_AA_VALID_AFTER_MAX_SECS,
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
             disable_fee_amm_check: false,
+            address_filter: AddressFilter::default(),
             additional_stateless_validation: None,
             additional_stateful_validation: None,
         }
@@ -750,6 +766,7 @@ where
             aa_valid_after_max_secs,
             max_tempo_authorizations,
             disable_fee_amm_check,
+            address_filter,
             additional_stateless_validation,
             additional_stateful_validation,
         } = self;
@@ -763,6 +780,7 @@ where
                 amm_liquidity_cache.clone(),
             )
             .with_disable_fee_amm_check(disable_fee_amm_check)
+            .with_address_filter(address_filter.clone())
         });
         let protocol_pool = Pool::new(
             validator,
@@ -859,6 +877,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{TempoNode, TempoNodeArgs, TempoPayloadBuilderBuilder, TempoPoolBuilder};
+    use alloy_primitives::Address;
 
     #[test]
     fn tempo_node_maps_pool_builder() {
@@ -881,6 +900,21 @@ mod tests {
             TempoNode::default().map_pool_builder(|pool| pool.with_disable_fee_amm_check(true));
 
         assert!(node.pool_builder.disable_fee_amm_check);
+    }
+
+    #[test]
+    fn tempo_node_configures_address_filter() {
+        let address = Address::with_last_byte(1);
+        let node = TempoNode::new(
+            &TempoNodeArgs {
+                txpool_filter: vec![address],
+                ..Default::default()
+            },
+            None,
+        );
+
+        assert_eq!(node.pool_builder.address_filter.len(), 1);
+        assert!(node.pool_builder.address_filter.contains(&address));
     }
 
     #[test]

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -9,7 +9,7 @@ use crate::{
         TempoToken, TempoTokenApiServer,
     },
 };
-use alloy_primitives::{Address, B256};
+use alloy_primitives::B256;
 use reth_chainspec::{ChainKind, EthChainSpec, Hardforks, NamedChain};
 use reth_ethereum::network::{NetworkHandle, PeersInfo as _, primitives::BasicNetworkPrimitives};
 use reth_node_api::{
@@ -74,9 +74,14 @@ pub struct TempoNodeArgs {
     #[arg(long = "txpool.max-tempo-authorizations", default_value_t = DEFAULT_MAX_TEMPO_AUTHORIZATIONS)]
     pub max_tempo_authorizations: usize,
 
-    /// Addresses checked against transaction senders and direct call targets during pool admission.
-    #[arg(long = "txpool.filter", value_name = "ADDRESS", value_delimiter = ',')]
-    pub txpool_filter: Vec<Address>,
+    /// Comma-separated addresses or a file containing comma/newline-separated addresses used for
+    /// transaction sender and direct call target checks.
+    #[arg(
+        long = "txpool.filter",
+        value_name = "ADDRESSES_OR_FILE",
+        value_parser = parse_address_filter
+    )]
+    pub txpool_filter: Option<AddressFilter>,
 
     /// Enable state provider metrics for the payload builder.
     #[arg(long = "builder.state-provider-metrics", default_value_t = false)]
@@ -118,7 +123,7 @@ impl Default for TempoNodeArgs {
         Self {
             aa_valid_after_max_secs: DEFAULT_AA_VALID_AFTER_MAX_SECS,
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
-            txpool_filter: Vec::new(),
+            txpool_filter: None,
             builder_state_provider_metrics: false,
             builder_disable_prewarming: false,
             builder_enable_prewarming: true,
@@ -135,7 +140,7 @@ impl TempoNodeArgs {
         TempoPoolBuilder {
             aa_valid_after_max_secs: self.aa_valid_after_max_secs,
             max_tempo_authorizations: self.max_tempo_authorizations,
-            address_filter: AddressFilter::new(self.txpool_filter.iter().copied()),
+            address_filter: self.txpool_filter.clone().unwrap_or_default(),
             ..Default::default()
         }
     }
@@ -151,6 +156,23 @@ impl TempoNodeArgs {
             enable_prewarming: !self.builder_disable_prewarming,
             enable_parallel: self.builder_parallel,
             build_time_multiplier: self.builder_build_time_multiplier,
+        }
+    }
+}
+
+fn parse_address_filter(value: &str) -> Result<AddressFilter, String> {
+    match value.parse::<AddressFilter>() {
+        Ok(filter) => Ok(filter),
+        Err(list_error) => {
+            let contents = std::fs::read_to_string(value).map_err(|file_error| {
+                format!(
+                    "invalid address list ({list_error}); failed to read `{value}` as a file: {file_error}"
+                )
+            })?;
+
+            contents
+                .parse::<AddressFilter>()
+                .map_err(|error| format!("invalid address list in `{value}`: {error}"))
         }
     }
 }
@@ -876,7 +898,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{TempoNode, TempoNodeArgs, TempoPayloadBuilderBuilder, TempoPoolBuilder};
+    use super::{
+        AddressFilter, TempoNode, TempoNodeArgs, TempoPayloadBuilderBuilder, TempoPoolBuilder,
+    };
     use alloy_primitives::Address;
 
     #[test]
@@ -907,7 +931,7 @@ mod tests {
         let address = Address::with_last_byte(1);
         let node = TempoNode::new(
             &TempoNodeArgs {
-                txpool_filter: vec![address],
+                txpool_filter: Some(AddressFilter::new([address])),
                 ..Default::default()
             },
             None,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -160,23 +160,6 @@ impl TempoNodeArgs {
     }
 }
 
-fn parse_address_filter(value: &str) -> Result<AddressFilter, String> {
-    match value.parse::<AddressFilter>() {
-        Ok(filter) => Ok(filter),
-        Err(list_error) => {
-            let contents = std::fs::read_to_string(value).map_err(|file_error| {
-                format!(
-                    "invalid address list ({list_error}); failed to read `{value}` as a file: {file_error}"
-                )
-            })?;
-
-            contents
-                .parse::<AddressFilter>()
-                .map_err(|error| format!("invalid address list in `{value}`: {error}"))
-        }
-    }
-}
-
 /// Builds the node's network and announces `tempo/1`.
 ///
 /// The protocol must be registered before the network starts. `RLPx`
@@ -893,6 +876,24 @@ where
                 build_time_multiplier: self.build_time_multiplier,
             },
         ))
+    }
+}
+
+/// Parses `value` as an address list, falling back to reading it as a file.
+fn parse_address_filter(value: &str) -> Result<AddressFilter, String> {
+    match value.parse::<AddressFilter>() {
+        Ok(filter) => Ok(filter),
+        Err(list_error) => {
+            let contents = std::fs::read_to_string(value).map_err(|file_error| {
+                format!(
+                    "invalid address list ({list_error}); failed to read `{value}` as a file: {file_error}"
+                )
+            })?;
+
+            contents
+                .parse::<AddressFilter>()
+                .map_err(|error| format!("invalid address list in `{value}`: {error}"))
+        }
     }
 }
 

--- a/crates/transaction-pool/src/address_filter.rs
+++ b/crates/transaction-pool/src/address_filter.rs
@@ -1,0 +1,171 @@
+//! Address checks for transaction pool admission.
+
+use crate::transaction::{TempoPoolTransactionError, TempoPooledTransaction};
+use alloy_primitives::{Address, map::AddressSet};
+use reth_transaction_pool::PoolTransaction;
+
+/// Addresses checked against transaction senders and direct call targets.
+///
+/// Ordinary Ethereum-style transactions have at most one direct call target. Tempo
+/// transactions may contain multiple calls, so every direct target is checked.
+#[derive(Clone, Debug, Default)]
+pub struct AddressFilter {
+    addresses: AddressSet,
+}
+
+impl AddressFilter {
+    /// Creates a filter from the given addresses.
+    pub fn new(addresses: impl IntoIterator<Item = Address>) -> Self {
+        Self {
+            addresses: addresses.into_iter().collect(),
+        }
+    }
+
+    /// Returns whether no address checks are configured.
+    pub fn is_empty(&self) -> bool {
+        self.addresses.is_empty()
+    }
+
+    /// Returns the number of unique configured addresses.
+    pub fn len(&self) -> usize {
+        self.addresses.len()
+    }
+
+    /// Returns whether the address is configured.
+    pub fn contains(&self, address: &Address) -> bool {
+        self.addresses.contains(address)
+    }
+
+    /// Checks the recovered sender and every direct call target in the transaction.
+    pub fn check(
+        &self,
+        transaction: &TempoPooledTransaction,
+    ) -> Result<(), TempoPoolTransactionError> {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let matched = self
+            .contains(transaction.sender_ref())
+            .then_some(*transaction.sender_ref())
+            .or_else(|| {
+                transaction
+                    .inner()
+                    .calls()
+                    .filter_map(|(kind, _)| kind.into_to())
+                    .find(|address| self.contains(address))
+            });
+
+        match matched {
+            Some(address) => Err(TempoPoolTransactionError::AddressCheck { address }),
+            None => Ok(()),
+        }
+    }
+}
+
+impl FromIterator<Address> for AddressFilter {
+    fn from_iter<T: IntoIterator<Item = Address>>(iter: T) -> Self {
+        Self::new(iter)
+    }
+}
+
+impl From<Vec<Address>> for AddressFilter {
+    fn from(addresses: Vec<Address>) -> Self {
+        Self::new(addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AddressFilter;
+    use crate::{test_utils::TxBuilder, transaction::TempoPoolTransactionError};
+    use alloy_primitives::{Address, Bytes, TxKind, U256};
+    use reth_transaction_pool::PoolTransaction;
+    use tempo_primitives::transaction::tempo_transaction::Call;
+
+    fn assert_address_check(result: Result<(), TempoPoolTransactionError>, expected: Address) {
+        assert!(matches!(
+            result,
+            Err(TempoPoolTransactionError::AddressCheck { address }) if address == expected
+        ));
+    }
+
+    #[test]
+    fn empty_filter_allows_transactions() {
+        let transaction = TxBuilder::eip1559(Address::with_last_byte(1)).build_eip1559();
+
+        assert!(AddressFilter::default().check(&transaction).is_ok());
+    }
+
+    #[test]
+    fn checks_recovered_sender() {
+        let transaction = TxBuilder::eip1559(Address::with_last_byte(1)).build_eip1559();
+        let sender = *transaction.sender_ref();
+        let filter = AddressFilter::new([sender]);
+
+        assert_address_check(filter.check(&transaction), sender);
+    }
+
+    #[test]
+    fn checks_ethereum_call_target() {
+        let target = Address::with_last_byte(2);
+        let transaction = TxBuilder::eip1559(target).build_eip1559();
+        let filter = AddressFilter::new([target]);
+
+        assert_address_check(filter.check(&transaction), target);
+    }
+
+    #[test]
+    fn checks_every_tempo_call_target() {
+        let sender = Address::with_last_byte(3);
+        let first_target = Address::with_last_byte(4);
+        let later_target = Address::with_last_byte(5);
+        let transaction = TxBuilder::aa(sender)
+            .calls(vec![
+                Call {
+                    to: TxKind::Call(first_target),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+                Call {
+                    to: TxKind::Call(later_target),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+            ])
+            .build();
+        let filter = AddressFilter::new([later_target]);
+
+        assert_address_check(filter.check(&transaction), later_target);
+    }
+
+    #[test]
+    fn ignores_unlisted_addresses_and_create_calls() {
+        let transaction = TxBuilder::aa(Address::with_last_byte(6))
+            .calls(vec![
+                Call {
+                    to: TxKind::Create,
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+                Call {
+                    to: TxKind::Call(Address::with_last_byte(7)),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+            ])
+            .build();
+        let filter = AddressFilter::new([Address::with_last_byte(8)]);
+
+        assert!(filter.check(&transaction).is_ok());
+    }
+
+    #[test]
+    fn deduplicates_configured_addresses() {
+        let address = Address::with_last_byte(9);
+        let filter = AddressFilter::new([address, address]);
+
+        assert_eq!(filter.len(), 1);
+        assert!(filter.contains(&address));
+    }
+}

--- a/crates/transaction-pool/src/address_filter.rs
+++ b/crates/transaction-pool/src/address_filter.rs
@@ -3,12 +3,13 @@
 use crate::transaction::{TempoPoolTransactionError, TempoPooledTransaction};
 use alloy_primitives::{Address, map::AddressSet};
 use reth_transaction_pool::PoolTransaction;
+use std::str::FromStr;
 
 /// Addresses checked against transaction senders and direct call targets.
 ///
 /// Ordinary Ethereum-style transactions have at most one direct call target. Tempo
 /// transactions may contain multiple calls, so every direct target is checked.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct AddressFilter {
     addresses: AddressSet,
 }
@@ -72,6 +73,33 @@ impl FromIterator<Address> for AddressFilter {
 impl From<Vec<Address>> for AddressFilter {
     fn from(addresses: Vec<Address>) -> Self {
         Self::new(addresses)
+    }
+}
+
+impl FromStr for AddressFilter {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut addresses = Vec::new();
+
+        for (line, values) in value.trim_start_matches('\u{feff}').lines().enumerate() {
+            for value in values
+                .split(',')
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                let address = value.parse::<Address>().map_err(|error| {
+                    format!("invalid address `{value}` on line {}: {error}", line + 1)
+                })?;
+                addresses.push(address);
+            }
+        }
+
+        if addresses.is_empty() {
+            return Err("no addresses provided".to_string());
+        }
+
+        Ok(Self::new(addresses))
     }
 }
 
@@ -167,5 +195,32 @@ mod tests {
 
         assert_eq!(filter.len(), 1);
         assert!(filter.contains(&address));
+    }
+
+    #[test]
+    fn parses_comma_and_newline_separated_addresses() {
+        let first = Address::with_last_byte(10);
+        let second = Address::with_last_byte(11);
+        let filter = format!("{first}, {second}\n\n{first},")
+            .parse::<AddressFilter>()
+            .unwrap();
+
+        assert_eq!(filter.len(), 2);
+        assert!(filter.contains(&first));
+        assert!(filter.contains(&second));
+    }
+
+    #[test]
+    fn rejects_empty_and_invalid_address_lists() {
+        assert_eq!(
+            "\n, \n".parse::<AddressFilter>().unwrap_err(),
+            "no addresses provided"
+        );
+        assert!(
+            "0x0000000000000000000000000000000000000001\nnot-an-address"
+                .parse::<AddressFilter>()
+                .unwrap_err()
+                .contains("invalid address `not-an-address` on line 2")
+        );
     }
 }

--- a/crates/transaction-pool/src/lib.rs
+++ b/crates/transaction-pool/src/lib.rs
@@ -6,6 +6,9 @@
 pub mod transaction;
 pub mod validator;
 
+mod address_filter;
+pub use address_filter::AddressFilter;
+
 pub use transaction::{KeychainSubject, RevokedKeys, SpendingLimitUpdates};
 
 // Tempo pool module with 2D nonce support

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -696,6 +696,16 @@ pub enum TempoPoolTransactionError {
         min_allowed: u64,
     },
 
+    /// A transaction matched a configured address check.
+    ///
+    /// Thrown during pool admission when the recovered sender or a direct call target
+    /// appears in the node's configured address filter.
+    #[error("Transaction address check failed for {address}")]
+    AddressCheck {
+        /// The address that matched the configured filter.
+        address: Address,
+    },
+
     /// A Tempo EVM validation error returned by the transaction pool.
     ///
     /// Thrown when `TempoEvm::validate_transaction` rejects the transaction with
@@ -715,6 +725,7 @@ impl PoolTransactionError for TempoPoolTransactionError {
             | Self::InvalidValidAfter(_)
             | Self::AccessKeyExpired { .. }
             | Self::KeyAuthorizationExpired { .. }
+            | Self::AddressCheck { .. }
             | Self::Keychain(_) => false,
             Self::SubblockNonceKey
             | Self::TooManyAuthorizations { .. }
@@ -1234,6 +1245,12 @@ mod tests {
                 TempoPoolTransactionError::KeyAuthorizationExpired {
                     expiry: 100,
                     min_allowed: 200,
+                },
+                false,
+            ),
+            (
+                TempoPoolTransactionError::AddressCheck {
+                    address: Address::repeat_byte(0x20),
                 },
                 false,
             ),

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -1,4 +1,5 @@
 use crate::{
+    AddressFilter,
     amm::AmmLiquidityCache,
     state_cache::{StateCache, StateCacheDb},
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
@@ -97,6 +98,8 @@ pub struct TempoTransactionValidator<Client, EvmConfig = TempoEvmConfig> {
     pub(crate) amm_liquidity_cache: AmmLiquidityCache,
     /// Whether to skip the FeeAMM liquidity check during pool admission.
     pub(crate) disable_fee_amm_check: bool,
+    /// Addresses checked against transaction senders and direct call targets.
+    address_filter: AddressFilter,
     /// Cached EVM environment from the latest tip block, updated on each `on_new_head_block`.
     cached_evm_env: RwLock<EvmEnv<TempoHardfork, TempoBlockEnv>>,
     /// Tip hash and cache of state reads shared across validation calls, replaced on each
@@ -141,6 +144,7 @@ where
             max_tempo_authorizations,
             amm_liquidity_cache,
             disable_fee_amm_check: false,
+            address_filter: AddressFilter::default(),
             cached_evm_env: parking_lot::RwLock::new(evm_env),
             cached_state: RwLock::new((latest_header.hash(), Arc::new(StateCache::default()))),
             active_hardfork,
@@ -150,6 +154,12 @@ where
     /// Configures whether to skip the FeeAMM liquidity check during pool admission.
     pub const fn with_disable_fee_amm_check(mut self, disable: bool) -> Self {
         self.disable_fee_amm_check = disable;
+        self
+    }
+
+    /// Configures transaction sender and direct call target checks.
+    pub fn with_address_filter(mut self, address_filter: AddressFilter) -> Self {
+        self.address_filter = address_filter;
         self
     }
 
@@ -423,6 +433,13 @@ where
 
         // Validate AA transaction field limits (pool-only DoS limits: calls, access list, token limits).
         if let Err(err) = self.ensure_aa_field_limits(&transaction) {
+            return TransactionValidationOutcome::Invalid(
+                transaction,
+                InvalidPoolTransactionError::other(err),
+            );
+        }
+
+        if let Err(err) = self.address_filter.check(&transaction) {
             return TransactionValidationOutcome::Invalid(
                 transaction,
                 InvalidPoolTransactionError::other(err),
@@ -829,7 +846,7 @@ mod tests {
     use super::*;
     use crate::{test_utils::TxBuilder, transaction::TempoPoolTransactionError};
     use alloy_consensus::{Header, Signed, Transaction, TxLegacy};
-    use alloy_primitives::{Address, B256, TxKind, U256, address, uint};
+    use alloy_primitives::{Address, B256, Bytes, TxKind, U256, address, uint};
     use alloy_signer::Signature;
     use reth_chainspec::EthChainSpec;
     use reth_primitives_traits::{Account, Bytecode, SignedTransaction};
@@ -1073,6 +1090,42 @@ mod tests {
         };
         let ephemeral_cache = validator.state_cache_for_tip(mismatched_tip_hash);
         assert!(!Arc::ptr_eq(&ephemeral_cache, &shared_cache));
+    }
+
+    #[tokio::test]
+    async fn address_filter_checks_later_tempo_calls_during_admission() {
+        let checked_address = Address::with_last_byte(0x42);
+        let transaction = TxBuilder::aa(Address::random())
+            .calls(vec![
+                Call {
+                    to: TxKind::Call(Address::with_last_byte(0x41)),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+                Call {
+                    to: TxKind::Call(checked_address),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                },
+            ])
+            .build();
+        let validator = setup_validator(&transaction, 1)
+            .with_address_filter(AddressFilter::new([checked_address]));
+
+        let outcome = validator
+            .validate_transaction(TransactionOrigin::External, transaction)
+            .await;
+
+        match outcome {
+            TransactionValidationOutcome::Invalid(_, ref err) => {
+                assert!(matches!(
+                    err.downcast_other_ref::<TempoPoolTransactionError>(),
+                    Some(TempoPoolTransactionError::AddressCheck { address })
+                        if *address == checked_address
+                ));
+            }
+            _ => panic!("Expected Invalid outcome with address check error, got: {outcome:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds `--txpool.filter` for transaction sender and direct call target checks during pool admission. The flag accepts either comma-separated addresses or a file whose addresses are separated by commas or lines, and checks every direct call in Tempo transactions.