### PR TITLE
chore: measure alloy-evm allocation fixes end to end (not for merging)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,8 +396,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
+source = "git+https://github.com/alloy-rs/evm?rev=611aa203773d0efd80cdb56fcaf07cf29346fdbf#611aa203773d0efd80cdb56fcaf07cf29346fdbf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -1180,7 +1179,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1191,7 +1190,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,7 +4483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6098,7 +6097,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7271,7 +7270,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12246,7 +12245,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12326,7 +12325,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13006,7 +13005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13286,7 +13285,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15370,7 +15369,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,6 +410,8 @@ vergen-git2 = "10.0.1"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
+# Measurement only: alloy-evm v0.38.0 plus alloy-rs/evm#405 and #406, not for merging.
+alloy-evm = { git = "https://github.com/alloy-rs/evm", rev = "611aa203773d0efd80cdb56fcaf07cf29346fdbf" }
 
 # Commonware v2026.7.0
 # commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }

--- a/crates/precompiles/src/lib.rs
+++ b/crates/precompiles/src/lib.rs
@@ -58,7 +58,7 @@ use tempo_primitives::TempoAddressExt;
 #[cfg(test)]
 use alloy::sol_types::SolInterface;
 use alloy::{primitives::Address, sol, sol_types::SolError};
-use alloy_evm::precompiles::{DynPrecompile, PrecompilesMap};
+use alloy_evm::precompiles::{DynPrecompile, PrecompileLookup, PrecompilesMap};
 use revm::{
     context::CfgEnv,
     handler::EthPrecompiles,
@@ -192,43 +192,76 @@ pub fn extend_tempo_precompiles(
 ) {
     let env = PrecompileEnv::new(cfg, actions, non_creditable_slots);
 
-    precompiles.set_precompile_lookup(move |address: &Address| {
+    precompiles.set_precompile_lookup(TempoPrecompileLookup { env });
+    // Tempo precompiles only depend on per-EVM state captured in `env`, so the resolved
+    // wrappers can be reused across calls instead of being rebuilt for every invocation.
+    precompiles.enable_lookup_cache();
+}
+
+/// Resolves Tempo precompiles by address.
+struct TempoPrecompileLookup {
+    env: PrecompileEnv,
+}
+
+impl PrecompileLookup for TempoPrecompileLookup {
+    fn lookup(&self, address: &Address) -> Option<DynPrecompile> {
+        let env = &self.env;
         if address.is_tip20() {
-            Some(TIP20Token::create_precompile(*address, &env))
+            Some(TIP20Token::create_precompile(*address, env))
         } else if *address == TIP20_FACTORY_ADDRESS {
-            Some(TIP20Factory::create_precompile(&env))
+            Some(TIP20Factory::create_precompile(env))
         } else if *address == TIP20_CHANNEL_RESERVE_ADDRESS && env.cfg.spec.is_t5() {
-            Some(TIP20ChannelReserve::create_precompile(&env))
+            Some(TIP20ChannelReserve::create_precompile(env))
         } else if *address == ADDRESS_REGISTRY_ADDRESS && env.cfg.spec.is_t3() {
-            Some(AddressRegistry::create_precompile(&env))
+            Some(AddressRegistry::create_precompile(env))
         } else if *address == TIP403_REGISTRY_ADDRESS {
-            Some(TIP403Registry::create_precompile(&env))
+            Some(TIP403Registry::create_precompile(env))
         } else if *address == TIP_FEE_MANAGER_ADDRESS {
-            Some(TipFeeManager::create_precompile(&env))
+            Some(TipFeeManager::create_precompile(env))
         } else if *address == STABLECOIN_DEX_ADDRESS {
-            Some(StablecoinDEX::create_precompile(&env))
+            Some(StablecoinDEX::create_precompile(env))
         } else if *address == NONCE_PRECOMPILE_ADDRESS {
-            Some(NonceManager::create_precompile(&env))
+            Some(NonceManager::create_precompile(env))
         } else if *address == VALIDATOR_CONFIG_ADDRESS {
-            Some(ValidatorConfig::create_precompile(&env))
+            Some(ValidatorConfig::create_precompile(env))
         } else if *address == ACCOUNT_KEYCHAIN_ADDRESS {
-            Some(AccountKeychain::create_precompile(&env))
+            Some(AccountKeychain::create_precompile(env))
         } else if *address == VALIDATOR_CONFIG_V2_ADDRESS {
-            Some(ValidatorConfigV2::create_precompile(&env))
+            Some(ValidatorConfigV2::create_precompile(env))
         } else if *address == SIGNATURE_VERIFIER_ADDRESS && env.cfg.spec.is_t3() {
-            Some(SignatureVerifier::create_precompile(&env))
+            Some(SignatureVerifier::create_precompile(env))
         } else if *address == RECEIVE_POLICY_GUARD_ADDRESS && env.cfg.spec.is_t6() {
-            Some(ReceivePolicyGuard::create_precompile(&env))
+            Some(ReceivePolicyGuard::create_precompile(env))
         } else if *address == STORAGE_CREDITS_ADDRESS && env.cfg.spec.is_t7() {
-            Some(StorageCredits::create_precompile(&env))
+            Some(StorageCredits::create_precompile(env))
         } else if *address == CURRENT_COMMITTEE_ADDRESS && env.cfg.spec.is_t8() {
-            Some(CurrentCommittee::create_precompile(&env))
+            Some(CurrentCommittee::create_precompile(env))
         } else if *address == ZONE_FACTORY_ADDRESS && env.cfg.spec.is_t10() {
-            Some(ZoneFactory::create_precompile(&env))
+            Some(ZoneFactory::create_precompile(env))
         } else {
             None
         }
-    });
+    }
+
+    fn contains(&self, address: &Address) -> bool {
+        let spec = self.env.cfg.spec;
+        address.is_tip20()
+            || *address == TIP20_FACTORY_ADDRESS
+            || (*address == TIP20_CHANNEL_RESERVE_ADDRESS && spec.is_t5())
+            || (*address == ADDRESS_REGISTRY_ADDRESS && spec.is_t3())
+            || *address == TIP403_REGISTRY_ADDRESS
+            || *address == TIP_FEE_MANAGER_ADDRESS
+            || *address == STABLECOIN_DEX_ADDRESS
+            || *address == NONCE_PRECOMPILE_ADDRESS
+            || *address == VALIDATOR_CONFIG_ADDRESS
+            || *address == ACCOUNT_KEYCHAIN_ADDRESS
+            || *address == VALIDATOR_CONFIG_V2_ADDRESS
+            || (*address == SIGNATURE_VERIFIER_ADDRESS && spec.is_t3())
+            || (*address == RECEIVE_POLICY_GUARD_ADDRESS && spec.is_t6())
+            || (*address == STORAGE_CREDITS_ADDRESS && spec.is_t7())
+            || (*address == CURRENT_COMMITTEE_ADDRESS && spec.is_t8())
+            || (*address == ZONE_FACTORY_ADDRESS && spec.is_t10())
+    }
 }
 
 sol! {

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -132,9 +132,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         key: U256,
         skip_cold_load: bool,
     ) -> Result<StateLoad<U256>, TempoPrecompileError> {
-        let mut account = self.internals.load_account_mut(address)?;
-        let val = account.sload(key, skip_cold_load)?;
-        Ok(StateLoad::new(val.present_value, val.is_cold))
+        Ok(self.internals.sload_skip_cold_load(address, key, skip_cold_load)?)
     }
 
     /// Performs a raw journaled SSTORE without metering gas or recording a storage action.
@@ -146,10 +144,7 @@ impl<'a> EvmPrecompileStorageProvider<'a> {
         value: U256,
         skip_cold_load: bool,
     ) -> Result<StateLoad<SStoreResult>, TempoPrecompileError> {
-        Ok(self
-            .internals
-            .load_account_mut(address)?
-            .sstore(key, value, skip_cold_load)?)
+        Ok(self.internals.sstore_skip_cold_load(address, key, value, skip_cold_load)?)
     }
 
     /// Performs a metered precompile SLOAD, optionally recording the storage action.


### PR DESCRIPTION
Measurement branch only. It pins alloy-evm to a v0.38.0 backport of alloy-rs/evm#405 (EvmInternals storage ops without boxed account handles, borrowed internals in the precompile runner) and alloy-rs/evm#406 (cheap `PrecompileLookup::contains` plus opt-in lookup memoization), and adopts them: the precompile storage provider uses `sload_skip_cold_load`/`sstore_skip_cold_load` directly, and the Tempo precompile lookup becomes a `PrecompileLookup` implementation with a prefix/address `contains` and the lookup cache enabled.

On the txgen TIP-20 execution bench this drops heap allocations from 98 to 69 per transaction. Local timings of that bench are inconclusive because it is sensitive to binary layout on this machine, so this PR exists to get a derek end-to-end comparison. The real adoption will land once an alloy-evm release contains both changes.