### PR TITLE
docs(tip-1096): anchor recovery leader to first imported header

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -136,23 +136,24 @@ than the Zone block's timestamp invalidates the block.
 The block may cross deposits, token enablements, sequencer-set changes, and
 leadership changes because it performs no operation governed by that historical
 state. Its beneficiary MUST equal the catch-up leader defined below; it is not
-checked against leaders effective for earlier headers in the imported range.
+re-evaluated against leaders effective for later headers in the imported range.
 
 ### Header-only canonicality
 
 The catch-up leader for a header-only block is the historical leader effective
-for the final Tempo header imported by that block. Every header-only block MUST
+for the first Tempo header imported by that block. Every header-only block MUST
 be produced by its catch-up leader and MUST set its beneficiary to that leader.
-A leadership change crossed earlier in the same imported header range does not
+A leadership change crossed later in the same imported header range does not
 change the catch-up leader for that block. A later header-only block derives its
-catch-up leader independently from its own final imported header.
+catch-up leader independently from its own first imported header.
 
 The final full block retains the existing leader rules. It MUST be produced by
 the leader effective for the Tempo header imported by its `advanceTempo` call,
 or by the leader selected by an active forced-recovery override. Therefore, if a
 header-only block begins while leader A is effective and its range crosses to
-leader B, B produces that block. If no forced recovery is active, B also MUST
-produce the final full block when its imported header is governed by B.
+leader B, A produces that block. A following header-only block beginning under
+leader B is produced by B. If no forced recovery is active, B also MUST produce
+the final full block when its imported header is governed by B.
 
 A header-only chain is authorized only as part of a batch that ends with a block
 that calls `advanceTempo()` to process incoming queues and does not contain any

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -136,23 +136,24 @@ than the Zone block's timestamp invalidates the block.
 The block may cross deposits, token enablements, sequencer-set changes, and
 leadership changes because it performs no operation governed by that historical
 state. Its beneficiary MUST equal the catch-up leader defined below; it is not
-checked against a leader derived from any intermediate or final imported header.
+re-evaluated against leaders effective for later headers in the imported range.
 
 ### Header-only canonicality
 
-The catch-up leader is the leader that produced the most recent full block. If
-forced recovery overrides that leader, the forced-recovery leader becomes the
-catch-up leader. Every header-only block after that full block MUST be produced
-by the catch-up leader and MUST set its beneficiary to the catch-up leader. A
-leadership change crossed by an imported header range does not change the
-catch-up leader.
+The catch-up leader for a header-only block is the historical leader effective
+for the first Tempo header imported by that block. Every header-only block MUST
+be produced by its catch-up leader and MUST set its beneficiary to that leader.
+A leadership change crossed later in the same imported header range does not
+change the catch-up leader for that block. A later header-only block derives its
+catch-up leader independently from its own first imported header.
 
 The final full block retains the existing leader rules. It MUST be produced by
 the leader effective for the Tempo header imported by its `advanceTempo` call,
 or by the leader selected by an active forced-recovery override. Therefore, if a
-header-only prefix crosses from leader A to leader B and no forced recovery is
-active, A produces the header-only prefix and B MUST produce the final full
-block.
+header-only block begins while leader A is effective and its range crosses to
+leader B, A produces that block. A following header-only block beginning under
+leader B is produced by B. If no forced recovery is active, B also MUST produce
+the final full block when its imported header is governed by B.
 
 A header-only chain is authorized only as part of a batch that ends with a block
 that calls `advanceTempo()` to process incoming queues and does not contain any

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -59,6 +59,12 @@ exactly one header.
 uint64 constant MAX_TEMPO_HEADERS_PER_ZONE_BLOCK = 1024;
 ```
 
+Within this inclusive range, no particular header count is canonical. A producer
+MAY import any number of currently available consecutive headers and does not
+need to wait until `MAX_TEMPO_HEADERS_PER_ZONE_BLOCK` headers are available.
+Peers MUST NOT reject an otherwise valid header-only block because a different
+valid split of the same catch-up range was possible.
+
 Each item is the canonical RLP encoding of a Tempo header:
 
 ```text
@@ -129,22 +135,24 @@ than the Zone block's timestamp invalidates the block.
 
 The block may cross deposits, token enablements, sequencer-set changes, and
 leadership changes because it performs no operation governed by that historical
-state. Its beneficiary is not checked against the historical or final-root
-leader.
+state. Its beneficiary MUST equal the catch-up leader defined below; it is not
+checked against a leader derived from any intermediate or final imported header.
 
 ### Header-only canonicality
 
-Header-only block validity does not bind the block beneficiary or producer to a
-Tempo leader. No historical or current Tempo leader is designated for a
-header-only block, and leadership changes within or after its imported range do
-not affect its validity.
+The catch-up leader is the leader that produced the most recent full block. If
+forced recovery overrides that leader, the forced-recovery leader becomes the
+catch-up leader. Every header-only block after that full block MUST be produced
+by the catch-up leader and MUST set its beneficiary to the catch-up leader. A
+leadership change crossed by an imported header range does not change the
+catch-up leader.
 
-Leader authority resumes at the final full block. That block MUST be produced by
-the leader effective for the Tempo header imported by its `advanceTempo` call.
-Therefore, if a header-only prefix crosses from leader A to leader B and the
-final full block imports a header governed by B, B MUST produce the final full
-block. The batch certificate commits transitively to all preceding leader-neutral
-header-only blocks.
+The final full block retains the existing leader rules. It MUST be produced by
+the leader effective for the Tempo header imported by its `advanceTempo` call,
+or by the leader selected by an active forced-recovery override. Therefore, if a
+header-only prefix crosses from leader A to leader B and no forced recovery is
+active, A produces the header-only prefix and B MUST produce the final full
+block.
 
 A header-only chain is authorized only as part of a batch that ends with a block
 that calls `advanceTempo()` to process incoming queues and does not contain any
@@ -153,22 +161,13 @@ further `advanceTempoHeaders()` calls that aren't followed by an `advanceTempo()
 The existing threshold settlement certificate commits to the Zone height and
 `BlockTransition`, whose `nextBlockHash` transitively commits to every
 header-only block in that batch, including their beneficiaries. Quorum members
-MUST validate the complete block sequence before signing, but they do not verify
-a Tempo-derived producer for the header-only blocks. The certificate therefore
-selects an exact transition rather than attesting that a particular Tempo leader
-produced those blocks.
-
-Any active sequencer may construct, propose, or relay a candidate header-only
-chain. It is not independently settlement-canonical and MUST NOT be submitted as
-a standalone batch. It becomes settlement-canonical only when `submitBatch`
-accepts the batch ending in its full block and the batch's `prevBlockHash`
-matches the portal's settled tip. Once accepted, portal tip continuity rejects
-every conflicting transition from that tip.
-
-This rule deliberately makes header-only coordination depend on the configured
-settlement threshold. In a one-of-one configuration, the sole sequencer chooses
-the canonical header-only chain. Full blocks retain the existing Tempo leader
-rules.
+MUST validate the complete block sequence, including the catch-up producer and
+beneficiary rules, before signing. The header-only chain is not independently
+settlement-canonical and MUST NOT be submitted as a standalone batch. It becomes
+settlement-canonical only when `submitBatch` accepts the batch ending in its full
+block and the batch's `prevBlockHash` matches the portal's settled tip. Once
+accepted, portal tip continuity rejects every conflicting transition from that
+tip.
 
 ### Full block
 

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -136,24 +136,23 @@ than the Zone block's timestamp invalidates the block.
 The block may cross deposits, token enablements, sequencer-set changes, and
 leadership changes because it performs no operation governed by that historical
 state. Its beneficiary MUST equal the catch-up leader defined below; it is not
-re-evaluated against leaders effective for later headers in the imported range.
+checked against leaders effective for earlier headers in the imported range.
 
 ### Header-only canonicality
 
 The catch-up leader for a header-only block is the historical leader effective
-for the first Tempo header imported by that block. Every header-only block MUST
+for the final Tempo header imported by that block. Every header-only block MUST
 be produced by its catch-up leader and MUST set its beneficiary to that leader.
-A leadership change crossed later in the same imported header range does not
+A leadership change crossed earlier in the same imported header range does not
 change the catch-up leader for that block. A later header-only block derives its
-catch-up leader independently from its own first imported header.
+catch-up leader independently from its own final imported header.
 
 The final full block retains the existing leader rules. It MUST be produced by
 the leader effective for the Tempo header imported by its `advanceTempo` call,
 or by the leader selected by an active forced-recovery override. Therefore, if a
 header-only block begins while leader A is effective and its range crosses to
-leader B, A produces that block. A following header-only block beginning under
-leader B is produced by B. If no forced recovery is active, B also MUST produce
-the final full block when its imported header is governed by B.
+leader B, B produces that block. If no forced recovery is active, B also MUST
+produce the final full block when its imported header is governed by B.
 
 A header-only chain is authorized only as part of a batch that ends with a block
 that calls `advanceTempo()` to process incoming queues and does not contain any


### PR DESCRIPTION
Defines the historical leader effective at the first imported header as the producer and beneficiary for each header-only recovery block. Clarifies that any header count within the existing 1–1024 bound is valid while the final full block retains scheduled-or-forced-recovery leadership.

Prompted by: @shekhirin