### PR TITLE
fix(bench): suppress noisy OTLP log targets

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -33,14 +33,14 @@ def log-filter-args [loud: bool] {
     if $loud { [] } else { ["--log.stdout.filter" "info"] }
 }
 
-# Keep benchmark OTLP logs useful without emitting high-volume HTTP transport internals.
+# Keep benchmark OTLP logs useful without emitting high-volume connection and storage internals.
 def benchmark-otlp-args [endpoint: string] {
     if $endpoint == "" {
         []
     } else {
         [
             $"--tracing-otlp=($endpoint)"
-            "--logs-otlp.filter=debug,h2=off,hyper=off,hyper_util=off"
+            "--logs-otlp.filter=debug,h2=off,hyper=off,hyper_util=off,jsonrpsee-server=off,storage::overlay=off"
         ]
     }
 }


### PR DESCRIPTION
Excludes `jsonrpsee-server` and `storage::overlay` from benchmark OTLP logs while retaining every other debug target. Connection-acceptance events alone emitted 14.7 GB across two recent E2E runs.

Validated with Nushell parsing and focused assertions for enabled and disabled OTLP endpoints.

Prompted by: @laibe