### PR TITLE
docs(tip-1096): align activation on T13

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -5,7 +5,7 @@ description: Allows Zones to catch up through bounded header-only blocks and pro
 authors: Dankrad Feist @dankrad
 status: Draft
 related: Tempo Zones, TIP-1091, https://github.com/tempoxyz/zones/pull/981
-protocolVersion: T13, Z1
+protocolVersion: T13
 ---
 
 # TIP-1096: Multi-block Tempo Imports for Zones
@@ -401,7 +401,7 @@ token counts.
 
 ### Events
 
-Z1 extends `ZoneInbox.TempoAdvanced` with the cumulative token-enablement cursor
+T13 extends `ZoneInbox.TempoAdvanced` with the cumulative token-enablement cursor
 after the full import:
 
 ```solidity
@@ -446,7 +446,7 @@ Consumers MUST NOT create or overwrite a withdrawal queue record for such an
 event. This occurs when the final full block finalizes an empty withdrawal batch;
 the `withdrawalBatchIndex` still advances exactly once.
 
-Before the coordinated T13/Z1 activation, `TempoAdvanced` and `BatchSubmitted`
+Before the coordinated T13 activation, `TempoAdvanced` and `BatchSubmitted`
 retain their legacy signatures without `lastProcessedEnabledTokenCount`.
 Because appending a field changes an event's signature hash, indexers and
 settlement tooling that span the activation boundary MUST recognize both the
@@ -462,8 +462,8 @@ token-enablement lifecycle event signatures remain unchanged.
 
 ## Activation and Compatibility
 
-This TIP activates through the coordinated T13 Tempo upgrade and Z1 Zone
-hardfork. T13 installs the new `ZonePortal` runtime and Z1 activates the new Zone
+This TIP activates through the coordinated T13 Tempo upgrade and Zone hardfork.
+T13 installs the new `ZonePortal` runtime and activates the new Zone
 block and execution rules. Implementations MUST coordinate both activation
 boundaries and MUST NOT produce, prove, or settle TIP-1096 blocks while only one
 side is active.


### PR DESCRIPTION
Aligns TIP-1096 activation across Tempo and Zones on T13, removing the separate Z1 designation.

Validation: `git diff --check`

Prompted by: @shekhirin