### PR TITLE
docs: fix outdated `generate-config` command

### DIFF
--- a/scripts/consensus/README.md
+++ b/scripts/consensus/README.md
@@ -29,6 +29,6 @@ Shared utilities for monitoring block production, starting/stopping validators, 
 
 To regenerate the validator configs, run the following command:
 ```bash
-cargo x generate-config --output scripts/consensus/configs --peers 4 --bootstrappers 1 --message-backlog 16384 --mailbox-size 16384 --deque-size 10 --from-port 8000 --fee-recipient 0x0000000000000000000000000000000000000000 --seed 0
+cargo x generate-localnet --output scripts/consensus/configs --validators 127.0.0.1:8000,127.0.0.1:8100,127.0.0.1:8200,127.0.0.1:8300 --seed 0
 ```
 


### PR DESCRIPTION
## Summary
The consensus e2e README references `cargo x generate-config`, but this subcommand doesn't exist in [`xtask/src/main.rs`](https://github.com/tempoxyz/tempo/blob/main/xtask/src/main.rs#L76-L88). The actual command is `cargo x generate-localnet`.

<img width="366" height="290" alt="image" src="https://github.com/user-attachments/assets/0792c883-1ef9-4920-a45b-40649e6d22e8" />

## Evidence
- `Action` enum in `xtask/src/main.rs` contains `GenerateLocalnet`, but no `GenerateConfig`
- `generate_localnet.rs` confirms `--output` and `--validators` (via `GenesisArgs`) are supported
- `genesis_args.rs` confirms `--validators` takes comma-separated `SocketAddr` and `--seed` is supported

## Change
Replace outdated command with:
```bash
cargo x generate-localnet --output scripts/consensus/configs --validators 127.0.0.1:8000,127.0.0.1:8100,127.0.0.1:8200,127.0.0.1:8300 --seed 0