### PR TITLE
deps: update reth from main (2026-09-08)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "bytes",
  "eyre",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10739,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10751,7 +10751,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10774,7 +10774,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10925,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11001,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11031,7 +11031,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11074,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11094,7 +11094,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11172,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11269,7 +11269,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11321,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11349,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11363,7 +11363,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11383,7 +11383,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11398,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11441,7 +11441,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11469,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11506,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11516,7 +11516,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "clap",
  "eyre",
@@ -11536,7 +11536,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11555,7 +11555,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11598,7 +11598,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11624,7 +11624,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11652,7 +11652,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11668,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
+source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "bytes",
  "eyre",
@@ -10703,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10715,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10739,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10751,7 +10751,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10774,7 +10774,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10817,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10867,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10894,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10910,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10925,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11001,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11031,7 +11031,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11074,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11094,7 +11094,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11125,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11172,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11222,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11238,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11269,7 +11269,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11321,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11349,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11363,7 +11363,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11383,7 +11383,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11398,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11424,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11441,7 +11441,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11469,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11506,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11516,7 +11516,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "clap",
  "eyre",
@@ -11536,7 +11536,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11555,7 +11555,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11598,7 +11598,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11624,7 +11624,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11652,7 +11652,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11668,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
+source = "git+https://github.com/paradigmxyz/reth?rev=f874000#f8740008d618aa3ee5d88ea145cfc6989b5c2339"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8983,8 +8983,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9010,8 +9010,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9041,8 +9041,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9061,8 +9061,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9074,8 +9074,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9159,8 +9159,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9169,8 +9169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9190,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9211,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9222,8 +9222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9239,8 +9239,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9253,8 +9253,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9266,8 +9266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9291,8 +9291,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9320,8 +9320,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,8 +9346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9376,8 +9376,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9391,8 +9391,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9416,8 +9416,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9440,8 +9440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9464,8 +9464,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9501,8 +9501,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9560,8 +9560,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9587,8 +9587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9610,8 +9610,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9637,8 +9637,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9686,7 +9686,6 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "schnellru",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9694,8 +9693,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,8 +9723,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,8 +9741,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,8 +9757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,8 +9781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,8 +9792,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,8 +9820,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,8 +9843,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,8 +9884,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,8 +9907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,8 +9923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,8 +9939,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,8 +9952,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,8 +9982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,8 +9996,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,8 +10006,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,8 +10032,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,8 +10052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,8 +10070,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,8 +10083,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,8 +10102,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,8 +10140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,8 +10154,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,8 +10164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,8 +10190,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,8 +10210,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,8 +10227,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,8 +10236,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "futures",
  "libc",
@@ -10251,8 +10250,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,8 +10259,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,8 +10273,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,8 +10332,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,8 +10357,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,8 +10381,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,8 +10396,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,8 +10410,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10428,8 +10427,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10452,8 +10451,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10520,8 +10519,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10575,8 +10574,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10624,8 +10623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10648,8 +10647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10672,8 +10671,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "bytes",
  "eyre",
@@ -10701,8 +10700,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10713,8 +10712,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10737,8 +10736,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10749,8 +10748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10772,8 +10771,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10782,9 +10781,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10815,8 +10814,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10865,8 +10864,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10892,8 +10891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10908,8 +10907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10923,8 +10922,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10999,8 +10998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11029,8 +11028,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11072,8 +11071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11092,8 +11091,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11123,8 +11122,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11170,8 +11169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11220,8 +11219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11236,8 +11235,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11252,9 +11251,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
+checksum = "f410d6bff1fd059ebaec2edeff1326f103f61162158411325d78158f94b2b4a9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11267,8 +11266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11319,8 +11318,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11347,8 +11346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11361,8 +11360,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11381,8 +11380,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11396,8 +11395,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11422,8 +11421,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11439,8 +11438,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11467,8 +11466,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11488,8 +11487,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11504,8 +11503,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11514,8 +11513,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "clap",
  "eyre",
@@ -11534,8 +11533,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11553,8 +11552,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11596,8 +11595,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11622,8 +11621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11650,8 +11649,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11666,8 +11665,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11683,7 +11682,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-tasks",
  "reth-trie",
- "reth-trie-sparse",
  "revm",
  "thiserror 2.0.18",
  "tracing",
@@ -11691,8 +11689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11703,8 +11701,6 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
- "serde",
- "serde_json",
  "slotmap",
  "smallvec",
  "strum",
@@ -11713,18 +11709,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
+checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11741,9 +11737,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf 0.14.0",
@@ -11753,9 +11749,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
+checksum = "f85bce65cc8969955309d5c4c37a63612209c720d040f1982dda6b59e39ab059"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11770,9 +11766,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
+checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11786,9 +11782,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11802,9 +11798,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -11816,9 +11812,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
+checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11835,9 +11831,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
+checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
 dependencies = [
  "auto_impl",
  "either",
@@ -11853,9 +11849,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c136a072540987ee442e9824631835520b13e5756f20780a637ba2e11f9c28"
+checksum = "79b609cb78fcb3a8c10f3190847c9bb0223423cf46e2de30a61ea9e37a3e6736"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11873,9 +11869,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
+checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11886,9 +11882,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
+checksum = "1e22eb3326b44ec0bc47a874966a562390e1613f1f0ba4dc4a1056e525e0f628"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11912,9 +11908,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11923,9 +11919,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201b9e973fe90b2effd9ab356d4f2a46ab56046ba9d46f163367553e72c045b0"
+checksum = "d9f1a3f2206f2ba4206fdeeddce6640eed3e26b8a13ac41444adb66b76d8e650"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dba4e59c3581a39e03e0b0b4a46ee9c41315b5d843b1e903271952b32bedb7c"
+checksum = "208699c66c453fbb4c50d2e602f8ceff8a5f1fa48ac8b6ee3b6357fdc93da311"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce7b00f0cb42c66ec353076ded1dff1fbf818f6e0e26c40c8a8456c04483fca4"
+checksum = "9c902f0ca3f8353c41e3e1ec3cf26be49412525bc48ab9d3c4710d7be4f01832"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64558980fb038cd34b4285ec2b36a2a8bd8d4ddd13b3f6e42d97cb5ee29938e"
+checksum = "fdcbd48d60e029be4a325c3a2f1312761caea4ed249f18ba9e8ed24ca1bf01e6"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffb0e793abdbaea9d01259493c8272c3af295d03389e70a2acdf53b57ad1edf"
+checksum = "59c9f7c535f99a7e7b64cc520968b09ed14cec3715572fcc277cfbff602808cd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2c0ec8425d9663dac939ba75750f17d2933d2f020814b4f8fde4a60da6d26"
+checksum = "1abd404fbc12f543823005146b73fd07621bdc0baaa950d26995c543a9d73811"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
+checksum = "40a7fd71864526bfeca8903010d5bb7fd28a0a4f5cc55818304c9cad8f0d63ab"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f40e33a0f588dde548c3b6767a71e61b593421a8c1b253b9cf1441dc7cf7ab5"
+checksum = "adfc2ba3fb0e865de4934bcad6d37fc51e9ffcd5294be1322eab38e4494e051b"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -1180,7 +1180,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1191,7 +1191,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4484,7 +4484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6098,7 +6098,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7271,7 +7271,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9783,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9886,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "clap",
  "eyre",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10008,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "serde",
  "serde_json",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10192,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "bytes",
  "futures",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "bindgen",
  "cc",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "futures",
  "libc",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10359,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "bytes",
  "eyre",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10750,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10893,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10909,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10924,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11000,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11030,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11124,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11237,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11320,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11382,7 +11382,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11397,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11440,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11489,7 +11489,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11515,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "clap",
  "eyre",
@@ -11535,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11554,7 +11554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11651,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=8ba930b#8ba930bface320822936cf7c04e59d6351e5c4bd"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -12246,7 +12246,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12326,7 +12326,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13006,7 +13006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -13168,9 +13168,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.7.2"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6415502cd1e9ed58b3ceb415164b812d5572757b1a6f0e280ae806723c1fab"
+checksum = "e452eb8cb83fc8b81597eb07c8d39f770d04905af9c5bffce8bea7213df29960"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -13286,7 +13286,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13500,8 +13500,6 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-engine-primitives",
  "reth-evm",
- "reth-network-api",
- "reth-network-p2p",
  "reth-node-builder",
  "reth-node-core",
  "reth-primitives-traits",
@@ -13870,6 +13868,7 @@ dependencies = [
  "alloy-evm",
  "alloy-json-abi",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-signer",
  "alloy-signer-local",
  "bitflags 2.11.1",
@@ -15371,7 +15370,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9301,12 +9301,12 @@ dependencies = [
  "metrics",
  "page_size",
  "parking_lot",
- "quanta",
  "reth-db-api",
  "reth-fs-util",
  "reth-libmdbx",
  "reth-metrics",
  "reth-nippy-jar",
+ "reth-primitives-traits",
  "reth-static-file-types",
  "reth-storage-errors",
  "reth-tracing",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10420,6 +10420,7 @@ dependencies = [
  "memmap2",
  "reth-fs-util",
  "serde",
+ "smallvec",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -10428,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10452,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10520,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10575,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10624,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10648,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10672,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "bytes",
  "eyre",
@@ -10685,6 +10686,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "metrics-process",
  "metrics-util",
+ "parking_lot",
  "pprof_util",
  "procfs",
  "reqwest 0.13.3",
@@ -10701,7 +10703,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10713,7 +10715,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10737,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10749,7 +10751,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10772,7 +10774,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10815,7 +10817,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10865,7 +10867,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10892,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10908,7 +10910,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10923,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10999,7 +11001,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11029,7 +11031,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11072,7 +11074,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11092,7 +11094,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11123,7 +11125,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11170,7 +11172,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11220,7 +11222,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11236,7 +11238,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11267,7 +11269,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11319,7 +11321,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11347,7 +11349,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11361,7 +11363,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11381,7 +11383,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11396,7 +11398,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11422,7 +11424,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11439,7 +11441,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11467,7 +11469,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11488,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11504,7 +11506,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11514,7 +11516,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "clap",
  "eyre",
@@ -11534,7 +11536,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11553,7 +11555,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11596,7 +11598,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11622,7 +11624,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11650,7 +11652,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11666,7 +11668,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11690,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=68877d5#68877d5fd7d146ef070bbe7dbabbe1097ea1da62"
+source = "git+https://github.com/paradigmxyz/reth?rev=b4cdc0e#b4cdc0e4fde16a5351d02769c046b90f1b068da0"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -13496,6 +13498,8 @@ dependencies = [
  "reth-ethereum",
  "reth-ethereum-engine-primitives",
  "reth-evm",
+ "reth-network-api",
+ "reth-network-p2p",
  "reth-node-builder",
  "reth-node-core",
  "reth-primitives-traits",
@@ -13864,7 +13868,6 @@ dependencies = [
  "alloy-evm",
  "alloy-json-abi",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-signer",
  "alloy-signer-local",
  "bitflags 2.11.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10629,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "bytes",
  "eyre",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10743,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10778,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10821,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11129,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11242,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11273,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11325,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11367,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11387,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11402,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11473,7 +11473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11510,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11520,7 +11520,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "clap",
  "eyre",
@@ -11540,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11559,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11628,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11696,7 +11696,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
+source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208699c66c453fbb4c50d2e602f8ceff8a5f1fa48ac8b6ee3b6357fdc93da311"
+checksum = "1dba4e59c3581a39e03e0b0b4a46ee9c41315b5d843b1e903271952b32bedb7c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -510,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c902f0ca3f8353c41e3e1ec3cf26be49412525bc48ab9d3c4710d7be4f01832"
+checksum = "ce7b00f0cb42c66ec353076ded1dff1fbf818f6e0e26c40c8a8456c04483fca4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -948,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcbd48d60e029be4a325c3a2f1312761caea4ed249f18ba9e8ed24ca1bf01e6"
+checksum = "c64558980fb038cd34b4285ec2b36a2a8bd8d4ddd13b3f6e42d97cb5ee29938e"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -962,9 +962,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c9f7c535f99a7e7b64cc520968b09ed14cec3715572fcc277cfbff602808cd"
+checksum = "1ffb0e793abdbaea9d01259493c8272c3af295d03389e70a2acdf53b57ad1edf"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abd404fbc12f543823005146b73fd07621bdc0baaa950d26995c543a9d73811"
+checksum = "32c2c0ec8425d9663dac939ba75750f17d2933d2f020814b4f8fde4a60da6d26"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a7fd71864526bfeca8903010d5bb7fd28a0a4f5cc55818304c9cad8f0d63ab"
+checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc2ba3fb0e865de4934bcad6d37fc51e9ffcd5294be1322eab38e4494e051b"
+checksum = "1f40e33a0f588dde548c3b6767a71e61b593421a8c1b253b9cf1441dc7cf7ab5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -13170,9 +13170,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e452eb8cb83fc8b81597eb07c8d39f770d04905af9c5bffce8bea7213df29960"
+checksum = "4c6415502cd1e9ed58b3ceb415164b812d5572757b1a6f0e280ae806723c1fab"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,17 +10576,19 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network",
  "alloy-primitives",
+ "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "eyre",
+ "futures",
  "http-body-util",
  "jsonrpsee",
  "reth-chainspec",
@@ -10613,8 +10615,10 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
+ "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
+ "reth-trie-common",
  "revm",
  "serde",
  "serde_json",
@@ -10625,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "bytes",
  "eyre",
@@ -10703,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10715,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10739,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10751,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10774,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10817,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10867,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10894,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10910,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10925,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11001,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11031,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11074,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11094,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11125,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11172,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11222,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11238,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11269,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11321,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11349,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11363,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11383,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11398,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11424,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11441,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11469,7 +11473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11490,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11506,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11516,7 +11520,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "clap",
  "eyre",
@@ -11536,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11555,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11598,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11624,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11652,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11668,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11696,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=f5648cf#f5648cfd953c1d4d8a48552e292c361f0f41f3f5"
+source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10629,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "bytes",
  "eyre",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10743,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10778,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10821,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11129,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11242,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11273,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11325,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11367,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11387,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11402,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11473,7 +11473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11510,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11520,7 +11520,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "clap",
  "eyre",
@@ -11540,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11559,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11628,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11696,7 +11696,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=0b30d58#0b30d58c3471be5cf40d4c6afd67efa40a328d38"
+source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10629,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "bytes",
  "eyre",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10743,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10778,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10821,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11129,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11242,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11273,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11325,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11367,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11387,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11402,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11473,7 +11473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11510,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11520,7 +11520,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "clap",
  "eyre",
@@ -11540,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11559,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11628,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11696,7 +11696,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b9cd22b#b9cd22bae84a5e53e7c4706d358c8d8cb6ac3242"
+source = "git+https://github.com/paradigmxyz/reth?rev=ed4fee7#ed4fee7e54a301bdc055748ecf70b395d28dff03"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-codecs = { version = "0.6.0", default-features = false }
+reth-codecs = { version = "0.7.0", default-features = false }
 reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
@@ -185,7 +185,7 @@ reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877
 reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-primitives-traits = { version = "0.6.0", default-features = false }
+reth-primitives-traits = { version = "0.7.0", default-features = false }
 reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
 reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
@@ -212,8 +212,8 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "0.42.2"
+revm = { version = "43.0.0", features = ["optional_fee_charge"], default-features = false }
+revm-inspectors = "0.43.0"
 
 alloy-json-abi = { version = "1.7.1", default-features = false }
 alloy-primitives = { version = "1.7.1", default-features = false }
@@ -224,7 +224,7 @@ alloy-consensus = { version = "2.4.1", default-features = false }
 alloy-contract = { version = "2.4.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.4.1", default-features = false }
-alloy-evm = { version = "0.38.0", default-features = false }
+alloy-evm = { version = "0.39.0", default-features = false }
 alloy-genesis = { version = "2.4.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-rpc = "2.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,69 +146,69 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "68877d5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f874000" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f874000", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,6 +176,7 @@ reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e", default-features = false }
 reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }
 reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b4cdc0e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,79 +146,78 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8ba930b", features = [
   "std",
   "optional-checks",
 ] }
 revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
 revm-inspectors = "0.42.2"
 
-alloy-json-abi = { version = "1.7.2", default-features = false }
-alloy-primitives = { version = "1.7.2", default-features = false }
-alloy-sol-types = { version = "1.7.2", default-features = false }
+alloy-json-abi = { version = "1.7.1", default-features = false }
+alloy-primitives = { version = "1.7.1", default-features = false }
+alloy-sol-types = { version = "1.7.1", default-features = false }
 
 alloy = { version = "2.4.1", default-features = false }
 alloy-consensus = { version = "2.4.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "f5648cf", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b9cd22b", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "ed4fee7", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "0b30d58", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,9 +216,9 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", feat
 revm = { version = "43.0.0", features = ["optional_fee_charge"], default-features = false }
 revm-inspectors = "0.43.0"
 
-alloy-json-abi = { version = "1.7.1", default-features = false }
-alloy-primitives = { version = "1.7.1", default-features = false }
-alloy-sol-types = { version = "1.7.1", default-features = false }
+alloy-json-abi = { version = "1.7.2", default-features = false }
+alloy-primitives = { version = "1.7.2", default-features = false }
+alloy-sol-types = { version = "1.7.2", default-features = false }
 
 alloy = { version = "2.4.1", default-features = false }
 alloy-consensus = { version = "2.4.1", default-features = false }

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -26,7 +26,7 @@ pub const fn abi_decoder_config_for_spec(
 ) -> alloy::sol_types::abi::AbiDecoderConfig {
     alloy::sol_types::abi::AbiDecoderConfig::new()
         .memory_limit(ABI_DECODER_MEMORY_LIMIT)
-        .strict(spec.is_t11())
+        .validate(spec.is_t11())
 }
 
 pub mod typed {

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -26,7 +26,7 @@ pub const fn abi_decoder_config_for_spec(
 ) -> alloy::sol_types::abi::AbiDecoderConfig {
     alloy::sol_types::abi::AbiDecoderConfig::new()
         .memory_limit(ABI_DECODER_MEMORY_LIMIT)
-        .validate(spec.is_t11())
+        .strict(spec.is_t11())
 }
 
 pub mod typed {

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -959,6 +959,17 @@ where
         transactions
     }
 
+    fn all_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        let mut transactions = self.protocol_pool.all_transactions_by_sender(sender);
+        self.aa_2d_pool
+            .read()
+            .append_all_transactions_by_sender(sender, &mut transactions);
+        transactions
+    }
+
     fn all_transaction_hashes(&self) -> Vec<B256> {
         let mut hashes = self.protocol_pool.all_transaction_hashes();
         hashes.extend(self.aa_2d_pool.read().all_transaction_hashes_iter());

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -961,6 +961,17 @@ where
         transactions
     }
 
+    fn all_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<Self::Transaction> {
+        let mut transactions = self.protocol_pool.all_transactions_by_sender(sender);
+        self.aa_2d_pool
+            .read()
+            .append_all_transactions_by_sender(sender, &mut transactions);
+        transactions
+    }
+
     fn all_transaction_hashes(&self) -> Vec<B256> {
         let mut hashes = self.protocol_pool.all_transaction_hashes();
         hashes.extend(self.aa_2d_pool.read().all_transaction_hashes_iter());

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -109,11 +109,13 @@ impl TempoPooledTransaction {
             calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas())
                 .saturating_add(value);
         let fee_token_cost = cost - value;
+        let in_memory_size = transaction.size();
         Self {
             inner: EthPooledTransaction {
                 transaction,
                 cost,
                 encoded_length,
+                in_memory_size,
                 blob_sidecar: EthBlobTransactionSidecar::None,
                 blob_cell_availability: None,
             },

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -694,6 +694,32 @@ impl AA2dPool {
         );
     }
 
+    /// Appends all transactions from `sender` to the provided collection.
+    pub(crate) fn append_all_transactions_by_sender(
+        &self,
+        sender: Address,
+        transactions: &mut AllPoolTransactions<TempoPooledTransaction>,
+    ) {
+        for tx in self.by_id.values() {
+            if tx.inner.transaction.sender() != sender {
+                continue;
+            }
+
+            if tx.is_pending() {
+                transactions.pending.push(tx.inner.transaction.clone());
+            } else {
+                transactions.queued.push(tx.inner.transaction.clone());
+            }
+        }
+
+        transactions.pending.extend(
+            self.expiring_nonce_txs
+                .values()
+                .filter(|tx| tx.transaction.sender() == sender)
+                .map(|tx| tx.transaction.clone()),
+        );
+    }
+
     /// Returns the best, executable transactions for this sub-pool
     pub(crate) fn best_transactions(&self) -> BestAA2dTransactions {
         self.best_transactions_with_base_fee(self.base_fee)
@@ -4183,6 +4209,40 @@ mod tests {
 
         assert_eq!(pending_hashes, expected_pending);
         assert_eq!(queued_hashes, expected_queued);
+    }
+
+    #[test]
+    fn test_append_all_transactions_by_sender() {
+        let mut pool = AA2dPool::default();
+        let sender = Address::random();
+        let other_sender = Address::random();
+
+        let pending_tx = TxBuilder::aa(sender).build();
+        let queued_tx = TxBuilder::aa(sender).nonce(2).build();
+        let expiring_tx = TxBuilder::aa(sender).nonce_key(U256::MAX).build();
+        let other_tx = TxBuilder::aa(other_sender).build();
+
+        let pending_hash = *pending_tx.hash();
+        let queued_hash = *queued_tx.hash();
+        let expiring_hash = *expiring_tx.hash();
+
+        for tx in [pending_tx, queued_tx, expiring_tx, other_tx] {
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(tx, TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T1,
+            )
+            .unwrap();
+        }
+
+        let mut transactions = AllPoolTransactions::default();
+        pool.append_all_transactions_by_sender(sender, &mut transactions);
+
+        let pending_hashes: HashSet<_> = transactions.pending.iter().map(|tx| *tx.hash()).collect();
+        let queued_hashes: HashSet<_> = transactions.queued.iter().map(|tx| *tx.hash()).collect();
+
+        assert_eq!(pending_hashes, HashSet::from([pending_hash, expiring_hash]));
+        assert_eq!(queued_hashes, HashSet::from([queued_hash]));
     }
 
     #[test]


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`5f02aa3...280a763`](https://github.com/paradigmxyz/reth/compare/5f02aa3...280a763)

🔗 Amp thread: https://ampcode.com/threads/T-01a07f01-60be-76a5-92a9-071ee087482d
**Engine**
- Added SSZ payload bodies, witness endpoints, and default proxy support; simplified transport and buffer reuse ([#26394](https://github.com/paradigmxyz/reth/pull/26394), [#26254](https://github.com/paradigmxyz/reth/pull/26254), [#26406](https://github.com/paradigmxyz/reth/pull/26406), [#27028](https://github.com/paradigmxyz/reth/pull/27028)).
- Fixed backfill finalization/state flushing, inclusion-list byte accounting, and simulated BAL hashes ([#26983](https://github.com/paradigmxyz/reth/pull/26983), [#26911](https://github.com/paradigmxyz/reth/pull/26911), [#27024](https://github.com/paradigmxyz/reth/pull/27024), [#27023](https://github.com/paradigmxyz/reth/pull/27023)).
- Reduced prewarming overhead by avoiding unused transaction clones and batching BAL slot dispatch ([#26944](https://github.com/paradigmxyz/reth/pull/26944), [#26955](https://github.com/paradigmxyz/reth/pull/26955)).

**RPC & Tracing**
- Improved `eth_getLogs` performance with windowed scans, bloom filtering, bounded buffers, and batched cache metrics ([#27000](https://github.com/paradigmxyz/reth/pull/27000), [#26946](https://github.com/paradigmxyz/reth/pull/26946), [#26971](https://github.com/paradigmxyz/reth/pull/26971), [#26968](https://github.com/paradigmxyz/reth/pull/26968)).
- Fixed `eth_getLogs` pending-head resolution, pruning validation, and blocking-I/O permit handling ([#27001](https://github.com/paradigmxyz/reth/pull/27001), [#27002](https://github.com/paradigmxyz/reth/pull/27002), [#26999](https://github.com/paradigmxyz/reth/pull/26999)).
- Added EIP-8037 tracing and lazy trace conversion; corrected missing-block and unknown-filter errors ([#26804](https://github.com/paradigmxyz/reth/pull/26804), [#27031](https://github.com/paradigmxyz/reth/pull/27031), [#27022](https://github.com/paradigmxyz/reth/pull/27022), [#27020](https://github.com/paradigmxyz/reth/pull/27020)).
- Reduced fee-history, oversized-block, and `txpool_contentFrom` overhead ([#26942](https://github.com/paradigmxyz/reth/pull/26942), [#27037](https://github.com/paradigmxyz/reth/pull/27037), [#26969](https://github.com/paradigmxyz/reth/pull/26969)).

**Trie**
- Fixed dirty-range processing and branch collapse in proof v2 ([#26842](https://github.com/paradigmxyz/reth/pull/26842), [#26843](https://github.com/paradigmxyz/reth/pull/26843)).
- Removed the sparse-trie recorder and optimized empty prefixes, branch hashes, address hashing, read-only overlays, and disabled tracing ([#26918](https://github.com/paradigmxyz/reth/pull/26918), [#26987](https://github.com/paradigmxyz/reth/pull/26987), [#26961](https://github.com/paradigmxyz/reth/pull/26961), [#26940](https://github.com/paradigmxyz/reth/pull/26940), [#26986](https://github.com/paradigmxyz/reth/pull/26986), [#26938](https://github.com/paradigmxyz/reth/pull/26938)).

**Overlay & Providers**
- Made historical execution state lazy, snapshotting parent blocks where needed, and removed obsolete historical/immediate state conversions ([#26907](https://github.com/paradigmxyz/reth/pull/26907), [#26917](https://github.com/paradigmxyz/reth/pull/26917), [#26904](https://github.com/paradigmxyz/reth/pull/26904), [#26922](https://github.com/paradigmxyz/reth/pull/26922)).
- Reduced execution-overlay setup overhead ([#26990](https://github.com/paradigmxyz/reth/pull/26990)).

**Transaction Pool**
- Reduced insertion and fee-rebuild work with cached transaction sizes, reusable buffers, changed-sender tracking, and per-sender highest nonces ([#27061](https://github.com/paradigmxyz/reth/pull/27061), [#27064](https://github.com/paradigmxyz/reth/pull/27064), [#27060](https://github.com/paradigmxyz/reth/pull/27060), [#26956](https://github.com/paradigmxyz/reth/pull/26956), [#26978](https://github.com/paradigmxyz/reth/pull/26978), [#26964](https://github.com/paradigmxyz/reth/pull/26964)).
- Released the receiver lock before transaction validation ([#27015](https://github.com/paradigmxyz/reth/pull/27015)).

**Networking**
- Added authenticated snap bytecode downloads and sped up response sizing ([#26898](https://github.com/paradigmxyz/reth/pull/26898), [#26965](https://github.com/paradigmxyz/reth/pull/26965)).
- Made discv5 startup non-blocking and rejected invalid discv4 packets before key recovery ([#26929](https://github.com/paradigmxyz/reth/pull/26929), [#26935](https://github.com/paradigmxyz/reth/pull/26935)).
- Fixed DNS discovery polling when tree roots remain unchanged ([#26937](https://github.com/paradigmxyz/reth/pull/26937)).
- Avoided copying IPC subscription payloads ([#26972](https://github.com/paradigmxyz/reth/pull/26972)).

**Database, Static Files & Pruning**
- Accelerated MDBX handle caches and transaction timing with fast hash maps and TSC-backed clocks ([#26967](https://github.com/paradigmxyz/reth/pull/26967), [#26941](https://github.com/paradigmxyz/reth/pull/26941), [#26992](https://github.com/paradigmxyz/reth/pull/26992)).
- Optimized static-file block lookups, allocation-free jar rows, lazy cursor buffers, and pruning shard reads ([#26943](https://github.com/paradigmxyz/reth/pull/26943), [#26951](https://github.com/paradigmxyz/reth/pull/26951), [#26975](https://github.com/paradigmxyz/reth/pull/26975), [#26900](https://github.com/paradigmxyz/reth/pull/26900)).

**Stages & ExEx**
- Logged bad block hashes and accelerated history-index caches ([#26909](https://github.com/paradigmxyz/reth/pull/26909), [#26950](https://github.com/paradigmxyz/reth/pull/26950)).
- Avoided cloning execution outcomes and buffered WAL notification serialization ([#26947](https://github.com/paradigmxyz/reth/pull/26947), [#26949](https://github.com/paradigmxyz/reth/pull/26949)).

**Consensus & EVM**
- Exposed receipt-validation helpers and reused receipt blooms for block log blooms ([#26919](https://github.com/paradigmxyz/reth/pull/26919), [#26939](https://github.com/paradigmxyz/reth/pull/26939)).

**CLI & Downloads**
- Added inline auth-RPC JWT secrets, configurable retry delays, and corrected minimal download defaults ([#27034](https://github.com/paradigmxyz/reth/pull/27034), [#27048](https://github.com/paradigmxyz/reth/pull/27048), [#26934](https://github.com/paradigmxyz/reth/pull/26934)).

**Metrics, Logging & Bench**
- Moved storage metric collection off the scrape path and reduced tracing allocation overhead ([#26734](https://github.com/paradigmxyz/reth/pull/26734), [#26953](https://github.com/paradigmxyz/reth/pull/26953)).
- Suppressed noisy overlay/static-file and benchmark OTLP logs ([#26916](https://github.com/paradigmxyz/reth/pull/26916), [#26908](https://github.com/paradigmxyz/reth/pull/26908)).

**Testing**
- Replaced timing sleeps with deterministic payload, finality, peer-tick, and metrics completion signals; added mock-server snapshot coverage ([#27041](https://github.com/paradigmxyz/reth/pull/27041), [#27014](https://github.com/paradigmxyz/reth/pull/27014), [#27045](https://github.com/paradigmxyz/reth/pull/27045), [#27047](https://github.com/paradigmxyz/reth/pull/27047), [#27009](https://github.com/paradigmxyz/reth/pull/27009)).

**Dependencies**
- Reapplied the revm 43 upgrade and bumped Reth to 2.5.2 ([#26859](https://github.com/paradigmxyz/reth/pull/26859), [#26921](https://github.com/paradigmxyz/reth/pull/26921)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-01a07f01-d342-76af-8c22-f8ca68ece7ff
- Upgraded Reth to revision `280a763` and aligned `reth-codecs`/`reth-primitives-traits` to `0.7.0`.
- Upgraded REVM to `43.x`, `revm-inspectors` to `0.43.0`, and `alloy-evm` to `0.39.0`; retained Alloy ABI crates at `1.7.2` for strict decoding and validation hardening.
- Preserved `AbiDecoderConfig::strict(spec.is_t11())` to enforce canonical ABI decoding at T11.
- Added sender-filtered transaction retrieval across both protocol and AA 2D pools, including pending, queued, and expiring-nonce transactions.
- Added the required `in_memory_size` field when constructing upgraded `EthPooledTransaction` values.
- Added coverage verifying AA sender filtering and correct pending/queued classification.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/34182345881)
