### PR TITLE
ci: install Terraform via gh-actions setup-terraform (signed releases)

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -461,10 +461,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        uses: tempoxyz/gh-actions/actions/setup-terraform@d9f22a1d62ed20d6d18b1dbbc33779b56996c068 # main
         with:
-          terraform_version: "1.14.7"
-          terraform_wrapper: false
+          version: 1.14.7
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master


### PR DESCRIPTION
## Why

`tempoxyz/gh-actions` now ships `setup-terraform` (tempoxyz/gh-actions#83): it downloads the release from releases.hashicorp.com, verifies HashiCorp's GPG signature on `SHA256SUMS` against the HashiCorp Security key pinned in the action, and only then checks the zip. `hashicorp/setup-terraform` verifies no signature. Switching also removes a third-party action ahead of the org-only actions policy.

## What changes at run time

- `terraform_version` becomes `version`; the composite takes exact versions only (default `1.14.7`, the version this org pins everywhere). Steps that previously had no version were installing *latest*; they now get `1.14.7` too.
- No stdout wrapper: this matches `terraform_wrapper: false`, which these steps already set or did not rely on (no `steps.*.outputs.stdout|exitcode` are read).
- The binary is installed under `RUNNER_TEMP` and put on `PATH`.

`actionlint` and `zizmor` report the same results as before on the changed files.

Files: .github/workflows/bench-e2e-multi-region.yml