### PR TITLE
ci: re-pin the vendored CodSpeed action to a commit that keeps its installer hashes

### DIFF
--- a/.github/workflows/codspeed-microbench.yml
+++ b/.github/workflows/codspeed-microbench.yml
@@ -149,7 +149,7 @@ jobs:
           # shellcheck disable=SC2086  # BUILD_ARGS must word-split into multiple cargo args
           cargo codspeed build $BUILD_ARGS
       - name: Run benchmark target(s)
-        uses: tempoxyz/gh-actions/vendor/CodSpeedHQ/action@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
+        uses: tempoxyz/gh-actions/vendor/CodSpeedHQ/action@58e2045a79b95e1867484a8e3cd28e7804d4cae1
         with:
           mode: ${{ steps.args.outputs.measurement_modes }}
           run: cargo codspeed run ${{ steps.args.outputs.run_args }}


### PR DESCRIPTION
## Summary

Re-pins `tempoxyz/gh-actions/vendor/CodSpeedHQ/action` to [`58e2045a79b95e1867484a8e3cd28e7804d4cae1`](https://github.com/tempoxyz/gh-actions/commit/58e2045a79b95e1867484a8e3cd28e7804d4cae1). The previous pin had pruned `.codspeed-runner-installer-hashes.json`, which the action's installer step loads to verify the runner download, so the CodSpeed microbenchmarks job failed with `Cannot find module` on that path. The new commit keeps the file.

No other change; the action is still the vendored copy of CodSpeedHQ/action v4.19.1.