### PR TITLE
fix(ci): reduce pull request latency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,38 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
+  check-changes:
+    name: Check Rust changes
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      rust: ${{ github.event_name != 'pull_request' || steps.filter.outputs.rust == 'true' }}
+    steps:
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            rust:
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - '.cargo/**'
+              - '.config/zepter.yaml'
+              - 'deny.toml'
+              - 'rust-toolchain*'
+              - 'rustfmt.toml'
+              - 'bin/**'
+              - 'crates/**'
+              - 'examples/**'
+              - 'xtask/**'
+              - '.github/scripts/check_no_std.sh'
+              - '.github/workflows/lint.yml'
+
   clippy:
     name: clippy
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 45
     env:
@@ -53,6 +83,8 @@ jobs:
 
   fmt:
     name: fmt
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -91,7 +123,8 @@ jobs:
       - run: cargo hack check --feature-powerset --depth 1 --partition ${{ matrix.partition }}/2
 
   docs:
-    if: ${{ github.repository == 'tempoxyz/tempo' }}
+    needs: check-changes
+    if: ${{ github.repository == 'tempoxyz/tempo' && needs.check-changes.outputs.rust == 'true' }}
     name: docs
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
@@ -158,12 +191,16 @@ jobs:
       - uses: crate-ci/typos@02ea592e44b3a53c302f697cddca7641cd051c3d # v1.45.0
 
   deny:
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     permissions:
       contents: read
     uses: tempoxyz/ci/.github/workflows/deny.yml@09f481293feb726bcd5c94853063b224a9b2ff24 # main
 
   zepter:
     name: zepter
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -186,6 +223,8 @@ jobs:
 
   no-std:
     name: no-std
+    needs: check-changes
+    if: needs.check-changes.outputs.rust == 'true'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -213,6 +252,7 @@ jobs:
     if: always()
     permissions: {}
     needs:
+      - check-changes
       - clippy
       - fmt
       - docs
@@ -225,5 +265,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
-          allowed-skips: ${{ github.repository != 'tempoxyz/tempo' && 'docs' || '' }}
+          allowed-skips: ${{ needs.check-changes.outputs.rust != 'true' && 'clippy,fmt,docs,deny,zepter,no-std' || (github.repository != 'tempoxyz/tempo' && 'docs' || '') }}
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -17,6 +17,16 @@ on:
       - ".github/workflows/update-reth.yml"
   merge_group:
   pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**/Cargo.toml"
+      - "tips/verify/**"
+      - "crates/contracts/**"
+      - "crates/precompiles/**"
+      - "scripts/foundry-patch.sh"
+      - ".github/workflows/specs.yml"
+      - ".github/workflows/update-reth.yml"
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,23 +51,16 @@ jobs:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
         with:
+          predicate-quantifier: every
           filters: |
             specs:
-              - 'tips/verify/**'
-              - 'crates/contracts/**'
+              - '{tips/verify/**,crates/contracts/**,crates/precompiles/**,.github/workflows/specs.yml}'
               - '!crates/contracts/CHANGELOG.md'
               - '!crates/contracts/Cargo.toml'
-              - 'crates/precompiles/**'
               - '!crates/precompiles/CHANGELOG.md'
               - '!crates/precompiles/Cargo.toml'
-              - '.github/workflows/specs.yml'
             foundry_smoke:
-              - 'Cargo.lock'
-              - 'Cargo.toml'
-              - 'crates/**/Cargo.toml'
-              - 'scripts/foundry-patch.sh'
-              - '.github/workflows/specs.yml'
-              - '.github/workflows/update-reth.yml'
+              - '{Cargo.lock,Cargo.toml,crates/**/Cargo.toml,scripts/foundry-patch.sh,.github/workflows/specs.yml,.github/workflows/update-reth.yml}'
       - name: Check release-only SDK crate changes
         id: release-only
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,37 +22,45 @@ env:
 
 jobs:
   check-precompiles:
-    name: Check precompiles changes
+    name: Check test changes
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      pull-requests: read
     outputs:
-      coverage: ${{ steps.check.outputs.coverage }}
+      coverage: ${{ github.event_name == 'pull_request' && steps.filter.outputs.coverage == 'true' }}
+      run_tests: ${{ github.event_name != 'pull_request' || steps.filter.outputs.tests == 'true' }}
+      run_tempoup: ${{ github.event_name != 'pull_request' || steps.filter.outputs.tempoup == 'true' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        if: github.event_name == 'pull_request'
         with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Check for precompiles changes
-        id: check
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          # Only run coverage on pull_request events when precompiles/contracts changed
-          if [[ "$EVENT_NAME" != "pull_request" ]]; then
-            echo "coverage=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping coverage: not a pull_request event (event: $EVENT_NAME)"
-          elif git diff --name-only origin/"$BASE_REF"...HEAD | grep -qE '^(crates/(precompiles|contracts)/|tips/verify/)'; then
-            echo "coverage=true" >> "$GITHUB_OUTPUT"
-            echo "Running coverage: precompiles/contracts changed"
-          else
-            echo "coverage=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping coverage: no precompiles/contracts changes"
-          fi
+          filters: |
+            tests:
+              - 'Cargo.lock'
+              - 'Cargo.toml'
+              - '.cargo/**'
+              - '.config/nextest.toml'
+              - 'rust-toolchain*'
+              - 'bin/**'
+              - 'crates/**'
+              - 'examples/**'
+              - 'scripts/**'
+              - 'tips/verify/**'
+              - 'xtask/**'
+              - '.github/workflows/test.yml'
+            tempoup:
+              - 'tempoup/**'
+              - '.github/workflows/test.yml'
+            coverage:
+              - 'crates/contracts/**'
+              - 'crates/precompiles/**'
+              - 'tips/verify/**'
 
   genesis:
     name: Genesis generation
+    needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tests == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     permissions:
@@ -87,6 +95,7 @@ jobs:
   test:
     name: test (${{ matrix.partition }}/2)
     needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tests == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     permissions:
@@ -151,6 +160,8 @@ jobs:
 
   e2e:
     name: e2e (${{ matrix.partition }}/4)
+    needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tests == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     permissions:
@@ -189,6 +200,8 @@ jobs:
 
   e2e-flaky:
     name: e2e-flaky
+    needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tests == 'true'
     runs-on: depot-ubuntu-latest-32
     timeout-minutes: 30
     continue-on-error: true
@@ -215,6 +228,8 @@ jobs:
 
   cli:
     name: CLI smoke tests
+    needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tests == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     permissions:
@@ -235,6 +250,8 @@ jobs:
 
   tempoup:
     name: tempoup installer tests
+    needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tempoup == 'true'
     runs-on: depot-ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -257,6 +274,8 @@ jobs:
 
   msrv:
     name: MSRV
+    needs: check-precompiles
+    if: needs.check-precompiles.outputs.run_tests == 'true'
     runs-on: depot-ubuntu-latest-4
     timeout-minutes: 30
     permissions:
@@ -294,4 +313,5 @@ jobs:
       - name: Decide whether the needed jobs succeeded or failed
         uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
+          allowed-skips: ${{ needs.check-precompiles.outputs.run_tests != 'true' && 'test,e2e,cli,msrv,genesis' || '' }}
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- Gate heavyweight Test/Lint jobs with PR-file classifiers while retaining the required success checks and always running typos.
- Limit Specs to dependency/spec/precompile changes and fix its exclusion matching.
- Replaying the latest 30 PRs sends 13 (43%) through the required-gate fast path and skips irrelevant Specs on 25 (83%); final job timings project the fast path at ~35s instead of ~6–8m.

## Profile
- A consensus-only baseline incorrectly reported `specs=true` and spent 7m36s in Specs because negated globs used the default `some` predicate.
- A representative baseline code PR took 6m21s in Test and 5m43s in Lint; Rust-sensitive PRs retain those jobs with a 3–5s classifier.

## Verification
- [Test](https://github.com/tempoxyz/tempo/actions/runs/33410282867), [Lint](https://github.com/tempoxyz/tempo/actions/runs/33410283568), [Specs](https://github.com/tempoxyz/tempo/actions/runs/33410283094), and [Actions scan](https://github.com/tempoxyz/tempo/actions/runs/33410283480) pass on the final commit.
- `actionlint -config-file .github/actionlint.yaml` passes for all changed workflows.
- `zizmor --offline` reports no new findings.
- Path fixtures cover Rust, TIP-only, bench-only, precompile, release-metadata, coverage, and workflow changes.

Prompted by: @shekhirin