### PR TITLE
docs(tip-1103): specify ValidatorConfig V3

### DIFF
--- a/tips/tip-1103.md
+++ b/tips/tip-1103.md
@@ -1,0 +1,355 @@
+---
+id: TIP-1103
+title: ValidatorConfig V3
+description: Decouples validator admission from validator-instance lifecycle management.
+authors: Janis (@superfluffy)
+status: Draft
+related: TIP-1017
+protocolVersion: n/a
+---
+
+# TIP-1103: ValidatorConfig V3
+
+## Abstract
+
+ValidatorConfig V3 separates permission to operate validators from registration of individual validator instances. The contract owner admits partner wallets to an allowlist and assigns each wallet a validator limit; an admitted partner can then add, deactivate, and update its own validator instances without further Tempo approval.
+
+Removing a validator does not remove the partner's permission to operate validators. The owner can separately remove a partner from the allowlist and optionally deactivate all validator instances controlled by that partner.
+
+## Motivation
+
+ValidatorConfig V2 couples admission and registration: its owner must add every validator instance. This makes routine scaling and replacement of partner infrastructure depend on a Tempo-operated transaction even after the partner has already been approved to participate in consensus.
+
+V3 introduces two independent lifecycles:
+
+1. **Partner admission**: Tempo admits or removes a wallet and sets how many active validator instances that wallet may control.
+2. **Validator registration**: an admitted partner manages its validator instances within that limit.
+
+This lets partners replace or remove infrastructure without losing their standing permission to operate validators, while retaining an owner-controlled emergency path to revoke a partner and deactivate all of its instances.
+
+ValidatorConfig V2 needed `rotateValidator` because permission to operate a validator was tied to having an entry in the validator list. Deactivating that entry did not leave the operator with an independent permission to register its replacement, so key replacement needed an in-place rotation operation. V3 makes rotation unnecessary: an allowlisted partner can deactivate the old validator and add a replacement while its admission remains intact. V3 therefore removes `rotateValidator` and represents replacement explicitly as one deactivation followed by one addition.
+
+## Assumptions
+
+- The contract owner remains the authority that admits partners, changes their limits, and revokes them.
+- A partner wallet is responsible for all active validators assigned to it. Compromise of that wallet permits mutation or deactivation of those validators, but not validators assigned to another partner.
+- Ed25519 proof of possession remains required when adding a validator.
+- Validator additions and deactivations continue to affect DKG player selection on the same schedule as ValidatorConfig V2.
+- The maximum per-partner limit is small enough that atomically deactivating all of a partner's validators fits within the block gas limit. V3 fixes this protocol maximum at 16 active validators per partner.
+- V2 validator history and public-key reservation remain intact across the V3 migration.
+
+If the atomic-removal gas assumption stops holding because execution pricing changes, partner revocation must be redesigned or the protocol maximum changed in a network upgrade before admitting partners at unsafe limits.
+
+## Threat Model
+
+- **Contract owner**: trusted to admit only approved partners, assign suitable limits, and revoke partners when required. A compromised owner can admit an attacker or deactivate any validator, as in V2.
+- **Allowlisted partner**: trusted only to manage its own validator instances. A malicious partner may churn its own entries or endpoints, but cannot exceed its limit, manage another partner's validators, reuse a reserved public key, or reuse an active ingress address.
+- **Validator Ed25519 key holder**: trusted to authorize installation of its public key through a domain-separated signature. Possession of this key alone does not grant partner admission or control of an existing validator entry.
+- **Transfer recipient**: must explicitly accept assignment of a validator. This prevents another partner from consuming its capacity by transferring unwanted validators to it.
+- Denial of service caused by an already-active validator failing to participate in DKG is outside this precompile's prevention boundary; the owner can revoke the partner and deactivate its validators.
+
+---
+
+# Specification
+
+## Precompile Address And Upgrade
+
+V3 replaces ValidatorConfig V2 at the existing precompile address:
+
+```solidity
+address constant VALIDATOR_CONFIG_ADDRESS = 0xCCCCCCCC00000000000000000000000000000001;
+```
+
+The V3 implementation MUST preserve all V2 validator entries, indices, public-key reservations, historical heights, and DKG configuration. At activation, every address controlling an active V2 validator becomes an allowlisted partner with a limit equal to the number of active validators assigned to that address. If that number exceeds 16, activation MUST fail. Addresses that control only deactivated validators are not allowlisted.
+
+Migration MUST be deterministic and complete before V3 mutators are enabled. The contract owner remains unchanged.
+
+## State Model
+
+V3 stores admission separately from validator-instance state:
+
+```solidity
+uint16 constant MAX_PARTNER_VALIDATOR_LIMIT = 16;
+
+struct Partner {
+    bool allowed;
+    uint16 validatorLimit;
+    uint16 activeValidatorCount;
+}
+
+struct Validator {
+    bytes32 publicKey;
+    address partner;
+    string ingress;
+    string egress;
+    uint64 index;
+    uint64 addedAtHeight;
+    uint64 deactivatedAtHeight;
+    address feeRecipient;
+}
+```
+
+`Partner.allowed` is the permission to register and manage validators. It is independent of `activeValidatorCount`: removing the partner's last validator MUST NOT change `allowed` or `validatorLimit`.
+
+A validator instance is primarily identified by its Ed25519 `publicKey` and network endpoints (`ingress`, `egress`). Its immutable `index` remains the canonical historical lookup key. `partner` identifies the wallet authorized to manipulate the active instance; it is not the validator's identity and may change through ownership transfer.
+
+The implementation MUST maintain an enumerable set of active validator indices for each partner so the owner can revoke a partner and deactivate all of its validators atomically. Updating this set MUST use swap-and-pop or equivalent bounded constant-time bookkeeping per validator mutation.
+
+## Interface
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title IValidatorConfigV3
+/// @notice Partner admission and validator-instance management for Tempo consensus.
+interface IValidatorConfigV3 {
+    error Unauthorized();
+    error PartnerNotAllowed(address partner);
+    error PartnerAlreadyAllowed(address partner);
+    error PartnerHasActiveValidators(address partner, uint16 count);
+    error InvalidValidatorLimit(uint16 limit);
+    error ValidatorLimitExceeded(address partner, uint16 limit);
+    error ValidatorNotFound();
+    error ValidatorAlreadyDeactivated();
+    error PublicKeyAlreadyExists();
+    error InvalidPublicKey();
+    error InvalidPartnerAddress();
+    error InvalidFeeRecipient();
+    error InvalidSignature();
+    error InvalidTransferAcceptance();
+    error IngressAlreadyExists(string ingress);
+    error NotIpPort(string input, string backtrace);
+    error NotIp(string input, string backtrace);
+
+    struct Partner {
+        bool allowed;
+        uint16 validatorLimit;
+        uint16 activeValidatorCount;
+    }
+
+    struct Validator {
+        bytes32 publicKey;
+        address partner;
+        string ingress;
+        string egress;
+        uint64 index;
+        uint64 addedAtHeight;
+        uint64 deactivatedAtHeight;
+        address feeRecipient;
+    }
+
+    /// @notice Returns the contract owner.
+    function owner() external view returns (address);
+
+    /// @notice Returns admission and capacity state for `partner`.
+    function partnerInfo(address partner) external view returns (Partner memory);
+
+    /// @notice Returns active validator indices controlled by `partner`.
+    function partnerValidators(address partner) external view returns (uint64[] memory);
+
+    /// @notice Returns all active validators.
+    function getActiveValidators() external view returns (Validator[] memory);
+
+    /// @notice Returns the number of historical validator entries.
+    function validatorCount() external view returns (uint64);
+
+    /// @notice Returns a validator by immutable historical index.
+    function validatorByIndex(uint64 index) external view returns (Validator memory);
+
+    /// @notice Returns the historical validator entry for `publicKey`.
+    function validatorByPublicKey(bytes32 publicKey) external view returns (Validator memory);
+
+    /// @notice Returns the next epoch configured for a fresh DKG ceremony, or zero.
+    function getNextFullDkgCeremony() external view returns (uint64);
+
+    /// @notice Admits `partner` with an active-validator limit.
+    /// @dev Owner only. `limit` must be in [1, MAX_PARTNER_VALIDATOR_LIMIT].
+    function addPartner(address partner, uint16 limit) external;
+
+    /// @notice Changes an admitted partner's validator limit.
+    /// @dev Owner only. Reverts when `limit` is below the partner's active count.
+    function setPartnerValidatorLimit(address partner, uint16 limit) external;
+
+    /// @notice Revokes a partner.
+    /// @dev Owner only. If `deactivateValidators` is true, atomically deactivates every
+    /// active validator assigned to the partner. Otherwise reverts if any remain active.
+    function removePartner(address partner, bool deactivateValidators) external;
+
+    /// @notice Adds a validator controlled by the caller.
+    /// @dev Caller must be allowlisted and below its limit. The Ed25519 signature proves
+    /// possession of `publicKey` and binds every argument plus caller, chain ID, and address(this).
+    function addValidator(
+        bytes32 publicKey,
+        string calldata ingress,
+        string calldata egress,
+        address feeRecipient,
+        bytes calldata signature
+    ) external returns (uint64 index);
+
+    /// @notice Irreversibly deactivates an active validator.
+    /// @dev Callable by the validator's partner or contract owner.
+    function deactivateValidator(uint64 index) external;
+
+    /// @notice Updates an active validator's network endpoints.
+    /// @dev Callable by the validator's partner or contract owner.
+    function setIpAddresses(
+        uint64 index,
+        string calldata ingress,
+        string calldata egress
+    ) external;
+
+    /// @notice Updates an active validator's fee recipient.
+    /// @dev Callable by the validator's partner or contract owner.
+    function setFeeRecipient(uint64 index, address feeRecipient) external;
+
+    /// @notice Assigns an active validator to another admitted partner.
+    /// @dev Callable by the current partner or contract owner. `acceptanceSignature` must be
+    /// an ECDSA signature by `newPartner`; the recipient must have spare validator capacity.
+    function transferValidatorOwnership(
+        uint64 index,
+        address newPartner,
+        uint256 deadline,
+        bytes calldata acceptanceSignature
+    ) external;
+
+    /// @notice Transfers contract ownership. Owner only.
+    function transferOwnership(address newOwner) external;
+
+    /// @notice Sets the next fresh DKG ceremony epoch. Owner only.
+    function setNextFullDkgCeremony(uint64 epoch) external;
+}
+```
+
+## Partner Admission
+
+`addPartner` MUST reject the zero address, an already-allowed address, a zero limit, or a limit greater than 16. A removed partner may later be admitted again; re-admission creates a new current permission without changing historical validator entries.
+
+`setPartnerValidatorLimit` MUST reject a removed or unknown partner, a limit outside `[1, 16]`, or a limit below `activeValidatorCount`. Raising or lowering a limit does not add or deactivate validators.
+
+`removePartner(partner, false)` MUST revert if `activeValidatorCount != 0`. On success it clears `allowed` and `validatorLimit`.
+
+`removePartner(partner, true)` MUST first clear `allowed`, then deactivate every active validator currently assigned to the partner at the current block height, set `activeValidatorCount` to zero, and clear `validatorLimit`. The transaction is atomic: either the partner is revoked and all of its validators are deactivated, or no state changes persist.
+
+## Validator Operations
+
+All partner-initiated mutations MUST require `msg.sender == validator.partner` and a current `allowed == true` entry. The contract owner MAY perform validator-level emergency operations for any active validator, but owner intervention MUST NOT be required for routine partner operations.
+
+- `addValidator` appends one active entry assigned to `msg.sender`. It MUST reject the call when `activeValidatorCount == validatorLimit` and increments the count exactly once on success.
+- `deactivateValidator` preserves V2's irreversible, deactivate-once behavior. It decrements the assigned partner's active count and does not change that partner's allowlist permission. Replacing a validator requires deactivating the old entry and adding a new entry.
+- `setIpAddresses` and `setFeeRecipient` preserve V2 behavior and authorization is based on partner assignment instead of a one-validator control address.
+- `transferValidatorOwnership` moves only authority and capacity accounting. It decrements the old partner's active count, increments the new partner's active count, and leaves validator identity, index, heights, public key, endpoints, and fee recipient unchanged.
+
+Public keys remain globally reserved after deactivation. Ingress addresses remain unique among active validators. `ingress`, `egress`, Ed25519 signature validation, historical heights, and DKG timing follow TIP-1017 unless this TIP explicitly changes them.
+
+## Signatures
+
+V3 uses new operation namespaces so V2 signatures cannot be replayed:
+
+```text
+TEMPO_VALIDATOR_CONFIG_V3_ADD_VALIDATOR
+TEMPO_VALIDATOR_CONFIG_V3_ACCEPT_TRANSFER
+```
+
+The add signature commits to chain ID, precompile address, caller partner, public key, ingress, egress, and fee recipient.
+
+Transfer acceptance uses EIP-712 and commits to chain ID, precompile address, validator index, current partner, new partner, the new partner's current transfer nonce, and `deadline`. A successful transfer consumes the nonce. Contract-wallet partners MUST be verified through ERC-1271; EOAs use ECDSA recovery. Expired acceptances revert.
+
+## Consensus Layer Integration
+
+Consensus continues to derive future DKG players from active validator entries using TIP-1017's height filtering. Allowlist entries are execution-layer authorization state and are not independently included in player selection.
+
+An add, individual deactivation, or revocation with bulk deactivation affects the next eligible DKG player set under the same boundary rules as V2. Every validator deactivated by one partner revocation receives the same `deactivatedAtHeight`.
+
+## Compatibility
+
+V3 retains V2 query and lifecycle semantics except for these intentional changes:
+
+- `validatorAddress` is replaced by `partner`; one partner can control multiple active validators.
+- `validatorByAddress` is replaced by `partnerValidators` because an address no longer identifies a single validator.
+- `addValidator` is called by an allowlisted partner and no longer accepts a validator control address.
+- `rotateValidator` is removed; an admitted partner replaces a validator by deactivating its old entry and adding a new one.
+- ownership transfer requires explicit acceptance by the destination partner.
+- V2 migration and initialization methods are not exposed after the V3 migration completes.
+
+# Tooling
+
+- Validator management tooling MUST add partner admission, limit update, partner removal, and bulk-deactivation commands.
+- Partner tooling MUST support self-service add, deactivate, endpoint update, fee-recipient update, and ownership transfer.
+- Signing libraries MUST implement the two V3 domains and ERC-1271-aware transfer acceptance.
+- Explorers and operator dashboards SHOULD show each partner's allowlist state, configured limit, active count, and active validator instances.
+- Migration tooling MUST dry-run V2 state, verify no migrated partner exceeds 16 active validators, and compare the complete V2/V3 validator history before enabling V3 writes.
+
+# Observability
+
+V3 MUST emit:
+
+```solidity
+event PartnerAdded(address indexed partner, uint16 validatorLimit);
+event PartnerValidatorLimitUpdated(
+    address indexed partner,
+    uint16 oldLimit,
+    uint16 newLimit
+);
+event PartnerRemoved(address indexed partner, uint16 validatorsDeactivated);
+event ValidatorAdded(
+    uint64 indexed index,
+    address indexed partner,
+    bytes32 indexed publicKey,
+    string ingress,
+    string egress,
+    address feeRecipient
+);
+event ValidatorDeactivated(
+    uint64 indexed index,
+    address indexed partner,
+    bytes32 indexed publicKey
+);
+event ValidatorIpAddressesUpdated(
+    uint64 indexed index,
+    string ingress,
+    string egress
+);
+event ValidatorFeeRecipientUpdated(uint64 indexed index, address feeRecipient);
+event ValidatorOwnershipTransferred(
+    uint64 indexed index,
+    address indexed oldPartner,
+    address indexed newPartner
+);
+```
+
+These events answer who is permitted to operate validators, how much capacity each partner has, which validator instances are active, why an instance left the configured set, and which identity or network fields changed. Alerts SHOULD fire when a partner is removed with bulk deactivation, a partner reaches its limit, or a transaction attempts to exceed a limit repeatedly.
+
+# Invariants
+
+## Admission And Capacity
+
+1. Every active validator is assigned to exactly one currently allowlisted partner.
+2. For every partner, `activeValidatorCount == partnerValidators(partner).length`.
+3. For every partner, `activeValidatorCount <= validatorLimit <= 16` while allowed.
+4. A successful individual validator deactivation does not change partner allowlist permission or limit.
+5. A removed partner has `allowed == false`, limit zero, active count zero, and no active assigned validators.
+6. Removing a partner with bulk deactivation is atomic and deactivates exactly the active validators assigned to that partner.
+
+## Isolation And Authorization
+
+1. An allowlisted partner cannot mutate a validator assigned to another partner.
+2. A non-allowlisted partner cannot add or mutate validators.
+3. Ownership transfer cannot exceed the destination partner's limit and cannot complete without destination acceptance.
+4. Failed or expired transfer acceptances do not change assignment, counts, or nonces.
+
+## Identity And History
+
+1. Public keys are unique across active and deactivated history and can never be reused.
+2. Active ingress addresses are unique.
+3. Validator indices and `addedAtHeight` are immutable.
+4. `deactivatedAtHeight` transitions at most once from zero to the current block height.
+5. Ownership transfer changes only partner assignment, partner capacity accounting, and transfer nonce.
+
+## Migration
+
+1. Every V2 validator entry appears exactly once in V3 with the same index, public key, endpoints, fee recipient, and lifecycle heights.
+2. Every active V2 validator is assigned to an allowlisted partner at activation.
+3. V3 writes remain disabled until migration is complete and the migrated active set exactly equals the V2 active set.
+
+Critical tests MUST cover every limit boundary, partner removal with zero/one/16 validators, rollback on failed bulk removal, cross-partner mutation attempts, contract-wallet transfer acceptance, replayed and expired signatures, migration with shared V2 control addresses, validator replacement through deactivate-then-add, and DKG player selection across add, deactivate, transfer, and partner-revocation boundaries.


### PR DESCRIPTION
[View the Markdown](https://github.com/tempoxyz/tempo/blob/tip/1103/tips/tip-1103.md) · [Render on tips.sh](https://tips.sh/1103)

Defines partner allowlisting separately from validator-instance registration and lets admitted partners manage multiple validators within an explicit limit.

Adds owner-controlled revocation with optional atomic deactivation of every validator assigned to the removed partner.

Prompted by: @SuperFluffy
