### PR TITLE
fix(txpool): resolve state provider overlay before validating

### DIFF
--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -46,6 +46,7 @@ use tempo_primitives::{
 use tempo_revm::{
     TempoBlockEnv, TempoInvalidTransaction, TempoStateAccess, error::FeePaymentError,
 };
+use tracing::debug;
 
 // Reject AA txs where `valid_before` is too close to current time (or already expired) to prevent block invalidation.
 const AA_VALID_BEFORE_MIN_SECS: u64 = 3;
@@ -84,6 +85,9 @@ const MAX_KEYCHAIN_CALL_SCOPES: u8 = 64;
 const MAX_KEYCHAIN_SELECTOR_RULES_PER_SCOPE: u8 = 64;
 /// Maximum number of recipients per selector rule.
 const MAX_KEYCHAIN_RECIPIENTS_PER_SELECTOR: u8 = 64;
+
+/// Maximum number of attempts to obtain a state provider that resolves its in-memory overlay.
+const MAX_STATE_PROVIDER_ATTEMPTS: u8 = 3;
 
 /// Validator for Tempo transactions.
 #[derive(Debug)]
@@ -365,12 +369,36 @@ where
     }
 
     /// Returns the latest state provider and a state cache valid for the provider's tip.
+    ///
+    /// The provider snapshots the database when it is created but only overlays the canonical
+    /// in-memory blocks on top of it when it first reads state. Persistence can complete in that
+    /// gap and drop those blocks from the in-memory chain while the snapshot still predates their
+    /// write, leaving the overlay unresolvable. Forcing the overlay here keeps that failure
+    /// recoverable, because a fresh provider observes the persisted blocks; deferring it to the
+    /// EVM would surface it as a fatal database error mid-validation instead.
     fn latest_state_provider_and_cache(
         &self,
     ) -> ProviderResult<(StateProviderBox, Arc<StateCache>)> {
-        let state_provider = self.inner.client().latest()?;
-        let latest_hash = self.inner.client().chain_info()?.best_hash;
-        Ok((state_provider, self.state_cache_for_tip(latest_hash)))
+        let mut attempt = 1;
+        loop {
+            let state_provider = self.inner.client().latest()?;
+            let latest_hash = self.inner.client().chain_info()?.best_hash;
+
+            // Any account read resolves the overlay; the account itself is irrelevant.
+            match state_provider.basic_account(&Address::ZERO) {
+                Ok(_) => return Ok((state_provider, self.state_cache_for_tip(latest_hash))),
+                Err(err) if attempt == MAX_STATE_PROVIDER_ATTEMPTS => return Err(err),
+                Err(err) => {
+                    debug!(
+                        target: "txpool",
+                        %err,
+                        attempt,
+                        "retrying state provider with an unresolvable in-memory overlay"
+                    );
+                    attempt += 1;
+                }
+            }
+        }
     }
 
     /// Returns the shared cache if it matches `tip_hash`, otherwise an empty ephemeral cache.


### PR DESCRIPTION
Pool validation intermittently failed with `-32603: Fatal precompile error: "block hash 0x.. does not exist in Headers table"`, taking down `gas::tip20_transfers::test_tip20_transfer_gas_snapshots` and `tempo_transaction::test_matrices_local::devnet` in CI ([example run](https://github.com/tempoxyz/tempo/actions/runs/33659584385/job/100346720398)).

`StateProviderFactory::latest` returns a provider that snapshots the database when it is created but only walks the canonical in-memory blocks on its first state read. In the validator that first read happens inside the EVM, so when persistence commits in between — dropping those blocks from the in-memory chain while the snapshot still predates their write — the overlay can no longer be anchored and the provider error reaches the caller wrapped as a fatal precompile error rather than a retryable one.

Resolving the overlay right after the provider is created keeps the failure recoverable: a fresh provider observes the persisted blocks, so a bounded retry gets a usable snapshot instead of aborting validation.

This is fixed upstream in https://github.com/paradigmxyz/reth/pull/26917 by snapshotting the parent blocks into the provider, and the workaround can go once we pick that up. Bumping the reth pin alone does not get us there today: reth's revm 43 reapply sits between our pinned revision and that fix, so it needs revm 43 and alloy-evm 0.39 here first (#7328).

Verified by widening the race window (persist and trim on every block, 150ms between `latest()` and the first state read): the tip20 gas matrix fails within two seconds with the exact CI error on main, and passes the full 85-case matrix with this change in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)