### PR TITLE
ci: install Foundry via gh-actions setup-foundry (attested releases)

### DIFF
--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   scan:
     if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
-    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@183a02178c660ce295e9a262edc5857cb7135f06 # main
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@9974f654e85ffade8a813c84157047910079be4c
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -180,7 +180,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 
@@ -208,7 +208,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 
@@ -233,7 +233,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
+        uses: tempoxyz/gh-actions/actions/setup-foundry@16356ec5155405ba5e33f5558e80b5bf77eb70ab
         with:
           version: nightly
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -16,3 +16,9 @@ rules:
       # update-reth intentionally persists its Derek token for authenticated git
       # pushes after checkout.
       - update-reth.yml:37
+  ref-version-mismatch:
+    # tempoxyz/gh-actions publishes no version tags, so a version comment on a pin to it
+    # (e.g. `# main`) can never match and the audit fires whenever gh-actions main moves.
+    # The shared scan workflow disables this audit by default for repos without their own
+    # zizmor config; this repo has one, so it opts out here. pinact covers third-party comments.
+    disable: true


### PR DESCRIPTION
## Why

`tempoxyz/gh-actions` now ships a first-party `setup-foundry` (tempoxyz/gh-actions#82) that installs Foundry directly from GitHub releases and verifies each tarball's SLSA provenance with `gh attestation verify` (built by `foundry-rs/foundry`'s release workflow at the resolved tag, or `master` for nightlies), on top of the `.sha256` check. `foundry-rs/foundry-toolchain` runs `foundryup` and verifies nothing it downloads. Switching also removes a third-party action ahead of the org-only actions policy.

## What changes at run time

- `version: nightly` resolves to the newest `nightly-<commit>` build, which is the same content the rolling `nightly` tag mirrors, but attested. `stable` resolves to the newest `vX.Y.Z` release. Explicit tags work as before.
- forge, cast, anvil and chisel are installed under `RUNNER_TEMP` and added to `PATH`; `foundryup` itself is not installed (nothing here referenced it).
- The RPC response cache (`~/.foundry/cache`) is kept with the same `cache`, `cache-key` and `cache-restore-keys` inputs and key scheme; the first run after merge is a cache miss because the key prefix changed from `linux-` to `Linux-`.
- Inputs are unchanged, so no `with:` blocks needed editing.

Pinned to gh-actions `main` at `16356ec5` (the commit that landed the verifying installer). `actionlint` and `zizmor` report the same results as before on the changed files.

Files: .github/workflows/specs.yml