### PR TITLE
docs(tip-1096): align activation on T12

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -5,7 +5,7 @@ description: Allows Zones to catch up through bounded header-only blocks and pro
 authors: Dankrad Feist @dankrad
 status: Draft
 related: Tempo Zones, TIP-1091, https://github.com/tempoxyz/zones/pull/981
-protocolVersion: T13, Z1
+protocolVersion: T12
 ---
 
 # TIP-1096: Multi-block Tempo Imports for Zones
@@ -320,10 +320,10 @@ After accepting the proof, `submitBatch` sets
 `lastProcessedEnabledTokenCount` to `nextProcessedTokenCount`. Skipping,
 reordering, replaying, or partially processing a suffix is invalid.
 
-When T13 replaces the T12 portal runtime, the new
+When T12 replaces the T11 portal runtime, the new
 `tokenEnablementCursorInitialized` storage slot is false. This flag serves as the
-in-contract T13 activation gate for the new token cursor; it does not disable
-unrelated T13 functionality. While it is false, the portal MUST reject new token
+in-contract T12 activation gate for the new token cursor; it does not disable
+unrelated T12 functionality. While it is false, the portal MUST reject new token
 enablements. Header-only Zone blocks MAY advance the local checkpoint during
 recovery, but they are not settlement boundaries. They may only form a prefix of
 the first post-activation batch, which MUST end in a full block and use
@@ -401,7 +401,7 @@ token counts.
 
 ### Events
 
-Z1 extends `ZoneInbox.TempoAdvanced` with the cumulative token-enablement cursor
+T12 extends `ZoneInbox.TempoAdvanced` with the cumulative token-enablement cursor
 after the full import:
 
 ```solidity
@@ -423,7 +423,7 @@ value also incorporates the authenticated migration prefix `N` described above.
 A full import emits `TempoAdvanced` even when neither deposits nor token
 enablements were processed.
 
-T13 likewise extends `ZonePortal.BatchSubmitted` with the cumulative cursor
+T12 likewise extends `ZonePortal.BatchSubmitted` with the cumulative cursor
 accepted by settlement:
 
 ```solidity
@@ -446,7 +446,7 @@ Consumers MUST NOT create or overwrite a withdrawal queue record for such an
 event. This occurs when the final full block finalizes an empty withdrawal batch;
 the `withdrawalBatchIndex` still advances exactly once.
 
-Before the coordinated T13/Z1 activation, `TempoAdvanced` and `BatchSubmitted`
+Before the coordinated T12 activation, `TempoAdvanced` and `BatchSubmitted`
 retain their legacy signatures without `lastProcessedEnabledTokenCount`.
 Because appending a field changes an event's signature hash, indexers and
 settlement tooling that span the activation boundary MUST recognize both the
@@ -462,8 +462,8 @@ token-enablement lifecycle event signatures remain unchanged.
 
 ## Activation and Compatibility
 
-This TIP activates through the coordinated T13 Tempo upgrade and Z1 Zone
-hardfork. T13 installs the new `ZonePortal` runtime and Z1 activates the new Zone
+This TIP activates through the coordinated T12 Tempo upgrade and Zone hardfork.
+T12 installs the new `ZonePortal` runtime and activates the new Zone
 block and execution rules. Implementations MUST coordinate both activation
 boundaries and MUST NOT produce, prove, or settle TIP-1096 blocks while only one
 side is active.
@@ -473,10 +473,10 @@ witness, state-transition function, and verifier atomically.
 Existing Zone checkpoint and deposit state are retained. Token-enablement cursors
 are initialized as specified above.
 
-Before installing T13, operators MUST ensure that the last T12-settled Zone state
+Before installing T12, operators MUST ensure that the last T11-settled Zone state
 can satisfy the initialization bounds. If either pre-existing backlog exceeds its
-new global limit, the backlog MUST be processed and settled under T12 before the
-upgrade; T13 deliberately cannot initialize the new token cursor from an
+new global limit, the backlog MUST be processed and settled under T11 before the
+upgrade; T12 deliberately cannot initialize the new token cursor from an
 oversized backlog.
 
 The existing `IZoneInbox.advanceTempo(bytes,...)` ABI remains unchanged.


### PR DESCRIPTION
Aligns TIP-1096 activation across Tempo and Zones on T12, with T11 retained as the pre-activation version.

Validation: `git diff --check`

Prompted by: @shekhirin