### PR TITLE
fix(ci): update reusable workflow pins

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -163,7 +163,7 @@ jobs:
   deny:
     permissions:
       contents: read
-    uses: tempoxyz/ci/.github/workflows/deny.yml@09f481293feb726bcd5c94853063b224a9b2ff24 # main
+    uses: tempoxyz/ci/.github/workflows/deny.yml@400fd3f4ee8c60dae645f7ea2c261aed6d66e5b5 # main
 
   zepter:
     name: zepter

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   scan:
     if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
-    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@9974f654e85ffade8a813c84157047910079be4c
+    uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@5d3a903b51ce8d1f6d363d1c59d7243ecf80f026
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Updates the reusable cargo-deny and GitHub Actions scanner workflows to revisions compatible with the current organization Actions policy.

Prompted by: @grandizzy
