### PR TITLE
perf(precompiles): allocate the non-creditable slot set lazily

### DIFF
--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -28,7 +28,11 @@ pub struct EvmPrecompileStorageProvider<'a> {
     gas_params: GasParams,
     tip1060_storage_credits_enabled: bool,
     tip1060_storage_credit_minting_enabled: bool,
-    non_creditable_slots: Rc<RefCell<NonCreditableSlots>>,
+    /// Transaction-local non-creditable slots, only present when a caller installed them.
+    ///
+    /// `None` behaves like an empty set, which avoids allocating one for every storage context
+    /// that never consults it.
+    non_creditable_slots: Option<Rc<RefCell<NonCreditableSlots>>>,
     /// Debug-only LIFO checkpoint validator. See [`Self::assert_lifo`].
     #[cfg(debug_assertions)]
     checkpoint_stack: Vec<(usize, usize)>,
@@ -56,7 +60,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
             gas_params,
             tip1060_storage_credits_enabled: spec.is_t7(),
             tip1060_storage_credit_minting_enabled: true,
-            non_creditable_slots: Rc::new(RefCell::new(NonCreditableSlots::empty())),
+            non_creditable_slots: None,
             #[cfg(debug_assertions)]
             checkpoint_stack: Vec::new(),
             actions: StorageActions::disabled(),
@@ -102,7 +106,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
 
     /// Sets the transaction-local non-creditable clear-slot context for this provider.
     pub fn with_non_creditable_slots(mut self, slots: Rc<RefCell<NonCreditableSlots>>) -> Self {
-        self.non_creditable_slots = slots;
+        self.non_creditable_slots = Some(slots);
         self
     }
 
@@ -329,8 +333,8 @@ impl crate::storage_credits::StorageCreditsBackend for EvmPrecompileStorageProvi
     #[inline]
     fn is_non_creditable_slot(&mut self, owner: Address, key: U256) -> bool {
         self.non_creditable_slots
-            .borrow()
-            .is_non_creditable_slot(owner, key)
+            .as_ref()
+            .is_some_and(|slots| slots.borrow().is_non_creditable_slot(owner, key))
     }
 
     #[inline]


### PR DESCRIPTION
`EvmPrecompileStorageProvider::new` allocated an `Rc<RefCell<NonCreditableSlots>>` for every storage context it was created for, even though most contexts never consult it: the handler opens six to eight contexts per transaction for fee, nonce and keychain work, and the precompile wrapper builds one per precompile call and immediately replaces the fresh allocation with the transaction's shared set. An absent set behaves exactly like an empty one, so the field is now an `Option` that stays `None` until a caller installs the transaction-scoped set.

On the txgen TIP-20 workload of the `tip20_execution` bench this removes 5 of the 98 heap allocations per transaction (measured with a counting global allocator wrapped around jemalloc in a throwaway copy of the bench). Individually this change is within the run-to-run noise of the `tip20_execution` bench (about ±4% between quiet runs). The combined branch of the nine precompile-path changes in this batch, measured the same way with a throwaway counting allocator wrapped around jemalloc, runs the 4096-transaction txgen workload in 28.4 ms (current hardfork) and 26.4 ms (latest) against baselines of 29.6 to 30.8 ms across five quiet runs, with allocations down from 98.0 to 89.0 per transaction.

CI's CodSpeed report (instruction-count based, so independent of binary layout) puts this at about +1% across the TIP-20 benchmarks, with the txgen TIP-20 execution benchmark at 142.0 → 140.9 ms (current) and 142.2 → 141.0 ms (latest).