### PR TITLE
fix(validator-config-v2): allow same-ingress key rotation in rotate_validator

### DIFF
--- a/crates/precompiles/src/validator_config_v2/mod.rs
+++ b/crates/precompiles/src/validator_config_v2/mod.rs
@@ -699,8 +699,6 @@ impl ValidatorConfigV2 {
             .require_owner_or_validator(sender, v.validator_address)?;
         self.require_new_pubkey(call.publicKey)?;
         Self::validate_endpoints(&call.ingress, &call.egress)?;
-
-        self.require_unique_ingress(&call.ingress)?;
         self.verify_validator_signature(
             SignatureKind::Rotate,
             &call.publicKey,
@@ -2646,7 +2644,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rotate_validator_rejects_same_ingress() -> eyre::Result<()> {
+    fn test_rotate_validator_allows_same_ingress_key_rotation() -> eyre::Result<()> {
         let mut storage = HashMapStorageProvider::new(1);
         let owner = Address::random();
         let validator = Address::random();
@@ -2684,7 +2682,7 @@ mod tests {
                         signature: new_sig.into(),
                     },
                 )
-                .is_err()
+                .is_ok()
             );
             Ok(())
         })


### PR DESCRIPTION
## Problem

`rotate_validator` calls `require_unique_ingress` at line 703 **before** `update_ingress_ip_tracking` at line 715. Since the validator's own ingress IP:port is already registered in `active_ingress_ips`, any attempt to rotate the Ed25519 key while keeping the same network endpoint fails with `IngressAlreadyExists`.

`update_ingress_ip_tracking` already handles this correctly: when `old_ingress_hash == new_ingress_hash` it is a no-op. But that branch was unreachable because `require_unique_ingress` rejected the call first.

Three pieces of evidence:
- **Dead code**: the same-hash branch in `update_ingress_ip_tracking` is unreachable from `rotate_validator`
- **Inconsistency**: `set_ip_addresses` uses only `update_ingress_ip_tracking` (no pre-check) and correctly allows same-ingress updates
- **Contradictory test**: `test_rotate_validator_rejects_same_ingress` has comment `// should succeed` but asserts `.is_err()`

**Impact**: validators cannot rotate their Ed25519 public keys without also changing their ingress endpoint. In key-compromise scenarios this forces unnecessary network address changes or blocks rotation entirely.

Fixes #7155

## Fix

Remove the `require_unique_ingress` call from `rotate_validator`. The uniqueness check inside `update_ingress_ip_tracking` already enforces that a *different* ingress isn't taken by another validator, while correctly allowing same-ingress as a no-op.

Also renames and fixes the contradictory test to assert `.is_ok()`, matching the comment that was already there.