### PR TITLE
refactor(consensus): split newPayload and forkchoiceUpdated

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -648,6 +648,26 @@ where
             // finalized blocks the EL already knows about. In this case, it
             // makes sense to ACK immediately rather than wait for an FCU
             // sweep.
+            // The execution layer confirms it is the block it finalized at
+            // this height before it is acknowledged.
+            let canonical = self
+                .execution_node
+                .canonical_block_hash(block.height().get())
+                .wrap_err_with(|| {
+                    format!(
+                        "failed reading canonical execution block hash at finalized block \
+                        height `{}`",
+                        block.height(),
+                    )
+                })?;
+            ensure!(
+                canonical == Some(block.digest().0),
+                "re-delivered finalized block `{}` at height `{}` conflicts with the \
+                execution layer's canonical block `{canonical:?}` at the same height, which \
+                the execution layer already considers final",
+                block.digest(),
+                block.height(),
+            );
             self.acknowledge(request);
         } else {
             self.pending_acknowledgements.push_back(request);

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -575,6 +575,17 @@ where
         build: Option<(Span, oneshot::Sender<TempoBuiltPayload>)>,
         response: eyre::Result<ForkchoiceUpdated>,
     ) -> eyre::Result<()> {
+        // FIXME: an update whose head is a canonical *ancestor* of reth's
+        // head (a re-anchor after a nullification, a repoint onto the
+        // finalized tip) is answered VALID without reth moving its canonical
+        // head, unless `always_process_payload_attributes_on_canonical_head`
+        // and `unwind_canonical_header` are enabled in its tree config.
+        // Tempo sets neither. The tracked head recorded below then differs
+        // from reth's until the next block on it lands; harmless for the
+        // executor (every update names its head explicitly, builds on the
+        // ancestor work), but RPC `latest` and the txpool stay on the
+        // nullified block for a round. Enabling the flags is a separate
+        // change; pre-existing on main.
         let diverged = || {
             format!(
                 "forkchoice update onto head `{}` at height `{}` and finalized block `{}` at \

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1191,6 +1191,17 @@ where
         if self.is_stale_forkchoice(target)? {
             // Nothing to submit: the execution layer is past this finality
             // already. The tracked state catches up to it.
+            //
+            // NOTE: this records a head the execution layer was never told
+            // about - the tracked head starts at the finalized floor at
+            // init, not at the execution layer's head, and moves along with
+            // finality here. That is fine: the recorded head is a canonical
+            // block the execution layer holds, so it is a valid anchor for
+            // convergence, and the first non-stale update names its head
+            // explicitly and realigns the two. The honest alternative,
+            // starting from the execution layer's own head, is unsafe: that
+            // head may sit on a branch nullified while the node was down,
+            // and the backfill's first update would then be rejected.
             self.notarized_tree.set_local_state(target);
             self.acknowledge_finalized();
             return Ok(false);

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -643,6 +643,11 @@ where
         self.notarized_tree
             .set_delivered_finalized(block.height(), block.digest());
         if block.height() <= self.notarized_tree.local_state().finalized.0 {
+            // NOTE: this block is already final on the execution layer. This
+            // can happen if marshal is anchored below the EL and delivers
+            // finalized blocks the EL already knows about. In this case, it
+            // makes sense to ACK immediately rather than wait for an FCU
+            // sweep.
             self.acknowledge(request);
         } else {
             self.pending_acknowledgements.push_back(request);

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1084,10 +1084,17 @@ where
                 self.pending_consensus_request = Some((round, ConsensusRequest::Verify(request)));
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
-                // Builds are registered via FCU setting the head hash to the
-                // parent. So running it with the head anywhere else would fight
-                // notarized-chain convergence.
-                if self.notarized_tree.is_local_head(build.digest) {
+                // Consensus builds on the pending head it reported. The build
+                // runs once the execution layer's head is there, waits while
+                // convergence is about to get there, and is dropped otherwise.
+                let pending_head = self.notarized_tree.pending_head();
+                if build.digest != pending_head {
+                    info!(
+                        %pending_head,
+                        build.parent = %build.digest,
+                        "build is not on the pending head, dropping it",
+                    );
+                } else if self.notarized_tree.is_local_head(pending_head) {
                     let target = self.notarized_tree.local_state();
                     if self.is_stale_forkchoice(target)? {
                         info!(
@@ -1104,7 +1111,7 @@ where
                         self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
                         return Ok(());
                     }
-                } else if self.is_convergence_target(build.digest) {
+                } else if self.is_convergence_target(pending_head) {
                     // Reschedules the request; the actor will not spin on
                     // `start_next_execution_request` as long as it remains
                     // scheduled before the select! in the select-loop (some

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -625,12 +625,14 @@ where
         );
         match status {
             Ok(PayloadStatusEnum::Valid) => {}
-            Ok(status) => bail!(
-                "payload status of finalized block `{}` at height `{}` was not \
-                valid: {status}",
-                block.digest(),
-                block.height(),
-            ),
+            Ok(status) => {
+                bail!(
+                    "payload status of finalized block `{}` at height `{}` was \
+                    not valid: {status}",
+                    block.digest(),
+                    block.height(),
+                );
+            }
             Err(error) => {
                 return Err(error.wrap_err(format!(
                     "failed delivering finalized block `{}` at height `{}`",

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1053,55 +1053,40 @@ where
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
                 // Builds are registered via FCU setting the head hash to the
-                // parent, so the parent must be known to the execution
-                // layer. The update moves the head onto it if it is not
-                // there yet: the parent is the pending head consensus
-                // reported, so there is no convergence to fight.
-                match self.build_target(build.digest) {
-                    BuildTarget::Ready(target) => {
-                        if self.is_stale_forkchoice(target)? {
-                            info!(
-                                build.parent = %build.digest,
-                                "tracked finality is below the execution layer's; dropping the build",
-                            );
-                        } else {
-                            let fut = execute_forkchoice(
-                                self.execution_node.clone(),
-                                cause.clone(),
-                                target,
-                                Some((cause, build)),
-                            );
-                            self.set_execution_task(ExecutionTask::new(
-                                ExecutionTaskType::Build,
-                                fut,
-                            ));
-                            return Ok(());
-                        }
-                    }
-                    BuildTarget::Stale => {
+                // parent. So running it with the head anywhere else would fight
+                // notarized-chain convergence.
+                if self.notarized_tree.is_local_head(build.digest) {
+                    let target = self.notarized_tree.local_state();
+                    if self.is_stale_forkchoice(target)? {
                         info!(
-                            finalized = %self.notarized_tree.delivered_finalized().1,
                             build.parent = %build.digest,
-                            "finality advanced past the parent to build on, dropping the build",
+                            "tracked finality is below the execution layer's; dropping the build",
                         );
+                    } else {
+                        let fut = execute_forkchoice(
+                            self.execution_node.clone(),
+                            cause.clone(),
+                            target,
+                            Some((cause, build)),
+                        );
+                        self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
+                        return Ok(());
                     }
+                } else if self.is_convergence_target(build.digest) {
                     // Reschedules the request; the actor will not spin on
                     // `start_next_execution_request` as long as it remains
                     // scheduled before the select! in the select-loop (some
                     // other event needs to take place first; ideally the
                     // result of the convergence target we are falling through
                     // to).
-                    BuildTarget::Unknown if self.is_convergence_target(build.digest) => {
-                        self.pending_consensus_request =
-                            Some((round, ConsensusRequest::Build { cause, build }));
-                    }
-                    BuildTarget::Unknown => {
-                        info!(
-                            execution.head_hash = %self.notarized_tree.local_state().head.1,
-                            build.parent = %build.digest,
-                            "not ready to build new block, dropping it",
-                        );
-                    }
+                    self.pending_consensus_request =
+                        Some((round, ConsensusRequest::Build { cause, build }));
+                } else {
+                    info!(
+                        execution.head_hash = %self.notarized_tree.local_state().head.1,
+                        build.parent = %build.digest,
+                        "not ready to build new block, dropping it",
+                    );
                 }
             }
             None => {}
@@ -1226,37 +1211,6 @@ where
 
         Ok((target != local).then_some(target))
     }
-
-    /// The forkchoice state a build on top of `parent` is registered with:
-    /// the head on the parent, finality on the delivered finalized block.
-    fn build_target(&self, parent: Digest) -> BuildTarget {
-        let Some(height) = self.notarized_tree.known_height(parent) else {
-            return BuildTarget::Unknown;
-        };
-        let (finalized_height, finalized_digest) = self.notarized_tree.delivered_finalized();
-        let target = self
-            .notarized_tree
-            .local_state()
-            .update_finalized(finalized_height, finalized_digest)
-            .update_head(height, parent);
-        if target.head.1 == parent {
-            BuildTarget::Ready(target)
-        } else {
-            BuildTarget::Stale
-        }
-    }
-}
-
-/// Whether a build can be registered on its parent, see
-/// [`Actor::build_target`].
-enum BuildTarget {
-    /// The forkchoice state to register the build with.
-    Ready(LocalState),
-    /// The parent is not known to the execution layer (yet).
-    Unknown,
-    /// Finality advanced past the parent: the build can never be
-    /// registered.
-    Stale,
 }
 
 #[instrument(skip_all, fields(height), err)]

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -87,6 +87,13 @@ use notarized_tree::{LocalState, NotarizedTree};
 /// How often to probe whether the execution layer is ready to process blocks.
 const EXECUTION_LAYER_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
+/// How many `VALID` new-payload answers - validations, notarized and
+/// finalized deliveries alike - are collected before a forkchoice update is
+/// forced. The execution layer persists
+/// and prunes relative to its canonical head, so blocks delivered ahead of
+/// the update that canonicalizes them stay in memory.
+const DELIVERIES_PER_FORKCHOICE_UPDATE: usize = 8;
+
 pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     context: ContextCell<TContext>,
 
@@ -122,6 +129,10 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// forkchoice update that finalizes them before they are acknowledged
     /// to the marshal actor. In height order.
     pending_acknowledgements: VecDeque<FinalizedBlockRequest>,
+
+    /// Blocks delivered since the last forkchoice update, see
+    /// [`DELIVERIES_PER_FORKCHOICE_UPDATE`].
+    deliveries_since_forkchoice: usize,
 
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
@@ -178,6 +189,10 @@ struct Metrics {
     /// the head; holds its last value while the pending head's height is
     /// unknown (its body has not arrived yet).
     convergence_depth: commonware_runtime::telemetry::metrics::Registered<Gauge>,
+    /// Number of notarized blocks the execution layer accepted that are not
+    /// on its canonical chain: delivered ahead of their forkchoice update,
+    /// or on branches other than the head's.
+    uncanonicalized_blocks: commonware_runtime::telemetry::metrics::Registered<Gauge>,
 }
 
 impl Metrics {
@@ -207,11 +222,18 @@ impl Metrics {
             (negative after a re-anchor below the head)",
             Gauge::default(),
         );
+        let uncanonicalized_blocks = context.register(
+            "uncanonicalized_blocks",
+            "number of notarized blocks the execution layer accepted that are not on its \
+            canonical chain",
+            Gauge::default(),
+        );
         Self {
             finalized_blocks_proposed_by_self,
             notarized_tree_blocks,
             finalization_lag,
             convergence_depth,
+            uncanonicalized_blocks,
         }
     }
 
@@ -223,6 +245,8 @@ impl Metrics {
         if let Some(depth) = depths.convergence_depth {
             self.convergence_depth.set(depth);
         }
+        self.uncanonicalized_blocks
+            .set(depths.uncanonicalized_blocks as i64);
     }
 }
 
@@ -307,6 +331,7 @@ where
 
             pending_finalizations: VecDeque::new(),
             pending_acknowledgements: VecDeque::new(),
+            deliveries_since_forkchoice: 0,
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -498,6 +523,7 @@ where
         let verdict = match status {
             Ok((PayloadStatusEnum::Valid, duration)) => {
                 self.notarized_tree.mark_delivered(&digest);
+                self.deliveries_since_forkchoice += 1;
                 Some(duration)
             }
             Ok((PayloadStatusEnum::Invalid { validation_error }, _)) => {
@@ -591,7 +617,10 @@ where
     /// fatal-on-failure backstop.
     fn handle_delivered(&mut self, digest: Digest, status: eyre::Result<PayloadStatusEnum>) {
         match status {
-            Ok(PayloadStatusEnum::Valid) => self.notarized_tree.mark_delivered(&digest),
+            Ok(PayloadStatusEnum::Valid) => {
+                self.notarized_tree.mark_delivered(&digest);
+                self.deliveries_since_forkchoice += 1;
+            }
             Ok(status) => {
                 warn!(
                     %status,
@@ -644,6 +673,7 @@ where
 
         self.notarized_tree
             .set_delivered_finalized(block.height(), block.digest());
+        self.deliveries_since_forkchoice += 1;
         if block.height() <= self.notarized_tree.local_state().finalized.0 {
             // NOTE: this block is already final on the execution layer. This
             // can happen if marshal is anchored below the EL and delivers
@@ -743,9 +773,10 @@ where
     }
 
     /// Climbs from the tracked finalized state to the finalized floor
-    /// before entering the loop: delivers every block, then finalizes the
-    /// floor with one forkchoice update. The head starts on the finalized
-    /// tip and follows it.
+    /// before entering the loop, finalizing every
+    /// [`DELIVERIES_PER_FORKCHOICE_UPDATE`] delivered blocks with one
+    /// forkchoice update. The head starts on the finalized tip and follows
+    /// it.
     async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
         let start = self.notarized_tree.local_state().finalized.0.get() + 1;
         let end = self.finalized_floor.get();
@@ -757,8 +788,8 @@ where
                 "backfilling finalized blocks before entering executor loop"
             );
         }
-        let mut floor = None;
-        for height in heights {
+        let mut delivered_since_forkchoice = 0;
+        for height in heights.clone() {
             let span = info_span!("backfill_on_start", %height);
             let block = get_block(
                 self.marshal.clone(),
@@ -783,32 +814,36 @@ where
                 "payload status of backfilled finalized block at height `{height}` was \
                 not valid: {status}",
             );
-            floor = Some((block.height(), block.digest(), span));
-        }
 
-        let Some((height, digest, span)) = floor else {
-            return Ok(());
-        };
-        let target = self
-            .notarized_tree
-            .local_state()
-            .update_finalized(height, digest);
-        let response = submit_forkchoice_update(&self.execution_node, span, target, None)
-            .await
-            .wrap_err_with(|| {
-                format!(
-                    "failed finalizing the backfilled finalized floor at height `{height}` \
-                    on the execution layer"
-                )
-            })?;
-        if !response.is_valid() {
-            bail!(
-                "forkchoice update finalizing the backfilled finalized floor at height \
-                `{height}` was not valid: {}",
-                response.payload_status,
-            );
+            delivered_since_forkchoice += 1;
+            if delivered_since_forkchoice < DELIVERIES_PER_FORKCHOICE_UPDATE
+                && height != *heights.end()
+            {
+                continue;
+            }
+            delivered_since_forkchoice = 0;
+
+            let target = self
+                .notarized_tree
+                .local_state()
+                .update_finalized(block.height(), block.digest());
+            let response = submit_forkchoice_update(&self.execution_node, span, target, None)
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed finalizing backfilled finalized block at height `{height}` \
+                        on the execution layer"
+                    )
+                })?;
+            if !response.is_valid() {
+                bail!(
+                    "forkchoice update finalizing the backfilled finalized block at height \
+                    `{height}` was not valid: {}",
+                    response.payload_status,
+                );
+            }
+            self.notarized_tree.set_local_state(target);
         }
-        self.notarized_tree.set_local_state(target);
         Ok(())
     }
 
@@ -1094,6 +1129,14 @@ where
             None => {}
         }
 
+        // Too many blocks delivered since the last forkchoice update: lock
+        // them in before delivering more.
+        if self.deliveries_since_forkchoice >= DELIVERIES_PER_FORKCHOICE_UPDATE
+            && self.start_forkchoice_update()?
+        {
+            return Ok(());
+        }
+
         // Finalizations are delivered in order and acknowledged so that the
         // marshal actor can make progress. Every finalized block is
         // delivered, whether or not the execution layer is thought to know
@@ -1126,6 +1169,9 @@ where
     /// Starts the forkchoice update onto the next target, if any; returns
     /// whether it did.
     fn start_forkchoice_update(&mut self) -> eyre::Result<bool> {
+        // Whatever was delivered is either covered by the update below or
+        // cannot be canonicalized by any update.
+        self.deliveries_since_forkchoice = 0;
         let Some(target) = self.next_forkchoice_target()? else {
             return Ok(false);
         };

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -466,25 +466,9 @@ where
             ExecutionTaskOutcome::Validated { request, status } => {
                 self.handle_validated(request, status)
             }
-            ExecutionTaskOutcome::Delivered { digest, status } => match status {
-                Ok(PayloadStatusEnum::Valid) => self.notarized_tree.mark_delivered(&digest),
-                // The block is withheld until the retry delay elapses so
-                // that it is not retried in a tight loop; the finalization
-                // pipeline remains the fatal-on-failure backstop.
-                Ok(status) => {
-                    warn!(
-                        %status,
-                        "execution layer did not accept the notarized block; withholding it",
-                    );
-                    let now = self.context.current();
-                    self.notarized_tree.mark_rejected(&digest, now);
-                }
-                Err(error) => {
-                    warn!(%error, "failed delivering notarized block; withholding it");
-                    let now = self.context.current();
-                    self.notarized_tree.mark_rejected(&digest, now);
-                }
-            },
+            ExecutionTaskOutcome::Delivered { digest, status } => {
+                self.handle_delivered(digest, status)
+            }
             ExecutionTaskOutcome::FinalizedDelivered { request, status } => {
                 self.handle_finalized_delivered(request, status)?
             }
@@ -601,6 +585,29 @@ where
         Ok(())
     }
 
+    /// `VALID` makes the notarized block known to the execution layer.
+    /// Anything else withholds it for the retry delay so that it is not
+    /// retried in a tight loop; the finalization pipeline remains the
+    /// fatal-on-failure backstop.
+    fn handle_delivered(&mut self, digest: Digest, status: eyre::Result<PayloadStatusEnum>) {
+        match status {
+            Ok(PayloadStatusEnum::Valid) => self.notarized_tree.mark_delivered(&digest),
+            Ok(status) => {
+                warn!(
+                    %status,
+                    "execution layer did not accept the notarized block; withholding it",
+                );
+                let now = self.context.current();
+                self.notarized_tree.mark_rejected(&digest, now);
+            }
+            Err(error) => {
+                warn!(%error, "failed delivering notarized block; withholding it");
+                let now = self.context.current();
+                self.notarized_tree.mark_rejected(&digest, now);
+            }
+        }
+    }
+
     /// A non-`VALID` answer is fatal. Otherwise the block becomes the next
     /// finalized target and is acknowledged once the forkchoice update
     /// finalizing it lands - or right away if the execution layer already
@@ -709,8 +716,9 @@ where
     }
 
     /// Climbs from the tracked finalized state to the finalized floor
-    /// before entering the loop, delivering and finalizing one block at a
-    /// time. The head starts on the finalized tip and follows it.
+    /// before entering the loop: delivers every block, then finalizes the
+    /// floor with one forkchoice update. The head starts on the finalized
+    /// tip and follows it.
     async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
         let start = self.notarized_tree.local_state().finalized.0.get() + 1;
         let end = self.finalized_floor.get();
@@ -722,6 +730,7 @@ where
                 "backfilling finalized blocks before entering executor loop"
             );
         }
+        let mut floor = None;
         for height in heights {
             let span = info_span!("backfill_on_start", %height);
             let block = get_block(
@@ -747,29 +756,32 @@ where
                 "payload status of backfilled finalized block at height `{height}` was \
                 not valid: {status}",
             );
-
-            let target = self
-                .notarized_tree
-                .local_state()
-                .update_finalized(block.height(), block.digest());
-            let response = submit_forkchoice_update(&self.execution_node, span, target, None)
-                .await
-                .wrap_err_with(|| {
-                    format!(
-                        "failed finalizing backfilled finalized block at height `{height}` \
-                        on the execution layer"
-                    )
-                })?;
-            if !response.is_valid() {
-                bail!(
-                    "forkchoice update finalizing the backfilled finalized block at height \
-                    `{height}` was not valid: {}",
-                    response.payload_status,
-                );
-            }
-            self.notarized_tree.set_local_state(target);
+            floor = Some((block.height(), block.digest(), span));
         }
 
+        let Some((height, digest, span)) = floor else {
+            return Ok(());
+        };
+        let target = self
+            .notarized_tree
+            .local_state()
+            .update_finalized(height, digest);
+        let response = submit_forkchoice_update(&self.execution_node, span, target, None)
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed finalizing the backfilled finalized floor at height `{height}` \
+                    on the execution layer"
+                )
+            })?;
+        if !response.is_valid() {
+            bail!(
+                "forkchoice update finalizing the backfilled finalized floor at height \
+                `{height}` was not valid: {}",
+                response.payload_status,
+            );
+        }
+        self.notarized_tree.set_local_state(target);
         Ok(())
     }
 

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1029,21 +1029,16 @@ where
         }
     }
 
-    /// Returns if the convergence machinery is expected to imminently make
-    /// `digest` available to the execution layer.
-    ///
-    /// There are 2 options:
-    ///
-    /// 1. either the block is already queued, or
-    /// 2. we expect the block to be scheduled next.
-    ///
-    /// Point 2 allows for marshal to deliver the next finalized block
-    /// just-in-time.
+    /// Whether `digest` is queued for delivery or is the next thing
+    /// convergence does, so that a request waiting on it is held rather
+    /// than failed.
     fn is_convergence_target(&self, digest: Digest) -> bool {
         self.pending_finalizations
             .iter()
             .any(|request| request.block.digest() == digest)
-            || self.notarized_tree.converges_imminently(digest)
+            || self
+                .notarized_tree
+                .converges_imminently(digest, self.context.current())
     }
 
     /// Picks the next execution task: consensus request, finalized

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1,8 +1,7 @@
 //! Drives the actual execution forwarding blocks and setting forkchoice state.
 //!
 //! This agent ingests (monotonically) increasing finalized blocks from the
-//! marshal actor and forwards them to the execution layer as `newPayload` +
-//! `forkchoiceUpdated` pairs.
+//! marshal actor and forwards them to the execution layer.
 //!
 //! In addition, the agent:
 //!
@@ -10,22 +9,27 @@
 //! 2. drives the execution layer toward that notarized head,
 //! 3. and validates and builds blocks.
 //!
-//! The notarization and finalization pipelines are strictly separate:
-//! the marshal actor informs the executor of the finalized network tip.
-//! Notarizations then are strictly above that finalized network tip. If the
-//! executor is at the finalized network tip, then the executor will forward
-//! the (notarized) child to the execution layer.
+//! # Delivery and forkchoice are separate steps
+//!
+//! `newPayload` delivers a block body and never moves the head; notarized
+//! blocks, finalized blocks, and validation probes are all deliveries.
+//! `forkchoiceUpdated` moves the head and the finalized block, on a later
+//! iteration, and only ever names blocks the execution layer has answered
+//! `VALID` for. One update covers everything delivered since the last one.
+//! Finalized blocks are acknowledged to the marshal actor once the update
+//! finalizing them is accepted, and finality work is scheduled ahead of
+//! notarized convergence.
 //!
 //! Requests to verify or build blocks work in a similar manner: a request to
-//! verify or build a block on top of some `$PARENT` will only pass if the the
-//! local tracked tip is at `$PARENT`.
+//! verify or build a block on top of some `$PARENT` will only pass if the
+//! execution layer is known to have `$PARENT`.
 //!
-//! # Notarizations are retried, finalizations are fatal
+//! # Notarized deliveries are retried, everything else is fatal
 //!
-//! A notarized block rejected by the execution layer is retried while it
-//! remains above the network finalized tip. Once that tip advances to or past
-//! the block's height, the notarized block is ejected. In contrast, an
-//! `INVALID` finalized block is a hard failure that shuts down the node.
+//! A rejected notarized delivery is retried while the block stays above the
+//! finalized tip. An `INVALID` finalized block is fatal, and so is any
+//! forkchoice update not answered `VALID`: the executor's view of the
+//! execution layer has diverged from it.
 
 use std::{
     collections::VecDeque,
@@ -35,7 +39,7 @@ use std::{
 
 use alloy_primitives::B256;
 
-use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
+use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatusEnum};
 use commonware_consensus::{
     Heightable as _,
     marshal::Update,
@@ -78,7 +82,7 @@ use crate::{
 mod tests;
 
 mod notarized_tree;
-use notarized_tree::{LocalState, NextToForward, NotarizedTree};
+use notarized_tree::{LocalState, NotarizedTree};
 
 /// How often to probe whether the execution layer is ready to process blocks.
 const EXECUTION_LAYER_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -111,8 +115,13 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// Armed only when no execution-layer work is active or queued.
     fcu_heartbeat_timer: OptionFuture<BoxFuture<'static, ()>>,
 
-    /// Finalized blocks waiting to be forwarded to the execution layer.
+    /// Finalized blocks waiting to be delivered to the execution layer.
     pending_finalizations: VecDeque<FinalizedBlockRequest>,
+
+    /// Finalized blocks the execution layer has accepted, waiting for the
+    /// forkchoice update that finalizes them before they are acknowledged
+    /// to the marshal actor. In height order.
+    pending_acknowledgements: VecDeque<FinalizedBlockRequest>,
 
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
@@ -254,7 +263,7 @@ where
         // blocks from the floor, so the tracked state must start there for
         // the re-delivery to line up; the already-finalized blocks are
         // acknowledged without involving the execution layer (see
-        // [`forward_finalized`]).
+        // [`Self::handle_finalized_delivered`]).
         let finalized = if finalized_floor.get() < execution_finalized_num_hash.number {
             let digest = execution_node
                 .canonical_block_hash(finalized_floor.get())
@@ -297,6 +306,7 @@ where
             fcu_heartbeat_timer: OptionFuture::none(),
 
             pending_finalizations: VecDeque::new(),
+            pending_acknowledgements: VecDeque::new(),
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -354,7 +364,16 @@ where
             self.notarized_tree.heal();
             self.metrics.observe(&self.notarized_tree);
 
-            self.start_next_execution_task();
+            if let Err(error) = self.start_next_execution_task() {
+                error_span!("shutdown").in_scope(|| {
+                    error!(
+                        %error,
+                        "executor failed scheduling execution-layer work; \
+                        shutting down to prevent consensus-execution divergence"
+                    )
+                });
+                break;
+            }
             self.update_notarized_block_fetch();
             self.update_fcu_heartbeat_timer();
 
@@ -388,18 +407,18 @@ where
 
                 msg = self.mailbox.next() => {
                     let Some(msg) = msg else { break; };
-                    if let Err(error) = self.handle_message(msg) {
+                    self.handle_message(msg);
+                },
+
+                _ = (&mut self.fcu_heartbeat_timer).fuse() => {
+                    if let Err(error) = self.send_forkchoice_update_heartbeat() {
                         error_span!("shutdown").in_scope(|| error!(
                             %error,
-                            "executor failed handling message; \
+                            "executor failed scheduling execution-layer work; \
                             shutting down to prevent consensus-execution divergence"
                         ));
                         break;
                     }
-                },
-
-                _ = (&mut self.fcu_heartbeat_timer).fuse() => {
-                    self.send_forkchoice_update_heartbeat();
                 },
             }
         }
@@ -409,8 +428,6 @@ where
         skip_all,
         fields(
             task_type = task.task_type.name(),
-            on_top_of.head = %task.on_top_of.head.1,
-            on_top_of.finalized = %task.on_top_of.finalized.1,
         ),
     )]
     fn set_execution_task(&mut self, mut task: ExecutionTask) {
@@ -422,13 +439,15 @@ where
         info!("execution task scheduled");
     }
 
+    /// Interprets the answer of a finished execution task: this is the one
+    /// place where the tracked execution-layer state is mutated and where
+    /// answers are turned into decisions - what to mark delivered, what to
+    /// withhold, what to acknowledge, and what is fatal.
     #[instrument(
         parent = &finished.span,
         skip_all,
         fields(
             task_type = finished.task_type.name(),
-            on_top_of.head = %finished.on_top_of.head.1,
-            on_top_of.finalized = %finished.on_top_of.finalized.1,
             target = ?finished.target(),
             outcome = finished.outcome.name(),
         ),
@@ -444,34 +463,223 @@ where
         );
         let ExecutionTaskFinished { outcome, .. } = finished;
         match outcome {
-            ExecutionTaskOutcome::Completed {
-                canonicalized,
-                payload_job,
-            } => {
-                if let Some(canonicalized) = canonicalized {
-                    // There is only one execution task running at a time,
-                    // and the tracked state is only mutated here to keep a
-                    // consistent view.
-                    self.notarized_tree.set_local_state(canonicalized);
+            ExecutionTaskOutcome::Validated { request, status } => {
+                self.handle_validated(request, status)
+            }
+            ExecutionTaskOutcome::Delivered { digest, status } => match status {
+                Ok(PayloadStatusEnum::Valid) => self.notarized_tree.mark_delivered(&digest),
+                // The block is withheld until the retry delay elapses so
+                // that it is not retried in a tight loop; the finalization
+                // pipeline remains the fatal-on-failure backstop.
+                Ok(status) => {
+                    warn!(
+                        %status,
+                        "execution layer did not accept the notarized block; withholding it",
+                    );
+                    let now = self.context.current();
+                    self.notarized_tree.mark_rejected(&digest, now);
                 }
-                if let Some(job) = payload_job {
-                    self.payload_jobs
-                        .push(run_payload_job(self.execution_node.clone(), job).boxed());
+                Err(error) => {
+                    warn!(%error, "failed delivering notarized block; withholding it");
+                    let now = self.context.current();
+                    self.notarized_tree.mark_rejected(&digest, now);
                 }
+            },
+            ExecutionTaskOutcome::FinalizedDelivered { request, status } => {
+                self.handle_finalized_delivered(request, status)?
             }
-            ExecutionTaskOutcome::NotarizedBlockRejected { digest, .. } => {
-                // The cause is logged by the task itself. The timestamp keeps
-                // the block from being retried in a tight loop: it is withheld
-                // until the retry delay elapses; the finalization pipeline
-                // remains the fatal-on-failure backstop.
-                let now = self.context.current();
-                self.notarized_tree.mark_rejected(&digest, now);
-            }
-            ExecutionTaskOutcome::Fatal { error } => {
-                return Err(error.wrap_err("execution task failed"));
-            }
+            ExecutionTaskOutcome::Forkchoice {
+                target,
+                build,
+                response,
+            } => self.handle_forkchoice_response(target, build, response)?,
         }
         Ok(())
+    }
+
+    /// Resolves a validation request from the execution layer's answer.
+    /// `VALID` and `INVALID` are verdicts; `SYNCING` (unknown parent),
+    /// `ACCEPTED`, and transport errors fail the request by dropping its
+    /// channel. Gaps are repaired by convergence, not on this path.
+    fn handle_validated(
+        &mut self,
+        request: Option<VerifyBlockRequest>,
+        status: eyre::Result<(PayloadStatusEnum, Duration)>,
+    ) {
+        let Some(request) = request else {
+            return;
+        };
+        let digest = request.block.digest();
+        let now = self.context.current();
+        let verdict = match status {
+            Ok((PayloadStatusEnum::Valid, duration)) => {
+                self.notarized_tree.mark_delivered(&digest);
+                Some(duration)
+            }
+            Ok((PayloadStatusEnum::Invalid { validation_error }, _)) => {
+                info!(
+                    validation_error,
+                    "execution layer returned that the block was invalid"
+                );
+                self.notarized_tree.mark_rejected(&digest, now);
+                None
+            }
+            Ok((PayloadStatusEnum::Syncing, _)) => {
+                warn!(
+                    "failed validating block because the execution layer reports \
+                    syncing: it does not know the block's parent; the notarized \
+                    chain convergence will repair the gap in the background"
+                );
+                return;
+            }
+            Ok((PayloadStatusEnum::Accepted, _)) => {
+                warn!(
+                    "failed validating block because payload was accepted, meaning \
+                    that it was not actually executed by the execution layer for \
+                    some reason"
+                );
+                self.notarized_tree.mark_rejected(&digest, now);
+                return;
+            }
+            Err(error) => {
+                warn!(%error, "failed validating block");
+                self.notarized_tree.mark_rejected(&digest, now);
+                return;
+            }
+        };
+        if request.response.send(verdict).is_err() {
+            info!(
+                "verification subscriber went away before the validation \
+                result could be delivered"
+            );
+        }
+    }
+
+    /// An accepted forkchoice update becomes the tracked state (mutated only
+    /// here). A rejected one is fatal: every target named is a block the
+    /// execution layer accepted, so the executor's view of the execution
+    /// layer has diverged from it.
+    fn handle_forkchoice_response(
+        &mut self,
+        target: LocalState,
+        build: Option<(Span, oneshot::Sender<TempoBuiltPayload>)>,
+        response: eyre::Result<ForkchoiceUpdated>,
+    ) -> eyre::Result<()> {
+        let diverged = || {
+            format!(
+                "forkchoice update onto head `{}` at height `{}` and finalized block `{}` at \
+                height `{}` failed; the executor's view of the execution layer has diverged \
+                from the execution layer",
+                target.head.1, target.head.0, target.finalized.1, target.finalized.0,
+            )
+        };
+        let response = response.wrap_err_with(diverged)?;
+        if !response.is_valid() {
+            return Err(Report::msg(response.payload_status)).wrap_err_with(diverged);
+        }
+
+        self.notarized_tree.set_local_state(target);
+        self.acknowledge_finalized();
+
+        // Dropping the build's response channel signals the failure to the
+        // subscriber.
+        match (build, response.payload_id) {
+            (Some((cause, response)), Some(payload_id)) => {
+                let job = StartPayloadJob {
+                    cause,
+                    payload_id,
+                    response,
+                };
+                self.payload_jobs
+                    .push(run_payload_job(self.execution_node.clone(), job).boxed());
+            }
+            (Some(_dropped_to_signal_failure), None) => {
+                warn!("execution layer did not return a payload id for the build request");
+            }
+            (None, _) => {}
+        }
+        Ok(())
+    }
+
+    /// A non-`VALID` answer is fatal. Otherwise the block becomes the next
+    /// finalized target and is acknowledged once the forkchoice update
+    /// finalizing it lands - or right away if the execution layer already
+    /// finalized it (a re-delivery). The marshal actor delivers the
+    /// finalized chain in order; that order is trusted, not checked.
+    fn handle_finalized_delivered(
+        &mut self,
+        request: FinalizedBlockRequest,
+        status: eyre::Result<PayloadStatusEnum>,
+    ) -> eyre::Result<()> {
+        let block = request.block.as_ref();
+        debug_assert!(
+            block.height() >= self.notarized_tree.delivered_finalized().0,
+            "finalized blocks are delivered in height order",
+        );
+        match status {
+            Ok(PayloadStatusEnum::Valid) => {}
+            Ok(status) => bail!(
+                "payload status of finalized block `{}` at height `{}` was not \
+                valid: {status}",
+                block.digest(),
+                block.height(),
+            ),
+            Err(error) => {
+                return Err(error.wrap_err(format!(
+                    "failed delivering finalized block `{}` at height `{}`",
+                    block.digest(),
+                    block.height(),
+                )));
+            }
+        }
+
+        self.notarized_tree
+            .set_delivered_finalized(block.height(), block.digest());
+        if block.height() <= self.notarized_tree.local_state().finalized.0 {
+            self.acknowledge(request);
+        } else {
+            self.pending_acknowledgements.push_back(request);
+        }
+        Ok(())
+    }
+
+    /// Acknowledges the queued blocks the last accepted forkchoice update
+    /// finalized. Deliveries are in chain order, so height identifies them.
+    fn acknowledge_finalized(&mut self) {
+        let finalized = self.notarized_tree.local_state().finalized.0;
+        while let Some(request) = self.pending_acknowledgements.front() {
+            if request.block.height() > finalized {
+                break;
+            }
+            let Some(request) = self.pending_acknowledgements.pop_front() else {
+                break;
+            };
+            self.acknowledge(request);
+        }
+    }
+
+    /// Acknowledges a block the execution layer finalized to the marshal actor.
+    fn acknowledge(&mut self, request: FinalizedBlockRequest) {
+        let FinalizedBlockRequest {
+            cause,
+            block,
+            acknowledgment,
+        } = request;
+        let _entered = cause.enter();
+        if let Some(public_key) = self.public_key.as_ref()
+            && block
+                .header()
+                .consensus_context
+                .is_some_and(|context| context.proposer.to_inner() == *public_key)
+        {
+            self.metrics.finalized_blocks_proposed_by_self.inc();
+        }
+        info!(
+            block.digest = %block.digest(),
+            block.height = %block.height(),
+            "finalized block is final on the execution layer; acknowledging it",
+        );
+        acknowledgment.acknowledge();
     }
 
     /// Waits until reth is ready to process blocks by repeatedly reaffirming the execution layer's
@@ -500,6 +708,9 @@ where
         Ok(())
     }
 
+    /// Climbs from the tracked finalized state to the finalized floor
+    /// before entering the loop, delivering and finalizing one block at a
+    /// time. The head starts on the finalized tip and follows it.
     async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
         let start = self.notarized_tree.local_state().finalized.0.get() + 1;
         let end = self.finalized_floor.get();
@@ -520,32 +731,43 @@ where
             )
             .await
             .wrap_err_with(|| format!("failed backfilling block for height `{height}`"))?;
+            let block = Arc::new(block);
 
-            let (ack, _wait) = Exact::handle();
-            let request = FinalizedBlockRequest {
-                cause: span,
-                block: Arc::new(block),
-                acknowledgment: ack,
-            };
-            let canonicalized = self.notarized_tree.local_state();
-            let target =
-                finalization_target(&self.execution_node, canonicalized, request.block.as_ref())?;
+            let status = deliver_block(&self.execution_node, block.clone(), None)
+                .instrument(span.clone())
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed forwarding backfilled finalized block at height `{height}` \
+                        to execution layer"
+                    )
+                })?;
+            ensure!(
+                status == PayloadStatusEnum::Valid,
+                "payload status of backfilled finalized block at height `{height}` was \
+                not valid: {status}",
+            );
 
-            let canonicalized = forward_finalized(
-                self.execution_node.clone(),
-                self.public_key.clone(),
-                self.metrics.clone(),
-                target,
-                request,
-            )
-            .await
-            .wrap_err_with(|| {
-                format!(
-                    "failed forwarding backfilled finalized block at height `{height}` \
-                    to execution layer"
-                )
-            })?;
-            self.notarized_tree.set_local_state(canonicalized);
+            let target = self
+                .notarized_tree
+                .local_state()
+                .update_finalized(block.height(), block.digest());
+            let response = submit_forkchoice_update(&self.execution_node, span, target, None)
+                .await
+                .wrap_err_with(|| {
+                    format!(
+                        "failed finalizing backfilled finalized block at height `{height}` \
+                        on the execution layer"
+                    )
+                })?;
+            if !response.is_valid() {
+                bail!(
+                    "forkchoice update finalizing the backfilled finalized block at height \
+                    `{height}` was not valid: {}",
+                    response.payload_status,
+                );
+            }
+            self.notarized_tree.set_local_state(target);
         }
 
         Ok(())
@@ -574,29 +796,31 @@ where
         }
     }
 
+    /// Re-affirms the tracked forkchoice state, unless the scheduler finds
+    /// real work to do first.
     #[instrument(skip_all)]
-    fn send_forkchoice_update_heartbeat(&mut self) {
+    fn send_forkchoice_update_heartbeat(&mut self) -> eyre::Result<()> {
         // The heartbeat timer is only armed while no other execution-layer
         // work is active or queued.
         if !self.execution_task.is_none() {
-            return;
+            return Ok(());
         }
 
-        self.start_next_execution_task();
+        self.start_next_execution_task()?;
         if !self.execution_task.is_none() {
-            return;
+            return Ok(());
         }
 
-        let on_top_of = self.notarized_tree.local_state();
-        let fut = execute_heartbeat(self.execution_node.clone(), on_top_of, Span::current());
-        self.set_execution_task(ExecutionTask::new(
-            ExecutionTaskType::Heartbeat,
-            on_top_of,
-            fut,
-        ));
+        let target = self.notarized_tree.local_state();
+        if self.is_stale_forkchoice(target)? {
+            return Ok(());
+        }
+        let fut = execute_forkchoice(self.execution_node.clone(), Span::current(), target, None);
+        self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Heartbeat, fut));
+        Ok(())
     }
 
-    fn handle_message(&mut self, message: Message) -> eyre::Result<()> {
+    fn handle_message(&mut self, message: Message) {
         let cause = message.cause;
         match message.command {
             Command::Build(build) => {
@@ -648,7 +872,6 @@ where
                 );
             }
         }
-        Ok(())
     }
 
     /// Records the context's parent as the pending head that consensus
@@ -749,6 +972,11 @@ where
             || self.notarized_tree.converges_imminently(digest)
     }
 
+    /// Picks the next execution task: consensus request, finalized
+    /// deliveries, the forkchoice update finalizing them, notarized
+    /// deliveries, the forkchoice update moving the head. Finality goes
+    /// first so a long notarized run never holds up acknowledgements;
+    /// deliveries go before the update so one update covers a whole run.
     #[instrument(
         skip_all,
         fields(
@@ -757,10 +985,11 @@ where
             current.finalized_height = %self.notarized_tree.local_state().finalized.0,
             current.finalized_digest = %self.notarized_tree.local_state().finalized.1,
         ),
+        err,
     )]
-    fn start_next_execution_task(&mut self) {
+    fn start_next_execution_task(&mut self) -> eyre::Result<()> {
         if !self.execution_task.is_none() {
-            return;
+            return Ok(());
         }
 
         // Latency critical requests come first: consensus is waiting on
@@ -771,19 +1000,11 @@ where
         // imminently.
         match self.pending_consensus_request.take() {
             Some((round, ConsensusRequest::Verify(request))) => {
-                if self
-                    .notarized_tree
-                    .is_local_notarized_or_finalized_tip(request.block.parent_digest())
-                    || !self.is_convergence_target(request.block.parent_digest())
-                {
-                    let on_top_of = self.notarized_tree.local_state();
+                let parent = request.block.parent_digest();
+                if self.notarized_tree.is_known(parent) || !self.is_convergence_target(parent) {
                     let fut = execute_validation(self.execution_node.clone(), request);
-                    self.set_execution_task(ExecutionTask::new(
-                        ExecutionTaskType::Verify,
-                        on_top_of,
-                        fut,
-                    ));
-                    return;
+                    self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Verify, fut));
+                    return Ok(());
                 }
 
                 // Reschedules the request; the actor will not spin on
@@ -795,65 +1016,210 @@ where
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
                 // Builds are registered via FCU setting the head hash to the
-                // parent. So running it with the head anywhere else would fight
-                // notarized-chain convergence.
-                if self.notarized_tree.is_local_head(build.digest) {
-                    let on_top_of = self.notarized_tree.local_state();
-                    let fut = execute_build(self.execution_node.clone(), on_top_of, cause, build);
-                    self.set_execution_task(ExecutionTask::new(
-                        ExecutionTaskType::Build,
-                        on_top_of,
-                        fut,
-                    ));
-                    return;
-                }
-                // Reschedules the request; the actor will not spin on
-                // `start_next_execution_request` as long as it remains
-                // scheduled before the select! in the select-loop (some other
-                // event needs to take place first; ideally the result of the
-                // convergence target we are falling through to).
-                if self.is_convergence_target(build.digest) {
-                    self.pending_consensus_request =
-                        Some((round, ConsensusRequest::Build { cause, build }));
-                } else {
-                    info!(
-                        execution.head_hash = %self.notarized_tree.local_state().head.1,
-                        build.parent = %build.digest,
-                        "not ready to build new block, dropping it",
-                    );
+                // parent, so the parent must be known to the execution
+                // layer. The update moves the head onto it if it is not
+                // there yet: the parent is the pending head consensus
+                // reported, so there is no convergence to fight.
+                match self.build_target(build.digest) {
+                    BuildTarget::Ready(target) => {
+                        if self.is_stale_forkchoice(target)? {
+                            info!(
+                                build.parent = %build.digest,
+                                "tracked finality is below the execution layer's; dropping the build",
+                            );
+                        } else {
+                            let fut = execute_forkchoice(
+                                self.execution_node.clone(),
+                                cause.clone(),
+                                target,
+                                Some((cause, build)),
+                            );
+                            self.set_execution_task(ExecutionTask::new(
+                                ExecutionTaskType::Build,
+                                fut,
+                            ));
+                            return Ok(());
+                        }
+                    }
+                    BuildTarget::Stale => {
+                        info!(
+                            finalized = %self.notarized_tree.delivered_finalized().1,
+                            build.parent = %build.digest,
+                            "finality advanced past the parent to build on, dropping the build",
+                        );
+                    }
+                    // Reschedules the request; the actor will not spin on
+                    // `start_next_execution_request` as long as it remains
+                    // scheduled before the select! in the select-loop (some
+                    // other event needs to take place first; ideally the
+                    // result of the convergence target we are falling through
+                    // to).
+                    BuildTarget::Unknown if self.is_convergence_target(build.digest) => {
+                        self.pending_consensus_request =
+                            Some((round, ConsensusRequest::Build { cause, build }));
+                    }
+                    BuildTarget::Unknown => {
+                        info!(
+                            execution.head_hash = %self.notarized_tree.local_state().head.1,
+                            build.parent = %build.digest,
+                            "not ready to build new block, dropping it",
+                        );
+                    }
                 }
             }
             None => {}
         }
 
-        if let Some(step) = self.notarized_tree.next_to_forward(self.context.current()) {
-            let on_top_of = self.notarized_tree.local_state();
-            let fut = execute_notarization(self.execution_node.clone(), on_top_of, step, None);
-            self.set_execution_task(ExecutionTask::new(
-                ExecutionTaskType::Notarize,
-                on_top_of,
-                fut,
-            ));
-            return;
+        // Finalizations are delivered in order and acknowledged so that the
+        // marshal actor can make progress. Every finalized block is
+        // delivered, whether or not the execution layer is thought to know
+        // it: a known block is answered `VALID` from its caches without
+        // being executed again.
+        if let Some(request) = self.pending_finalizations.pop_front() {
+            let fut = execute_finalization(self.execution_node.clone(), request);
+            self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Finalize, fut));
+            return Ok(());
         }
 
-        // Finalizations are forwarded in order and acknowledged so that the
-        // marshal actor can make progress.
-        if let Some(request) = self.pending_finalizations.pop_front() {
-            let on_top_of = self.notarized_tree.local_state();
-            self.set_execution_task(ExecutionTask::new(
-                ExecutionTaskType::Finalize,
-                on_top_of,
-                execute_finalization(
-                    self.execution_node.clone(),
-                    self.public_key.clone(),
-                    self.metrics.clone(),
-                    on_top_of,
-                    request,
-                ),
-            ));
+        // With the finalized queue drained, delivered finalized blocks that
+        // await their acknowledgement are locked in before notarized
+        // convergence continues. The update takes the head target that is
+        // known at this point along.
+        if !self.pending_acknowledgements.is_empty() && self.start_forkchoice_update()? {
+            return Ok(());
+        }
+
+        if let Some(block) = self.notarized_tree.next_to_deliver(self.context.current()) {
+            let fut = execute_delivery(self.execution_node.clone(), block);
+            self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Deliver, fut));
+            return Ok(());
+        }
+
+        self.start_forkchoice_update()?;
+        Ok(())
+    }
+
+    /// Starts the forkchoice update onto the next target, if any; returns
+    /// whether it did.
+    fn start_forkchoice_update(&mut self) -> eyre::Result<bool> {
+        let Some(target) = self.next_forkchoice_target()? else {
+            return Ok(false);
+        };
+        if self.is_stale_forkchoice(target)? {
+            // Nothing to submit: the execution layer is past this finality
+            // already. The tracked state catches up to it.
+            self.notarized_tree.set_local_state(target);
+            self.acknowledge_finalized();
+            return Ok(false);
+        }
+        let fut = execute_forkchoice(self.execution_node.clone(), Span::current(), target, None);
+        self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Forkchoice, fut));
+        Ok(true)
+    }
+
+    /// Whether `target` finalizes below the execution layer's own finality,
+    /// so that submitting it would move finality backwards. The tracked
+    /// state trails execution-layer finality after a snapshot restore until
+    /// the marshal actor's re-deliveries catch up. A tracked finalized block
+    /// the execution layer's canonical chain contradicts is fatal.
+    fn is_stale_forkchoice(&self, target: LocalState) -> eyre::Result<bool> {
+        let execution_finalized = self.execution_node.finalized_num_hash();
+        if execution_finalized.number < target.finalized.0.get() {
+            return Ok(false);
+        }
+        let canonical_digest = self
+            .execution_node
+            .canonical_block_hash(target.finalized.0.get())
+            .wrap_err_with(|| {
+                format!(
+                    "failed reading canonical execution block hash at the tracked \
+                    finalized height `{}`",
+                    target.finalized.0,
+                )
+            })?
+            .ok_or_else(|| {
+                eyre!(
+                    "no canonical execution block hash at the tracked finalized height \
+                    `{}`, even though it is at or below the execution layer's finalized \
+                    height `{}`",
+                    target.finalized.0,
+                    execution_finalized.number,
+                )
+            })?;
+        ensure!(
+            canonical_digest == target.finalized.1.0,
+            "tracked finalized block `{}` at height `{}` conflicts with the execution \
+            layer's canonical block `{canonical_digest}` at the same height, which the \
+            execution layer already considers final; two different blocks must never be \
+            finalized at the same height",
+            target.finalized.1,
+            target.finalized.0,
+        );
+        Ok(execution_finalized.number > target.finalized.0.get())
+    }
+
+    /// The next forkchoice state, if it differs from the tracked one: the
+    /// delivered finalized block, and the highest delivered block on the
+    /// pending head's ancestry. A head the tree cannot place is checked
+    /// against the canonical chain and moved onto the finalized block if it
+    /// does not descend from it.
+    fn next_forkchoice_target(&self) -> eyre::Result<Option<LocalState>> {
+        let local = self.notarized_tree.local_state();
+        let (finalized_height, finalized_digest) = self.notarized_tree.delivered_finalized();
+        let mut target = local.update_finalized(finalized_height, finalized_digest);
+        if let Some((height, digest)) = self.notarized_tree.next_head(self.context.current()) {
+            target = target.update_head(height, digest);
+        }
+
+        if target.finalized != local.finalized && target.head == local.head {
+            let canonical_hash = self
+                .execution_node
+                .canonical_block_hash(finalized_height.get())
+                .wrap_err_with(|| {
+                    format!(
+                        "failed reading canonical execution block hash at finalized \
+                        block height `{finalized_height}`",
+                    )
+                })?;
+            let head_descends_from_finalized = canonical_hash == Some(finalized_digest.0);
+            if !head_descends_from_finalized {
+                target = target.update_head(finalized_height, finalized_digest);
+            }
+        }
+
+        Ok((target != local).then_some(target))
+    }
+
+    /// The forkchoice state a build on top of `parent` is registered with:
+    /// the head on the parent, finality on the delivered finalized block.
+    fn build_target(&self, parent: Digest) -> BuildTarget {
+        let Some(height) = self.notarized_tree.known_height(parent) else {
+            return BuildTarget::Unknown;
+        };
+        let (finalized_height, finalized_digest) = self.notarized_tree.delivered_finalized();
+        let target = self
+            .notarized_tree
+            .local_state()
+            .update_finalized(finalized_height, finalized_digest)
+            .update_head(height, parent);
+        if target.head.1 == parent {
+            BuildTarget::Ready(target)
+        } else {
+            BuildTarget::Stale
         }
     }
+}
+
+/// Whether a build can be registered on its parent, see
+/// [`Actor::build_target`].
+enum BuildTarget {
+    /// The forkchoice state to register the build with.
+    Ready(LocalState),
+    /// The parent is not known to the execution layer (yet).
+    Unknown,
+    /// Finality advanced past the parent: the build can never be
+    /// registered.
+    Stale,
 }
 
 #[instrument(skip_all, fields(height), err)]
@@ -985,19 +1351,14 @@ struct VerifyBlockRequest {
     response: oneshot::Sender<Option<Duration>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ForkchoiceUpdateKind {
-    Heartbeat,
-    Canonicalize { head_or_finalized: HeadOrFinalized },
-}
-
 #[derive(Debug, Clone, Copy)]
 enum ExecutionTaskType {
     Heartbeat,
     Verify,
     Build,
-    Notarize,
+    Deliver,
     Finalize,
+    Forkchoice,
 }
 
 impl ExecutionTaskType {
@@ -1006,28 +1367,27 @@ impl ExecutionTaskType {
             Self::Heartbeat => "heartbeat",
             Self::Verify => "verify",
             Self::Build => "build",
-            Self::Notarize => "notarize",
+            Self::Deliver => "deliver",
             Self::Finalize => "finalize",
+            Self::Forkchoice => "forkchoice",
         }
     }
 }
 
 struct ExecutionTask {
     task_type: ExecutionTaskType,
-    on_top_of: LocalState,
     span: Span,
     started_at: Instant,
     fut: BoxFuture<'static, ExecutionTaskOutcome>,
 }
 
 impl ExecutionTask {
-    fn new<F>(task_type: ExecutionTaskType, on_top_of: LocalState, fut: F) -> Self
+    fn new<F>(task_type: ExecutionTaskType, fut: F) -> Self
     where
         F: Future<Output = ExecutionTaskOutcome> + Send + 'static,
     {
         Self {
             task_type,
-            on_top_of,
             span: Span::none(),
             started_at: Instant::now(),
             fut: fut.boxed(),
@@ -1037,7 +1397,6 @@ impl ExecutionTask {
 
 struct ExecutionTaskFinished {
     task_type: ExecutionTaskType,
-    on_top_of: LocalState,
     span: Span,
     started_at: Instant,
     outcome: ExecutionTaskOutcome,
@@ -1046,9 +1405,10 @@ struct ExecutionTaskFinished {
 impl ExecutionTaskFinished {
     fn target(&self) -> Option<LocalState> {
         match &self.outcome {
-            ExecutionTaskOutcome::Completed { canonicalized, .. } => *canonicalized,
-            ExecutionTaskOutcome::NotarizedBlockRejected { target, .. } => Some(*target),
-            ExecutionTaskOutcome::Fatal { .. } => None,
+            ExecutionTaskOutcome::Forkchoice { target, .. } => Some(*target),
+            ExecutionTaskOutcome::Validated { .. }
+            | ExecutionTaskOutcome::Delivered { .. }
+            | ExecutionTaskOutcome::FinalizedDelivered { .. } => None,
         }
     }
 }
@@ -1067,7 +1427,6 @@ impl Future for ExecutionTask {
         };
         std::task::Poll::Ready(ExecutionTaskFinished {
             task_type: self.task_type,
-            on_top_of: self.on_top_of,
             span,
             started_at: self.started_at,
             outcome,
@@ -1075,29 +1434,41 @@ impl Future for ExecutionTask {
     }
 }
 
+/// What an execution task got back from its single engine call, reported
+/// uninterpreted; [`Actor::handle_execution_task_finished`] decides.
 enum ExecutionTaskOutcome {
-    Completed {
-        canonicalized: Option<LocalState>,
-        /// A payload build that the forkchoice update kicked off on the
-        /// execution layer and that still needs to be driven to completion.
-        payload_job: Option<StartPayloadJob>,
+    /// The request travels back for its verdict; `None` if the subscriber
+    /// went away meanwhile. The status comes with the time taken.
+    Validated {
+        request: Option<VerifyBlockRequest>,
+        status: eyre::Result<(PayloadStatusEnum, Duration)>,
     },
-    /// A notarized block could not be forwarded and should be retried later.
-    NotarizedBlockRejected {
+    /// A notarized block was delivered through a bare new-payload request.
+    Delivered {
         digest: Digest,
-        target: LocalState,
+        status: eyre::Result<PayloadStatusEnum>,
     },
-    Fatal {
-        error: Report,
+    /// The request travels back for its acknowledgement.
+    FinalizedDelivered {
+        request: FinalizedBlockRequest,
+        status: eyre::Result<PayloadStatusEnum>,
+    },
+    /// The raw answer to a forkchoice update, together with the build
+    /// subscriber it carried.
+    Forkchoice {
+        target: LocalState,
+        build: Option<(Span, oneshot::Sender<TempoBuiltPayload>)>,
+        response: eyre::Result<ForkchoiceUpdated>,
     },
 }
 
 impl ExecutionTaskOutcome {
     fn name(&self) -> &'static str {
         match self {
-            Self::Completed { .. } => "completed",
-            Self::NotarizedBlockRejected { .. } => "rejected",
-            Self::Fatal { .. } => "fatal",
+            Self::Validated { .. } => "validated",
+            Self::Delivered { .. } => "delivered",
+            Self::FinalizedDelivered { .. } => "finalized-delivered",
+            Self::Forkchoice { .. } => "forkchoice",
         }
     }
 }
@@ -1110,119 +1481,55 @@ struct StartPayloadJob {
     response: oneshot::Sender<TempoBuiltPayload>,
 }
 
+/// Submits a forkchoice update targeting `target`, with the build's payload
+/// attributes if the build is still wanted. A no-op update is submitted
+/// regardless (heartbeats rely on this).
 #[instrument(
     skip_all,
     parent = &cause,
     fields(
-        head_block_hash = %canonicalized.head.1,
-        head_block_height = %canonicalized.head.0,
-        finalized_block_hash = %canonicalized.finalized.1,
-        finalized_block_height = %canonicalized.finalized.0,
+        head_block_hash = %target.head.1,
+        head_block_height = %target.head.0,
+        finalized_block_hash = %target.finalized.1,
+        finalized_block_height = %target.finalized.0,
+        build = build.is_some(),
     ),
 )]
-async fn execute_heartbeat(
+async fn execute_forkchoice(
     execution_node: impl ExecutionLayer,
-    canonicalized: LocalState,
     cause: Span,
+    target: LocalState,
+    build: Option<(Span, Build)>,
 ) -> ExecutionTaskOutcome {
-    if let Err(error) = submit_forkchoice_update(
-        &execution_node,
-        cause,
-        canonicalized,
-        None,
-        ForkchoiceUpdateKind::Heartbeat,
-    )
-    .await
-    {
-        warn!(%error, "forkchoice update heartbeat failed");
-    }
-    ExecutionTaskOutcome::Completed {
-        canonicalized: None,
-        payload_job: None,
-    }
-}
+    let build = build.filter(|(_, build)| {
+        if build.response.is_canceled() {
+            info!("dropping payload build request: the subscriber went away while it was queued");
+            return false;
+        }
+        true
+    });
+    let (build, attributes) = match build {
+        Some((
+            cause,
+            Build {
+                round: _,
+                digest: _,
+                attributes,
+                response,
+            },
+        )) => (Some((cause, response)), Some(*attributes)),
+        None => (None, None),
+    };
 
-/// Registers the payload build on top of its parent (`digest`) via a
-/// forkchoice update.
-///
-/// The caller dispatches a build only when the execution layer's head
-/// already is the parent (see [`Actor::start_next_execution_task`]), so
-/// the forkchoice update re-affirms the head instead of moving it; the
-/// Engine API requires the update regardless, because builds can only be
-/// registered through forkchoice updates. The update is still submitted
-/// when the build is dropped as canceled below - a no-op re-affirmation,
-/// doubling as a head refresh.
-#[instrument(
-    skip_all,
-    parent = &cause,
-    fields(%digest),
-)]
-async fn execute_build(
-    execution_node: impl ExecutionLayer,
-    canonicalized: LocalState,
-    cause: Span,
-    Build {
-        round: _,
-        digest,
-        attributes,
+    let response = submit_forkchoice_update(&execution_node, cause, target, attributes).await;
+    ExecutionTaskOutcome::Forkchoice {
+        target,
+        build,
         response,
-    }: Build,
-) -> ExecutionTaskOutcome {
-    let mut build_attributes = Some((*attributes, response));
-    if build_attributes
-        .as_ref()
-        .is_some_and(|(_, response)| response.is_canceled())
-    {
-        info!("dropping payload build request: the subscriber went away while it was queued");
-        build_attributes.take();
-    }
-
-    let (attributes, payload_response) = build_attributes.unzip();
-
-    // The forkchoice update is submitted even if it would not change the
-    // forkchoice state: the execution layer treats it as a no-op (the FCU
-    // heartbeat relies on this).
-    match submit_forkchoice_update(
-        &execution_node,
-        cause.clone(),
-        canonicalized,
-        attributes,
-        ForkchoiceUpdateKind::Canonicalize {
-            head_or_finalized: HeadOrFinalized::Head,
-        },
-    )
-    .await
-    {
-        Ok(payload_id) => {
-            let payload_job = match (payload_response, payload_id) {
-                (Some(response), Some(payload_id)) => Some(StartPayloadJob {
-                    cause,
-                    payload_id,
-                    response,
-                }),
-                (Some(_dropped_to_signal_failure), None) => {
-                    warn!("execution layer did not return a payload id for the build request");
-                    None
-                }
-                (None, _) => None,
-            };
-            ExecutionTaskOutcome::Completed {
-                canonicalized: Some(canonicalized),
-                payload_job,
-            }
-        }
-        Err(error) => {
-            // Dropping the response channels signals the failure to the
-            // subscribers; the cause is only logged here.
-            warn!(%error, "forkchoice update failed");
-            ExecutionTaskOutcome::Completed {
-                canonicalized: None,
-                payload_job: None,
-            }
-        }
     }
 }
 
+/// Delivers a finalized block through a bare new-payload request.
 #[instrument(
     skip_all,
     parent = &request.cause,
@@ -1233,71 +1540,33 @@ async fn execute_build(
 )]
 async fn execute_finalization(
     execution_node: impl ExecutionLayer,
-    public_key: Option<PublicKey>,
-    metrics: Metrics,
-    canonicalized: LocalState,
     request: FinalizedBlockRequest,
 ) -> ExecutionTaskOutcome {
-    let target = match finalization_target(&execution_node, canonicalized, request.block.as_ref()) {
-        Ok(target) => target,
-        Err(error) => return ExecutionTaskOutcome::Fatal { error },
-    };
-    match forward_finalized(execution_node, public_key, metrics, target, request).await {
-        Ok(target) => ExecutionTaskOutcome::Completed {
-            canonicalized: Some(target),
-            payload_job: None,
-        },
-        Err(error) => ExecutionTaskOutcome::Fatal { error },
-    }
+    // The validator set can be omitted for finalized blocks.
+    let status = deliver_block(&execution_node, request.block.clone(), None).await;
+    ExecutionTaskOutcome::FinalizedDelivered { request, status }
 }
 
+/// Delivers a notarized block through a bare new-payload request.
 #[instrument(
     skip_all,
     fields(
-        block.digest = %step.digest(),
-        block.height = %step.height(),
+        block.digest = %block.digest(),
+        block.height = %block.height(),
     ),
 )]
-async fn execute_notarization(
+async fn execute_delivery(
     execution_node: impl ExecutionLayer,
-    on_top_of: LocalState,
-    step: NextToForward,
-    validator_set: Option<Vec<B256>>,
+    block: Arc<Block>,
 ) -> ExecutionTaskOutcome {
-    let digest = step.digest();
-    let is_repoint = matches!(step, NextToForward::Repoint(..));
-    let target = on_top_of.update_head(step.height(), digest);
-    match forward_notarized(execution_node, on_top_of, target, step, validator_set).await {
-        Ok(canonicalized) => ExecutionTaskOutcome::Completed {
-            canonicalized: Some(canonicalized),
-            payload_job: None,
-        },
-        // A failed repoint is fatal: the target is expected to be an ancestor
-        // of the current canonical chain. Anything but success means that CL
-        // and EL disagree.
-        Err(error) if is_repoint => ExecutionTaskOutcome::Fatal {
-            error: error
-                .wrap_err("failed repointing the execution layer's head onto the finalized tip"),
-        },
-        // The cause is logged by `forward_notarized`.
-        Err(_logged) => ExecutionTaskOutcome::NotarizedBlockRejected { digest, target },
-    }
+    let digest = block.digest();
+    let status = deliver_block(&execution_node, block, None).await;
+    ExecutionTaskOutcome::Delivered { digest, status }
 }
 
-/// Drives a validation request against the execution layer via a single
-/// new-payload request.
-///
-/// The request deliberately does not repair gaps: if the execution layer does
-/// not know the block's parent, validation fails (dropping the response
-/// channel signals this to the subscriber) and the executor converges the
-/// execution layer on the notarized chain in the background instead of on
-/// this latency-critical path.
-///
-/// The subscriber dropping its receiver (because consensus aborted the view)
-/// abandons the request; the notarized tree retains the block body
-/// recorded from the request, so the execution layer still converges on the
-/// notarized tip afterwards. Validation errors are not fatal for the executor
-/// because consensus treats a failed verification as a rejected proposal.
+/// Probes the execution layer with the block to validate and hands the
+/// request back with the answer. A subscriber that went away abandons the
+/// request; the recorded body still serves convergence.
 #[instrument(
     skip_all,
     parent = &request.cause,
@@ -1309,74 +1578,53 @@ async fn execute_notarization(
 )]
 async fn execute_validation(
     execution_node: impl ExecutionLayer,
-    request: VerifyBlockRequest,
+    mut request: VerifyBlockRequest,
 ) -> ExecutionTaskOutcome {
-    let VerifyBlockRequest {
-        cause: _,
-        block,
-        validator_set,
-        mut response,
-    } = request;
-
-    let work = validate_block(&execution_node, block, validator_set);
+    let validation_start = Instant::now();
+    let work = deliver_block(
+        &execution_node,
+        request.block.clone(),
+        request.validator_set.clone(),
+    );
     futures::pin_mut!(work);
 
-    let result = select! {
+    let status = select! {
         biased;
 
-        res = &mut work => res,
+        status = &mut work => status
+            .map(|status| (status, validation_start.elapsed()))
+            .wrap_err("failed sending new-payload request to execution layer to validate block"),
 
         // Stops waiting for the verdict; the execution layer may still
         // process the new-payload request. The notarized tree
         // keeps driving the execution layer independently of this request's
         // lifetime.
-        () = response.cancellation() => {
+        () = request.response.cancellation() => {
             info!(
                 "verification subscriber went away before the block was \
                 validated; abandoning the request"
             );
-            return ExecutionTaskOutcome::Completed {
-                canonicalized: None,
-                payload_job: None,
+            return ExecutionTaskOutcome::Validated {
+                request: None,
+                status: Err(eyre!("verification subscriber went away")),
             };
         }
     };
 
-    match result {
-        Ok(verdict) => {
-            if response.send(verdict).is_err() {
-                info!(
-                    "verification subscriber went away before the validation \
-                    result could be delivered"
-                );
-            }
-        }
-        Err(error) => {
-            // Dropping the response channel signals the failure to the
-            // subscriber; the cause is only logged here.
-            warn!(%error, "failed validating block");
-        }
-    }
-    ExecutionTaskOutcome::Completed {
-        canonicalized: None,
-        payload_job: None,
+    ExecutionTaskOutcome::Validated {
+        request: Some(request),
+        status,
     }
 }
 
-/// Validates `block` against the execution layer via a new-payload request.
-///
-/// Returns the validation duration when the block is valid, `None` when the
-/// execution layer rejected it, and an error when validation was not
-/// possible.
-async fn validate_block(
+/// Submits `block` to the execution layer through a new-payload request and
+/// returns the reported payload status.
+async fn deliver_block(
     execution_node: &impl ExecutionLayer,
     block: Arc<Block>,
     validator_set: Option<Vec<B256>>,
-) -> eyre::Result<Option<Duration>> {
-    use alloy_rpc_types_engine::PayloadStatusEnum;
-
+) -> eyre::Result<PayloadStatusEnum> {
     let (block, block_access_list) = Arc::unwrap_or_clone(block).into_parts();
-    let validation_start = Instant::now();
     let payload_status = execution_node
         .new_payload(TempoExecutionData {
             block,
@@ -1384,31 +1632,13 @@ async fn validate_block(
             validator_set,
         })
         .await
-        .wrap_err("failed sending new-payload request to execution layer to validate block")?;
-    match payload_status.status {
-        PayloadStatusEnum::Valid => Ok(Some(validation_start.elapsed())),
-        PayloadStatusEnum::Invalid { validation_error } => {
-            info!(
-                validation_error,
-                "execution layer returned that the block was invalid"
-            );
-            Ok(None)
-        }
-        PayloadStatusEnum::Accepted => {
-            bail!(
-                "failed validating block because payload was accepted, meaning \
-                that it was not actually executed by the execution layer for \
-                some reason"
-            );
-        }
-        PayloadStatusEnum::Syncing => {
-            bail!(
-                "failed validating block because the execution layer reports \
-                syncing: it does not know the block's parent; the notarized \
-                chain convergence will repair the gap in the background"
-            );
-        }
+        .wrap_err("failed sending new-payload request to execution layer")?;
+    if payload_status.is_valid() {
+        info!(%payload_status, "execution layer reported payload status");
+    } else {
+        warn!(%payload_status, "execution layer reported payload status");
     }
+    Ok(payload_status.status)
 }
 
 /// Drives a payload build on the execution layer to completion.
@@ -1478,6 +1708,8 @@ async fn run_payload_job(
     }
 }
 
+/// Submits the forkchoice update and returns the raw response. Whether to
+/// submit is decided by the caller.
 #[instrument(
     skip_all,
     parent = &cause,
@@ -1486,293 +1718,18 @@ async fn run_payload_job(
         head_block_height = %canonicalized.head.0,
         finalized_block_hash = %canonicalized.finalized.1,
         finalized_block_height = %canonicalized.finalized.0,
-        ?kind,
     ),
+    err(level = Level::WARN),
 )]
 async fn submit_forkchoice_update(
     execution_node: &impl ExecutionLayer,
     cause: Span,
     canonicalized: LocalState,
     attrs: Option<TempoPayloadAttributes>,
-    kind: ForkchoiceUpdateKind,
-) -> eyre::Result<Option<PayloadId>> {
-    // The execution layer's finalized tip only ever advances. The tracked
-    // state can trail the execution layer's finality: it starts at the
-    // consensus finalized floor, which can sit below the execution layer's
-    // finalized tip after a snapshot restore, and only catches up as the
-    // marshal re-delivers the already-finalized blocks.
-    //
-    // Whenever the execution layer's finality is at or ahead of the tracked
-    // finalized block, that block must lie on the execution layer's
-    // canonical chain - anything else means two conflicting blocks were
-    // finalized. A forkchoice state whose finalized block is strictly below
-    // the execution layer's own is stale in its entirety and is not
-    // submitted. Callers treat the skip as a no-op; a payload-build request
-    // affected by it fails through the missing payload ID.
-    if let execution_finalized = execution_node.finalized_num_hash()
-        && execution_finalized.number >= canonicalized.finalized.0.get()
-    {
-        let canonical_digest = execution_node
-            .canonical_block_hash(canonicalized.finalized.0.get())
-            .wrap_err_with(|| {
-                format!(
-                    "failed reading canonical execution block hash at the tracked \
-                    finalized height `{}`",
-                    canonicalized.finalized.0,
-                )
-            })?
-            .ok_or_else(|| {
-                eyre!(
-                    "no canonical execution block hash at the tracked \
-                    finalized height `{}`, even though it is at or below the \
-                    execution layer's finalized height `{}`",
-                    canonicalized.finalized.0,
-                    execution_finalized.number,
-                )
-            })?;
-        ensure!(
-            canonical_digest == canonicalized.finalized.1.0,
-            "tracked finalized block `{}` at height `{}` conflicts with the \
-            execution layer's canonical block `{canonical_digest}` at the same \
-            height, which the execution layer already considers final; two \
-            different blocks must never be finalized at the same height",
-            canonicalized.finalized.1,
-            canonicalized.finalized.0,
-        );
-
-        if execution_finalized.number > canonicalized.finalized.0.get() {
-            debug!(
-                execution_finalized_height = execution_finalized.number,
-                execution_finalized_hash = %execution_finalized.hash,
-                "tracked finalized state is below the execution layer's \
-                finalized tip; skipping the forkchoice update",
-            );
-            return Ok(None);
-        }
-    }
-
+) -> eyre::Result<ForkchoiceUpdated> {
     let fcu_response = execution_node
         .fork_choice_updated(canonicalized.to_forkchoice_state(), attrs)
         .await
         .wrap_err("failed requesting execution layer to update forkchoice state")?;
-
-    if fcu_response.is_invalid() {
-        warn!(
-            payload_status = %fcu_response.payload_status,
-            "execution layer reported FCU status",
-        );
-    } else {
-        info!(
-            payload_status = %fcu_response.payload_status,
-            "execution layer reported FCU status",
-        );
-    }
-
-    if !fcu_response.is_valid() {
-        return Err(Report::msg(fcu_response.payload_status))
-            .wrap_err("forkchoice-update was not valid");
-    }
-
-    Ok(fcu_response.payload_id)
-}
-
-fn finalization_target(
-    execution_node: &impl ExecutionLayer,
-    canonicalized: LocalState,
-    block: &Block,
-) -> eyre::Result<LocalState> {
-    // All blocks (finalized and notarized) arrive in the EL via the executor
-    // actor. There is no pipeline sync and no other way to drive the EL
-    // forward at this point.
-    //
-    // The tracked finalized state starts at the lower of the execution
-    // layer's finalized tip and the consensus finalized floor - the lowest
-    // point the marshal delivers finalized blocks from. A delivery below the
-    // tracked state is therefore a protocol violation.
-    //
-    // Under normal operation, all blocks arrive in sequence. Only at startup
-    // does the marshal actor forward a block at the height of the finalized
-    // floor (this can include genesis).
-    ensure!(
-        block.height() >= canonicalized.finalized.0,
-        "finalized block with digest `{}` at height `{}` is below the \
-        executor's tracked finalized block `{}` at height `{}`; finalized \
-        blocks must only ever be delivered at or on top of the tracked state",
-        block.digest(),
-        block.height(),
-        canonicalized.finalized.1,
-        canonicalized.finalized.0,
-    );
-
-    if block.height() == canonicalized.finalized.0 {
-        ensure!(
-            block.digest() == canonicalized.finalized.1,
-            "finalized block with digest `{}` at height `{}` conflicts with \
-            the executor's tracked finalized block `{}` at the same height; \
-            two different blocks must never be finalized at the same height",
-            block.digest(),
-            block.height(),
-            canonicalized.finalized.1,
-        );
-        return Ok(canonicalized);
-    }
-
-    let canonical_hash = execution_node
-        .canonical_block_hash(block.height().get())
-        .wrap_err_with(|| {
-            format!(
-                "failed reading canonical execution block hash at finalized block height `{}`",
-                block.height(),
-            )
-        })?;
-    let head_descends_from_finalized = canonical_hash == Some(block.digest().0);
-
-    Ok(if head_descends_from_finalized {
-        canonicalized.update_finalized(block.height(), block.digest())
-    } else {
-        canonicalized
-            .update_finalized(block.height(), block.digest())
-            .update_head(block.height(), block.digest())
-    })
-}
-
-#[instrument(
-    skip_all,
-    fields(
-        block.digest = %request.block.digest(),
-        block.height = %request.block.height(),
-    ),
-    err(level = Level::WARN),
-    ret,
-)]
-async fn forward_finalized(
-    execution_node: impl ExecutionLayer,
-    public_key: Option<PublicKey>,
-    metrics: Metrics,
-    target: LocalState,
-    request: FinalizedBlockRequest,
-) -> eyre::Result<LocalState> {
-    let FinalizedBlockRequest {
-        cause,
-        block,
-        acknowledgment,
-    } = request;
-
-    let consensus_context = block.header().consensus_context;
-
-    let (execution_block, block_access_list) = (*block).clone().into_parts();
-    let payload_status = execution_node
-        .new_payload(TempoExecutionData {
-            block: execution_block,
-            block_access_list,
-            // can be omitted for finalized blocks
-            validator_set: None,
-        })
-        .await
-        .wrap_err(
-            "failed sending new-payload request to execution engine to \
-                query payload status of finalized block",
-        )?;
-
-    ensure!(
-        payload_status.status == PayloadStatusEnum::Valid,
-        "payload status of finalized block was not valid: {payload_status}"
-    );
-
-    submit_forkchoice_update(
-        &execution_node,
-        cause.clone(),
-        target,
-        None,
-        ForkchoiceUpdateKind::Canonicalize {
-            head_or_finalized: HeadOrFinalized::Finalized,
-        },
-    )
-    .await?;
-
-    if let Some(public_key) = public_key.as_ref()
-        && consensus_context.is_some_and(|context| context.proposer.to_inner() == *public_key)
-    {
-        metrics.finalized_blocks_proposed_by_self.inc();
-    }
-
-    acknowledgment.acknowledge();
-
-    Ok(target)
-}
-
-/// Drives convergence of the EL to the pending notarized tip.
-///
-/// The caller is responsible for only forwarding blocks that link to the
-/// canonicalized state, so the new-payload request must come back valid;
-/// anything else is an error.
-#[instrument(
-    skip_all,
-    fields(
-        block.digest = %step.digest(),
-        block.height = %step.height(),
-    ),
-    err(level = Level::WARN),
-)]
-async fn forward_notarized(
-    execution_node: impl ExecutionLayer,
-    on_top_of: LocalState,
-    target: LocalState,
-    step: NextToForward,
-    validator_set: Option<Vec<B256>>,
-) -> eyre::Result<LocalState> {
-    if let NextToForward::Block(block) = step {
-        let (block, block_access_list) = Arc::unwrap_or_clone(block).into_parts();
-        let payload_status = execution_node
-            .new_payload(TempoExecutionData {
-                block,
-                block_access_list,
-                validator_set,
-            })
-            .await
-            .wrap_err(
-                "failed sending new-payload request to execution engine to \
-                forward notarized block",
-            )?;
-        ensure!(
-            payload_status.is_valid(),
-            "payload status of notarized block was neither valid nor invalid \
-            (likely syncing): `{payload_status}`",
-        );
-    }
-
-    // The forkchoice update is skipped when it would not change anything,
-    // but the state is reported either way so that the tree's tracked
-    // state stays consistent.
-    if target == on_top_of {
-        return Ok(target);
-    }
-    submit_forkchoice_update(
-        &execution_node,
-        Span::current(),
-        target,
-        None,
-        ForkchoiceUpdateKind::Canonicalize {
-            head_or_finalized: HeadOrFinalized::Head,
-        },
-    )
-    .await?;
-    Ok(target)
-}
-
-/// Marker to indicate whether the head hash or finalized hash should be updated.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HeadOrFinalized {
-    Head,
-    Finalized,
-}
-
-impl std::fmt::Display for HeadOrFinalized {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let msg = match self {
-            Self::Head => "head",
-            Self::Finalized => "finalized",
-        };
-        f.write_str(msg)
-    }
+    Ok(fcu_response)
 }

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -1,7 +1,8 @@
 //! The notarized tree: the executor's record of the chain above the
-//! finalized tip, of the forkchoice state the execution layer last
-//! accepted, and of how far that state has converged onto the pending
-//! head's ancestry.
+//! finalized tip, of which of those blocks the execution layer has
+//! accepted, of the forkchoice state the execution layer last accepted,
+//! and of how far that state has converged onto the pending head's
+//! ancestry.
 
 use std::{
     collections::HashMap,
@@ -22,23 +23,34 @@ use crate::consensus::{Digest, block::Block};
 mod tests;
 
 /// How long a notarized block the execution layer failed to process is
-/// withheld from forwarding before it becomes eligible for a retry.
+/// withheld from delivery and forkchoice updates before it becomes
+/// eligible for a retry.
 pub(super) const NOTARIZED_REJECTION_RETRY_DELAY: Duration = Duration::from_secs(10);
 
-/// A block known to the executor together with the validator set to validate
-/// it against.
+/// A block known to the executor together with what the execution layer
+/// has said about it.
 #[derive(Clone, Debug)]
 pub(super) struct BlockEntry {
     pub(super) block: Arc<Block>,
+    /// The execution layer accepted the block through a new-payload request.
+    delivered: bool,
     rejected_at: Option<SystemTime>,
 }
 
 impl BlockEntry {
-    /// Whether the block may be forwarded at `now`: it is not withheld by
-    /// a rejection younger than [`NOTARIZED_REJECTION_RETRY_DELAY`].
+    /// Whether the block may be delivered or made the head at `now`: it is
+    /// not withheld by a rejection younger than
+    /// [`NOTARIZED_REJECTION_RETRY_DELAY`].
     fn forwardable(&self, now: SystemTime) -> bool {
         self.rejected_at
             .is_none_or(|rejected_at| now >= rejected_at + NOTARIZED_REJECTION_RETRY_DELAY)
+    }
+
+    /// The round the block's parent was notarized in, derived from the
+    /// block's consensus context.
+    fn parent_round(&self) -> Round {
+        let context = self.block.context();
+        Round::new(context.round.epoch(), context.parent.0)
     }
 }
 
@@ -91,8 +103,9 @@ impl LocalState {
     }
 }
 
-/// Tracks notarized blocks at the tip of the chain and returns which block can
-/// be forwarded to the EL next.
+/// Tracks notarized blocks at the tip of the chain and returns which block
+/// can be delivered to the execution layer next, and which block the
+/// execution layer's head can be moved onto.
 ///
 /// The canonical target is `pending_head`: the parent of the most recent
 /// consensus context. This is expected to be reported by the simplex engine via
@@ -113,29 +126,33 @@ impl LocalState {
 /// The tree holds data strictly above the finalized *network* tip,
 /// which it tracks itself: recording and pruning are guarded against it.
 ///
-/// The tree is self-canonicalizing: [`Self::next_to_forward`] walks the
-/// pending head's ancestry down to the nearest *anchor* the execution
-/// layer provably has - its own head, or the network's finalized tip -
-/// and hands out the block directly above it, derived fresh on every
-/// query. There is no cached convergence state that could go stale
-/// against a fork. When the pending head is the finalized tip itself,
-/// there is no block above the anchor: the step is a bare forkchoice
-/// update repointing the head onto the tip.
+/// # Delivery and forkchoice are separate steps
+///
+/// [`Self::next_to_deliver`] hands out the next block whose parent the
+/// execution layer *knows* (accepted through a delivery or validation, or
+/// part of the tracked state) for a bare new-payload request.
+/// [`Self::next_head`] names the highest known block on the pending head's
+/// ancestry for a forkchoice update, so an update can never make the
+/// execution layer sync. Both walk the ancestry fresh on every query.
 ///
 /// Recording methods only insert primary state (the pending head, the
-/// local state, and bodies, guarded against the finalized tip);
-/// [`Self::heal`], run by the actor once per event-loop iteration, prunes
-/// what the advancing finalized tip covers.
+/// local state, bodies and their delivery status, guarded against the
+/// finalized tip); [`Self::heal`], run by the actor once per event-loop
+/// iteration, prunes what the advancing finalized tip covers.
 #[derive(Debug)]
 pub(super) struct NotarizedTree {
     /// The latest observed finalized tip of the network: the tree's
     /// lower bound. The tree only records notarized blocks above this finalized
     /// tip.
     network_finalized_tip: (Round, Height, Digest),
+    /// The highest finalized block the execution layer accepted through a
+    /// new-payload request: the finalized side of the next forkchoice
+    /// update. Sits between `local_finalized_tip` and
+    /// `network_finalized_tip`.
+    delivered_finalized: (Height, Digest),
     /// The finalized tip as canonicalized on the execution layer: the
     /// finalized side of the last accepted forkchoice state. Trails
-    /// `network_finalized_tip` until the finalization pipeline catches up,
-    /// which forwarding is gated on.
+    /// `delivered_finalized` until the forkchoice update lands.
     local_finalized_tip: (Height, Digest),
     /// The pending head reported by the most recent consensus context: the
     /// tip of the canonical path the execution layer's head is converged
@@ -163,36 +180,6 @@ pub(super) struct Depths {
     /// below the head; `None` while the pending head's body - and with it
     /// its height - is unknown.
     pub(super) convergence_depth: Option<i64>,
-}
-
-/// The next convergence step toward the pending head, returned by
-/// [`NotarizedTree::next_to_forward`].
-#[derive(Debug)]
-pub(super) enum NextToForward {
-    /// Forward this block: a new-payload request followed by a forkchoice
-    /// update making it the head.
-    Block(Arc<Block>),
-    /// Repoint the head onto the already-known finalized tip with a bare
-    /// forkchoice update; there is no block to deliver.
-    Repoint(Height, Digest),
-}
-
-impl NextToForward {
-    /// The digest of the block the step converges the head onto.
-    pub(super) fn digest(&self) -> Digest {
-        match self {
-            Self::Block(block) => block.digest(),
-            Self::Repoint(_, digest) => *digest,
-        }
-    }
-
-    /// The height of the block the step converges the head onto.
-    pub(super) fn height(&self) -> Height {
-        match self {
-            Self::Block(block) => block.height(),
-            Self::Repoint(height, _) => *height,
-        }
-    }
 }
 
 /// The parent of the most recent consensus context: the notarized block
@@ -224,6 +211,7 @@ impl NotarizedTree {
     ) -> Self {
         Self {
             network_finalized_tip,
+            delivered_finalized: local_state.finalized,
             local_finalized_tip: local_state.finalized,
             pending_head: PendingHead::finalized_tip(network_finalized_tip),
             local_head: local_state.head,
@@ -239,6 +227,12 @@ impl NotarizedTree {
             head: self.local_head,
             finalized: self.local_finalized_tip,
         }
+    }
+
+    /// The highest finalized block the execution layer accepted: the
+    /// finalized target of the next forkchoice update.
+    pub(super) fn delivered_finalized(&self) -> (Height, Digest) {
+        self.delivered_finalized
     }
 
     /// A snapshot of the tree's convergence measures, for metrics.
@@ -263,44 +257,59 @@ impl NotarizedTree {
         }
     }
 
-    /// Returns if `digest` is at the head or finalized tip of the tracked EL state.
-    pub(super) fn is_local_notarized_or_finalized_tip(&self, digest: Digest) -> bool {
-        self.local_head.1 == digest || self.local_finalized_tip.1 == digest
+    /// Whether the execution layer has `digest`: the tracked head or
+    /// finalized block, the delivered finalized block, or a delivered entry.
+    pub(super) fn is_known(&self, digest: Digest) -> bool {
+        self.known_height(digest).is_some()
     }
 
-    /// Returns if `digest` is at the head of the tracked EL state.
-    pub(super) fn is_local_head(&self, digest: Digest) -> bool {
-        self.local_head.1 == digest
+    /// The height of `digest` if the execution layer has it.
+    pub(super) fn known_height(&self, digest: Digest) -> Option<Height> {
+        if self.local_head.1 == digest {
+            return Some(self.local_head.0);
+        }
+        if self.local_finalized_tip.1 == digest {
+            return Some(self.local_finalized_tip.0);
+        }
+        if self.delivered_finalized.1 == digest {
+            return Some(self.delivered_finalized.0);
+        }
+        self.blocks
+            .get(&digest)
+            .filter(|entry| entry.delivered)
+            .map(|entry| entry.block.height())
     }
 
-    /// Whether convergence is expected to make `digest` known to the
-    /// execution layer imminently (or if the execution layer is already
-    /// converged).
-    ///
-    /// These are the conditions:
-    ///
-    /// 1. `digest` is the local finalized tip or head, or
-    /// 2. `digest` is the network finalized tip, and the network finalized
-    ///    tip is the next block to be delivered (known fact: marshal only
-    ///    delivers finalized tips if a certificate and block are available).
-    /// 3. `digest` is the pending head, its body is in hand, and it sits
-    ///    directly on a converged anchor - the local head, or the local
-    ///    finalized tip for a fork switch replayed from the tip. One
-    ///    forward step remains either way.
+    /// Whether the execution layer has `digest` or is one step from it: the
+    /// network finalized tip about to be delivered by the marshal actor, or
+    /// the pending head with its body in hand and its parent known.
     pub(super) fn converges_imminently(&self, digest: Digest) -> bool {
-        self.is_local_notarized_or_finalized_tip(digest)
+        self.is_known(digest)
             || (self.network_finalized_tip.2 == digest
-                && self.local_finalized_tip.0.next() == self.network_finalized_tip.1)
+                && self.delivered_finalized.0.next() == self.network_finalized_tip.1)
             || (self.pending_head.digest == digest
-                && self.blocks.get(&digest).is_some_and(|entry| {
-                    self.is_local_notarized_or_finalized_tip(entry.block.parent_digest())
-                }))
+                && self
+                    .blocks
+                    .get(&digest)
+                    .is_some_and(|entry| self.is_known(entry.block.parent_digest())))
     }
 
-    /// Records a forkchoice state newly accepted by the execution layer.
+    /// Records an accepted forkchoice state. A finalized block the tree did
+    /// not see delivered (startup backfill) advances the delivered one too.
     pub(super) fn set_local_state(&mut self, local_state: LocalState) {
         self.local_head = local_state.head;
         self.local_finalized_tip = local_state.finalized;
+        if local_state.finalized.0 > self.delivered_finalized.0 {
+            self.delivered_finalized = local_state.finalized;
+        }
+    }
+
+    /// Records a finalized block the execution layer accepted; a no-op at
+    /// or below the tracked height.
+    pub(super) fn set_delivered_finalized(&mut self, height: Height, digest: Digest) {
+        if height > self.delivered_finalized.0 {
+            self.delivered_finalized = (height, digest);
+        }
     }
 
     /// Records a consensus context's parent as the pending head of the
@@ -315,6 +324,8 @@ impl NotarizedTree {
     /// Records the body of a block unless the finalized tip covers its
     /// height. Such a stale block is expunged so that it is neither
     /// fetched nor forwarded again.
+    ///
+    /// Re-recording clears a rejection but keeps the delivery status.
     pub(super) fn record_block(&mut self, block: Arc<Block>) {
         if block.height() <= self.network_finalized_tip.1 {
             debug!(
@@ -325,10 +336,16 @@ impl NotarizedTree {
             self.remove(&block.digest());
             return;
         }
+        let digest = block.digest();
+        let delivered = self
+            .blocks
+            .get(&digest)
+            .is_some_and(|entry| entry.delivered);
         self.blocks.insert(
-            block.digest(),
+            digest,
             BlockEntry {
                 block,
+                delivered,
                 rejected_at: None,
             },
         );
@@ -348,11 +365,11 @@ impl NotarizedTree {
     /// traded for recovery speed, bounded by the advancing finalized tip,
     /// which sweeps everything it passes.
     pub(super) fn heal(&mut self) {
-        // `first_missing_ancestor` and `next_to_forward` bound their walks
-        // by the network's finalized tip, which is only correct while the
-        // locally canonicalized finalized tip does not run ahead of it. The
-        // marshal actor upholds this: it reports a finalized tip before
-        // delivering the finalized blocks covered by it.
+        // `first_missing_ancestor`, `next_to_deliver` and `next_head` bound
+        // their walks by the network's finalized tip, which is only correct
+        // while the locally canonicalized finalized tip does not run ahead
+        // of it. The marshal actor upholds this: it reports a finalized tip
+        // before delivering the finalized blocks covered by it.
         debug_assert!(
             self.local_finalized_tip.0 <= self.network_finalized_tip.1,
             "the locally canonicalized finalized tip must never run ahead of \
@@ -372,14 +389,25 @@ impl NotarizedTree {
         }
     }
 
-    /// Marks the block as rejected by the execution layer at `now`,
-    /// excluding it from forwarding until
-    /// [`NOTARIZED_REJECTION_RETRY_DELAY`] has elapsed or the entry is
-    /// expunged.
-    pub(super) fn mark_rejected(&mut self, digest: &Digest, now: SystemTime) {
+    /// Marks the block as accepted by the execution layer, clearing any
+    /// rejection.
+    pub(super) fn mark_delivered(&mut self, digest: &Digest) {
         if let Some(entry) = self.blocks.get_mut(digest) {
-            entry.rejected_at = Some(now);
+            entry.delivered = true;
+            entry.rejected_at = None;
         }
+    }
+
+    /// Withholds the block from delivery for [`NOTARIZED_REJECTION_RETRY_DELAY`]
+    /// after `now` and revokes its delivery status. Returns whether the tree
+    /// holds the block.
+    pub(super) fn mark_rejected(&mut self, digest: &Digest, now: SystemTime) -> bool {
+        let Some(entry) = self.blocks.get_mut(digest) else {
+            return false;
+        };
+        entry.rejected_at = Some(now);
+        entry.delivered = false;
+        true
     }
 
     /// Removes a block from the tree, re-setting a pending head naming it
@@ -417,45 +445,45 @@ impl NotarizedTree {
         }
     }
 
-    /// Returns the next convergence step toward the pending head.
-    ///
-    /// Returns a block if it is directly above the anchor (this can be
-    /// the local head or local finalized tip).
-    ///
-    /// Returns just a digest if the execution layer is to be re-pointed to the
-    /// an ancestor of the current local head.
-    ///
-    /// *NOTE:* This digest right now only works for the finalized tip.
-    ///
-    /// **FIXME:** Allow for repointing to any ancestor.
-    pub(super) fn next_to_forward(&self, now: SystemTime) -> Option<NextToForward> {
-        if self.local_finalized_tip.0 < self.network_finalized_tip.1 {
-            return None;
-        }
-        let (_, finalized_height, finalized_digest) = self.network_finalized_tip;
+    /// The lowest block on the pending head's ancestry the execution layer
+    /// does not have but whose parent it has, if the ancestry is walkable
+    /// and no block on the way is withheld.
+    pub(super) fn next_to_deliver(&self, now: SystemTime) -> Option<Arc<Block>> {
+        let (_, finalized_height, _) = self.network_finalized_tip;
 
-        let mut child: Option<&BlockEntry> = None;
+        let mut candidate: Option<&BlockEntry> = None;
         let mut digest = self.pending_head.digest;
-        while digest != self.local_head.1 && digest != finalized_digest {
+        while !self.is_known(digest) {
             let entry = self.blocks.get(&digest)?;
-            if entry.block.height() <= finalized_height {
+            if entry.block.height() <= finalized_height || !entry.forwardable(now) {
                 return None;
             }
-            child = Some(entry);
+            candidate = Some(entry);
             digest = entry.block.parent_digest();
         }
-        match child {
-            Some(entry) => entry
-                .forwardable(now)
-                .then(|| NextToForward::Block(entry.block.clone())),
-            // If the anchor is the local finalized tip and the notarized branch
-            // is stranded, repoint to the finalized tip.
-            //
-            // NOTE: This works because we short-circuit on
-            // `local_finalized < network_finalized`. If we did not do that,
-            // this would potentially trigger a SYNCING.
-            None => (digest == finalized_digest && self.local_head.1 != finalized_digest)
-                .then_some(NextToForward::Repoint(finalized_height, finalized_digest)),
+        candidate.map(|entry| entry.block.clone())
+    }
+
+    /// The highest block on the pending head's ancestry the execution layer
+    /// has, if it is not the head already, the ancestry down to it is
+    /// walkable, and no block on the way is withheld. Bottoming out on the
+    /// finalized tip repoints onto it.
+    pub(super) fn next_head(&self, now: SystemTime) -> Option<(Height, Digest)> {
+        let (_, finalized_height, _) = self.network_finalized_tip;
+
+        let mut digest = self.pending_head.digest;
+        loop {
+            if digest == self.local_head.1 {
+                return None;
+            }
+            if let Some(height) = self.known_height(digest) {
+                return Some((height, digest));
+            }
+            let entry = self.blocks.get(&digest)?;
+            if entry.block.height() <= finalized_height || !entry.forwardable(now) {
+                return None;
+            }
+            digest = entry.block.parent_digest();
         }
     }
 
@@ -483,8 +511,7 @@ impl NotarizedTree {
             if entry.block.height() <= finalized_height {
                 break;
             }
-            let context = entry.block.context();
-            round = Round::new(context.round.epoch(), context.parent.0);
+            round = entry.parent_round();
             digest = entry.block.parent_digest();
         }
         None

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -180,6 +180,9 @@ pub(super) struct Depths {
     /// below the head; `None` while the pending head's body - and with it
     /// its height - is unknown.
     pub(super) convergence_depth: Option<i64>,
+    /// Number of held blocks the execution layer accepted that are not on
+    /// its canonical chain: delivered above the head, or on other branches.
+    pub(super) uncanonicalized_blocks: usize,
 }
 
 /// The parent of the most recent consensus context: the notarized block
@@ -247,6 +250,18 @@ impl NotarizedTree {
                 .get(&self.pending_head.digest)
                 .map(|entry| entry.block.height())
         };
+        // The head's ancestry held by the tree is the canonical part.
+        let mut canonical = std::collections::HashSet::new();
+        let mut digest = self.local_head.1;
+        while let Some(entry) = self.blocks.get(&digest) {
+            canonical.insert(digest);
+            digest = entry.block.parent_digest();
+        }
+        let uncanonicalized_blocks = self
+            .blocks
+            .iter()
+            .filter(|(digest, entry)| entry.delivered && !canonical.contains(digest))
+            .count();
         Depths {
             blocks: self.blocks.len(),
             finalization_lag: network_finalized_height
@@ -254,6 +269,7 @@ impl NotarizedTree {
                 .saturating_sub(self.local_finalized_tip.0.get()),
             convergence_depth: pending_height
                 .map(|height| height.get() as i64 - self.local_head.0.get() as i64),
+            uncanonicalized_blocks,
         }
     }
 

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -301,18 +301,16 @@ impl NotarizedTree {
             .map(|entry| entry.block.height())
     }
 
-    /// Whether the execution layer has `digest` or is one step from it: the
-    /// network finalized tip about to be delivered by the marshal actor, or
-    /// the pending head with its body in hand and its parent known.
-    pub(super) fn converges_imminently(&self, digest: Digest) -> bool {
-        self.is_known(digest)
+    /// Whether `digest` is the next thing convergence does: the head target
+    /// of the next forkchoice update, the next block to deliver, or the next
+    /// finalized block the marshal actor delivers.
+    pub(super) fn converges_imminently(&self, digest: Digest, now: SystemTime) -> bool {
+        self.next_head(now).is_some_and(|(_, head)| head == digest)
+            || self
+                .next_to_deliver(now)
+                .is_some_and(|block| block.digest() == digest)
             || (self.network_finalized_tip.2 == digest
                 && self.delivered_finalized.0.next() == self.network_finalized_tip.1)
-            || (self.pending_head.digest == digest
-                && self
-                    .blocks
-                    .get(&digest)
-                    .is_some_and(|entry| self.is_known(entry.block.parent_digest())))
     }
 
     /// Records an accepted forkchoice state. A finalized block the tree did

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -263,6 +263,11 @@ impl NotarizedTree {
         self.known_height(digest).is_some()
     }
 
+    /// Returns if `digest` is at the head of the tracked EL state.
+    pub(super) fn is_local_head(&self, digest: Digest) -> bool {
+        self.local_head.1 == digest
+    }
+
     /// The height of `digest` if the execution layer has it.
     pub(super) fn known_height(&self, digest: Digest) -> Option<Height> {
         if self.local_head.1 == digest {

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -222,6 +222,11 @@ impl NotarizedTree {
         }
     }
 
+    /// The block consensus reported building on: the convergence target.
+    pub(super) fn pending_head(&self) -> Digest {
+        self.pending_head.digest
+    }
+
     /// A snapshot of the latest forkchoice state accepted by the execution
     /// layer, for execution tasks to extend. States the execution layer
     /// accepts are reported back via [`Self::set_local_state`].

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -516,48 +516,51 @@ fn finalized_tip_reroots_a_head_stranded_on_an_orphaned_branch() {
     assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
 }
 
-/// The deferral predicate for consensus requests: a parent converges
-/// imminently when the execution layer already knows it, or when it is
-/// the pending head, its body in hand, one delivery above a known block -
-/// and does not when it is further out, its body needs a fetch, or it
-/// belongs to a superseded report.
+/// The deferral predicate for consensus requests: a block is imminent when
+/// it is the next block to deliver or the next head target, and not when it
+/// is further out, its body needs a fetch, or it is already converged.
 #[test]
-fn convergence_is_imminent_only_one_delivery_from_a_known_block() {
+fn convergence_is_imminent_for_the_next_delivery_or_head_target() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // The delivered finalized tip is converged already.
-    assert!(tree.converges_imminently(finalized));
+    // The converged finalized tip is nothing convergence still does;
+    // callers check for known blocks first.
+    assert!(!tree.converges_imminently(finalized, T0));
 
     // A pending head whose recorded body sits directly on a known block
-    // (here the finalized tip) is one delivery away ...
+    // (here the finalized tip) is the next delivery ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
-    assert!(tree.converges_imminently(a.digest()));
+    assert!(tree.converges_imminently(a.digest(), T0));
 
     // ... but two deliveries away is not imminent: a needs a delivery
     // first. The delivery alone suffices; the head need not move.
     let b = block(2, 12, a.digest());
     record(&mut tree, &b);
-    assert!(!tree.converges_imminently(b.digest()));
+    assert!(!tree.converges_imminently(b.digest(), T0));
     delivered(&mut tree, &a);
-    assert!(tree.converges_imminently(b.digest()));
-    // The superseded a stays imminent because the execution layer knows it.
-    assert!(tree.converges_imminently(a.digest()));
+    assert!(tree.converges_imminently(b.digest(), T0));
+    // The delivered a is the next head target: imminent as well.
+    assert!(tree.converges_imminently(a.digest(), T0));
 
     // A pending head whose body is not in hand needs a fetch first: the
     // report alone does not make it imminent.
     let c = block(3, 13, b.digest());
     report_parent(&mut tree, &c);
     tree.heal();
-    assert!(!tree.converges_imminently(c.digest()));
+    assert!(!tree.converges_imminently(c.digest(), T0));
 
     // A sibling fork one step above the finalized tip is imminent even
     // though it is not the head's child: it is delivered directly on top
     // of the tip.
     let a2 = block(4, 11, finalized);
     record(&mut tree, &a2);
-    assert!(tree.converges_imminently(a2.digest()));
+    assert!(tree.converges_imminently(a2.digest(), T0));
+
+    // A withheld block is not delivered next.
+    tree.mark_rejected(&a2.digest(), T0);
+    assert!(!tree.converges_imminently(a2.digest(), T0));
 }
 
 /// The tree's convergence measures: block-body count, the undelivered
@@ -620,18 +623,18 @@ fn next_finalized_delivery_is_imminent() {
     let next = block(1, 11, finalized);
     tree.set_network_finalized_tip(round(1), Height::new(11), next.digest());
     tree.heal();
-    assert!(tree.converges_imminently(next.digest()));
+    assert!(tree.converges_imminently(next.digest(), T0));
 
     // Two above: an undelivered block sits below the tip.
     let above = block(2, 12, next.digest());
     tree.set_network_finalized_tip(round(2), Height::new(12), above.digest());
     tree.heal();
-    assert!(!tree.converges_imminently(above.digest()));
+    assert!(!tree.converges_imminently(above.digest(), T0));
 
     // The gap closes as deliveries land - before the forkchoice update
     // finalizing them.
     tree.set_delivered_finalized(Height::new(11), next.digest());
-    assert!(tree.converges_imminently(above.digest()));
+    assert!(tree.converges_imminently(above.digest(), T0));
 }
 
 /// Blocks the execution layer knows: the canonicalized state, the

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -7,7 +7,7 @@ use commonware_consensus::{CertifiableBlock as _, Heightable as _};
 
 use std::time::{Duration, SystemTime};
 
-use super::{LocalState, NOTARIZED_REJECTION_RETRY_DELAY, NextToForward, NotarizedTree};
+use super::{LocalState, NOTARIZED_REJECTION_RETRY_DELAY, NotarizedTree};
 use crate::consensus::{Digest, block::Block};
 
 /// The reference "now" for tree queries; tests state rejection times
@@ -75,30 +75,33 @@ fn record(tree: &mut NotarizedTree, block: &Block) {
     tree.heal();
 }
 
-/// The next block to forward, if any; panics if the next convergence step
-/// is a repoint instead of a block.
-fn next_block(tree: &NotarizedTree, now: SystemTime) -> Option<std::sync::Arc<Block>> {
-    match tree.next_to_forward(now) {
-        Some(NextToForward::Block(block)) => Some(block),
-        Some(NextToForward::Repoint(height, digest)) => {
-            panic!("expected a block to forward, got a repoint to `{digest}` at `{height}`")
-        }
-        None => None,
-    }
+/// The digest of the next block to deliver, if any.
+fn next_delivery(tree: &NotarizedTree, now: SystemTime) -> Option<Digest> {
+    tree.next_to_deliver(now).map(|block| block.digest())
 }
 
-/// Simulates the completed forward of `block`: the execution layer
-/// accepted it as its new head, and the resulting forkchoice state is
-/// reported back into the tree.
-fn forwarded(tree: &mut NotarizedTree, block: &Block) {
+/// Simulates the completed delivery of `block`: the execution layer
+/// accepted its new-payload request.
+fn delivered(tree: &mut NotarizedTree, block: &Block) {
+    tree.mark_delivered(&block.digest());
+}
+
+/// Simulates an accepted forkchoice update moving the head onto `block`.
+fn head_moved(tree: &mut NotarizedTree, block: &Block) {
     let local_state = tree
         .local_state()
         .update_head(block.height(), block.digest());
     tree.set_local_state(local_state);
 }
 
+/// Simulates full convergence onto `block`: delivered, then made the head.
+fn converged(tree: &mut NotarizedTree, block: &Block) {
+    delivered(tree, block);
+    head_moved(tree, block);
+}
+
 #[test]
-fn forwards_chain_on_top_of_finalized_tip_in_order() {
+fn delivers_chain_on_top_of_finalized_tip_bottom_up() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
@@ -107,15 +110,24 @@ fn forwards_chain_on_top_of_finalized_tip_in_order() {
     record(&mut tree, &a);
     record(&mut tree, &b);
 
-    let next = next_block(&tree, T0).expect("chain start");
-    assert_eq!(next.digest(), a.digest());
+    // Only the block directly above a known block can be delivered; there
+    // is no known block to move the head onto yet.
+    assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
+    assert_eq!(tree.next_head(T0), None);
 
-    forwarded(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain continues");
-    assert_eq!(next.digest(), b.digest());
+    // Once a is delivered, b is deliverable and a is the highest known
+    // block on the path: the head can already move onto it.
+    delivered(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), a.digest())));
 
-    forwarded(&mut tree, &b);
-    assert!(next_block(&tree, T0).is_none());
+    // With the whole path delivered, one forkchoice update covers it.
+    delivered(&mut tree, &b);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+
+    head_moved(&mut tree, &b);
+    assert_eq!(tree.next_head(T0), None);
 }
 
 #[test]
@@ -126,63 +138,65 @@ fn sibling_notarized_in_later_round_supersedes() {
     let a1 = block(1, 11, finalized);
     let a2 = block(2, 11, finalized);
     record(&mut tree, &a1);
-    // The stale sibling was forwarded and become the head ...
-    forwarded(&mut tree, &a1);
+    // The stale sibling was converged onto and became the head ...
+    converged(&mut tree, &a1);
 
     // ... but a report of its sibling redefines the canonical path; the
     // walk anchors at the finalized tip, and the superseding sibling is
-    // forwarded next.
+    // delivered next and then made the head.
     record(&mut tree, &a2);
-    let next = next_block(&tree, T0).expect("supersede fork");
-    assert_eq!(next.digest(), a2.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(a2.digest()));
+    delivered(&mut tree, &a2);
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), a2.digest())));
 }
 
 #[test]
-fn fork_replays_from_the_nearest_anchor() {
+fn fork_extends_from_the_nearest_known_block() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // F - N0 - N1 - N2 is forwarded in full ...
+    // F - N0 - N1 - N2 is converged onto in full ...
     let n0 = block(1, 11, finalized);
     let n1 = block(2, 12, n0.digest());
     let n2 = block(3, 13, n1.digest());
     record(&mut tree, &n0);
     record(&mut tree, &n1);
     record(&mut tree, &n2);
-    forwarded(&mut tree, &n2);
-    assert!(next_block(&tree, T0).is_none());
+    delivered(&mut tree, &n0);
+    delivered(&mut tree, &n1);
+    converged(&mut tree, &n2);
+    assert_eq!(next_delivery(&tree, T0), None);
 
     // ... when F - N0 - N1' - N3 becomes the canonical chain. The report
-    // arrives before the bodies; forwarding stalls until the ancestry
+    // arrives before the bodies; delivery stalls until the ancestry
     // is walkable.
     let n1p = block(4, 12, n0.digest());
     let n3 = block(5, 13, n1p.digest());
     report_parent(&mut tree, &n3);
     tree.heal();
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 
     // N3's body arrives, but its parent N1' is still missing: the
     // ancestry does not reach down to a block the execution layer has.
     tree.record_block(n3.clone().into());
     tree.heal();
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 
     // N1' arrives via the fetch machinery, completing the ancestry. The
-    // head (N2) sits off the new canonical path and is no anchor, so the
-    // walk runs to the finalized tip and the path is replayed from there:
-    // the trunk block N0 - already known to the execution layer, which
-    // answers it from its caches - comes first, then the fork branch.
+    // head (N2) sits off the new canonical path, but the trunk block N0 is
+    // known to the execution layer: the fork branch is delivered from
+    // directly above it, and the head can be moved back onto N0 meanwhile.
     tree.record_block(n1p.clone().into());
     tree.heal();
-
-    let next = next_block(&tree, T0).expect("trunk replay");
-    assert_eq!(next.digest(), n0.digest());
-    forwarded(&mut tree, &n0);
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), n1p.digest());
-    forwarded(&mut tree, &n1p);
-    let next = next_block(&tree, T0).expect("fork tip");
-    assert_eq!(next.digest(), n3.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(n1p.digest()));
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), n0.digest())));
+    delivered(&mut tree, &n1p);
+    assert_eq!(next_delivery(&tree, T0), Some(n3.digest()));
+    delivered(&mut tree, &n3);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(13), n3.digest())));
 }
 
 #[test]
@@ -190,12 +204,13 @@ fn fork_during_ancestor_fetch_keeps_the_fetch_target() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // F - N1 - N2 is forwarded in full ...
+    // F - N1 - N2 is converged onto in full ...
     let n1 = block(1, 11, finalized);
     let n2 = block(2, 12, n1.digest());
     record(&mut tree, &n1);
     record(&mut tree, &n2);
-    forwarded(&mut tree, &n2);
+    delivered(&mut tree, &n1);
+    converged(&mut tree, &n2);
 
     // ... when the chain forks to F - N3 - N4. N3's report arrives first
     // (from the context preceding N4's validation) and becomes the
@@ -213,24 +228,25 @@ fn fork_during_ancestor_fetch_keeps_the_fetch_target() {
     tree.heal();
 
     // ... and the fetch target is unchanged — N3, re-derived from N4's
-    // context — so the in-flight fetch for N3 is kept, and forwarding
+    // context — so the in-flight fetch for N3 is kept, and delivery
     // stalls on the gap meanwhile.
     assert_eq!(tree.first_missing_ancestor(), Some((round(3), n3.digest())),);
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
 
     // The landed fetch delivers N3's body, completing the ancestry down
-    // to the finalized tip - the anchor while the head sits on the
-    // orphaned branch.
+    // to the finalized tip - the nearest known block while the head sits
+    // on the orphaned branch.
     tree.record_block(n3.clone().into());
     tree.heal();
 
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), n3.digest());
-    forwarded(&mut tree, &n3);
-    let next = next_block(&tree, T0).expect("fork tip");
-    assert_eq!(next.digest(), n4.digest());
-    forwarded(&mut tree, &n4);
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), Some(n3.digest()));
+    delivered(&mut tree, &n3);
+    assert_eq!(next_delivery(&tree, T0), Some(n4.digest()));
+    delivered(&mut tree, &n4);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), n4.digest())));
+    head_moved(&mut tree, &n4);
+    assert_eq!(tree.next_head(T0), None);
 }
 
 #[test]
@@ -246,16 +262,15 @@ fn heads_off_the_canonical_path_are_no_anchor() {
     record(&mut tree, &b2);
 
     // A head off the canonical path (b1 was superseded by b2) is no
-    // anchor: the walk runs to the finalized tip, and the path is
-    // replayed from there - the common parent a first (a cached no-op
-    // for the execution layer), then the superseding sibling.
-    forwarded(&mut tree, &a);
-    forwarded(&mut tree, &b1);
-    let next = next_block(&tree, T0).expect("replayed parent");
-    assert_eq!(next.digest(), a.digest());
-    forwarded(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain continues");
-    assert_eq!(next.digest(), b2.digest());
+    // anchor: the superseding sibling is delivered on top of the common
+    // parent a, which the execution layer knows, and the head - until b2
+    // is delivered - can only be moved back onto a.
+    delivered(&mut tree, &a);
+    converged(&mut tree, &b1);
+    assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), a.digest())));
+    delivered(&mut tree, &b2);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b2.digest())));
 }
 
 #[test]
@@ -271,8 +286,9 @@ fn missing_body_caps_the_chain() {
     report_parent(&mut tree, &b);
     record(&mut tree, &c);
 
-    forwarded(&mut tree, &a);
-    assert!(next_block(&tree, T0).is_none());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 }
 
 #[test]
@@ -358,7 +374,7 @@ fn finalized_tip_never_regresses() {
     record(&mut tree, &b);
     tree.set_network_finalized_tip(round(1), Height::new(11), a.digest());
     tree.heal();
-    forwarded(&mut tree, &b);
+    converged(&mut tree, &b);
 
     // A tip below the tracked one (replayed on startup) is ignored: the
     // boundary, the tree's data, and the local head stay untouched.
@@ -428,11 +444,11 @@ fn validation_cached_ancestors_complete_the_ancestry_without_a_fetch() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // The old fork F - A is forwarded in full ...
+    // The old fork F - A is converged onto in full ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
-    forwarded(&mut tree, &a);
-    assert!(next_block(&tree, T0).is_none());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), None);
 
     // ... while the winning fork's ancestor B1 is cached by its validation
     // — a body without any report; it is never named a pending head.
@@ -449,14 +465,11 @@ fn validation_cached_ancestors_complete_the_ancestry_without_a_fetch() {
     tree.heal();
     assert_eq!(tree.first_missing_ancestor(), None);
 
-    // ... but the heal pass walks the ancestry and re-roots the stranded
-    // meet down to the fork point, and the fork branch is forwarded
-    // from its start.
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), b1.digest());
-    forwarded(&mut tree, &b1);
-    let next = next_block(&tree, T0).expect("fork tip");
-    assert_eq!(next.digest(), b2.digest());
+    // ... but the walk down the ancestry finds the fork point at the
+    // finalized tip, and the fork branch is delivered from its start.
+    assert_eq!(next_delivery(&tree, T0), Some(b1.digest()));
+    delivered(&mut tree, &b1);
+    assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
 }
 
 #[test]
@@ -464,12 +477,13 @@ fn finalized_tip_reroots_a_head_stranded_on_an_orphaned_branch() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // The fork F - A1 - A2 is reported and forwarded in full ...
+    // The fork F - A1 - A2 is reported and converged onto in full ...
     let a1 = block(1, 11, finalized);
     let a2 = block(2, 12, a1.digest());
     record(&mut tree, &a1);
     record(&mut tree, &a2);
-    forwarded(&mut tree, &a2);
+    delivered(&mut tree, &a1);
+    converged(&mut tree, &a2);
 
     // ... when the network finalizes B1, A1's sibling, orphaning the
     // branch the head sits on. The heal pass re-sets the fork's pending
@@ -480,50 +494,55 @@ fn finalized_tip_reroots_a_head_stranded_on_an_orphaned_branch() {
     tree.heal();
     assert_eq!(tree.pending_head.digest, b1.digest());
 
-    // The finalization pipeline delivers B1; the head - sitting on the
-    // orphaned branch - is rebased onto it (mirroring
-    // `forward_finalized`), which also reopens the forwarding gate.
+    // Nothing can be named while B1 is undelivered; its delivery through
+    // the finalization pipeline makes it the head target (a repoint) ...
+    assert_eq!(tree.next_head(T0), None);
+    tree.set_delivered_finalized(Height::new(11), b1.digest());
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), b1.digest())));
+
+    // ... and the accepted forkchoice update rebases the stranded head.
     let local_state = tree
         .local_state()
         .update_finalized(Height::new(11), b1.digest())
         .update_head(Height::new(11), b1.digest());
     tree.set_local_state(local_state);
+    assert_eq!(tree.next_head(T0), None);
 
-    // The next report builds on B2: the rebased head B1 anchors the
-    // walk, so B2 is forwarded without any fetch.
+    // The next report builds on B2: the rebased head B1 is known, so B2
+    // is delivered without any fetch.
     report_parent(&mut tree, &b2);
     tree.record_block(b2.clone().into());
     tree.heal();
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), b2.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
 }
 
 /// The deferral predicate for consensus requests: a parent converges
-/// imminently when the execution layer already has it (head or finalized
-/// tip), or when it is the pending head, its body in hand, one forward
-/// step above a converged anchor - and does not when it is further out,
-/// its body needs a fetch, or it belongs to a superseded report.
+/// imminently when the execution layer already knows it, or when it is
+/// the pending head, its body in hand, one delivery above a known block -
+/// and does not when it is further out, its body needs a fetch, or it
+/// belongs to a superseded report.
 #[test]
-fn convergence_is_imminent_only_one_step_from_an_anchor() {
+fn convergence_is_imminent_only_one_delivery_from_a_known_block() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
     // The delivered finalized tip is converged already.
     assert!(tree.converges_imminently(finalized));
 
-    // A pending head whose recorded body sits directly on the head (here
-    // still the finalized tip) is one forward step away ...
+    // A pending head whose recorded body sits directly on a known block
+    // (here the finalized tip) is one delivery away ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
     assert!(tree.converges_imminently(a.digest()));
 
-    // ... but two steps away is not imminent: b needs a forwarded first.
+    // ... but two deliveries away is not imminent: a needs a delivery
+    // first. The delivery alone suffices; the head need not move.
     let b = block(2, 12, a.digest());
     record(&mut tree, &b);
     assert!(!tree.converges_imminently(b.digest()));
-    forwarded(&mut tree, &a);
+    delivered(&mut tree, &a);
     assert!(tree.converges_imminently(b.digest()));
-    // The superseded a stays imminent only because the head sits on it.
+    // The superseded a stays imminent because the execution layer knows it.
     assert!(tree.converges_imminently(a.digest()));
 
     // A pending head whose body is not in hand needs a fetch first: the
@@ -534,8 +553,8 @@ fn convergence_is_imminent_only_one_step_from_an_anchor() {
     assert!(!tree.converges_imminently(c.digest()));
 
     // A sibling fork one step above the finalized tip is imminent even
-    // though it is not the head's child: the replay from the tip anchor
-    // hands it out directly.
+    // though it is not the head's child: it is delivered directly on top
+    // of the tip.
     let a2 = block(4, 11, finalized);
     record(&mut tree, &a2);
     assert!(tree.converges_imminently(a2.digest()));
@@ -570,7 +589,8 @@ fn depths_measure_backlogs() {
     assert_eq!(tree.depths().convergence_depth, None);
 
     // A re-anchor below the head measures negative.
-    forwarded(&mut tree, &b);
+    delivered(&mut tree, &a);
+    converged(&mut tree, &b);
     tree.set_pending_head(round(4), a.digest());
     assert_eq!(tree.depths().convergence_depth, Some(-1));
 
@@ -586,8 +606,8 @@ fn next_finalized_delivery_is_imminent() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // One above the local finalized tip: the marshal's next dispatch is
-    // the tip itself.
+    // One above the delivered finalized block: the marshal's next
+    // dispatch is the tip itself.
     let next = block(1, 11, finalized);
     tree.set_network_finalized_tip(round(1), Height::new(11), next.digest());
     tree.heal();
@@ -599,53 +619,93 @@ fn next_finalized_delivery_is_imminent() {
     tree.heal();
     assert!(!tree.converges_imminently(above.digest()));
 
-    // The gap closes as deliveries land.
-    let local_state = tree
-        .local_state()
-        .update_finalized(Height::new(11), next.digest())
-        .update_head(Height::new(11), next.digest());
-    tree.set_local_state(local_state);
+    // The gap closes as deliveries land - before the forkchoice update
+    // finalizing them.
+    tree.set_delivered_finalized(Height::new(11), next.digest());
     assert!(tree.converges_imminently(above.digest()));
 }
 
+/// Blocks the execution layer knows: the canonicalized state, the
+/// delivered finalized block, and delivered notarized blocks - not
+/// recorded bodies the execution layer has not seen.
+#[test]
+fn known_blocks_are_the_canonicalized_state_and_delivered_blocks() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+    assert_eq!(tree.known_height(finalized), Some(Height::new(10)));
+
+    // A recorded body is not known until delivered.
+    let a = block(1, 11, finalized);
+    record(&mut tree, &a);
+    assert!(!tree.is_known(a.digest()));
+    delivered(&mut tree, &a);
+    assert_eq!(tree.known_height(a.digest()), Some(Height::new(11)));
+
+    // Re-recording the body keeps the delivery status.
+    tree.record_block(a.clone().into());
+    assert!(tree.is_known(a.digest()));
+
+    // A delivered finalized block is known before it is canonicalized.
+    let f = block(2, 11, finalized);
+    tree.set_network_finalized_tip(round(2), Height::new(11), f.digest());
+    tree.heal();
+    assert!(!tree.is_known(f.digest()));
+    tree.set_delivered_finalized(Height::new(11), f.digest());
+    assert_eq!(tree.known_height(f.digest()), Some(Height::new(11)));
+    assert_eq!(
+        tree.delivered_finalized(),
+        (Height::new(11), f.digest()),
+        "the delivered finalized block is the next finalized target",
+    );
+
+    // Canonicalizing a finalized block the tree did not see delivered
+    // (the startup backfill) advances the delivered finalized block too.
+    let g = block(3, 12, f.digest());
+    tree.set_network_finalized_tip(round(3), Height::new(12), g.digest());
+    tree.heal();
+    tree.set_local_state(LocalState {
+        head: (Height::new(12), g.digest()),
+        finalized: (Height::new(12), g.digest()),
+    });
+    assert_eq!(tree.delivered_finalized(), (Height::new(12), g.digest()));
+    assert!(tree.is_known(g.digest()));
+}
+
 /// A head stranded on an abandoned notarized branch while consensus
-/// re-anchors on the (already forwarded) finalized tip itself: the walk in
-/// `next_to_forward` cannot reach an anchor - it only hands out blocks
-/// strictly above one - so `repoint_to_finalized_tip` must take over and
-/// report the tip to repoint the head onto.
+/// re-anchors on the (already delivered) finalized tip itself: there is
+/// nothing to deliver, and the head target is the tip.
 #[test]
 fn stranded_head_is_repointed_onto_the_finalized_tip() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
     // No convergence step while the head sits on the finalized tip.
-    assert!(tree.next_to_forward(T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 
-    // A block is notarized and forwarded, then its view nullifies and the
-    // network abandons it; consensus re-anchors on the finalized tip.
+    // A block is notarized and converged onto, then its view nullifies
+    // and the network abandons it; consensus re-anchors on the finalized
+    // tip.
     let abandoned = block(1, 11, finalized);
     record(&mut tree, &abandoned);
-    forwarded(&mut tree, &abandoned);
+    converged(&mut tree, &abandoned);
     tree.set_pending_head(round(0), finalized);
     tree.heal();
 
-    // There is no block above the anchor to hand out; the step is the
-    // repoint.
-    let Some(NextToForward::Repoint(height, digest)) = tree.next_to_forward(T0) else {
-        panic!("stranded head must be repointed");
-    };
-    assert_eq!((height, digest), (Height::new(10), finalized));
+    // There is no block to deliver; the head target is the tip.
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(10), finalized)));
 
     // The repoint forkchoice update is accepted: the head is back on the
     // tip and there is nothing left to do.
-    let local_state = tree.local_state().update_head(height, digest);
+    let local_state = tree.local_state().update_head(Height::new(10), finalized);
     tree.set_local_state(local_state);
     assert_eq!(tree.local_state().head, (Height::new(10), finalized));
-    assert!(tree.next_to_forward(T0).is_none());
+    assert_eq!(tree.next_head(T0), None);
 }
 
 /// No repoint while the finalized-block delivery for the tip is still
-/// outstanding: the finalization pipeline moves the head then.
+/// outstanding: the tip cannot be named before the execution layer has it.
 #[test]
 fn no_repoint_while_the_finalized_tip_delivery_is_outstanding() {
     let finalized = Digest(B256::repeat_byte(0xff));
@@ -653,24 +713,29 @@ fn no_repoint_while_the_finalized_tip_delivery_is_outstanding() {
 
     let a1 = block(1, 11, finalized);
     record(&mut tree, &a1);
-    forwarded(&mut tree, &a1);
+    converged(&mut tree, &a1);
 
-    // A sibling of the forwarded block finalizes; its delivery has not
+    // A sibling of the converged block finalizes; its delivery has not
     // arrived yet. A report re-anchoring on it must not trigger a repoint.
     let b1 = block(2, 11, finalized);
     tree.set_network_finalized_tip(round(2), Height::new(11), b1.digest());
     tree.set_pending_head(round(2), b1.digest());
     tree.heal();
-    assert!(tree.next_to_forward(T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 
-    // The delivery lands (mirroring `forward_finalized`), rebasing the
-    // head; there is nothing left to repoint.
+    // The delivery lands: the head target is the finalized block ...
+    tree.set_delivered_finalized(Height::new(11), b1.digest());
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), b1.digest())));
+
+    // ... and once the forkchoice update rebased the head, there is
+    // nothing left to repoint.
     let local_state = tree
         .local_state()
         .update_finalized(Height::new(11), b1.digest())
         .update_head(Height::new(11), b1.digest());
     tree.set_local_state(local_state);
-    assert!(tree.next_to_forward(T0).is_none());
+    assert_eq!(tree.next_head(T0), None);
 }
 
 #[test]
@@ -678,33 +743,33 @@ fn reported_parents_supersede_by_report_order_not_notarization_order() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // X and its child Y are forwarded in full ...
+    // X and its child Y are converged onto in full ...
     let x = block(1, 11, finalized);
     let y = block(2, 12, x.digest());
     record(&mut tree, &x);
     record(&mut tree, &y);
-    forwarded(&mut tree, &y);
-    assert!(next_block(&tree, T0).is_none());
+    delivered(&mut tree, &x);
+    converged(&mut tree, &y);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 
     // ... but Y never certifies, and a later context reports the *older*
-    // X as the parent being built on. With the head still on Y - not on
-    // X's ancestry - the walk anchors at the finalized tip and hands out
-    // X itself, so that its forkchoice update repoints the head.
+    // X as the parent being built on. X is known to the execution layer:
+    // nothing is delivered, the head is repointed onto X directly.
     report_parent(&mut tree, &x);
     tree.heal();
-    let next = next_block(&tree, T0).expect("repoint to older parent");
-    assert_eq!(next.digest(), x.digest());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), x.digest())));
     // Once the head is X, there is nothing left to do.
-    forwarded(&mut tree, &x);
-    assert!(next_block(&tree, T0).is_none());
+    head_moved(&mut tree, &x);
+    assert_eq!(tree.next_head(T0), None);
 
     // A context building on Y again re-roots forward: Y is the pending
-    // head once more and, with the head on X, is simply the next block
-    // to forward.
+    // head once more and, being known, simply the next head.
     report_parent(&mut tree, &y);
     tree.heal();
-    let next = next_block(&tree, T0).expect("flip back");
-    assert_eq!(next.digest(), y.digest());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), y.digest())));
 }
 
 #[test]
@@ -712,29 +777,28 @@ fn head_reported_while_the_ancestry_was_unwalkable_is_found() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // A is picked up for forwarding ...
+    // A is picked up for delivery ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain start");
-    assert_eq!(next.digest(), a.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
 
-    // ... and while the forward is in flight, B's report arrives without
-    // its body. The completed forward makes A the head, but the pending
+    // ... and while the delivery is in flight, B's report arrives without
+    // its body. The completed delivery makes A known, but the pending
     // head's ancestry is not walkable yet, so nothing can be handed out.
     let b = block(2, 12, a.digest());
     report_parent(&mut tree, &b);
     tree.heal();
-    forwarded(&mut tree, &a);
-    assert!(next_block(&tree, T0).is_none());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
 
-    // B's body closes the gap: the head A - derived fresh as the anchor
-    // - is found, and B is the next block to forward. (A cached
+    // B's body closes the gap: the known A - derived fresh as the anchor
+    // - is found, and B is the next block to deliver. (A cached
     // convergence position would have missed A's head report while the
     // ancestry was unwalkable and re-selected A forever.)
     tree.record_block(b.clone().into());
     tree.heal();
-    let next = next_block(&tree, T0).expect("gap closed");
-    assert_eq!(next.digest(), b.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
 }
 
 #[test]
@@ -747,28 +811,63 @@ fn rejected_blocks_are_withheld_until_the_retry_delay_elapses() {
     record(&mut tree, &a);
     record(&mut tree, &b);
 
-    // The rejected candidate halts forwarding until the retry delay has
+    // The rejected candidate halts delivery until the retry delay has
     // fully elapsed.
-    tree.mark_rejected(&a.digest(), T0);
-    assert!(next_block(&tree, T0).is_none());
+    assert!(tree.mark_rejected(&a.digest(), T0));
+    assert_eq!(next_delivery(&tree, T0), None);
     let just_before_retry = T0 + NOTARIZED_REJECTION_RETRY_DELAY - Duration::from_millis(1);
-    assert!(next_block(&tree, just_before_retry).is_none());
-    let next = next_block(&tree, T0 + NOTARIZED_REJECTION_RETRY_DELAY).expect("rejection expired");
-    assert_eq!(next.digest(), a.digest());
+    assert_eq!(next_delivery(&tree, just_before_retry), None);
+    assert_eq!(
+        next_delivery(&tree, T0 + NOTARIZED_REJECTION_RETRY_DELAY),
+        Some(a.digest())
+    );
 
     // Re-recording the body clears the timestamp.
     tree.mark_rejected(&a.digest(), T0);
     tree.record_block(a.clone().into());
     tree.heal();
-    let next = next_block(&tree, T0).expect("timestamp cleared");
-    assert_eq!(next.digest(), a.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
 
     // Blocks above the rejected one are unaffected once the head is
     // past it.
     tree.mark_rejected(&a.digest(), T0);
-    forwarded(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain continues");
-    assert_eq!(next.digest(), b.digest());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
+
+    // Blocks the tree does not hold cannot be marked.
+    assert!(!tree.mark_rejected(&Digest(B256::repeat_byte(0xaa)), T0));
+}
+
+/// A rejection revokes the block's delivery status: the execution layer
+/// refused a forkchoice update naming it, so it is delivered anew - after
+/// the retry delay - before it is named again.
+#[test]
+fn rejection_revokes_delivery() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    let a = block(1, 11, finalized);
+    let b = block(2, 12, a.digest());
+    record(&mut tree, &a);
+    record(&mut tree, &b);
+    delivered(&mut tree, &a);
+    delivered(&mut tree, &b);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+
+    // The forkchoice update onto b fails: b is unknown again and withheld,
+    // which also withholds the head move onto its known parent.
+    tree.mark_rejected(&b.digest(), T0);
+    assert!(!tree.is_known(b.digest()));
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
+
+    // After the delay, b is delivered again, and a fresh acceptance clears
+    // the rejection.
+    let retry = T0 + NOTARIZED_REJECTION_RETRY_DELAY;
+    assert_eq!(next_delivery(&tree, retry), Some(b.digest()));
+    assert_eq!(tree.next_head(retry), Some((Height::new(11), a.digest())));
+    delivered(&mut tree, &b);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
 }
 
 #[test]

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -573,8 +573,11 @@ fn depths_measure_backlogs() {
     assert_eq!(depths.blocks, 0);
     assert_eq!(depths.finalization_lag, 0);
     assert_eq!(depths.convergence_depth, Some(0));
+    assert_eq!(depths.uncanonicalized_blocks, 0);
 
     // Two recorded blocks, the pending head two above the local head.
+    // Recorded bodies are not uncanonicalized until delivered; delivered
+    // ones are until the head passes them.
     let a = block(1, 11, finalized);
     let b = block(2, 12, a.digest());
     record(&mut tree, &a);
@@ -582,6 +585,12 @@ fn depths_measure_backlogs() {
     let depths = tree.depths();
     assert_eq!(depths.blocks, 2);
     assert_eq!(depths.convergence_depth, Some(2));
+    assert_eq!(depths.uncanonicalized_blocks, 0);
+    delivered(&mut tree, &a);
+    delivered(&mut tree, &b);
+    assert_eq!(tree.depths().uncanonicalized_blocks, 2);
+    head_moved(&mut tree, &a);
+    assert_eq!(tree.depths().uncanonicalized_blocks, 1);
 
     // A pending head without a body has no known height.
     let c = block(3, 13, b.digest());

--- a/crates/consensus/src/executor/actor/tests/backfill.rs
+++ b/crates/consensus/src/executor/actor/tests/backfill.rs
@@ -105,13 +105,9 @@ fn backfill_then_converges_onto_a_notarized_extension() {
         assert_eq!(h.execution.new_payloads(), vec![d1, d2, d3, d4]);
         assert_eq!(
             h.execution.fcus(),
-            vec![
-                STARTUP_FCU,
-                (d1, d1, false),
-                (d2, d2, false),
-                (d4, d2, false),
-            ],
-            "notarized convergence must preserve the backfilled finalized boundary",
+            vec![STARTUP_FCU, (d2, d2, false), (d4, d2, false)],
+            "the backfill finalizes the floor with one update, and notarized \
+            convergence must preserve that boundary",
         );
         assert_eq!(h.execution.finalized(), Some((2, d2)));
     });

--- a/crates/consensus/src/executor/actor/tests/backfill.rs
+++ b/crates/consensus/src/executor/actor/tests/backfill.rs
@@ -109,7 +109,6 @@ fn backfill_then_converges_onto_a_notarized_extension() {
                 STARTUP_FCU,
                 (d1, d1, false),
                 (d2, d2, false),
-                (d3, d2, false),
                 (d4, d2, false),
             ],
             "notarized convergence must preserve the backfilled finalized boundary",
@@ -316,8 +315,9 @@ fn snapshot_restore_replays_below_execution_finality_without_forkchoice_updates(
             })
             .start(&context);
 
-        // Re-delivery of the block at the floor: acknowledged, but no
-        // forkchoice update is submitted for the stale state.
+        // Re-delivery of the block at the floor: delivered (the execution
+        // layer answers from its caches) and acknowledged on that answer;
+        // no forkchoice update is submitted for the stale state.
         h.deliver_finalized(b1)
             .await
             .expect("the re-delivered block should be acknowledged");

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -11,7 +11,8 @@ use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::TempoConsensusContext;
 
 use super::harness::{
-    ElCall, ForkchoiceStateExt as _, GENESIS, Harness, built_payload, make_block, round,
+    ElCall, ForkchoiceStateExt as _, GENESIS, Harness, STARTUP_FCU, built_payload, make_block,
+    round,
 };
 use crate::consensus::Digest;
 
@@ -221,20 +222,12 @@ fn build_canceled_while_queued_still_reaffirms_the_head() {
         h.deliver_finalized(b1)
             .await
             .expect("finalized block should be acknowledged");
-        h.wait_until(|| {
-            h.execution
-                .fcus()
-                .iter()
-                .filter(|(head, ..)| *head == d1)
-                .count()
-                >= 2
-        })
-        .await;
 
-        assert!(
-            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
-            "the canceled build must not submit attributes; the FCU degrades \
-            to a bare head re-affirmation",
+        assert_eq!(
+            h.execution.fcus(),
+            vec![STARTUP_FCU, (d1, d1, false)],
+            "the canceled build must not submit attributes; its FCU degrades \
+            to the bare head and finality update",
         );
         assert!(h.execution.pending_payload_jobs().is_empty());
     });
@@ -344,10 +337,12 @@ fn aborted_payload_job_fails_the_build_without_shutdown() {
 }
 
 #[test_traced]
-fn rejected_build_forkchoice_update_fails_the_build_without_shutdown() {
+fn rejected_build_forkchoice_update_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
+        // The build re-affirms the tracked state; a rejection means the
+        // execution layer disagrees with the executor about that state.
         h.execution.script_fcu(
             ForkchoiceState::from_finalized_head(GENESIS, GENESIS),
             Ok(PayloadStatusEnum::Invalid {
@@ -357,18 +352,15 @@ fn rejected_build_forkchoice_update_fails_the_build_without_shutdown() {
         let rx = h.build(round(1), GENESIS);
         rx.await.expect_err("the failed FCU must fail the build");
 
-        // Build failures are not fatal for the executor.
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(2), b1)
+        h.actor
             .await
-            .expect("verification should complete");
-        assert!(verdict.is_some());
+            .expect("actor should shut down cleanly on a rejected build forkchoice update");
+        assert!(h.execution.pending_payload_jobs().is_empty());
     });
 }
 
 #[test_traced]
-fn forkchoice_update_transport_error_fails_the_build_without_shutdown() {
+fn build_forkchoice_update_transport_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
@@ -380,14 +372,10 @@ fn forkchoice_update_transport_error_fails_the_build_without_shutdown() {
         rx.await
             .expect_err("an FCU transport error must fail the build");
 
-        // Build transport failures are request-local. The actor remains
-        // available for later consensus work.
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(2), b1)
+        h.actor
             .await
-            .expect("verification should complete after the FCU transport error");
-        assert!(verdict.is_some());
+            .expect("actor should shut down cleanly on a build forkchoice transport error");
+        assert!(h.execution.pending_payload_jobs().is_empty());
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -181,8 +181,8 @@ fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
         let h = Harness::start_at_genesis(&context);
 
         // a1 is known to the execution layer through its validation, but
-        // consensus never reports it as the pending head: the head will not
-        // converge onto it, so a build on top of it cannot be held.
+        // consensus never reports it as the pending head: a build on top of
+        // it is not what consensus builds on.
         let a1 = make_block(1, 1, GENESIS);
         let da1 = a1.digest();
         h.verify(round(1), a1)
@@ -197,6 +197,44 @@ fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
             !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
             "no build may be registered off the pending head's path",
         );
+    });
+}
+
+#[test_traced]
+fn build_on_a_head_the_network_finalized_past_is_dropped() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+
+        // The head sits on notarized a1.
+        let a1 = make_block(1, 1, GENESIS);
+        let da1 = a1.digest();
+        h.verify(round(1), a1)
+            .await
+            .expect("a1 should validate")
+            .expect("a1 should be valid");
+        h.report_pending_head(2, 1, da1);
+        h.wait_until(|| h.execution.head() == da1).await;
+
+        // The network finalizes b1 on another branch. The tip report alone
+        // re-anchors the pending head onto the tip, so a1 is no longer what
+        // consensus builds on: the build is dropped before the finalized
+        // block is even delivered, and no payload is registered on the
+        // abandoned head.
+        let b1 = make_block(3, 1, GENESIS);
+        let db1 = b1.digest();
+        h.deliver_tip(round(3), 1, db1);
+        h.build(round(4), da1)
+            .await
+            .expect_err("the build on the abandoned head must fail");
+        assert!(
+            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
+            "no payload may be registered on the abandoned head",
+        );
+
+        h.deliver_finalized(b1)
+            .await
+            .expect("b1 should be acknowledged");
+        assert_eq!(h.execution.head(), db1);
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -176,6 +176,31 @@ fn build_on_an_unknown_parent_is_dropped() {
 }
 
 #[test_traced]
+fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // a1 is known to the execution layer through its validation, but
+        // consensus never reports it as the pending head: the head will not
+        // converge onto it, so a build on top of it cannot be held.
+        let a1 = make_block(1, 1, GENESIS);
+        let da1 = a1.digest();
+        h.verify(round(1), a1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+
+        let rx = h.build(round(2), da1);
+        rx.await
+            .expect_err("a build whose parent the head will not reach must fail");
+        assert!(
+            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
+            "no build may be registered off the pending head's path",
+        );
+    });
+}
+
+#[test_traced]
 fn queued_build_is_dropped_when_finality_advances_past_its_parent() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -223,11 +223,12 @@ fn build_canceled_while_queued_still_reaffirms_the_head() {
             .await
             .expect("finalized block should be acknowledged");
 
+        h.wait_until(|| h.execution.fcus().len() == 3).await;
         assert_eq!(
             h.execution.fcus(),
-            vec![STARTUP_FCU, (d1, d1, false)],
+            vec![STARTUP_FCU, (d1, d1, false), (d1, d1, false)],
             "the canceled build must not submit attributes; its FCU degrades \
-            to the bare head and finality update",
+            to a bare re-affirmation of the head",
         );
         assert!(h.execution.pending_payload_jobs().is_empty());
     });

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -72,16 +72,12 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
         assert_eq!(
             h.execution.new_payloads(),
             vec![d1, d2, d3],
-            "blocks are forwarded bottom-up",
+            "blocks are delivered bottom-up",
         );
         assert_eq!(
             h.execution.fcus(),
-            vec![
-                STARTUP_FCU,
-                (d1, GENESIS, false),
-                (d2, GENESIS, false),
-                (d3, GENESIS, false)
-            ],
+            vec![STARTUP_FCU, (d3, GENESIS, false)],
+            "one forkchoice update moves the head across the whole delivered run",
         );
     });
 }
@@ -219,10 +215,13 @@ fn new_payload_transport_error_is_withheld_then_retried() {
 }
 
 #[test_traced]
-fn rejected_notarized_fcu_does_not_advance_the_tracked_state() {
+fn rejected_notarized_fcu_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
+        // The forkchoice update names a block the execution layer accepted
+        // through its delivery. A rejection means the executor's view of the
+        // execution layer has diverged from it: the node shuts down.
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution.script_fcu(
@@ -235,79 +234,44 @@ fn rejected_notarized_fcu_does_not_advance_the_tracked_state() {
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
-        h.wait_until(|| h.execution.fcus().len() == 2).await;
-        h.run_for(Duration::from_millis(10)).await;
 
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a rejected forkchoice update");
         assert!(
             h.execution.knows_block(d1),
             "the successful new-payload call must leave the block known to the EL",
         );
+        assert_eq!(h.execution.fcus().len(), 2);
         assert_eq!(
             h.execution.head(),
             GENESIS,
             "the rejected FCU must not move the EL head",
         );
-
-        // Re-anchor consensus on genesis. If the actor had advanced its own
-        // tracked head despite the rejected FCU, it would now issue a repoint.
-        h.report_pending_head(3, 0, GENESIS);
-        let candidate = make_block(3, 1, GENESIS);
-        assert!(
-            h.verify(round(3), candidate)
-                .await
-                .expect("the actor should continue serving validation")
-                .is_some(),
-        );
-        h.run_for(Duration::from_millis(10)).await;
-        assert_eq!(
-            h.execution.fcus().len(),
-            2,
-            "the actor and EL must agree that the head remained at genesis",
-        );
     });
 }
 
 #[test_traced]
-fn rejected_notarized_fcu_is_withheld_then_retried() {
+fn notarized_fcu_transport_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
-        // An FCU rejection uses the shared notarized-block retry mechanism:
-        // the block is withheld for the rejection delay, and heartbeats drive
-        // the scheduler until it becomes eligible to be forwarded again.
-        let h = Harness::builder()
-            .harness_options(HarnessOptions {
-                fcu_heartbeat_interval: Duration::from_millis(200),
-                ..Default::default()
-            })
-            .start(&context);
+        let h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
-        let state = ForkchoiceState::from_finalized_head(GENESIS, d1);
         h.execution.script_fcu(
-            state,
-            Ok(PayloadStatusEnum::Invalid {
-                validation_error: "transient".into(),
-            }),
+            ForkchoiceState::from_finalized_head(GENESIS, d1),
+            Err("connection closed"),
         );
-        h.execution.script_fcu(state, Ok(PayloadStatusEnum::Valid));
 
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
-        h.wait_until(|| h.execution.new_payloads() == vec![d1])
-            .await;
 
-        h.run_for(Duration::from_secs(5)).await;
-        assert_eq!(
-            h.execution.new_payloads(),
-            vec![d1],
-            "a rejected FCU must not trigger a tight convergence retry",
-        );
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a forkchoice transport error");
+        assert_eq!(h.execution.new_payloads(), vec![d1]);
         assert_eq!(h.execution.head(), GENESIS);
-
-        h.run_for(Duration::from_secs(4)).await;
-        h.wait_until(|| h.execution.head() == d1).await;
-        assert_eq!(h.execution.new_payloads(), vec![d1, d1]);
     });
 }
 
@@ -525,7 +489,10 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
         let fetches = h.marshal.subscribe_log().len();
 
         // Flip back to branch B: both bodies are still resident, so the
-        // re-convergence must not fetch anything.
+        // re-convergence must not fetch anything. The execution layer
+        // already knows the branch, so the head is repointed onto it with a
+        // bare forkchoice update.
+        let payloads_before = h.execution.new_payloads();
         h.report_pending_head(5, 2, d2);
         h.wait_until(|| h.execution.head() == d2).await;
         assert_eq!(
@@ -533,7 +500,12 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
             fetches,
             "flip-flopping between branches must reuse resident bodies",
         );
-        assert_eq!(h.execution.new_payloads().last(), Some(&d2));
+        assert_eq!(
+            h.execution.new_payloads(),
+            payloads_before,
+            "a branch the execution layer knows is not delivered again",
+        );
+        assert_eq!(h.execution.fcus().last(), Some(&(d2, GENESIS, false)));
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -83,6 +83,45 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
 }
 
 #[test_traced]
+fn long_delivery_runs_are_locked_in_every_few_blocks() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // Ten notarized blocks above genesis, all bodies fetched tip-down.
+        let mut blocks = Vec::new();
+        let mut parent = GENESIS;
+        for height in 1..=10 {
+            let block = make_block(height, height, parent);
+            parent = block.digest();
+            blocks.push(block);
+        }
+        let digests = blocks.iter().map(|b| b.digest()).collect::<Vec<_>>();
+        h.report_pending_head(11, 10, digests[9]);
+        for block in blocks.iter().rev() {
+            h.wait_until(|| {
+                h.marshal
+                    .fulfill_subscription(block.digest(), block.clone())
+            })
+            .await;
+        }
+
+        // The run is delivered bottom-up, with a forkchoice update forced
+        // after every eight deliveries so that the execution layer never
+        // holds more than that many uncanonicalized blocks.
+        h.wait_until(|| h.execution.head() == digests[9]).await;
+        assert_eq!(h.execution.new_payloads(), digests);
+        assert_eq!(
+            h.execution.fcus(),
+            vec![
+                STARTUP_FCU,
+                (digests[7], GENESIS, false),
+                (digests[9], GENESIS, false),
+            ],
+        );
+    });
+}
+
+#[test_traced]
 fn dropped_body_fetch_is_retried() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -354,6 +354,31 @@ fn forkchoice_update_transport_error_is_fatal() {
 }
 
 #[test_traced]
+fn conflicting_finalized_block_at_the_tracked_height_is_fatal() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+
+        let b1 = make_block(1, 1, GENESIS);
+        h.deliver_tip(round(1), 1, b1.digest());
+        h.deliver_finalized(b1)
+            .await
+            .expect("first block should be acknowledged");
+
+        // A different block at the height the execution layer already
+        // finalized means consensus failed fundamentally; the execution
+        // layer's canonical chain is what the re-delivery is checked against.
+        let conflicting = make_block(9, 1, GENESIS);
+        h.deliver_finalized(conflicting)
+            .await
+            .expect_err("a conflicting finalized block must not be acknowledged");
+
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a fatal error");
+    });
+}
+
+#[test_traced]
 fn redelivered_finalized_block_at_the_tracked_state_is_acknowledged() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -1,7 +1,8 @@
 //! Scenario tests for the finalization pipeline: finalized blocks arriving
-//! from the marshal actor are forwarded to the execution layer as
-//! `newPayload` + `forkchoiceUpdated` pairs, in order, and acknowledged
-//! only once the execution layer accepted them.
+//! from the marshal actor are delivered to the execution layer through
+//! `newPayload` in order, finalized through a subsequent
+//! `forkchoiceUpdated` that may cover several deliveries, and acknowledged
+//! only once that forkchoice update has been accepted.
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
 use commonware_macros::test_traced;
@@ -12,6 +13,7 @@ use super::harness::{
     ElCall, ForkchoiceStateExt as _, GENESIS, Harness, HarnessOptions, STARTUP_FCU,
     STARTUP_FCU_CALL, make_block, make_block_with_proposer, round,
 };
+use crate::consensus::Digest;
 
 fn finalized_blocks_proposed_by_self(h: &Harness) -> u64 {
     h.metrics()
@@ -57,19 +59,31 @@ fn finalized_blocks_are_forwarded_in_order() {
         let b3 = make_block(3, 3, b2.digest());
         let digests = [b1.digest(), b2.digest(), b3.digest()];
 
+        // Hold the first delivery open so that the later blocks queue up
+        // behind it, as they do when the execution layer is catching up.
+        let release_first = h
+            .execution
+            .script_delayed_new_payload(digests[0], Ok(PayloadStatusEnum::Valid));
         h.deliver_tip(round(3), 3, b3.digest());
         let w1 = h.deliver_finalized(b1);
         let w2 = h.deliver_finalized(b2);
         let w3 = h.deliver_finalized(b3);
+        h.wait_until(|| h.execution.new_payloads() == vec![digests[0]])
+            .await;
+        release_first
+            .send(())
+            .expect("first delivery should still be gated");
         w1.await.expect("first block should be acknowledged");
         w2.await.expect("second block should be acknowledged");
         w3.await.expect("third block should be acknowledged");
 
         assert_eq!(h.execution.new_payloads(), digests);
-        let expected_fcus = std::iter::once(STARTUP_FCU)
-            .chain(digests.map(|digest| (digest, digest, false)))
-            .collect::<Vec<_>>();
-        assert_eq!(h.execution.fcus(), expected_fcus);
+        assert_eq!(
+            h.execution.fcus(),
+            vec![STARTUP_FCU, (digests[2], digests[2], false)],
+            "queued finalized blocks are delivered back to back and finalized \
+            by a single forkchoice update",
+        );
         assert_eq!(h.execution.finalized(), Some((3, digests[2])));
     });
 }
@@ -181,16 +195,46 @@ fn new_payload_transport_error_is_fatal() {
     });
 }
 
+/// Converges the head onto `a1 -> a2` (branch A) through validations and
+/// pending-head reports, then reports an unknown block as the pending head
+/// so that the pending head's ancestry is not walkable: the forkchoice step
+/// cannot derive the head from the tree and must consult the execution
+/// layer's canonical chain when finality advances.
+async fn converge_on_branch_a_with_unwalkable_pending_head(h: &Harness) -> (Digest, Digest) {
+    let a1 = make_block(1, 1, GENESIS);
+    let a2 = make_block(2, 2, a1.digest());
+    let (da1, da2) = (a1.digest(), a2.digest());
+    for (view, block, digest) in [(1, a1, da1), (2, a2, da2)] {
+        h.verify(round(view), block)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+        h.report_pending_head(view + 1, view, digest);
+        h.wait_until(|| h.execution.head() == digest).await;
+    }
+
+    let unknown = make_block(4, 3, da2).digest();
+    h.report_pending_head(5, 4, unknown);
+    h.wait_until(|| h.marshal.open_subscriptions() == vec![(unknown, round(4))])
+        .await;
+    (da1, da2)
+}
+
 #[test_traced]
 fn canonical_block_lookup_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
+        let (_, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+        let fcus_before = h.execution.fcus();
 
-        let b1 = make_block(1, 1, GENESIS);
+        // b1 finalizes below the head on another branch. Whether the head
+        // descends from it is read from the canonical chain; the read
+        // failing must not let the finalization through.
+        let b1 = make_block(3, 1, GENESIS);
         h.execution
             .script_canonical_block_hash(1, Err("database unavailable"));
 
-        h.deliver_tip(round(1), 1, b1.digest());
+        h.deliver_tip(round(3), 1, b1.digest());
         h.deliver_finalized(b1)
             .await
             .expect_err("a canonical lookup failure must not acknowledge the finalized block");
@@ -198,8 +242,55 @@ fn canonical_block_lookup_error_is_fatal() {
         h.actor
             .await
             .expect("actor should shut down cleanly on a canonical lookup error");
-        assert!(h.execution.new_payloads().is_empty());
-        assert_eq!(h.execution.fcus(), vec![STARTUP_FCU]);
+        assert_eq!(
+            h.execution.fcus(),
+            fcus_before,
+            "no forkchoice update may follow the failed lookup",
+        );
+        assert_eq!(h.execution.head(), da2);
+    });
+}
+
+#[test_traced]
+fn finalizing_below_a_head_on_another_branch_moves_the_head() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+        let (_, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+
+        // b1 finalizes at height 1 on branch B while the head is a2 at
+        // height 2 on branch A. The head does not descend from the
+        // finalized block, so it is moved onto it.
+        let b1 = make_block(3, 1, GENESIS);
+        let db1 = b1.digest();
+        h.deliver_tip(round(3), 1, db1);
+        h.deliver_finalized(b1)
+            .await
+            .expect("the finalized branch should be acknowledged");
+
+        assert_eq!(h.execution.fcus().last(), Some(&(db1, db1, false)));
+        assert_eq!(h.execution.head(), db1);
+        assert_eq!(h.execution.finalized(), Some((1, db1)));
+        assert_ne!(da2, db1);
+    });
+}
+
+#[test_traced]
+fn finalizing_below_a_descending_head_keeps_the_head() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+        let (da1, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+
+        // a1 finalizes below the head a2 while the pending head's ancestry
+        // is not walkable. The canonical chain shows that the head descends
+        // from a1, so only finality moves.
+        h.deliver_tip(round(3), 1, da1);
+        h.deliver_finalized(make_block(1, 1, GENESIS))
+            .await
+            .expect("the finalized ancestor should be acknowledged");
+
+        assert_eq!(h.execution.fcus().last(), Some(&(da2, da1, false)));
+        assert_eq!(h.execution.head(), da2);
+        assert_eq!(h.execution.finalized(), Some((1, da1)));
     });
 }
 
@@ -263,57 +354,6 @@ fn forkchoice_update_transport_error_is_fatal() {
 }
 
 #[test_traced]
-fn finalized_block_below_the_tracked_state_is_fatal() {
-    deterministic::Runner::default().start(|context| async move {
-        let mut h = Harness::start_at_genesis(&context);
-
-        let b1 = make_block(1, 1, GENESIS);
-        let b2 = make_block(2, 2, b1.digest());
-        h.deliver_tip(round(2), 2, b2.digest());
-        h.deliver_finalized(b1.clone())
-            .await
-            .expect("first block should be acknowledged");
-        h.deliver_finalized(b2)
-            .await
-            .expect("second block should be acknowledged");
-
-        // Delivering a block below the tracked finalized height violates
-        // the in-order delivery protocol.
-        h.deliver_finalized(b1)
-            .await
-            .expect_err("a block below the tracked finalized state must not be acknowledged");
-
-        h.actor
-            .await
-            .expect("actor should shut down cleanly on a fatal error");
-    });
-}
-
-#[test_traced]
-fn conflicting_finalized_block_at_the_tracked_height_is_fatal() {
-    deterministic::Runner::default().start(|context| async move {
-        let mut h = Harness::start_at_genesis(&context);
-
-        let b1 = make_block(1, 1, GENESIS);
-        h.deliver_tip(round(1), 1, b1.digest());
-        h.deliver_finalized(b1)
-            .await
-            .expect("first block should be acknowledged");
-
-        // A different block finalized at the same height means consensus
-        // failed fundamentally.
-        let conflicting = make_block(9, 1, GENESIS);
-        h.deliver_finalized(conflicting)
-            .await
-            .expect_err("a conflicting finalized block must not be acknowledged");
-
-        h.actor
-            .await
-            .expect("actor should shut down cleanly on a fatal error");
-    });
-}
-
-#[test_traced]
 fn redelivered_finalized_block_at_the_tracked_state_is_acknowledged() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
@@ -341,14 +381,11 @@ fn redelivered_finalized_block_at_the_tracked_state_is_acknowledged() {
                     finalized: d1,
                     with_attrs: false,
                 },
+                // The redelivery is delivered again - the execution layer
+                // answers from its caches - and acknowledged on that answer;
+                // the block is final already, so no forkchoice update follows.
                 ElCall::NewPayload(d1),
-                ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false,
-                },
             ],
-            "a redelivery is re-checked and re-affirmed before acknowledgment",
         );
         assert_eq!(h.execution.finalized(), Some((1, d1)),);
     });

--- a/crates/consensus/src/executor/actor/tests/metrics.rs
+++ b/crates/consensus/src/executor/actor/tests/metrics.rs
@@ -2,11 +2,11 @@
 //! tree unit tests cover the arithmetic; these tests prove that the actor
 //! publishes the measures after processing real messages and EL outcomes.
 
-use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use alloy_rpc_types_engine::PayloadStatusEnum;
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 
-use super::harness::{ForkchoiceStateExt as _, GENESIS, Harness, make_block, round};
+use super::harness::{GENESIS, Harness, make_block, round};
 
 fn gauge(h: &Harness, name: &str) -> i64 {
     let name = format!("executor_{name}");
@@ -128,16 +128,21 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         }
         h.wait_until(|| gauge(&h, "convergence_depth") == 0).await;
 
-        // Keep the re-anchor from completing so the signed distance remains
-        // observable: the pending head is b1 at height 1 while the accepted
-        // local head remains b2 at height 2.
-        h.execution.script_fcu(
-            ForkchoiceState::from_finalized_head(GENESIS, d1),
+        // Re-anchor onto a1, a sibling of b1 at height 1 the execution layer
+        // rejects: the block is withheld, so the pending head stays at
+        // height 1 while the accepted local head remains b2 at height 2, and
+        // the signed distance is observable.
+        let a1 = make_block(4, 1, GENESIS);
+        let da1 = a1.digest();
+        h.execution.script_new_payload(
+            da1,
             Ok(PayloadStatusEnum::Invalid {
                 validation_error: "re-anchor rejected by test".into(),
             }),
         );
-        h.report_pending_head(4, 1, d1);
+        h.report_pending_head(5, 4, da1);
+        h.wait_until(|| h.marshal.fulfill_subscription(da1, a1.clone()))
+            .await;
         h.wait_until(|| gauge(&h, "convergence_depth") == -1).await;
         assert_eq!(h.execution.head(), d2);
     });

--- a/crates/consensus/src/executor/actor/tests/metrics.rs
+++ b/crates/consensus/src/executor/actor/tests/metrics.rs
@@ -147,3 +147,37 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         assert_eq!(h.execution.head(), d2);
     });
 }
+
+#[test_traced]
+fn uncanonicalized_blocks_tracks_delivered_blocks_off_the_canonical_chain() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+        assert_eq!(gauge(&h, "uncanonicalized_blocks"), 0);
+
+        // A validated block is known to the execution layer but not its
+        // head yet.
+        let b1 = make_block(1, 1, GENESIS);
+        let d1 = b1.digest();
+        h.verify(round(1), b1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 1)
+            .await;
+
+        // Moving the head onto it canonicalizes it.
+        h.report_pending_head(2, 1, d1);
+        h.wait_until(|| h.execution.head() == d1).await;
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 0)
+            .await;
+
+        // A validated sibling stays on a side branch.
+        let a1 = make_block(3, 1, GENESIS);
+        h.verify(round(3), a1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 1)
+            .await;
+    });
+}

--- a/crates/consensus/src/executor/actor/tests/mod.rs
+++ b/crates/consensus/src/executor/actor/tests/mod.rs
@@ -1,12 +1,12 @@
 use alloy_primitives::B256;
-use commonware_consensus::types::{Height, Round};
+use commonware_consensus::types::Round;
 use futures::executor::block_on;
 
 use commonware_consensus::Heightable as _;
 
 use super::{
     ConsensusRequest, ExecutionTask, ExecutionTaskOutcome, ExecutionTaskType, VerifyBlockRequest,
-    notarized_tree::LocalState, queue_consensus_request,
+    queue_consensus_request,
 };
 use crate::consensus::Digest;
 
@@ -25,27 +25,20 @@ use harness::{make_block, round};
 
 #[test]
 fn execution_task_finishes_with_an_outcome() {
-    let state = LocalState {
-        head: (Height::new(1), Digest(B256::repeat_byte(1))),
-        finalized: (Height::new(0), Digest(B256::ZERO)),
-    };
     let mut task = ExecutionTask::new(
         ExecutionTaskType::Verify,
-        state,
-        futures::future::ready(ExecutionTaskOutcome::Completed {
-            canonicalized: None,
-            payload_job: None,
+        futures::future::ready(ExecutionTaskOutcome::Validated {
+            request: None,
+            status: Err(eyre::eyre!("abandoned")),
         }),
     );
 
     assert!(matches!(task.task_type, ExecutionTaskType::Verify));
-    assert_eq!(task.on_top_of, state);
     let finished = block_on(&mut task);
     assert!(matches!(finished.task_type, ExecutionTaskType::Verify));
-    assert_eq!(finished.on_top_of, state);
     assert!(matches!(
         finished.outcome,
-        ExecutionTaskOutcome::Completed { .. }
+        ExecutionTaskOutcome::Validated { request: None, .. }
     ));
 }
 

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -54,50 +54,6 @@ fn slow_marshal_fetch_does_not_block_validation() {
 }
 
 #[test_traced]
-fn slow_marshal_fetch_does_not_block_building() {
-    deterministic::Runner::default().start(|context| async move {
-        let h = Harness::start_at_genesis(&context);
-
-        // Leave the missing pending head's marshal subscription unresolved.
-        let pending = make_block(1, 1, GENESIS);
-        let pending_digest = pending.digest();
-        h.report_pending_head(2, 1, pending_digest);
-        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(1))])
-            .await;
-
-        // A proposal build on the known local head must be registered and
-        // delivered independently of the pending body fetch.
-        let proposal = make_block(3, 1, GENESIS);
-        let proposal_digest = proposal.digest();
-        h.execution.script_built_payload(built_payload(&proposal));
-        let build = h.build(round(3), GENESIS);
-        futures::pin_mut!(build);
-        let deadline = h.run_for(Duration::from_millis(100));
-        futures::pin_mut!(deadline);
-        let payload = match futures::future::select(build, deadline).await {
-            Either::Left((payload, _deadline)) => {
-                payload.expect("build should complete while the fetch is pending")
-            }
-            Either::Right(((), _build)) => {
-                panic!("the pending marshal fetch blocked building")
-            }
-        };
-
-        let (block, _) = payload.into_execution_payload();
-        assert_eq!(block.hash(), proposal_digest.0);
-        assert!(
-            h.execution.fcus().contains(&(GENESIS, GENESIS, true)),
-            "the attribute-carrying build FCU must reach the execution layer",
-        );
-        assert_eq!(
-            h.marshal.open_subscriptions(),
-            vec![(pending_digest, round(1))],
-            "building must not cancel or consume the independent body fetch",
-        );
-    });
-}
-
-#[test_traced]
 fn payload_resolution_does_not_occupy_the_execution_task_slot() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -1,6 +1,6 @@
 //! Scenario tests for the actor's scheduling invariants: one execution-layer
-//! task at a time, consensus requests before convergence before
-//! finalization, the FCU heartbeat, and shutdown.
+//! task at a time, consensus requests before finality work before notarized
+//! convergence, the FCU heartbeat, and shutdown.
 
 use std::time::Duration;
 
@@ -280,15 +280,14 @@ fn one_execution_task_at_a_time_and_consensus_requests_win_the_next_slot() {
             vec![
                 STARTUP_FCU_CALL,
                 ElCall::NewPayload(d1),
-                ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false
-                },
-                // The validation of b2 runs before b2's finalization: its
-                // new-payload probe is not followed by a forkchoice update.
+                // The validation of b2 runs before b2's finalization and
+                // before the forkchoice update finalizing b1: its
+                // new-payload probe wins the slot as soon as it is free.
                 ElCall::NewPayload(d2),
+                // b2 was pruned from the tree by the tip covering it, so its
+                // finalization delivers it again ...
                 ElCall::NewPayload(d2),
+                // ... and one forkchoice update finalizes both blocks.
                 ElCall::Fcu {
                     head: d2,
                     finalized: d2,
@@ -354,14 +353,16 @@ fn consensus_work_takes_priority_over_ready_convergence() {
             vec![
                 STARTUP_FCU_CALL,
                 ElCall::NewPayload(d1),
+                // Both operations were ready when the delivery of b1
+                // released the slot, but latency-critical consensus work
+                // ran first. Finality is locked in next, before notarized
+                // convergence delivers b2 and moves the head onto it.
+                ElCall::NewPayload(candidate_digest),
                 ElCall::Fcu {
                     head: d1,
                     finalized: d1,
                     with_attrs: false,
                 },
-                // Both operations were ready when finalization released the
-                // slot, but latency-critical consensus work ran first.
-                ElCall::NewPayload(candidate_digest),
                 ElCall::NewPayload(d2),
                 ElCall::Fcu {
                     head: d2,
@@ -374,65 +375,58 @@ fn consensus_work_takes_priority_over_ready_convergence() {
 }
 
 #[test_traced]
-fn convergence_takes_priority_over_queued_finalization() {
+fn finality_is_locked_in_before_notarized_convergence() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
-        let d1 = b1.digest();
+        let b2 = make_block(2, 2, b1.digest());
+        let (d1, d2) = (b1.digest(), b2.digest());
         let release_finalization = h
             .execution
             .script_delayed_new_payload(d1, Ok(PayloadStatusEnum::Valid));
-        h.execution
-            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
-        h.deliver_tip(round(1), 1, d1);
-        let first_finalization = h.deliver_finalized(b1.clone());
+        h.deliver_tip(round(2), 2, d2);
+        let w1 = h.deliver_finalized(b1);
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
             .await;
 
-        // Make convergence onto b2 ready above the finalized boundary.
-        let b2 = make_block(2, 2, d1);
-        let d2 = b2.digest();
-        h.report_pending_head(3, 2, d2);
-        h.wait_until(|| h.marshal.fulfill_subscription(d2, b2.clone()))
+        // Make convergence onto the notarized n3 ready above the finalized
+        // boundary while the first finalized delivery still owns the slot,
+        // and queue the second finalized block behind it.
+        let n3 = make_block(3, 3, d2);
+        let d3 = n3.digest();
+        h.report_pending_head(4, 3, d3);
+        h.wait_until(|| h.marshal.fulfill_subscription(d3, n3.clone()))
             .await;
         h.run_for(Duration::from_millis(10)).await;
-
-        // Queue a valid finalization redelivery. Once the first delivery
-        // advances local finality to b1, this and convergence are both ready.
-        let redelivery = h.deliver_finalized(b1);
+        let w2 = h.deliver_finalized(b2);
         h.run_for(Duration::from_millis(10)).await;
 
         release_finalization
             .send(())
             .expect("finalization should still be gated");
-        first_finalization
-            .await
-            .expect("first delivery should be acknowledged");
-        redelivery.await.expect("redelivery should be acknowledged");
+        w1.await.expect("first block should be acknowledged");
+        w2.await.expect("second block should be acknowledged");
+        h.wait_until(|| h.execution.head() == d3).await;
 
         assert_eq!(
             h.execution.calls(),
             vec![
                 STARTUP_FCU_CALL,
                 ElCall::NewPayload(d1),
-                ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false,
-                },
-                // Convergence wins the newly available slot.
+                // The queued finalized range is drained and locked in with
+                // one forkchoice update before the notarized block is
+                // delivered, even though n3 was ready first.
                 ElCall::NewPayload(d2),
                 ElCall::Fcu {
                     head: d2,
-                    finalized: d1,
+                    finalized: d2,
                     with_attrs: false,
                 },
-                // Only then is the queued finalization redelivery handled.
-                ElCall::NewPayload(d1),
+                ElCall::NewPayload(d3),
                 ElCall::Fcu {
-                    head: d2,
-                    finalized: d1,
+                    head: d3,
+                    finalized: d2,
                     with_attrs: false,
                 },
             ],
@@ -536,7 +530,7 @@ fn heartbeat_timer_is_rearmed_after_work_finishes() {
 }
 
 #[test_traced]
-fn idle_actor_sends_forkchoice_heartbeats_and_survives_their_failure() {
+fn idle_actor_sends_forkchoice_heartbeats() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::builder()
             .harness_options(HarnessOptions {
@@ -559,23 +553,37 @@ fn idle_actor_sends_forkchoice_heartbeats_and_survives_their_failure() {
                 .all(|fcu| *fcu == (GENESIS, GENESIS, false)),
             "heartbeats re-affirm the tracked state",
         );
-
-        // Failing heartbeats are logged, not fatal.
-        h.execution.reject_all_fcus(true);
-        h.run_for(Duration::from_secs(1)).await;
-        h.execution.reject_all_fcus(false);
-
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(1), b1)
-            .await
-            .expect("the actor must still be serving requests");
-        assert!(verdict.is_some());
     });
 }
 
 #[test_traced]
-fn idle_actor_survives_heartbeat_transport_error() {
+fn rejected_heartbeat_is_fatal() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::builder()
+            .harness_options(HarnessOptions {
+                fcu_heartbeat_interval: Duration::from_millis(300),
+                ..Default::default()
+            })
+            .start(&context);
+
+        // A heartbeat re-affirms the state the execution layer last
+        // accepted. Rejecting it means the execution layer no longer agrees
+        // with the executor about its own state. (The startup readiness
+        // probe must pass first.)
+        h.wait_until(|| h.execution.fcus().len() == 1).await;
+        h.execution.reject_all_fcus(true);
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a rejected heartbeat");
+        assert_eq!(
+            h.execution.fcus(),
+            vec![STARTUP_FCU, (GENESIS, GENESIS, false)]
+        );
+    });
+}
+
+#[test_traced]
+fn heartbeat_transport_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::builder()
             .harness_options(HarnessOptions {
@@ -585,25 +593,14 @@ fn idle_actor_survives_heartbeat_transport_error() {
             .start(&context);
         let state = ForkchoiceState::from_finalized_head(GENESIS, GENESIS);
         h.execution.script_fcu(state, Err("connection closed"));
-        h.execution.script_fcu(state, Ok(PayloadStatusEnum::Valid));
 
-        h.wait_until(|| h.execution.fcus().len() == 3).await;
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a heartbeat transport error");
         assert_eq!(
             h.execution.fcus(),
-            vec![
-                STARTUP_FCU,
-                (GENESIS, GENESIS, false),
-                (GENESIS, GENESIS, false),
-            ],
-            "a failed heartbeat must not stop the explicitly accepted next heartbeat",
+            vec![STARTUP_FCU, (GENESIS, GENESIS, false)]
         );
-
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(1), b1)
-            .await
-            .expect("actor must keep serving after a heartbeat transport error");
-        assert!(verdict.is_some());
     });
 }
 


### PR DESCRIPTION
Splits block delivery via `newPayload` and moving the execution layer via `forkchoiceUpdated` so that these can be performed independently of each other.

This simplifies thinking about how the contract between CL and EL is upheld (all FCUs must now be VALID, fatal otherwise). And it reduces the number of messages sent between CL and EL (before, each block delivery incurred one FCU; now an FCU is only performed for a range of blocks.