### PR TITLE
perf(txpool): refresh AA 2D pool base fee on canonical state change

### DIFF
--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1271,7 +1271,12 @@ where
     }
 
     fn on_canonical_state_change(&self, update: CanonicalStateUpdate<'_, Self::Block>) {
-        self.protocol_pool.on_canonical_state_change(update)
+        // Keep the AA 2D pool's base fee in sync with the protocol pool. Reth only calls
+        // `set_block_info` at startup and after deep reorgs, so without this the 2D pool would
+        // keep ordering its eviction sets against a stale base fee once the fee starts moving.
+        let pending_basefee = update.pending_block_base_fee;
+        self.protocol_pool.on_canonical_state_change(update);
+        self.aa_2d_pool.write().set_base_fee(pending_basefee);
     }
 
     fn update_accounts(&self, accounts: Vec<ChangedAccount>) {
@@ -1630,6 +1635,44 @@ mod tests {
             },
         );
         provider
+    }
+
+    #[test]
+    fn canonical_state_change_refreshes_aa_2d_base_fee() {
+        use reth_primitives_traits::SealedBlock;
+        use reth_transaction_pool::PoolUpdateKind;
+
+        let pool = create_test_pool(create_provider_with_tip());
+        let initial_base_fee = pool.aa_2d_pool.read().base_fee();
+
+        let new_tip = SealedBlock::seal_slow(Block {
+            header: TempoHeader {
+                inner: Header {
+                    gas_limit: TEMPO_T1_TX_GAS_LIMIT_CAP,
+                    base_fee_per_gas: Some(initial_base_fee),
+                    excess_blob_gas: Some(0),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            body: Default::default(),
+        });
+        let pending_block_base_fee = initial_base_fee + 1_000;
+
+        pool.on_canonical_state_change(CanonicalStateUpdate {
+            new_tip: &new_tip,
+            pending_block_base_fee,
+            pending_block_blob_fee: None,
+            changed_accounts: Vec::new(),
+            mined_transactions: Vec::new(),
+            update_kind: PoolUpdateKind::Commit,
+        });
+
+        assert_eq!(pool.aa_2d_pool.read().base_fee(), pending_block_base_fee);
+        assert_eq!(
+            pool.protocol_pool.block_info().pending_basefee,
+            pending_block_base_fee
+        );
     }
 
     #[test]

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -180,6 +180,12 @@ impl AA2dPool {
         self.metrics.set_transaction_counts(total, pending, queued);
     }
 
+    /// Returns the base fee the eviction orders are currently keyed against.
+    #[cfg(test)]
+    pub(crate) const fn base_fee(&self) -> u64 {
+        self.base_fee
+    }
+
     pub(crate) fn set_base_fee(&mut self, base_fee: u64) {
         if self.base_fee == base_fee {
             return;


### PR DESCRIPTION
The AA 2D pool keys its eviction sets and best-transaction orders by base fee, but the only place that updated that base fee was `set_block_info`, which reth calls at startup and after deep reorgs. `on_canonical_state_change` only forwarded to the protocol pool. Once the T7 dynamic base fee starts moving, the 2D pool keeps ordering against a stale value, so every `best_transactions` call takes the slow path in `best_transactions_with_base_fee`: the expiring-nonce order and the independent order are rebuilt from scratch with priority recomputation under the pool read lock, instead of cloning the maintained orders. The stale value also meant eviction ordering used outdated priorities.

This forwards the pending base fee from the canonical state update to the 2D pool, mirroring what `set_block_info` already does. The rebuild now happens once per block on the maintenance path, and only when the base fee actually changed, while payload builds hit the clone fast path.