### PR TITLE
fix(consensus): validate decoded block bodies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13494,6 +13494,7 @@ dependencies = [
  "rand 0.10.2",
  "rand 0.8.6",
  "rand_core 0.10.1",
+ "reth-consensus",
  "reth-consensus-common",
  "reth-engine-primitives",
  "reth-ethereum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13509,6 +13509,7 @@ dependencies = [
  "tempo-chainspec",
  "tempo-consensus-config",
  "tempo-dkg-onchain-artifacts",
+ "tempo-evm",
  "tempo-node",
  "tempo-payload-types",
  "tempo-precompiles",

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -20,6 +20,7 @@ tempo-alloy.workspace = true
 tempo-chainspec = { workspace = true, features = ["reth"] }
 tempo-consensus-config.workspace = true
 tempo-dkg-onchain-artifacts.workspace = true
+tempo-evm.workspace = true
 tempo-node.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-payload-types.workspace = true

--- a/crates/consensus/Cargo.toml
+++ b/crates/consensus/Cargo.toml
@@ -66,6 +66,7 @@ prometheus-client.workspace = true
 rand.workspace = true
 rand_08.workspace = true
 
+reth-consensus.workspace = true
 reth-consensus-common.workspace = true
 reth-engine-primitives.workspace = true
 rand_core.workspace = true

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -629,12 +629,12 @@ impl Inner<Init> {
         let block_access_list_size_bytes = block_access_list
             .as_ref()
             .map_or(0, |block_access_list| block_access_list.encode_size());
-        let proposal = Block::from_execution_block_with_encoded_cache(
+        let proposal = Block::try_from_execution_block_with_encoded_cache(
             block,
             block_access_list,
             execution_block_encoded,
         )
-        .wrap_err("payload builder produced an invalid block access list")?;
+        .wrap_err("payload builder produced an invalid block")?;
         let block_size_estimate_bytes =
             execution_block_rlp_size_estimate_bytes + block_access_list_size_bytes;
         let validator_marshal_persist = marshal_persist.estimate(block_size_estimate_bytes);

--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -62,10 +62,10 @@ impl BlockAccessListError {
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
     /// The execution block body does not match the commitments in its header.
-    #[error("execution block body does not match its header: {0}")]
+    #[error("execution block body does not match its header")]
     Body(#[from] ConsensusError),
     /// The BAL sidecar does not match the commitment in the execution block header.
-    #[error("block access list does not match its header commitment: {0}")]
+    #[error("block access list does not match its header commitment")]
     BlockAccessList(#[from] BlockAccessListError),
 }
 

--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -18,7 +18,6 @@ use commonware_cryptography::{
     Committable, Digestible, Signer as _,
     ed25519::{PrivateKey, PublicKey},
 };
-use reth_consensus_common::validation::validate_body_against_header;
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
 use std::fmt::Display;
 use tempo_payload_types::EncodedBlock;
@@ -26,6 +25,7 @@ use tempo_primitives::TempoConsensusContext;
 use tracing::warn;
 
 use crate::consensus::Digest;
+use tempo_evm::consensus::validate_body_against_header;
 
 /// Error returned when a BAL sidecar does not match the execution block header.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]

--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -18,6 +18,7 @@ use commonware_cryptography::{
     Committable, Digestible, Signer as _,
     ed25519::{PrivateKey, PublicKey},
 };
+use reth_consensus::ConsensusError;
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
 use std::fmt::Display;
 use tempo_payload_types::EncodedBlock;
@@ -53,6 +54,29 @@ impl BlockAccessListError {
             Self::HashMismatch { .. } => {
                 commonware_codec::Error::Invalid("block access list", "hash does not match header")
             }
+        }
+    }
+}
+
+/// Error returned when an execution block or its consensus sidecars are invalid.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    /// The execution block body does not match the commitments in its header.
+    #[error("execution block body does not match its header: {0}")]
+    Body(#[from] ConsensusError),
+    /// The BAL sidecar does not match the commitment in the execution block header.
+    #[error("block access list does not match its header commitment: {0}")]
+    BlockAccessList(#[from] BlockAccessListError),
+}
+
+impl Error {
+    fn codec_error(self) -> commonware_codec::Error {
+        match self {
+            Self::Body(error) => commonware_codec::Error::Wrapped(
+                "validating execution block body against header",
+                error.into(),
+            ),
+            Self::BlockAccessList(error) => error.codec_error(),
         }
     }
 }
@@ -94,15 +118,16 @@ impl PartialEq for Block {
 impl Eq for Block {}
 
 impl Block {
-    /// Creates a block from an execution-layer block and optional BAL.
-    pub(crate) fn from_execution_block<T>(
+    /// Creates a block after validating its body and optional BAL against the header.
+    pub(crate) fn try_from_execution_block<T>(
         execution_block: T,
         block_access_list: Option<Bytes>,
-    ) -> Result<Self, BlockAccessListError>
+    ) -> Result<Self, Error>
     where
         T: Into<SealedOrRecoveredBlock<tempo_primitives::Block>>,
     {
         let execution_block = execution_block.into();
+        validate_body_against_header(execution_block.body(), execution_block.header())?;
         validate_block_access_list_hash(
             execution_block.block_access_list_hash(),
             block_access_list.as_ref(),
@@ -114,16 +139,16 @@ impl Block {
         ))
     }
 
-    /// Creates a block with a shared execution-layer RLP byte cache.
-    pub(crate) fn from_execution_block_with_encoded_cache<T>(
+    /// Creates a validated block with a shared execution-layer RLP byte cache.
+    pub(crate) fn try_from_execution_block_with_encoded_cache<T>(
         execution_block: T,
         block_access_list: Option<Bytes>,
         execution_block_encoded: EncodedBlock,
-    ) -> Result<Self, BlockAccessListError>
+    ) -> Result<Self, Error>
     where
         T: Into<SealedOrRecoveredBlock<tempo_primitives::Block>>,
     {
-        let mut block = Self::from_execution_block(execution_block, block_access_list)?;
+        let mut block = Self::try_from_execution_block(execution_block, block_access_list)?;
         block.execution_block_encoded = execution_block_encoded;
         Ok(block)
     }
@@ -294,13 +319,6 @@ impl Read for Block {
             commonware_codec::Error::Wrapped("reading RLP encoded block", rlp_err.into())
         })?;
 
-        validate_body_against_header(inner.body(), inner.header()).map_err(|error| {
-            commonware_codec::Error::Wrapped(
-                "validating execution block body against header",
-                error.into(),
-            )
-        })?;
-
         #[cfg(feature = "bal")]
         let block_access_list = {
             if inner.block_access_list_hash().is_some() {
@@ -318,7 +336,7 @@ impl Read for Block {
         let block_access_list = None;
 
         let execution_block_encoded = EncodedBlock::new(bytes.into());
-        Self::from_execution_block_with_encoded_cache(
+        Self::try_from_execution_block_with_encoded_cache(
             inner,
             block_access_list,
             execution_block_encoded,
@@ -446,9 +464,9 @@ mod tests {
     use reth_node_core::primitives::SealedBlock;
     use tempo_primitives::{Block as TempoBlock, TempoHeader};
 
-    use super::Block;
     #[cfg(feature = "bal")]
     use super::BlockAccessListError;
+    use super::{Block, Error};
 
     fn execution_block_with_block_access_list_hash(
         block_access_list_hash: B256,
@@ -514,7 +532,7 @@ mod tests {
                 ..Default::default()
             },
         });
-        let expected = Block::from_execution_block(execution_block.clone(), None)
+        let expected = Block::try_from_execution_block(execution_block.clone(), None)
             .expect("block has no BAL side data");
         let mut block_bytes = Vec::new();
         alloy_rlp::Encodable::encode(&execution_block, &mut block_bytes);
@@ -565,6 +583,27 @@ mod tests {
         );
     }
 
+    #[test]
+    fn constructor_rejects_execution_body_that_does_not_match_header() {
+        let execution_block = SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: alloy_consensus::Header {
+                    withdrawals_root: Some(B256::ZERO),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: BlockBody {
+                withdrawals: Some(Default::default()),
+                ..Default::default()
+            },
+        });
+
+        let err = Block::try_from_execution_block(execution_block, None).unwrap_err();
+
+        assert!(matches!(err, Error::Body(_)));
+    }
+
     #[cfg(not(feature = "bal"))]
     #[test]
     fn read_rejects_block_access_list_hash_when_bal_feature_disabled() {
@@ -594,23 +633,26 @@ mod tests {
 
         let block_access_list = bytes!("0xc0");
         let err =
-            Block::from_execution_block(execution_block, Some(block_access_list)).unwrap_err();
+            Block::try_from_execution_block(execution_block, Some(block_access_list)).unwrap_err();
 
-        assert_eq!(err, BlockAccessListError::Unexpected);
+        assert!(matches!(
+            err,
+            Error::BlockAccessList(BlockAccessListError::Unexpected)
+        ));
     }
 
     #[cfg(feature = "bal")]
     #[test]
     fn rejects_missing_block_access_list_with_header_hash() {
         let execution_block = execution_block_with_block_access_list_hash(B256::ZERO);
-        let err = Block::from_execution_block(execution_block, None).unwrap_err();
+        let err = Block::try_from_execution_block(execution_block, None).unwrap_err();
 
-        assert_eq!(
+        assert!(matches!(
             err,
-            BlockAccessListError::Missing {
+            Error::BlockAccessList(BlockAccessListError::Missing {
                 expected: B256::ZERO
-            }
-        );
+            })
+        ));
     }
 
     #[cfg(feature = "bal")]
@@ -635,7 +677,8 @@ mod tests {
         let execution_block =
             execution_block_with_block_access_list_hash(keccak256(block_access_list.as_ref()));
         let block =
-            Block::from_execution_block(execution_block, Some(block_access_list.clone())).unwrap();
+            Block::try_from_execution_block(execution_block, Some(block_access_list.clone()))
+                .unwrap();
 
         let encoded = block.encode();
         let decoded = Block::read_cfg(&mut encoded.as_ref(), &()).unwrap();
@@ -653,15 +696,15 @@ mod tests {
         let block_access_list = bytes!("0xc0");
         let execution_block = execution_block_with_block_access_list_hash(B256::ZERO);
         let err =
-            Block::from_execution_block(execution_block, Some(block_access_list)).unwrap_err();
+            Block::try_from_execution_block(execution_block, Some(block_access_list)).unwrap_err();
 
-        assert_eq!(
+        assert!(matches!(
             err,
-            BlockAccessListError::HashMismatch {
+            Error::BlockAccessList(BlockAccessListError::HashMismatch {
                 expected: B256::ZERO,
-                actual: keccak256(bytes!("0xc0").as_ref())
-            }
-        );
+                actual,
+            }) if actual == keccak256(bytes!("0xc0").as_ref())
+        ));
     }
 
     #[cfg(feature = "bal")]

--- a/crates/consensus/src/consensus/block.rs
+++ b/crates/consensus/src/consensus/block.rs
@@ -18,6 +18,7 @@ use commonware_cryptography::{
     Committable, Digestible, Signer as _,
     ed25519::{PrivateKey, PublicKey},
 };
+use reth_consensus_common::validation::validate_body_against_header;
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
 use std::fmt::Display;
 use tempo_payload_types::EncodedBlock;
@@ -293,6 +294,13 @@ impl Read for Block {
             commonware_codec::Error::Wrapped("reading RLP encoded block", rlp_err.into())
         })?;
 
+        validate_body_against_header(inner.body(), inner.header()).map_err(|error| {
+            commonware_codec::Error::Wrapped(
+                "validating execution block body against header",
+                error.into(),
+            )
+        })?;
+
         #[cfg(feature = "bal")]
         let block_access_list = {
             if inner.block_access_list_hash().is_some() {
@@ -430,6 +438,7 @@ fn validate_block_access_list_hash(
 mod tests {
     #[cfg(feature = "bal")]
     use alloy_consensus::BlockHeader as _;
+    use alloy_consensus::{BlockBody, EMPTY_ROOT_HASH};
     use alloy_primitives::{B256, bytes, keccak256};
     #[cfg(not(feature = "bal"))]
     use commonware_codec::Write as _;
@@ -448,7 +457,7 @@ mod tests {
             header: TempoHeader {
                 inner: alloy_consensus::Header {
                     base_fee_per_gas: Some(0),
-                    withdrawals_root: Some(B256::ZERO),
+                    withdrawals_root: Some(EMPTY_ROOT_HASH),
                     blob_gas_used: Some(0),
                     excess_blob_gas: Some(0),
                     parent_beacon_block_root: Some(B256::ZERO),
@@ -458,7 +467,10 @@ mod tests {
                 },
                 ..Default::default()
             },
-            body: Default::default(),
+            body: BlockBody {
+                withdrawals: Some(Default::default()),
+                ..Default::default()
+            },
         })
     }
 
@@ -488,7 +500,7 @@ mod tests {
                     gas_limit: 30_000_000,
                     timestamp: 1_700_000_000,
                     base_fee_per_gas: Some(1_000_000_000),
-                    withdrawals_root: Some(B256::ZERO),
+                    withdrawals_root: Some(EMPTY_ROOT_HASH),
                     blob_gas_used: Some(0),
                     excess_blob_gas: Some(0),
                     parent_beacon_block_root: Some(B256::ZERO),
@@ -497,7 +509,10 @@ mod tests {
                 },
                 ..Default::default()
             },
-            body: Default::default(),
+            body: BlockBody {
+                withdrawals: Some(Default::default()),
+                ..Default::default()
+            },
         });
         let expected = Block::from_execution_block(execution_block.clone(), None)
             .expect("block has no BAL side data");
@@ -511,6 +526,43 @@ mod tests {
         let encoded = decoded.encode();
 
         assert_eq!(encoded.as_ref(), block_bytes.as_slice());
+    }
+
+    #[test]
+    fn read_rejects_execution_body_that_does_not_match_header() {
+        let execution_block = SealedBlock::seal_slow(TempoBlock {
+            header: TempoHeader {
+                inner: alloy_consensus::Header {
+                    base_fee_per_gas: Some(0),
+                    withdrawals_root: Some(B256::ZERO),
+                    blob_gas_used: Some(0),
+                    excess_blob_gas: Some(0),
+                    parent_beacon_block_root: Some(B256::ZERO),
+                    requests_hash: Some(B256::ZERO),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: BlockBody {
+                withdrawals: Some(Default::default()),
+                ..Default::default()
+            },
+        });
+        let mut encoded = Vec::new();
+        alloy_rlp::Encodable::encode(&execution_block, &mut encoded);
+
+        let err = Block::read_cfg(&mut encoded.as_slice(), &()).unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                commonware_codec::Error::Wrapped(
+                    "validating execution block body against header",
+                    _
+                )
+            ),
+            "unexpected error: {err:?}"
+        );
     }
 
     #[cfg(not(feature = "bal"))]

--- a/crates/consensus/src/feed/ingress.rs
+++ b/crates/consensus/src/feed/ingress.rs
@@ -80,7 +80,7 @@ mod tests {
         block_on(async {
             let (sender, mut receiver) = futures::channel::mpsc::unbounded();
             let mut mailbox = Mailbox::new(sender);
-            let block = Block::from_execution_block(
+            let block = Block::try_from_execution_block(
                 SealedBlock::seal_slow(TempoBlock {
                     header: TempoHeader {
                         inner: Header {

--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -16,6 +16,7 @@ use commonware_parallel::Sequential;
 use rand_core::CryptoRng;
 use tempo_chainspec::NetworkIdentity;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
+use tempo_evm::consensus::validate_body_against_header;
 use tempo_node::rpc::consensus::CertifiedBlock;
 
 use crate::{config::NAMESPACE, consensus::Digest, epoch::SchemeProvider};
@@ -85,6 +86,9 @@ impl FinalizationVerifier {
         rng: &mut impl CryptoRng,
         certified: &CertifiedBlock,
     ) -> Result<Finalization<Scheme<PublicKey, MinSig>, Digest>, Error> {
+        validate_body_against_header(certified.block.body(), certified.block.header())
+            .map_err(|error| Error::BlockBodyMismatch(error.to_string()))?;
+
         // TODO: Decode certificates when constructing `CertifiedBlock` instead of keeping their
         // bytes opaque and decoding them at each consumer.
         let bytes = alloy_primitives::hex::decode(&certified.certificate)
@@ -177,6 +181,9 @@ pub enum CertificateVerificationError {
 /// An error returned while verifying a Tempo finalization certificate.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    /// The block body did not match the commitments in its header.
+    #[error("finalized block body does not match its header: {0}")]
+    BlockBodyMismatch(String),
     /// The certificate was not valid hex or did not decode as a Tempo finalization.
     #[error("malformed finalization certificate")]
     MalformedCertificate(#[source] MalformedCertificateError),

--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -14,6 +14,7 @@ use commonware_cryptography::{
 };
 use commonware_parallel::Sequential;
 use rand_core::CryptoRng;
+use reth_consensus::ConsensusError;
 use tempo_chainspec::NetworkIdentity;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
 use tempo_evm::consensus::validate_body_against_header;
@@ -87,7 +88,7 @@ impl FinalizationVerifier {
         certified: &CertifiedBlock,
     ) -> Result<Finalization<Scheme<PublicKey, MinSig>, Digest>, Error> {
         validate_body_against_header(certified.block.body(), certified.block.header())
-            .map_err(|error| Error::BlockBodyMismatch(error.to_string()))?;
+            .map_err(Error::BlockBodyMismatch)?;
 
         // TODO: Decode certificates when constructing `CertifiedBlock` instead of keeping their
         // bytes opaque and decoding them at each consumer.
@@ -182,8 +183,8 @@ pub enum CertificateVerificationError {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// The block body did not match the commitments in its header.
-    #[error("finalized block body does not match its header: {0}")]
-    BlockBodyMismatch(String),
+    #[error("finalized block body does not match its header")]
+    BlockBodyMismatch(#[source] ConsensusError),
     /// The certificate was not valid hex or did not decode as a Tempo finalization.
     #[error("malformed finalization certificate")]
     MalformedCertificate(#[source] MalformedCertificateError),

--- a/crates/consensus/src/finalization_verifier/test.rs
+++ b/crates/consensus/src/finalization_verifier/test.rs
@@ -1,8 +1,10 @@
-use alloy_consensus::BlockHeader as _;
+use alloy_consensus::{BlockHeader as _, Header};
 use commonware_consensus::types::{Epoch, FixedEpocher};
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
+use reth_node_core::primitives::SealedBlock;
 use tempo_chainspec::NetworkIdentity;
+use tempo_primitives::{Block as TempoBlock, BlockBody, TempoHeader};
 
 use super::{Error, FinalizationVerifier};
 use crate::follow::test_utils::{
@@ -64,6 +66,47 @@ fn rejects_epoch_mismatching_block_height() {
                 expected: 1,
                 actual: 0,
             }) if height == EPOCH_LENGTH.get()
+        ));
+    });
+}
+
+#[test_traced]
+fn rejects_block_body_that_does_not_match_header() {
+    deterministic::Runner::default().start(|mut context| async move {
+        let fixture = dkg_fixture(&mut context, Epoch::zero());
+        let verifier = FinalizationVerifier::new(
+            NetworkIdentity {
+                from_epoch: 0,
+                identity: *fixture.outcome.network_identity(),
+            },
+            FixedEpocher::new(EPOCH_LENGTH),
+        );
+
+        let block = make_block(1, None);
+        let finalization = make_finalization(&block, Epoch::zero(), &fixture.schemes);
+        let mut certified = make_certified_block(block, &finalization);
+        let hash = certified.block.hash();
+        certified.block = SealedBlock::new_unchecked(
+            TempoBlock {
+                header: TempoHeader {
+                    inner: Header {
+                        number: 1,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+                body: BlockBody {
+                    withdrawals: Some(Default::default()),
+                    ..Default::default()
+                },
+            },
+            hash,
+        )
+        .into();
+
+        assert!(matches!(
+            verifier.decode_and_verify(&mut context, &certified),
+            Err(Error::BlockBodyMismatch(_))
         ));
     });
 }

--- a/crates/consensus/src/follow/executor/fcu.rs
+++ b/crates/consensus/src/follow/executor/fcu.rs
@@ -118,7 +118,7 @@ mod tests {
             header: tempo_header(height, round),
             body: BlockBody::default(),
         };
-        Block::from_execution_block(SealedBlock::seal_slow(block), None)
+        Block::try_from_execution_block(SealedBlock::seal_slow(block), None)
             .expect("test block should not contain BAL side data")
     }
 

--- a/crates/consensus/src/follow/executor/test/utils.rs
+++ b/crates/consensus/src/follow/executor/test/utils.rs
@@ -62,7 +62,7 @@ fn make_block_with_round(height: u64, parent_hash: B256, round: Option<Round>) -
         header,
         body: BlockBody::default(),
     };
-    Block::from_execution_block(SealedBlock::seal_slow(inner), None)
+    Block::try_from_execution_block(SealedBlock::seal_slow(inner), None)
         .expect("test block should not contain BAL side data")
 }
 

--- a/crates/consensus/src/follow/resolver/mod.rs
+++ b/crates/consensus/src/follow/resolver/mod.rs
@@ -30,6 +30,7 @@ use reth_provider::{
     BlockReader as _, BlockSource,
     providers::{BlockchainProvider, ProviderNodeTypes},
 };
+use tempo_evm::consensus::validate_body_against_header;
 use tempo_node::{node::TempoNode, rpc::consensus::CertifiedBlock};
 use tempo_primitives::Block as TempoBlock;
 use tracing::{debug, error, instrument, warn};
@@ -256,6 +257,13 @@ async fn resolve_block<P: BlockProvider, U: Upstream>(
 #[instrument(skip_all, fields(%height))]
 async fn resolve_finalized<U: Upstream>(upstream: &U, height: Height) -> Option<Bytes> {
     let certified_block = upstream.get_finalization(height).await?;
+
+    if let Err(error) =
+        validate_body_against_header(certified_block.block.body(), certified_block.block.header())
+    {
+        warn!(%error, "upstream finalized block body does not match its header");
+        return None;
+    }
 
     let finalization = alloy_primitives::hex::decode(&certified_block.certificate)
         .map_err(Report::new)

--- a/crates/consensus/src/follow/resolver/test/mod.rs
+++ b/crates/consensus/src/follow/resolver/test/mod.rs
@@ -11,6 +11,8 @@ use commonware_runtime::{Metrics as _, Runner as _, deterministic};
 use futures::executor::block_on;
 use parking_lot::Mutex;
 use prometheus_client::metrics::counter::Counter;
+use reth_node_core::primitives::SealedBlock;
+use tempo_primitives::{Block as TempoBlock, BlockBody};
 
 use super::{
     Fetcher, MAX_RETRY_DELAY, RETRY_STATE_TTL, RetryState, resolve_block, resolve_finalized,
@@ -87,6 +89,32 @@ fn malformed_finalization_is_retried() {
         let height = Height::new(6);
         let (mut certified, _) = make_certified_block(height);
         certified.certificate = "not-hex".to_string();
+        upstream.add_finalization(height, certified);
+
+        assert_eq!(resolve_finalized(&upstream, height).await, None);
+        assert_eq!(upstream.finalization_reads(), 1);
+    });
+}
+
+#[test]
+fn finalized_block_with_mismatched_body_is_retried() {
+    block_on(async {
+        let upstream = StubUpstream::default();
+        let height = Height::new(6);
+        let (mut certified, _) = make_certified_block(height);
+        let sealed = certified.block.into_sealed_block();
+        let (inner, hash) = sealed.split();
+        certified.block = SealedBlock::new_unchecked(
+            TempoBlock {
+                header: inner.header,
+                body: BlockBody {
+                    withdrawals: Some(Default::default()),
+                    ..inner.body
+                },
+            },
+            hash,
+        )
+        .into();
         upstream.add_finalization(height, certified);
 
         assert_eq!(resolve_finalized(&upstream, height).await, None);

--- a/crates/consensus/src/follow/resolver/test/utils.rs
+++ b/crates/consensus/src/follow/resolver/test/utils.rs
@@ -42,7 +42,7 @@ pub(super) fn make_block(height: u64) -> Block {
         header,
         body: BlockBody::default(),
     };
-    Block::from_execution_block(SealedBlock::seal_slow(inner), None)
+    Block::try_from_execution_block(SealedBlock::seal_slow(inner), None)
         .expect("test block should not contain BAL side data")
 }
 

--- a/crates/consensus/src/follow/test_utils.rs
+++ b/crates/consensus/src/follow/test_utils.rs
@@ -88,7 +88,7 @@ fn make_block_with_parent(
         body: BlockBody::default(),
     };
 
-    Block::from_execution_block(SealedBlock::seal_slow(inner), None)
+    Block::try_from_execution_block(SealedBlock::seal_slow(inner), None)
         .expect("test block should not contain BAL side data")
 }
 

--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -12,7 +12,6 @@ use jsonrpsee::{
 };
 use rand_08::Rng as _;
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
-use tempo_evm::consensus::validate_body_against_header;
 use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query, TempoConsensusApiClient};
 use tempo_primitives::{TempoHeader, TempoTxEnvelope};
 use tempo_telemetry_util::display_duration;
@@ -443,9 +442,8 @@ async fn get_block(client: Arc<WsClient>, digest: Digest) -> eyre::Result<Option
     let block = block
         .map(|block| {
             ensure!(block.hash() == digest.0, "mismatched block hash");
-            validate_body_against_header(block.body(), block.header())
-                .wrap_err("upstream block body does not match its header")?;
-            Ok(Block::from_execution_block_unchecked(block, None))
+            Block::try_from_execution_block(block, None)
+                .wrap_err("upstream block or consensus sidecar is invalid")
         })
         .transpose()?;
 

--- a/crates/consensus/src/follow/upstream/actor.rs
+++ b/crates/consensus/src/follow/upstream/actor.rs
@@ -12,6 +12,7 @@ use jsonrpsee::{
 };
 use rand_08::Rng as _;
 use reth_primitives_traits::{SealedBlock, SealedOrRecoveredBlock};
+use tempo_evm::consensus::validate_body_against_header;
 use tempo_node::rpc::consensus::{CertifiedBlock, Event, Query, TempoConsensusApiClient};
 use tempo_primitives::{TempoHeader, TempoTxEnvelope};
 use tempo_telemetry_util::display_duration;
@@ -442,6 +443,8 @@ async fn get_block(client: Arc<WsClient>, digest: Digest) -> eyre::Result<Option
     let block = block
         .map(|block| {
             ensure!(block.hash() == digest.0, "mismatched block hash");
+            validate_body_against_header(block.body(), block.header())
+                .wrap_err("upstream block body does not match its header")?;
             Ok(Block::from_execution_block_unchecked(block, None))
         })
         .transpose()?;

--- a/crates/consensus/src/storage/hybrid/test/utils.rs
+++ b/crates/consensus/src/storage/hybrid/test/utils.rs
@@ -68,7 +68,7 @@ pub(in crate::storage) fn make_block(height: u64, parent_hash: B256) -> Block {
     };
     let body = BlockBody::default();
     let inner = TempoBlock { header, body };
-    Block::from_execution_block(SealedBlock::seal_slow(inner), None)
+    Block::try_from_execution_block(SealedBlock::seal_slow(inner), None)
         .expect("test block should not carry BAL side data")
 }
 

--- a/crates/evm/src/consensus/mod.rs
+++ b/crates/evm/src/consensus/mod.rs
@@ -33,6 +33,14 @@ pub const ALLOWED_FUTURE_BLOCK_TIME_MILLIS: u64 = 0;
 /// Maximum extra data size for Tempo blocks.
 pub const TEMPO_MAXIMUM_EXTRA_DATA_SIZE: usize = 10 * 1_024; // 10KiB
 
+/// Validates that an execution block body matches the commitments in its header.
+pub fn validate_body_against_header(
+    body: &BlockBody,
+    header: &TempoHeader,
+) -> Result<(), ConsensusError> {
+    reth_consensus_common::validation::validate_body_against_header(body, header)
+}
+
 /// Tempo consensus implementation.
 #[derive(Debug, Clone)]
 pub struct TempoConsensus<C = TempoChainSpec> {
@@ -186,7 +194,7 @@ where
         body: &BlockBody,
         header: &SealedHeader<TempoHeader>,
     ) -> Result<(), ConsensusError> {
-        Consensus::<Block>::validate_body_against_header(&self.inner, body, header)
+        validate_body_against_header(body, header.header())
     }
 
     fn validate_block_pre_execution(


### PR DESCRIPTION
Validates decoded consensus block bodies against their header commitments before Commonware can persist them. Adds regression coverage for mismatched withdrawals roots in both BAL configurations.

Prompted by: @SuperFluffy