### PR TITLE
perf(builder): release state hook and BAL sender before merging transitions

### DIFF
--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -1012,15 +1012,16 @@ where
         let (evm, execution_result) = executor.finish()?;
         let evm_env = evm.into_env();
 
-        // merge all transitions into bundle state before deriving the hashed post-state
-        db.merge_transitions(BundleRetention::Reverts);
-
         // Drop the state hook to signal that execution is complete and the sparse trie task can
-        // finalize the state root.
+        // finalize the state root. Nothing commits to `db` after `finish`, so this can happen
+        // before the transitions are merged, letting the trie finalization overlap with it.
         db.set_state_hook(None);
 
         // Drop the BAL task sender to trigger finalization.
         let bal_rx = bal_task_handle.map(|handle| handle.into_bal_rx());
+
+        // merge all transitions into bundle state before deriving the hashed post-state
+        db.merge_transitions(BundleRetention::Reverts);
 
         let hashed_state = if let Some(Ok(hashed_state)) = state_root_handle
             .as_mut()


### PR DESCRIPTION
During payload finalization the builder merged all transitions into the bundle state before dropping the state hook and the BAL task sender. Those two drops are what tell the sparse trie task and the BAL task that execution is complete, so their finalization could not start until `merge_transitions` had finished, serializing that work ahead of them on the builder finish path.

Nothing commits to the database after `executor.finish()` returns, so the hook and the sender can be released right after it. `merge_transitions` still runs before the hashed post-state fallback and block assembly read the bundle state, it just overlaps with the trie and BAL finalization now.