### PR TITLE
fix(consensus): delay finalized block ACKs until persistence

### DIFF
--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -19,10 +19,10 @@ use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Pacer, Spawner, Storage,
     buffer::paged::CacheRef, spawn_cell,
 };
-use commonware_utils::NZUsize;
 use eyre::{OptionExt as _, WrapErr as _};
 use futures::future::try_join_all;
 use rand_core::{CryptoRng, Rng};
+use reth_engine_primitives::DEFAULT_PERSISTENCE_THRESHOLD;
 use tempo_node::TempoFullNode;
 use tracing::info;
 
@@ -42,8 +42,12 @@ use super::block::Block;
 /// To better support peers near tip during network instability, we multiply
 /// the consensus activity timeout by this factor.
 const SYNCER_ACTIVITY_TIMEOUT_MULTIPLIER: u64 = 10;
-// Ensure the marshal delivers blocks sequentially.
-const MAX_PENDING_ACKS: NonZeroUsize = NZUsize!(1);
+// Reth starts persistence only after the number of canonical in-memory blocks
+// exceeds this threshold. Allow twice that many outstanding blocks so marshal
+// cannot stall immediately before the flush trigger.
+const MAX_PENDING_ACKS: NonZeroUsize =
+    NonZeroUsize::new(DEFAULT_PERSISTENCE_THRESHOLD as usize * 2)
+        .expect("twice Reth's persistence threshold is nonzero");
 
 /// Settings for [`Engine`].
 ///

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -42,12 +42,21 @@ use super::block::Block;
 /// To better support peers near tip during network instability, we multiply
 /// the consensus activity timeout by this factor.
 const SYNCER_ACTIVITY_TIMEOUT_MULTIPLIER: u64 = 10;
-// Reth starts persistence only after the number of canonical in-memory blocks
-// exceeds this threshold. Allow twice that many outstanding blocks so marshal
-// cannot stall immediately before the flush trigger.
-const MAX_PENDING_ACKS: NonZeroUsize =
-    NonZeroUsize::new(DEFAULT_PERSISTENCE_THRESHOLD as usize * 2)
-        .expect("twice Reth's persistence threshold is nonzero");
+/// Maximum number of finalized blocks marshal may deliver without receiving
+/// acknowledgements from the executor.
+///
+/// The executor acknowledges blocks only after Reth persists them, while Reth
+/// starts persistence only after its canonical in-memory block count exceeds
+/// [`DEFAULT_PERSISTENCE_THRESHOLD`]. A depth of 70 (ten times the current
+/// threshold) gives persistence enough runway to start and finish without
+/// stalling marshal and, consequently, consensus progress.
+const MAX_PENDING_ACKS: NonZeroUsize = NonZeroUsize::new(70).expect("70 is nonzero");
+
+const _: () = assert!(
+    MAX_PENDING_ACKS.get() as u64 > DEFAULT_PERSISTENCE_THRESHOLD
+        && (MAX_PENDING_ACKS.get() as u64).is_multiple_of(DEFAULT_PERSISTENCE_THRESHOLD),
+    "marshal pending-ack depth must be a multiple of and exceed Reth's persistence threshold",
+);
 
 /// Settings for [`Engine`].
 ///

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -114,6 +114,10 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// Finalized blocks waiting to be forwarded to the execution layer.
     pending_finalizations: VecDeque<FinalizedBlockRequest>,
 
+    /// Acknowledgements for forwarded finalized blocks, ordered by height and
+    /// held until Reth has persisted the corresponding blocks.
+    pending_finalization_acknowledgments: VecDeque<FinalizationAcknowledgment>,
+
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
     /// slot because a node either verifies or proposes in a round, never
@@ -297,6 +301,7 @@ where
             fcu_heartbeat_timer: OptionFuture::none(),
 
             pending_finalizations: VecDeque::new(),
+            pending_finalization_acknowledgments: VecDeque::new(),
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -347,6 +352,16 @@ where
         });
 
         loop {
+            if let Err(error) = self.acknowledge_persisted_finalizations() {
+                error_span!("shutdown").in_scope(|| {
+                    error!(
+                        %error,
+                        "executor failed checking persisted execution-layer height; shutting down"
+                    )
+                });
+                break;
+            }
+
             // The tree is pruned to the advancing finalized tip here,
             // before the scheduling decisions below read it. The select
             // branches only record primary state. Metrics observe the same
@@ -459,6 +474,20 @@ where
                         .push(run_payload_job(self.execution_node.clone(), job).boxed());
                 }
             }
+            ExecutionTaskOutcome::Finalized {
+                canonicalized,
+                acknowledgment,
+            } => {
+                self.notarized_tree.set_local_state(canonicalized);
+                if let Some(last) = self.pending_finalization_acknowledgments.back() {
+                    assert!(
+                        last.height <= acknowledgment.height,
+                        "invariant violation: finalization acknowledgements must be ordered by height"
+                    );
+                }
+                self.pending_finalization_acknowledgments
+                    .push_back(acknowledgment);
+            }
             ExecutionTaskOutcome::NotarizedBlockRejected { digest, .. } => {
                 // The cause is logged by the task itself. The timestamp keeps
                 // the block from being retried in a tight loop: it is withheld
@@ -470,6 +499,29 @@ where
             ExecutionTaskOutcome::Fatal { error } => {
                 return Err(error.wrap_err("execution task failed"));
             }
+        }
+        Ok(())
+    }
+
+    fn acknowledge_persisted_finalizations(&mut self) -> eyre::Result<()> {
+        if self.pending_finalization_acknowledgments.is_empty() {
+            return Ok(());
+        }
+
+        let persisted_height = self
+            .execution_node
+            .persisted_block_number()
+            .wrap_err("failed reading persisted execution-layer height")?;
+        while self
+            .pending_finalization_acknowledgments
+            .front()
+            .is_some_and(|acknowledgment| acknowledgment.height.get() <= persisted_height)
+        {
+            self.pending_finalization_acknowledgments
+                .pop_front()
+                .expect("front was present")
+                .acknowledgment
+                .acknowledge();
         }
         Ok(())
     }
@@ -531,7 +583,7 @@ where
             let target =
                 finalization_target(&self.execution_node, canonicalized, request.block.as_ref())?;
 
-            let canonicalized = forward_finalized(
+            let (canonicalized, acknowledgment) = forward_finalized(
                 self.execution_node.clone(),
                 self.public_key.clone(),
                 self.metrics.clone(),
@@ -545,6 +597,7 @@ where
                     to execution layer"
                 )
             })?;
+            acknowledgment.acknowledgment.acknowledge();
             self.notarized_tree.set_local_state(canonicalized);
         }
 
@@ -898,6 +951,12 @@ struct FinalizedBlockRequest {
     acknowledgment: Exact,
 }
 
+#[derive(Debug)]
+struct FinalizationAcknowledgment {
+    height: Height,
+    acknowledgment: Exact,
+}
+
 /// An in-flight fetch of a notarized block body that is missing from the
 /// tree, keyed by the digest being fetched and the round it was
 /// notarized in.
@@ -1047,6 +1106,7 @@ impl ExecutionTaskFinished {
     fn target(&self) -> Option<LocalState> {
         match &self.outcome {
             ExecutionTaskOutcome::Completed { canonicalized, .. } => *canonicalized,
+            ExecutionTaskOutcome::Finalized { canonicalized, .. } => Some(*canonicalized),
             ExecutionTaskOutcome::NotarizedBlockRejected { target, .. } => Some(*target),
             ExecutionTaskOutcome::Fatal { .. } => None,
         }
@@ -1082,6 +1142,10 @@ enum ExecutionTaskOutcome {
         /// execution layer and that still needs to be driven to completion.
         payload_job: Option<StartPayloadJob>,
     },
+    Finalized {
+        canonicalized: LocalState,
+        acknowledgment: FinalizationAcknowledgment,
+    },
     /// A notarized block could not be forwarded and should be retried later.
     NotarizedBlockRejected {
         digest: Digest,
@@ -1096,6 +1160,7 @@ impl ExecutionTaskOutcome {
     fn name(&self) -> &'static str {
         match self {
             Self::Completed { .. } => "completed",
+            Self::Finalized { .. } => "finalized",
             Self::NotarizedBlockRejected { .. } => "rejected",
             Self::Fatal { .. } => "fatal",
         }
@@ -1243,9 +1308,9 @@ async fn execute_finalization(
         Err(error) => return ExecutionTaskOutcome::Fatal { error },
     };
     match forward_finalized(execution_node, public_key, metrics, target, request).await {
-        Ok(target) => ExecutionTaskOutcome::Completed {
-            canonicalized: Some(target),
-            payload_job: None,
+        Ok((canonicalized, acknowledgment)) => ExecutionTaskOutcome::Finalized {
+            canonicalized,
+            acknowledgment,
         },
         Err(error) => ExecutionTaskOutcome::Fatal { error },
     }
@@ -1651,7 +1716,7 @@ async fn forward_finalized(
     metrics: Metrics,
     target: LocalState,
     request: FinalizedBlockRequest,
-) -> eyre::Result<LocalState> {
+) -> eyre::Result<(LocalState, FinalizationAcknowledgment)> {
     let FinalizedBlockRequest {
         cause,
         block,
@@ -1659,6 +1724,7 @@ async fn forward_finalized(
     } = request;
 
     let consensus_context = block.header().consensus_context;
+    let height = block.height();
 
     let (execution_block, block_access_list) = (*block).clone().into_parts();
     let payload_status = execution_node
@@ -1696,9 +1762,13 @@ async fn forward_finalized(
         metrics.finalized_blocks_proposed_by_self.inc();
     }
 
-    acknowledgment.acknowledge();
-
-    Ok(target)
+    Ok((
+        target,
+        FinalizationAcknowledgment {
+            height,
+            acknowledgment,
+        },
+    ))
 }
 
 /// Drives convergence of the EL to the pending notarized tip.

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -517,6 +517,28 @@ where
             .front()
             .is_some_and(|acknowledgment| acknowledgment.height.get() <= persisted_height)
         {
+            let acknowledgment = self
+                .pending_finalization_acknowledgments
+                .front()
+                .expect("front was present");
+            let persisted_digest = self
+                .execution_node
+                .persisted_block_hash(acknowledgment.height.get())
+                .wrap_err_with(|| {
+                    format!(
+                        "failed reading persisted execution block hash at height `{}`",
+                        acknowledgment.height
+                    )
+                })?;
+            if persisted_digest != Some(acknowledgment.digest.0) {
+                debug!(
+                    height = %acknowledgment.height,
+                    expected_digest = %acknowledgment.digest,
+                    ?persisted_digest,
+                    "persisted execution block does not match finalized block"
+                );
+                break;
+            }
             self.pending_finalization_acknowledgments
                 .pop_front()
                 .expect("front was present")
@@ -954,6 +976,7 @@ struct FinalizedBlockRequest {
 #[derive(Debug)]
 struct FinalizationAcknowledgment {
     height: Height,
+    digest: Digest,
     acknowledgment: Exact,
 }
 
@@ -1725,6 +1748,7 @@ async fn forward_finalized(
 
     let consensus_context = block.header().consensus_context;
     let height = block.height();
+    let digest = block.digest();
 
     let (execution_block, block_access_list) = (*block).clone().into_parts();
     let payload_status = execution_node
@@ -1766,6 +1790,7 @@ async fn forward_finalized(
         target,
         FinalizationAcknowledgment {
             height,
+            digest,
             acknowledgment,
         },
     ))

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -1,7 +1,7 @@
 //! Scenario tests for the finalization pipeline: finalized blocks arriving
 //! from the marshal actor are forwarded to the execution layer as
 //! `newPayload` + `forkchoiceUpdated` pairs, in order, and acknowledged
-//! only once the execution layer accepted them.
+//! only once the execution layer persisted them.
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
 use commonware_macros::test_traced;
@@ -71,6 +71,41 @@ fn finalized_blocks_are_forwarded_in_order() {
             .collect::<Vec<_>>();
         assert_eq!(h.execution.fcus(), expected_fcus);
         assert_eq!(h.execution.finalized(), Some((3, digests[2])));
+    });
+}
+
+#[test_traced]
+fn finalized_blocks_are_acknowledged_through_persisted_height() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+        h.execution.persist_forkchoice_updates(false);
+
+        let b1 = make_block(1, 1, GENESIS);
+        let b2 = make_block(2, 2, b1.digest());
+        let b3 = make_block(3, 3, b2.digest());
+        let d3 = b3.digest();
+
+        h.deliver_tip(round(3), 3, d3);
+        let w1 = h.deliver_finalized(b1);
+        let w2 = h.deliver_finalized(b2);
+        let w3 = h.deliver_finalized(b3);
+        futures::pin_mut!(w1, w2, w3);
+
+        h.wait_until(|| h.execution.finalized() == Some((3, d3)))
+            .await;
+        assert!(futures::poll!(&mut w1).is_pending());
+        assert!(futures::poll!(&mut w2).is_pending());
+        assert!(futures::poll!(&mut w3).is_pending());
+
+        h.execution.set_persisted_block_number(2);
+        h.deliver_tip(round(3), 3, d3);
+        (&mut w1).await.expect("height 1 should be acknowledged");
+        (&mut w2).await.expect("height 2 should be acknowledged");
+        assert!(futures::poll!(&mut w3).is_pending());
+
+        h.execution.set_persisted_block_number(3);
+        h.deliver_tip(round(3), 3, d3);
+        w3.await.expect("height 3 should be acknowledged");
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -110,6 +110,37 @@ fn finalized_blocks_are_acknowledged_through_persisted_height() {
 }
 
 #[test_traced]
+fn finalized_block_is_not_acknowledged_until_its_digest_is_persisted() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+        h.execution.persist_forkchoice_updates(false);
+
+        let block = make_block(1, 1, GENESIS);
+        let digest = block.digest();
+        let abandoned_digest = make_block(9, 1, GENESIS).digest();
+        h.deliver_tip(round(1), 1, digest);
+        let waiter = h.deliver_finalized(block);
+        futures::pin_mut!(waiter);
+
+        h.wait_until(|| h.execution.finalized() == Some((1, digest)))
+            .await;
+        h.execution.set_persisted_block_hash(1, abandoned_digest);
+        h.deliver_tip(round(1), 1, digest);
+        h.run_for(std::time::Duration::from_millis(1)).await;
+        assert!(
+            futures::poll!(&mut waiter).is_pending(),
+            "persisting a different block at the same height must not resolve the ACK"
+        );
+
+        h.execution.set_persisted_block_hash(1, digest);
+        h.deliver_tip(round(1), 1, digest);
+        waiter
+            .await
+            .expect("the finalized block's persisted digest should resolve the ACK");
+    });
+}
+
+#[test_traced]
 fn syncing_finalized_block_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/harness.rs
+++ b/crates/consensus/src/executor/actor/tests/harness.rs
@@ -234,6 +234,8 @@ where
 struct FakeExecutionInner {
     genesis: B256,
     state: Mutex<ElState>,
+    persisted_block_number: AtomicU64,
+    persist_forkchoice_updates: AtomicBool,
     calls: Mutex<Vec<ElCall>>,
     /// Complete new-payload outcome sequences keyed by block hash. A digest
     /// absent from this map uses the fake's stateful default behavior; a
@@ -312,6 +314,8 @@ impl FakeExecution {
                     head: genesis,
                     finalized: None,
                 }),
+                persisted_block_number: AtomicU64::new(0),
+                persist_forkchoice_updates: AtomicBool::new(true),
                 calls: Mutex::new(Vec::new()),
                 payload_overrides: ScriptedResults::new(),
                 payload_validator_sets: Mutex::new(Vec::new()),
@@ -349,6 +353,19 @@ impl FakeExecution {
 
     pub(super) fn set_finalized(&self, height: u64, digest: Digest) {
         self.inner.state.lock().finalized = Some(BlockNumHash::new(height, digest.0));
+        self.set_persisted_block_number(height);
+    }
+
+    pub(super) fn set_persisted_block_number(&self, height: u64) {
+        self.inner
+            .persisted_block_number
+            .store(height, Ordering::SeqCst);
+    }
+
+    pub(super) fn persist_forkchoice_updates(&self, persist: bool) {
+        self.inner
+            .persist_forkchoice_updates
+            .store(persist, Ordering::SeqCst);
     }
 
     /// Makes `block` servable through `block_by_digest`.
@@ -572,6 +589,11 @@ impl FakeExecution {
                 finalized_height,
                 fcu.finalized_block_hash,
             ));
+            if self.inner.persist_forkchoice_updates.load(Ordering::SeqCst) {
+                self.inner
+                    .persisted_block_number
+                    .fetch_max(finalized_height, Ordering::SeqCst);
+            }
         }
 
         PayloadStatusEnum::Valid
@@ -598,6 +620,10 @@ impl ExecutionLayer for FakeExecution {
             .lock()
             .finalized
             .unwrap_or_else(|| BlockNumHash::new(0, self.genesis_hash()))
+    }
+
+    fn persisted_block_number(&self) -> eyre::Result<u64> {
+        Ok(self.inner.persisted_block_number.load(Ordering::SeqCst))
     }
 
     fn genesis_hash(&self) -> B256 {

--- a/crates/consensus/src/executor/actor/tests/harness.rs
+++ b/crates/consensus/src/executor/actor/tests/harness.rs
@@ -162,6 +162,9 @@ struct ElState {
     /// The canonical index: height -> hash, derived from accepted
     /// forkchoice updates (plus seeded history).
     canonical: BTreeMap<u64, B256>,
+    /// Blocks written to the fake database, independently of the in-memory
+    /// canonical index.
+    persisted: BTreeMap<u64, B256>,
     head: B256,
     finalized: Option<BlockNumHash>,
 }
@@ -311,6 +314,7 @@ impl FakeExecution {
                 state: Mutex::new(ElState {
                     blocks: HashMap::from([(genesis, (0, B256::ZERO))]),
                     canonical: BTreeMap::from([(0, genesis)]),
+                    persisted: BTreeMap::from([(0, genesis)]),
                     head: genesis,
                     finalized: None,
                 }),
@@ -357,9 +361,23 @@ impl FakeExecution {
     }
 
     pub(super) fn set_persisted_block_number(&self, height: u64) {
+        let mut state = self.inner.state.lock();
+        let persisted = state
+            .canonical
+            .range(..=height)
+            .map(|(&height, &digest)| (height, digest))
+            .collect::<Vec<_>>();
+        state.persisted.extend(persisted);
         self.inner
             .persisted_block_number
             .store(height, Ordering::SeqCst);
+    }
+
+    pub(super) fn set_persisted_block_hash(&self, height: u64, digest: Digest) {
+        self.inner.state.lock().persisted.insert(height, digest.0);
+        self.inner
+            .persisted_block_number
+            .fetch_max(height, Ordering::SeqCst);
     }
 
     pub(super) fn persist_forkchoice_updates(&self, persist: bool) {
@@ -590,6 +608,12 @@ impl FakeExecution {
                 fcu.finalized_block_hash,
             ));
             if self.inner.persist_forkchoice_updates.load(Ordering::SeqCst) {
+                let persisted = state
+                    .canonical
+                    .range(..=finalized_height)
+                    .map(|(&height, &digest)| (height, digest))
+                    .collect::<Vec<_>>();
+                state.persisted.extend(persisted);
                 self.inner
                     .persisted_block_number
                     .fetch_max(finalized_height, Ordering::SeqCst);
@@ -624,6 +648,10 @@ impl ExecutionLayer for FakeExecution {
 
     fn persisted_block_number(&self) -> eyre::Result<u64> {
         Ok(self.inner.persisted_block_number.load(Ordering::SeqCst))
+    }
+
+    fn persisted_block_hash(&self, height: u64) -> eyre::Result<Option<B256>> {
+        Ok(self.inner.state.lock().persisted.get(&height).copied())
     }
 
     fn genesis_hash(&self) -> B256 {

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -11,7 +11,7 @@ use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{Clock, Metrics, Spawner};
 use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
 use reth_node_builder::PayloadKind;
-use reth_provider::{BlockHashReader as _, BlockReader as _, BlockSource};
+use reth_provider::{BlockHashReader as _, BlockNumReader as _, BlockReader as _, BlockSource};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
 use tokio::sync::oneshot;
@@ -72,6 +72,9 @@ pub(crate) trait ExecutionLayer: Clone + Send + Sync + 'static {
     /// The execution layer's finalized block, falling back to genesis if no
     /// block has been explicitly finalized yet.
     fn finalized_num_hash(&self) -> BlockNumHash;
+
+    /// Highest block persisted in Reth's database, excluding in-memory state.
+    fn persisted_block_number(&self) -> eyre::Result<u64>;
 
     /// The hash of the genesis block.
     fn genesis_hash(&self) -> B256;
@@ -157,6 +160,10 @@ impl ExecutionLayer for Arc<TempoFullNode> {
             .canonical_in_memory_state()
             .get_finalized_num_hash()
             .unwrap_or_else(|| BlockNumHash::new(0, self.genesis_hash()))
+    }
+
+    fn persisted_block_number(&self) -> eyre::Result<u64> {
+        self.provider.last_block_number().map_err(Into::into)
     }
 
     fn genesis_hash(&self) -> B256 {

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -11,7 +11,10 @@ use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{Clock, Metrics, Spawner};
 use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
 use reth_node_builder::PayloadKind;
-use reth_provider::{BlockHashReader as _, BlockNumReader as _, BlockReader as _, BlockSource};
+use reth_provider::{
+    BlockHashReader as _, BlockNumReader as _, BlockReader as _, BlockSource,
+    DatabaseProviderFactory as _,
+};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
 use tokio::sync::oneshot;
@@ -75,6 +78,9 @@ pub(crate) trait ExecutionLayer: Clone + Send + Sync + 'static {
 
     /// Highest block persisted in Reth's database, excluding in-memory state.
     fn persisted_block_number(&self) -> eyre::Result<u64>;
+
+    /// Persisted database block hash at `height`, excluding in-memory state.
+    fn persisted_block_hash(&self, height: u64) -> eyre::Result<Option<B256>>;
 
     /// The hash of the genesis block.
     fn genesis_hash(&self) -> B256;
@@ -164,6 +170,10 @@ impl ExecutionLayer for Arc<TempoFullNode> {
 
     fn persisted_block_number(&self) -> eyre::Result<u64> {
         self.provider.last_block_number().map_err(Into::into)
+    }
+
+    fn persisted_block_hash(&self, height: u64) -> eyre::Result<Option<B256>> {
+        Ok(self.provider.database_provider_ro()?.block_hash(height)?)
     }
 
     fn genesis_hash(&self) -> B256 {


### PR DESCRIPTION
Queues finalized-block ACKs by height and releases them only after Reth's database tip reaches each block and its persisted hash matches the finalized digest. Sets marshal's pending-ACK depth to 70 so Reth persistence can trigger without blocking consensus progress.

Prompted by: @SuperFluffy