### PR TITLE
perf(txpool): use cached hardfork for expiring nonce check during validation

### DIFF
--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -603,14 +603,8 @@ where
                         );
                     }
 
-                    // Check if T1 hardfork is active for expiring nonce handling
-                    let current_time = self.inner.fork_tracker().tip_timestamp();
-                    let is_t1_active = self
-                        .inner
-                        .chain_spec()
-                        .is_t1_active_at_timestamp(current_time);
-
-                    if is_t1_active && nonce_key == TEMPO_EXPIRING_NONCE_KEY {
+                    // Expiring nonces are only recognized once T1 is active at the tip.
+                    if spec.is_t1() && nonce_key == TEMPO_EXPIRING_NONCE_KEY {
                         // Expiring nonce transactions are validated by the EVM
                     } else {
                         // This is a 2D nonce transaction - validate against 2D nonce


### PR DESCRIPTION
`validate_one_with_evm` already loads the active hardfork once from the validator's atomic cache, but the expiring-nonce branch for AA 2D transactions still went back to the chain spec and resolved T1 against the fork tracker's tip timestamp for every transaction. Both values derive from the same tip, so this reuses the cached `spec` and drops the per-transaction chain spec lookup.