### PR TITLE
ci: drop unused matrix-outputs-write step from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,3 @@ jobs:
           if-no-files-found: "error"
           name: ${{ matrix.binary }}
           path: target/${{ inputs.profile || 'debug' }}/${{ matrix.binary }}
-      - uses: cloudposse/github-action-matrix-outputs-write@ed06cf3a6bf23b8dce36d1cf0d63123885bb8375 # v1.0.0
-        id: out
-        with:
-          matrix-step-name: ${{ github.job }}
-          matrix-key: ${{ matrix.binary }}
-          outputs: |-
-            artifact_id: ${{ steps.binary_upload.outputs.artifact-id }}


### PR DESCRIPTION
## Why

`cloudposse/github-action-matrix-outputs-write` exists to let matrix legs publish per-leg outputs: it sets step outputs and uploads a hash-named artifact for the companion `-read` action to merge later. In this workflow nothing consumes either: the `build` job declares no `outputs:`, nothing references the step, and the read action is not used anywhere in the org. The step has only uploaded one unread artifact per binary on every build.

It is also one of the third-party actions we would otherwise have to vendor for the org-only actions policy, and the largest after `dawidd6/action-download-artifact` (71 MB with its committed `node_modules`).

## What changed

The step is removed; the upload step and everything before it are untouched. The per-binary artifacts keep their binary names, so anything that ever needs one can fetch it with `actions/download-artifact` by name.

`actionlint` and `zizmor` report the same results as before. The same change is proposed in the shared `rust-build-binaries` workflow in `tempoxyz/gh-actions`.