### PR TITLE
ci: replace dawidd6/action-download-artifact with actions/download-artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,15 +86,43 @@ jobs:
         with:
           components: llvm-tools-preview
 
+      # test.yml uploads its coverage as cargo-test-coverage[-<partition>] artifacts on the
+      # run for this commit. Resolve that run, then fetch with the GitHub-authored action.
+      - name: Find cargo test coverage artifacts
+        id: cargo-coverage
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
+        run: |
+          set -euo pipefail
+          find_run() {
+            gh run list -R "$GITHUB_REPOSITORY" --workflow test.yml --commit "$COMMIT_SHA" \
+              --status "$1" --limit 1 --json databaseId --jq '.[0].databaseId // empty'
+          }
+          run_id=$(find_run success)
+          [[ -n "$run_id" ]] || run_id=$(find_run completed)
+          count=0
+          if [[ -n "$run_id" ]]; then
+            count=$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$run_id/artifacts?per_page=100" \
+              --jq '[.artifacts[] | select(.expired | not) | select(.name | startswith("cargo-test-coverage"))] | length')
+          fi
+          if [[ "$count" -eq 0 ]]; then
+            echo "::warning::No cargo-test-coverage artifacts for $COMMIT_SHA (test.yml run: ${run_id:-none}); continuing with forge coverage only"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found $count cargo-test-coverage artifact(s) in test.yml run $run_id"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download cargo test coverage
-        uses: dawidd6/action-download-artifact@8305c0f1062bb0d184d09ef4493ecb9288447732 # v20
+        if: steps.cargo-coverage.outputs.found == 'true'
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          workflow: test.yml
-          name: cargo-test-coverage
+          run-id: ${{ steps.cargo-coverage.outputs.run-id }}
+          github-token: ${{ github.token }}
+          pattern: cargo-test-coverage*
           path: cargo-coverage
-          if_no_artifact_found: warn
-          search_artifacts: true
-          commit: ${{ inputs.commit_sha }}
         continue-on-error: true
 
       - name: Download forge test coverage
@@ -112,12 +140,15 @@ jobs:
           LLVM_BIN="$(rustc --print sysroot)/lib/rustlib/$(rustc -vV | grep host | cut -d' ' -f2)/bin"
           mkdir -p coverage-report
 
-          # Collect profdata files
+          # Collect profdata files. Each downloaded artifact lands in its own directory under
+          # cargo-coverage/ (one per test partition); the flat path is kept for older layouts.
           PROFDATA_FILES=""
-          if [[ -f cargo-coverage/cargo-test.profdata ]]; then
-            PROFDATA_FILES="$PROFDATA_FILES cargo-coverage/cargo-test.profdata"
-            echo "Found cargo test coverage"
-          fi
+          for profdata in cargo-coverage/cargo-test.profdata cargo-coverage/*/cargo-test.profdata; do
+            if [[ -f "$profdata" ]]; then
+              PROFDATA_FILES="$PROFDATA_FILES $profdata"
+              echo "Found cargo test coverage: $profdata"
+            fi
+          done
           if [[ -f forge-coverage/coverage/forge-test.profdata ]]; then
             PROFDATA_FILES="$PROFDATA_FILES forge-coverage/coverage/forge-test.profdata"
             echo "Found forge test coverage"
@@ -139,14 +170,15 @@ jobs:
             chmod +x forge-coverage/foundry/target/release/forge
             OBJECT_FLAGS="$OBJECT_FLAGS --object=forge-coverage/foundry/target/release/forge"
           fi
-          if [[ -d cargo-coverage/precompiles-bin ]]; then
-            for bin in cargo-coverage/precompiles-bin/*; do
-              if [[ -f "$bin" ]]; then
-                chmod +x "$bin"
-                OBJECT_FLAGS="$OBJECT_FLAGS --object=$bin"
-              fi
-            done
-          fi
+          # Every partition ships the same test binaries, so pass each binary name once.
+          declare -A SEEN_BIN=()
+          for bin in cargo-coverage/precompiles-bin/* cargo-coverage/*/precompiles-bin/*; do
+            if [[ -f "$bin" && -z "${SEEN_BIN[$(basename "$bin")]:-}" ]]; then
+              SEEN_BIN[$(basename "$bin")]=1
+              chmod +x "$bin"
+              OBJECT_FLAGS="$OBJECT_FLAGS --object=$bin"
+            fi
+          done
 
           if [[ -z "$OBJECT_FLAGS" ]]; then
             echo "No binaries found"


### PR DESCRIPTION
## Why

The org is moving to a GitHub Actions policy that only allows tempoxyz-owned and GitHub-authored actions (see the vendoring work in `tempoxyz/gh-actions`). `dawidd6/action-download-artifact` is the largest third-party action in that inventory (92 MB with its committed `node_modules`), and everything it does here can be done by the GitHub-authored `actions/download-artifact` once the workflow run is resolved with `gh`.

## What changed

- A small `gh` step resolves the newest completed `test.yml` run for `inputs.commit_sha` (preferring a successful one) and counts its unexpired `cargo-test-coverage*` artifacts. If there are none it emits the same kind of warning the old step did and the download is skipped.
- `actions/download-artifact` (the pin already used in this file for forge coverage) downloads those artifacts by `run-id` with `pattern: cargo-test-coverage*`, so each partition lands in its own directory under `cargo-coverage/`.
- The merge script now collects `cargo-test.profdata` and `precompiles-bin/` from those per-artifact directories as well as the flat layout, and passes each test binary to `llvm-cov` once (every partition ships the same binaries).

## This step has been a silent no-op since March

`test.yml` has uploaded `cargo-test-coverage-<partition>` since the test parallelisation in #3075 (2026-03-10), while this workflow kept asking for the exact name `cargo-test-coverage`. The most recent real run (specs.yml run 33567425107, job "Merge Precompiles Coverage") logs:

```
==> Artifact name: cargo-test-coverage
##[warning]no matching workflow run found with any artifacts?
```

so PR coverage comments have only included forge coverage. With the pattern download and the merge-script change, cargo coverage is included again.

## Validation

- The lookup was run locally against commit `98807d5e` (whose coverage job ran): it resolved test.yml run 33567424810 and found `cargo-test-coverage-2`.
- `actionlint` and `zizmor` report exactly the same findings as before the change.
- The coverage job only runs when precompiles change, so CI on this PR does not exercise it; the first PR that touches `crates/precompiles` or `crates/contracts` after merge will.