### PR TITLE
perf(precompiles): avoid RefCell borrow tracking in HandlerCache::get_or_insert_mut

### DIFF
--- a/crates/precompiles/src/storage/types/cache.rs
+++ b/crates/precompiles/src/storage/types/cache.rs
@@ -188,8 +188,9 @@ where
     /// Returns a mutable reference to a lazily initialized handler for the given key.
     #[inline]
     pub(crate) fn get_or_insert_mut(&mut self, key: &K, f: impl FnOnce() -> H) -> &mut H {
-        let mut cache = self.inner.borrow_mut();
-        let ptr = match &mut *cache {
+        // `&mut self` already guarantees exclusive access, so skip the `RefCell` borrow tracking.
+        let cache = self.inner.get_mut();
+        let ptr = match cache {
             HandlerCacheState::Linear(linear) => {
                 if let Some(ptr) = linear.find_mut(key) {
                     ptr
@@ -198,7 +199,7 @@ where
                 } else {
                     let map = Self::promote_to_map(linear);
                     *cache = HandlerCacheState::Mapped(map);
-                    match &mut *cache {
+                    match cache {
                         HandlerCacheState::Mapped(map) => map.get_or_insert_mut(key, f),
                         HandlerCacheState::Linear(_) => unreachable!("handler cache was promoted"),
                     }


### PR DESCRIPTION
`HandlerCache::get_or_insert_mut` takes `&mut self` but still went through `RefCell::borrow_mut`, paying the borrow-flag update and keeping a panic path in what is the mutable mapping index used by every precompile write. With exclusive access already guaranteed by the signature, `RefCell::get_mut` gives the same reference without the runtime check. Behavior is unchanged. Individually this change is within the run-to-run noise of the `tip20_execution` bench (about ±4% between quiet runs). The combined branch of the nine precompile-path changes in this batch, measured the same way with a throwaway counting allocator wrapped around jemalloc, runs the 4096-transaction txgen workload in 28.4 ms (current hardfork) and 26.4 ms (latest) against baselines of 29.6 to 30.8 ms across five quiet runs, with allocations down from 98.0 to 89.0 per transaction.

CI's CodSpeed report (instruction-count based) shows no measurable change on the execution benchmarks (txgen TIP-20 execution 142.2 → 141.6 ms).