### PR TITLE
docs(tip-1016): update gas accounting specification

### DIFF
--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, this gas does not count against block gas limit but it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into execution and state gas, ensuring the `GAS` opcode accurately reflects the execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput.
+Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, this gas does not count against block gas limit but it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into execution and reservoir gas, ensuring the `GAS` opcode accurately reflects the execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput.
 
 ## Motivation
 

--- a/tips/tip-1016.md
+++ b/tips/tip-1016.md
@@ -12,7 +12,7 @@ protocolVersion: TBD
 
 ## Abstract
 
-Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, this gas does not count against block gas limit but it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into execution and reservoir gas, ensuring the `GAS` opcode accurately reflects the execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput. 
+Storage creation operations (new state elements, account creation, contract code storage) continue to consume and be charged for gas, this gas does not count against block gas limit but it is capped by max tx gas limit [EIP-7825](https://eips.ethereum.org/EIPS/eip-7825). Gas accounting uses a **reservoir model** (aligned with [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) that splits gas into execution and state gas, ensuring the `GAS` opcode accurately reflects the execution budget. This allows increasing contract code pricing to 2,500 gas/byte without preventing large contract deployments, and prevents new account creation from reducing effective throughput.
 
 ## Motivation
 
@@ -23,11 +23,11 @@ TIP-1000 increased storage creation costs to 250,000 gas per operation and 1,000
    - Keep general gas limit at 30M (would prefer lower)
    - Limit contract code to 1,000 gas/byte (would prefer 2,500)
 
-2. **New account throughput penalty**: TIP-20 transfer to new address costs ~300,000 gas total (~55k execution + 245k state) vs ~50,000 gas to existing. At 500M payment lane gas limit:
-   - Without exemption (single dimension): only ~1,700 new account transfers/block = ~3,400 TPS
-   - With reservoir model (block limits apply to execution gas only): ~9,090 new account transfers/block = ~18,200 TPS
-   - Existing account transfers: ~10,000 transfers/block = ~20,000 TPS
-   - ~5x throughput improvement for new accounts by exempting state gas from block limits
+2. **New balance throughput penalty**: A TIP-20 transfer to an address without an existing balance slot uses ~47,000 execution gas + 245,000 state gas = ~292,000 gas total, versus ~43,000 execution gas when the balance slot already exists. At a 500M payment lane gas limit:
+   - Without exemption (single dimension): only ~1,712 new-balance transfers/block = ~3,424 TPS
+   - With reservoir model (block limits apply to execution gas only): ~10,638 new-balance transfers/block = ~21,276 TPS
+   - Existing-balance transfers: ~11,627 transfers/block = ~23,254 TPS
+   - ~6.2x throughput improvement for new balances by exempting state gas from block limits
 
 The root cause: state gas counts against limits designed for execution time constraints. Storage creation is permanent (disk) not ephemeral (CPU), and shouldn't be bounded by per-block execution limits.
 
@@ -39,10 +39,12 @@ Simply exempting state gas from protocol limits without changing EVM internals c
 
 2. **Broken gas patterns**: Contracts relying on `gasleft()` for loop guards, subcall gas forwarding (63/64 rule), and relay/meta-transaction patterns would see incorrect values, potentially leading to unexpected OOG reverts.
 
-The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) solves this by maintaining three internal counters:
-* execution `remaining` gas is reflecting execution budget, used by cpu and state creation. Returned by `GAS` opcode.
-* `reservoir` is holding overflow can be only be used for state creation
-* `state_gas` is tracking cumulative state gas consumed during execution.
+The reservoir model (from [EIP-8037](https://eips.ethereum.org/EIPS/eip-8037)) maintains four internal accounting counters:
+
+* `remaining` holds regular execution gas. Execution charges always draw from it, state-gas charges draw from it only after the reservoir is exhausted, and the `GAS` opcode returns it.
+* `reservoir` holds gas above the regular execution budget and can only pay state-gas charges.
+* `state_gas_spent` is the signed net state gas charged by the frame. It can become negative when a child restores state created by its parent.
+* `state_gas_spilled` is local to each frame and tracks the portion of that frame's state gas drawn from `remaining` after the reservoir was exhausted. This lets frame rollback return gas to the pool from which it was charged; on successful frame completion, the counter is propagated to the parent so a later parent rollback can restore it correctly.
 
 ---
 
@@ -62,28 +64,30 @@ At the transaction level, the user pays for both. At the block level, only execu
 
 Storage creation operations split their cost between execution gas (computational overhead) and state gas (permanent storage burden).
 
-The SSTORE split is inherited from [TIP-1060](tip-1060.md): the TIP-1000 creation cost (`SSTORE_CREATE_COST = 250,000`) is already split there into the residual (`SSTORE_SET_COST = 5,000`, charged by the SSTORE gas function on clean creations) and the creditable portion (`STORAGE_CREDIT_VALUE = 245,000`, governed by the storage-credit mechanism). TIP-1016 mirrors the TIP-1060 gas table entries exactly and only moves the creditable portion from execution gas into state gas — a clean creation costs exactly what it does under TIP-1060, but only the residual counts toward protocol limits.
+The SSTORE split is inherited from [TIP-1060](tip-1060.md): the TIP-1000 creation cost (`SSTORE_CREATE_COST = 250,000`) is split into the residual (`SSTORE_SET_COST = 5,000`, charged by the SSTORE gas function on clean creations) and the creditable portion (`STORAGE_CREDIT_VALUE = 245,000`, governed by the storage-credit mechanism). TIP-1016 preserves these values and moves the creditable portion from execution gas into state gas.
 
 | Operation | Execution Gas | Storage Gas | Total |
 |-----------|---------------|-------------|-------|
-| Cold SSTORE (zero → non-zero) | 7,200 | 245,000 | 252,200 |
-| Hot SSTORE (non-zero → non-zero) | 2,900 | 0 | 2,900 |
+| Cold SSTORE creation (zero → non-zero, no credit applied) | 7,200 | 245,000 | 252,200 |
+| Warm SSTORE update (non-zero → non-zero) | 2,900 | 0 | 2,900 |
 | Account creation (nonce 0 → 1) | 25,000 | 225,000 | 250,000 |
 | Contract code storage (per byte) | 200 | 2,300 | 2,500 |
-| Contract creation (fixed upfront cost) | 32,000 | 468,000 | 500,000 |
+| Contract-creation transaction (intrinsic surcharge) | 32,000 | 468,000 | 500,000 |
+| `CREATE`/`CREATE2` (fixed upfront cost) | 32,000 | 468,000 | 500,000 |
 | EIP-7702 delegation (per auth) | 25,000 | 225,000 | 250,000 |
 
-For zero-to-non-zero `SSTORE`, Tempo keeps revm's decomposed Berlin accounting, with the same
-table entries as TIP-1060: `GAS_WARM_ACCESS` (100) plus `sstore_set_without_load_cost`
-(`SSTORE_SET_COST` = 5,000), for a 5,100 execution-gas write path. When the slot is cold, the
-existing Berlin cold-slot access charge (`GAS_COLD_SLOAD = 2,100`) is retained on top of that
-write component, for a total of 7,200 execution gas before state gas.
+For zero-to-non-zero `SSTORE`, Tempo keeps TIP-1060's decomposed Berlin accounting:
+`GAS_WARM_ACCESS` (100) plus `SSTORE_SET_COST` (5,000), for a 5,100 execution-gas warm write
+path. A cold slot adds `GAS_COLD_SLOAD` (2,100), for 7,200 execution gas before state gas.
+TIP-1060 keeps the storage-clearing refund at zero because storage-credit minting replaces it.
+The SSTORE creation row shows the upfront cost without a storage credit applied; its 245,000
+state-gas component is governed by TIP-1060's credit mode and settlement rules.
 
 ### EIP-7702 Delegation Pricing
 
 Each EIP-7702 authorization writes a 23-byte delegation designator (`0xef0100 || address`) to the authority account's code field. This is permanent state: redelegation overwrites the account's code pointer but the old code entry persists in the code database.
 
-The base cost per authorization is **25,000 execution gas + 225,000 state gas = 250,000 total**, matching account creation. This reverts the TIP-1000 reduction to 12,500 gas per authorization.
+The base cost per authorization remains **25,000 execution gas + 225,000 state gas = 250,000 total**. This reverts the TIP-1000 reduction to 12,500 gas per authorization.
 
 For authorizations where `auth.nonce == 0` (new account), the account creation cost (25,000 execution + 225,000 state) applies in addition to the delegation cost, for a total of 500,000 gas.
 
@@ -161,13 +165,14 @@ The `state_gas_reservoir` holds gas that exceeds the per-transaction execution g
 - **State gas** charges deduct from `state_gas_reservoir` first; when the reservoir is exhausted, from `gas_left`.
 - When an opcode requires both execution and state gas, the execution gas charge MUST be applied first. If the execution gas charge triggers an out-of-gas error, the state gas charge is not applied.
 - The **`GAS` opcode** returns `gas_left` only (excluding the reservoir).
-- The reservoir is passed **in full** to child frames (no 63/64 rule). On child success, the remaining `state_gas_reservoir` is returned to the parent.
-- On child **revert** or **exceptional halt**, all state gas consumed by the child, both from the reservoir and any that spilled into `gas_left`, is restored to the parent's reservoir. On child **exceptional halt**, only `gas_left` is consumed (zeroed). State gas is fully preserved on failure because state changes are reverted, so no state was actually grown.
-  - **Note**: State gas that originally spilled from the reservoir into `gas_left` is restored as reservoir gas, not as `gas_left`. A child frame that performs cold SSTOREs drawing from `gas_left` (because the reservoir was exhausted) and then reverts will return that gas to the parent's reservoir, where it can only be used for future state operations — not for execution gas. This is a known consequence of the EIP-8037 design that avoids tracking the original source of state gas charges per frame. The effect is bounded: it can only convert `gas_left` that was spent on state operations into reservoir gas, and only on child failure paths.
-- On **exceptional halt**, remaining `gas_left` is attributed to `execution_gas_used` and set to zero (all execution gas consumed), consistent with existing EVM out-of-gas semantics. The `state_gas_reservoir` is not consumed — it is returned to the parent frame or preserved at the top level, consistent with the principle that state gas pays for long-term state growth which does not occur on failure.
+- The reservoir is passed **in full** to child frames (no 63/64 rule). On every child outcome, the parent adopts the child's resulting `state_gas_reservoir`.
+- On child **success**, unused `gas_left` is returned to the parent. The child's net `state_gas_spent`, frame-local `state_gas_spilled`, and execution refund counter are added to the parent's counters.
+- On child **revert** or **exceptional halt**, the child first rolls back its own state-gas charges in last-in, first-out order: `gas_left += state_gas_spilled` and `state_gas_reservoir += state_gas_spent - state_gas_spilled`. Both state-gas counters are then reset to zero, and the child's execution refund counter is dropped.
+  - On **revert**, the child's resulting `gas_left`, including the returned spill, is returned to the parent. The restored reservoir is adopted by the parent, but no child state-gas or refund counters are propagated.
+  - On **exceptional halt**, the same state-gas rollback occurs first, then the child's `gas_left` is set to zero and is not returned to the parent. The restored reservoir is still adopted by the parent, but no child state-gas or refund counters are propagated.
 - **System transactions** are not subject to the `max_transaction_gas_limit` cap; their entire `available_gas` is placed in `gas_left` with `state_gas_reservoir = 0`.
 
-The two counters are returned by the transaction output. Besides the two counters, the EVM also keeps track of `execution_state_gas_used` and `execution_gas_used` during block execution. `state_gas` costs are added to `execution_state_gas_used` while `execution_gas` costs are added to `execution_gas_used`. These two counters are also returned by the transaction output.
+The transaction output returns the remaining gas counters and `execution_gas_used`. Tempo does not track an `execution_state_gas_used` counter: state gas is accounted within the gas tracker through `state_gas_spent` for charging, refill, and transaction settlement, but it is not accumulated into a block state-gas counter. `execution_gas_used` records execution-only gas consumption before refunds and is used with intrinsic execution gas, the execution-gas refund, and the calldata floor to calculate the transaction's contribution to `block_execution_gas_used`.
 
 ## Transaction Gas Used
 
@@ -182,7 +187,7 @@ tx_gas_used_after_refund = max(
 )
 ```
 
-**Divergence from EIP-8037**: EIP-8037 caps the refund at 20% of gas used (EIP-3529); Tempo applies `refund_counter` in full, as [TIP-1060](./tip-1060.md) removed the cap. The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) ensures the user always pays at least the calldata floor, even if refunds would bring the total below it. Refunds apply only to user-paid gas; block-level accounting uses `tx_execution_gas` (execution gas only, no refund subtracted) — see [Block-Level Gas Accounting](#block-level-gas-accounting).
+**Divergence from EIP-8037**: EIP-8037 caps the refund at 20% of gas used (EIP-3529); Tempo applies `refund_counter` in full, as [TIP-1060](./tip-1060.md) removed the cap. The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) ensures the user always pays at least the calldata floor, even if refunds would bring the total below it. The same execution-gas refund also reduces block-level execution gas — see [Block-Level Gas Accounting](#block-level-gas-accounting).
 
 **Note**: EIP-8037 uses `tx_gas_used` in the refund and post-refund formulas, but that variable is not defined in the same code block. TIP-1016 uses `tx_gas_used_before_refund` consistently to avoid ambiguity.
 
@@ -191,14 +196,20 @@ tx_gas_used_after_refund = max(
 At block level, only **execution gas** counts toward block gas limits. State gas is exempt — it is not tracked at the block level and does not constrain block capacity.
 
 ```python
-tx_execution_gas = intrinsic_execution_gas + tx_output.execution_gas_used
+tx_execution_gas_before_refund = intrinsic_execution_gas + tx_output.execution_gas_used
+tx_execution_gas_after_refund = tx_execution_gas_before_refund - tx_gas_refund
 
-block_output.block_execution_gas_used += max(tx_execution_gas, calldata_floor_gas_cost)
+block_output.block_execution_gas_used += max(
+    tx_execution_gas_after_refund,
+    calldata_floor_gas_cost
+)
 ```
 
-The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) ensures calldata-heavy transactions consume at least the floor cost worth of block capacity. The floor applies to execution gas only — state gas remains fully exempt from block limits.
+Tempo intentionally does not adopt [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778). [TIP-1060](./tip-1060.md) removes the storage-clearing refund and replaces it with storage credits, so the refund counter cannot reduce block gas for a committed storage deletion. The remaining execution refunds reverse restore-to-original write charges and therefore reduce the transaction's execution gas before its block contribution is calculated. State gas cannot absorb these refunds and remains fully exempt from block limits.
 
-Per [EIP-7778](https://eips.ethereum.org/EIPS/eip-7778), `tx_execution_gas` is the pre-refund value: `tx_gas_refund` is **not** subtracted from block accounting. This prevents block gas limit circumvention via refundable operations while preserving user incentives to clean up state.
+`tx_gas_refund` cannot exceed `tx_execution_gas_before_refund`, so the subtraction does not require saturation or a zero floor.
+
+The `max` with `calldata_floor_gas_cost` ([EIP-7623](https://eips.ethereum.org/EIPS/eip-7623)) is applied after the refund, ensuring calldata-heavy transactions still consume at least the floor cost worth of block capacity.
 
 The block header `gas_used` field is set to:
 
@@ -218,24 +229,30 @@ The base fee update rule uses this same value:
 gas_used_delta = parent.gas_used - parent.gas_target
 ```
 
-**Note**: Tempo has two block limits — general gas limit (~25M) for contracts and payment lane limit (500M) for simple transfers. In both lanes, only execution gas counts toward the limit; state gas is exempt.
+**Note**: Tempo has two block limits — a general gas limit of 30M gas for contracts and a payment lane limit of 500M gas for simple transfers. In both lanes, only execution gas counts toward the limit; state gas is exempt.
 
-**Divergence from EIP-8037**: EIP-8037 uses a bottleneck model where `gas_used = max(block_execution_gas, block_state_gas)`, effectively capping state gas at the block gas limit. TIP-1016 instead exempts state gas entirely from block limits, relying on fixed high prices (250,000 gas per state element) as the economic deterrent for state growth.
+**Divergence from EIP-8037**: EIP-8037 uses a bottleneck model where `gas_used = max(block_execution_gas, block_state_gas)`, effectively capping state gas at the block gas limit. TIP-1016 instead exempts state gas entirely from block limits, relying on fixed high prices (for example, 245,000 state gas per storage slot) as the economic deterrent for state growth.
 
-## SSTORE Slot Restoration
+## Interaction with TIP-1060
 
-Slot restoration (0→X→0 within one transaction) is settled in two dimensions:
+[TIP-1060](./tip-1060.md) remains authoritative for storage-credit minting, consumption, modes, and settlement. TIP-1016 does not introduce a separate SSTORE slot-restoration mechanism or change which storage transitions mint or consume credits.
 
-- **Execution gas**: the write component (`SSTORE_SET_COST` = 5,000; EIP-8037 equivalent: 2,800) is refunded via `refund_counter`. The EIP-3529 clearing refund remains zero per TIP-1060. Refunds on `refund_counter` are dropped when the recording frame reverts.
-- **State gas**: the 245,000 creditable portion never flows through `refund_counter` — it follows [TIP-1060](./tip-1060.md) storage credits, with TIP-1016 changing only the gas dimension: creations charge state gas, and end-of-transaction settlement returns `min(pending, balance) × 245,000` via a reservoir refill, so `state_gas_spent` reflects only state actually created. In the default `Refund` mode a 0→X→0 pattern therefore gets the 245,000 back at settlement (the x→0 clear mints the credit that settlement consumes); other modes and non-creditable slots follow TIP-1060 (credit kept in `Preserve`, spent directly in `Direct`, no mint for non-creditable slots).
+TIP-1060 accounts the 245,000 gas-backed value represented by a storage credit as execution gas. Under TIP-1016, the same amount is charged as state gas instead. The 5,000 `SSTORE_SET_COST` component and warm or cold access charge remain execution gas.
 
-**Divergence from EIP-8037**: EIP-8037 restores 0→x→0 state gas by refilling the reservoir directly at the restoring SSTORE; TIP-1016 reaches the same result for the default `Refund` mode via credit mint plus settlement, but the outcome is mode- and slot-dependent per TIP-1060.
+The TIP-1060 behavior is otherwise unchanged:
+
+- A committed nonzero-to-zero storage transition mints one account-local storage credit instead of receiving a storage-clearing refund.
+- A zero-to-nonzero storage transition either charges 245,000 state gas or consumes one storage credit, depending on the account's `Refund`, `Preserve`, or `Direct` mode.
+- In `Refund` mode, the creation charges 245,000 state gas upfront. End-of-transaction settlement consumes available credits and returns the corresponding state gas through reservoir refill, not through the execution-gas `refund_counter`.
+- In `Preserve` mode, the creation charges 245,000 state gas and leaves the credit balance unchanged.
+- In `Direct` mode, an available credit covers the 245,000 state-gas charge synchronously; otherwise the creation charges state gas normally.
+- Credit minting, consumption, pending settlement, account locality, journaling, and exclusions for protocol bookkeeping slots continue to follow TIP-1060.
 
 ## Revert Behavior for State Gas
 
-State gas charged for account creation (`CREATE`, `CALL` to new account, and EOA delegation) is consumed even if the frame reverts — state changes are rolled back but gas is not refunded. This is consistent with pre-EIP-8037 behavior where `GAS_NEW_ACCOUNT` was consumed on revert.
+State gas for conditional account creation by `CALL`, `CREATE`, or `CREATE2` is charged in the creating frame before entering the child. If the child reverts or halts exceptionally, or creation otherwise completes without creating the account leaf, the upfront state-gas charge is refilled in LIFO order because no durable state was created. A successful creation keeps the charge.
 
-This is achieved structurally: `GAS_NEW_ACCOUNT` state gas is charged in the **parent frame** before creating the child frame. On child revert, `handle_reservoir_remaining_gas` rolls back only the child's own state-gas charges (per Invariant 14) — the parent's prior charge is preserved. Similarly, `GAS_CREATE` state gas for contract deployment is charged in the parent before the child initcode runs.
+EIP-7702 authorization changes are applied during pre-execution and persist even if subsequent EVM execution reverts, so their state-gas charges are not refilled for an execution-frame failure.
 
 ## Receipt Semantics
 
@@ -249,7 +266,7 @@ Contract code storage cost increases from 1,000 to **2,500 gas/byte** (200 execu
 
 When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed, gas is charged differently based on whether the deployment succeeds or fails. Given bytecode `B` (length `L`) returned by initcode and `H = keccak256(B)`:
 
-**When opcode execution starts:** Always charge `GAS_CREATE` (Tempo: 32,000 execution + 468,000 state; EIP-8037: 9,000 execution + `112 × cpsb` state)
+**When creation starts:** Charge the 32,000 execution-gas portion of `GAS_CREATE`. If the destination account does not exist and the creation will add a new account leaf, charge the 468,000 state-gas portion in the creating frame before entering the initcode frame. If the destination already has an account leaf, the account-creation state portion is not charged.
 
 **During initcode execution:** Charge the actual gas consumed by the initcode execution
 
@@ -257,21 +274,22 @@ When a contract creation transaction or opcode (`CREATE`/`CREATE2`) is executed,
 - Charge `GAS_CODE_DEPOSIT * L` (200 execution + 2,300 state per byte) and persist `B` under `H`, then link `codeHash` to `H`
 - Charge `HASH_COST(L)` where `HASH_COST(L) = 6 × ceil(L / 32)` to compute `H`
 
-**Failure paths** (REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
+**Failure paths** (address collision, REVERT, OOG/invalid during initcode, OOG during code deposit, or `L > MAX_CODE_SIZE`):
 - Do NOT charge `GAS_CODE_DEPOSIT * L` or `HASH_COST(L)`
 - No code is stored; no `codeHash` is linked to the account
 - The account remains unchanged or non-existent
+- If the 468,000 account-creation state-gas portion of `GAS_CREATE` was charged, refill it in LIFO order: first to `gas_left` up to the creating frame's `state_gas_spilled`, then to `state_gas_reservoir`. Decrement `state_gas_spent` by the same amount. The 32,000 execution-gas portion and execution gas consumed by the failed creation are not refilled.
+- Apply the same state-gas refill rule to a failed top-level contract-creation transaction.
 
-This is aligned with EIP-8037's deployment flow, where `GAS_CODE_DEPOSIT` is charged only on the success path.
+This is aligned with EIP-8037's deployment flow: the account-creation state charge is conditional and refilled when no account is created, while `GAS_CODE_DEPOSIT` is charged only on the success path.
 
 ### Example: 24KB Contract Deployment
 
 Operation | Execution gas | State gas
 ----------|---------|----------
 Contract code | `24,576 × 200 = 4,915,200` | `24,576 × 2,300 = 56,524,800`
-Contract fixed upfront | `32,000` | `468,000`
+Contract fixed upfront (new account) | `32,000` | `468,000`
 Deployment logic | ~2M | 0
-----------|---------|----------
 **Totals:** | ~7M (counts toward protocol limits via `gas_left`) | ~57M (served from `state_gas_reservoir`, doesn't count toward protocol limits)
 
 Total gas: ~64M (user must authorize with `gas_limit >= 64M`)
@@ -280,38 +298,40 @@ Total gas: ~64M (user must authorize with `gas_limit >= 64M`)
 
 ## Examples
 
-### TIP-20 Transfer to New Address
-- Transfer logic: ~50,000 execution gas
-- New balance slot: 5,100 execution gas + 245,000 state gas
-- **Total**: ~55,000 execution gas + 245,000 state gas = ~300,000 gas
-- User must authorize: `gas_limit >= 300,000`
-- Counts toward block limit: ~55,000 execution gas
+The TIP-20 figures below are rounded up from the T12 transfer test fixture. Exact execution gas can vary slightly with calldata and the policy or reward path.
+
+### TIP-20 Transfer to Address Without an Existing Balance Slot
+- Execution, including the new balance-slot path: ~47,000 gas
+- New balance slot: 245,000 state gas
+- **Total**: ~47,000 execution gas + 245,000 state gas = ~292,000 gas
+- User must authorize: `gas_limit >= 292,000`
+- Counts toward block limit: ~47,000 execution gas
 - Reservoir initialization (assuming `max_transaction_gas_limit = 16M`):
   - `intrinsic_gas = intrinsic_execution + intrinsic_state ≈ 21,000 + 0 = 21,000`
-  - `available_gas = 300,000 - 21,000 = 279,000`
+  - `available_gas ≈ 292,000 - 21,000 = 271,000`
   - `execution_gas_budget = 16M - 21,000 ≈ 15,979,000`
-  - `gas_left = min(15,979,000, 279,000) = 279,000`
-  - `state_gas_reservoir = 279,000 - 279,000 = 0`
+  - `gas_left = min(15,979,000, 271,000) = 271,000`
+  - `state_gas_reservoir = 271,000 - 271,000 = 0`
   - Since total < `max_transaction_gas_limit`, all gas fits in `gas_left`; state gas draws from `gas_left`
-- `GAS` opcode accurately reflects execution budget (~279,000 before execution)
-- Block accounting: adds ~55,000 to `block_execution_gas_used` (state gas is exempt from block limits)
-- Total cost: ~300,000 gas
+- `GAS` opcode accurately reflects the available gas (~271,000 before execution, using the approximate intrinsic gas above)
+- Block accounting: adds ~47,000 to `block_execution_gas_used` (state gas is exempt from block limits)
+- Total cost: ~292,000 gas
 
-### TIP-20 Transfer to Existing Address
-- Transfer logic: ~50,000 execution gas
-- Update existing slot: included in transfer logic
-- **Total**: ~50,000 execution gas
-- User must authorize: `gas_limit >= 50,000`
-- Counts toward block limit: ~50,000 execution gas
-- Total cost: ~50,000 gas
+### TIP-20 Transfer to Address With an Existing Balance Slot
+- Execution, including the existing balance-slot update: ~43,000 gas
+- State gas: 0
+- **Total**: ~43,000 execution gas
+- User must authorize: `gas_limit >= 43,000`
+- Counts toward block limit: ~43,000 execution gas
+- Total cost: ~43,000 gas
 
 ### Block Throughput
 At 500M payment lane gas limit (only execution gas counts toward block limits):
 
-- **New account transfers**: ~55k execution gas each → ~9,090 transfers/block ≈ 18,200 TPS
-- **Existing account transfers**: ~50k execution gas each → ~10,000 transfers/block ≈ 20,000 TPS
+- **New-balance transfers**: ~47,000 execution gas each → ~10,638 transfers/block ≈ 21,276 TPS
+- **Existing-balance transfers**: ~43,000 execution gas each → ~11,627 transfers/block ≈ 23,254 TPS
 - **Mixed workload**: Only execution gas constrains capacity. A block can contain any mix of new and existing transfers as long as total execution gas ≤ 500M. State gas doesn't reduce block capacity.
-- **vs TIP-1000**: ~9,090 new account transfers/block vs ~1,700 without exemption (~5x improvement)
+- **vs TIP-1000**: ~10,638 new-balance transfers/block vs ~1,712 without exemption (~6.2x improvement)
 
 ---
 
@@ -320,7 +340,7 @@ At 500M payment lane gas limit (only execution gas counts toward block limits):
 1. **User Authorization**: Total gas used (execution + state) MUST NOT exceed `transaction.gas_limit` (prevents surprise costs)
 2. **Protocol Transaction Limit**: Execution gas (via `gas_left`) MUST NOT exceed `max_transaction_gas_limit` (EIP-7825 limit, e.g. 16M)
 3. **Protocol Block Limits**: Block `execution_gas` MUST NOT exceed applicable limit:
-   - General transactions: `general_gas_limit` (25M target, currently 30M)
+   - General transactions: `general_gas_limit` (30M gas)
    - Payment lane transactions: `payment_lane_limit` (500M)
 4. **State Gas Exemption**: State gas MUST NOT count toward protocol limits (transaction or block). State gas is uncapped at the block level.
 5. **Reservoir Model**: Gas accounting MUST use the reservoir model — `gas_left` and `state_gas_reservoir` initialized from `tx.gas`, with state gas drawing from reservoir first
@@ -330,14 +350,14 @@ At 500M payment lane gas limit (only execution gas counts toward block limits):
 9. **Execution Gas Component**: Storage creation operations MUST charge execution gas for computational overhead (writing, hashing)
 10. **Total Cost**: Transaction cost MUST equal `(execution_gas + state_gas) × (base_fee_per_gas + priority_fee)`
 11. **Gas Split**: Storage creation operations MUST split cost into execution gas (computational) and state gas (permanent burden)
-12. **Hot vs Cold**: Hot SSTORE (non-zero → non-zero) has NO state gas component; cold SSTORE (zero → non-zero) has both
-13. **Refund via Counter**: The execution write component of SSTORE slot restoration (`SSTORE_SET_COST`) MUST be refunded via `refund_counter`, not direct gas decrements; the 245,000 creditable portion MUST NOT — it is settled via TIP-1060 credits and reservoir refill (see [SSTORE Slot Restoration](#sstore-slot-restoration))
-14. **Revert Behavior**: On child revert or exceptional halt, the child's state-gas charges MUST be rolled back — the reservoir-drawn portion to the parent's `state_gas_reservoir`, the spilled portion to regular `remaining` (consumed on exceptional halt) — **except** state gas for account creation (`GAS_NEW_ACCOUNT`), which MUST be consumed even on revert
-15. **Execution Gas Floor**: The execution gas component of each storage creation operation MUST be at least the pre-TIP-1000 (standard EVM) cost for that operation (account creation: 25,000, CREATE base: 32,000, code deposit: 200/byte), except SSTORE, whose execution component mirrors the TIP-1060 gas table (`SSTORE_SET_COST = 5,000` as the write component, on top of the standard access gas) so that clean creations are priced identically to TIP-1060
-16. **EIP-7702 Delegation**: Each EIP-7702 authorization MUST charge 25,000 execution gas + 225,000 state gas (250,000 total). Authorizations with `auth.nonce == 0` MUST additionally charge the account creation cost (25,000 execution + 225,000 state)
-17. **Precompile Consistency**: All precompile storage operations MUST use the same gas accounting path as standard EVM SSTORE, inheriting the execution/state gas split automatically
-18. **Keychain Authorization**: Keychain `authorize_key` intrinsic gas MUST split SSTORE costs using the same execution/state ratio as standard EVM SSTOREs (5,000 execution + 245,000 state per new slot, access charges separate)
-19. **Calldata Floor (EIP-7623)**: The calldata floor (`TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata + 21000`) MUST apply to execution gas only — it MUST NOT interact with `state_gas_reservoir`. Transaction validation MUST reject when `max(intrinsic_execution_gas, calldata_floor_gas_cost) > max_transaction_gas_limit`. Post-execution `tx_gas_used_after_refund` and block `block_execution_gas_used` MUST be at least `calldata_floor_gas_cost`
+12. **SSTORE State Gas**: Warm or cold access affects only the execution-gas access charge. A zero-to-nonzero storage transition follows TIP-1060: its 245,000 state-gas component is charged, covered by a credit, or returned at settlement according to the account's mode and available credits. A nonzero-to-nonzero transition has no state-creation gas
+13. **TIP-1060 Storage Credits**: TIP-1016 MUST NOT introduce a separate SSTORE restoration mechanism. TIP-1060 remains authoritative for credit minting, consumption, modes, and settlement. Its credit-backed creation amount MUST be accounted as 245,000 state gas rather than execution gas, and settlement MUST return that amount through reservoir refill rather than `refund_counter` (see [Interaction with TIP-1060](#interaction-with-tip-1060))
+14. **Revert Behavior**: On child revert or exceptional halt, the child's state-gas charges MUST be refilled in LIFO order — first to the child's regular `remaining` up to its frame-local `state_gas_spilled`, then to `state_gas_reservoir`. On revert, the resulting `remaining` returns to the parent; on exceptional halt, it is consumed. Upfront state gas for a conditional `CALL`/`CREATE` account creation MUST also be refilled when no account leaf is created
+15. **EIP-7702 Delegation**: Each EIP-7702 authorization MUST charge 25,000 execution gas + 225,000 state gas (250,000 total). Authorizations with `auth.nonce == 0` MUST additionally charge the account creation cost (25,000 execution + 225,000 state)
+16. **Precompile Consistency**: All precompile storage operations MUST use the same gas accounting path as standard EVM SSTORE, inheriting the execution/state gas split automatically
+17. **Keychain Authorization**: Keychain `authorize_key` intrinsic gas MUST split SSTORE costs using the same execution/state ratio as standard EVM SSTOREs (5,000 execution + 245,000 state per new slot, access charges separate)
+18. **Calldata Floor (EIP-7623)**: The calldata floor (`TOTAL_COST_FLOOR_PER_TOKEN * tokens_in_calldata + 21000`) MUST apply to execution gas only — it MUST NOT interact with `state_gas_reservoir`. Transaction validation MUST reject when `max(intrinsic_execution_gas, calldata_floor_gas_cost) > max_transaction_gas_limit`. Post-execution `tx_gas_used_after_refund` and block `block_execution_gas_used` MUST be at least `calldata_floor_gas_cost`
+19. **Block Refunds**: Tempo MUST intentionally omit EIP-7778 because TIP-1060 removes the storage-clearing refund and replaces it with storage credits. The full remaining execution-gas refund MUST be subtracted from execution gas before calculating the transaction's contribution to `block_execution_gas_used`; the calldata floor MUST be applied after this subtraction
 
 ---
 
@@ -347,11 +367,9 @@ This TIP adopts the **reservoir model** from [EIP-8037](https://eips.ethereum.or
 
 | Aspect | EIP-8037 | TIP-1016 |
 |--------|----------|----------|
-| State gas pricing | Dynamic `cost_per_state_byte` scaling with block gas limit | Fixed costs (e.g., 245,000 per slot) — Tempo uses fixed high prices for state growth protection |
 | Gas cost harmonization | Harmonizes all state creation to uniform cost-per-byte | Maintains Tempo-specific pricing from TIP-1000 |
-| Target state growth | 100 GiB/year dynamic target | Economic deterrence via fixed high costs |
+| Target state growth | 120 GiB/year at a 150M reference block gas limit | Economic deterrence via fixed high costs |
 | Block-level gas accounting | Bottleneck model: `max(block_execution_gas, block_state_gas)` | Execution gas only; state gas fully exempt from block limits |
-| Block gas limit range | 60M–300M+ (Ethereum L1 scaling) | 25M general + 500M payment lane (Tempo dual-lane) |
-| Quantization | Top-5 significant bits with offset for `cost_per_state_byte` | Not applicable (fixed costs) |
+| Block gas limit range | 60M–300M+ (Ethereum L1 scaling) | 30M general + 500M payment lane (Tempo dual-lane) |
 
-The core EVM mechanism — reservoir model, `GAS` opcode semantics, revert behavior, contract deployment flow, and receipt semantics — is shared with EIP-8037, minimizing implementation divergence from upstream. Two divergences remain: at the block level, TIP-1016 exempts state gas entirely from block limits rather than using EIP-8037's bottleneck model; and slot restoration flows through TIP-1060 storage credits rather than EIP-8037's direct state-gas refill (see [SSTORE Slot Restoration](#sstore-slot-restoration)).
+The core EVM mechanism — reservoir model, `GAS` opcode semantics, revert behavior, contract deployment flow, and receipt semantics — is shared with EIP-8037, minimizing implementation divergence from upstream. Two divergences remain: at the block level, TIP-1016 exempts state gas entirely from block limits rather than using EIP-8037's bottleneck model; and storage creation and deletion continue to use TIP-1060 storage credits, with the credit-backed amount moved to state gas (see [Interaction with TIP-1060](#interaction-with-tip-1060)).


### PR DESCRIPTION
Updates TIP-1016 gas accounting to match TIP-1060 pricing and the current reservoir and refill behavior. Clarifies block refunds, contract-creation failure refills, and tested TIP-20 execution gas estimates.