### PR TITLE
fix(precompiles): enable strict ABI decoding at T11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,8 +277,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201b9e973fe90b2effd9ab356d4f2a46ab56046ba9d46f163367553e72c045b0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -443,8 +444,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba4e59c3581a39e03e0b0b4a46ee9c41315b5d843b1e903271952b32bedb7c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -508,8 +510,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce7b00f0cb42c66ec353076ded1dff1fbf818f6e0e26c40c8a8456c04483fca4"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -945,8 +948,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64558980fb038cd34b4285ec2b36a2a8bd8d4ddd13b3f6e42d97cb5ee29938e"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -958,8 +962,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffb0e793abdbaea9d01259493c8272c3af295d03389e70a2acdf53b57ad1edf"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -976,8 +981,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2c0ec8425d9663dac939ba75750f17d2933d2f020814b4f8fde4a60da6d26"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -993,8 +999,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1002,8 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f40e33a0f588dde548c3b6767a71e61b593421a8c1b253b9cf1441dc7cf7ab5"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -13160,8 +13168,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.7.1"
-source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6415502cd1e9ed58b3ceb415164b812d5572757b1a6f0e280ae806723c1fab"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,8 +278,7 @@ dependencies = [
 [[package]]
 name = "alloy-dyn-abi"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1a3f2206f2ba4206fdeeddce6640eed3e26b8a13ac41444adb66b76d8e650"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -445,8 +444,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "208699c66c453fbb4c50d2e602f8ceff8a5f1fa48ac8b6ee3b6357fdc93da311"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -511,8 +509,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c902f0ca3f8353c41e3e1ec3cf26be49412525bc48ab9d3c4710d7be4f01832"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -949,8 +946,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcbd48d60e029be4a325c3a2f1312761caea4ed249f18ba9e8ed24ca1bf01e6"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -963,8 +959,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-expander"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c9f7c535f99a7e7b64cc520968b09ed14cec3715572fcc277cfbff602808cd"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -982,8 +977,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-input"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abd404fbc12f543823005146b73fd07621bdc0baaa950d26995c543a9d73811"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -1000,8 +994,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a7fd71864526bfeca8903010d5bb7fd28a0a4f5cc55818304c9cad8f0d63ab"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1010,8 +1003,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfc2ba3fb0e865de4934bcad6d37fc51e9ffcd5294be1322eab38e4494e051b"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -13169,8 +13161,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e452eb8cb83fc8b81597eb07c8d39f770d04905af9c5bffce8bea7213df29960"
+source = "git+https://github.com/alloy-rs/core?rev=0fe71bdd7dafa9b31cbcce8508a6480540c038c0#0fe71bdd7dafa9b31cbcce8508a6480540c038c0"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,6 +411,13 @@ vergen-git2 = "10.0.1"
 
 [patch.crates-io]
 
+# TODO: remove once https://github.com/alloy-rs/core/pull/1180 is released.
+alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
+alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
+alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
+alloy-sol-macro-expander = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
+alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
+
 # Commonware v2026.7.0
 # commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
 # commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,9 +215,9 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", feat
 revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
 revm-inspectors = "0.42.2"
 
-alloy-json-abi = { version = "1.7.1", default-features = false }
-alloy-primitives = { version = "1.7.1", default-features = false }
-alloy-sol-types = { version = "1.7.1", default-features = false }
+alloy-json-abi = { version = "1.7.2", default-features = false }
+alloy-primitives = { version = "1.7.2", default-features = false }
+alloy-sol-types = { version = "1.7.2", default-features = false }
 
 alloy = { version = "2.4.1", default-features = false }
 alloy-consensus = { version = "2.4.1", default-features = false }
@@ -410,13 +410,6 @@ vergen-git2 = "10.0.1"
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
 
 [patch.crates-io]
-
-# TODO: remove once https://github.com/alloy-rs/core/pull/1180 is released.
-alloy-dyn-abi = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
-alloy-json-abi = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
-alloy-primitives = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
-alloy-sol-macro-expander = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
-alloy-sol-types = { git = "https://github.com/alloy-rs/core", rev = "0fe71bdd7dafa9b31cbcce8508a6480540c038c0" }
 
 # Commonware v2026.7.0
 # commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }

--- a/crates/hardfork/src/lib.rs
+++ b/crates/hardfork/src/lib.rs
@@ -233,6 +233,11 @@ impl TempoHardfork {
         *self as u8
     }
 
+    /// Returns the latest defined Tempo hardfork.
+    pub const fn latest() -> Self {
+        Self::VARIANTS[Self::VARIANTS.len() - 1]
+    }
+
     /// Returns the hardfork at the given [`Self::VARIANTS`] position, see
     /// [`Self::variant_index`].
     ///

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -10,6 +10,7 @@ use alloy::{
     sol_types::{SolCall, SolError},
 };
 use revm::precompile::{PrecompileHalt, PrecompileOutput, PrecompileResult};
+use tempo_chainspec::hardfork::TempoHardfork;
 
 sol! {
     error StaticCallNotAllowed();
@@ -18,10 +19,14 @@ sol! {
 /// Maximum memory the ABI decoder may allocate for a precompile call.
 pub const ABI_DECODER_MEMORY_LIMIT: usize = 16 * 1024 * 1024;
 
-/// Returns the ABI decoder configuration used for precompile calls.
+/// Returns the hardfork-aware ABI decoder configuration used to dispatch precompile calls.
 #[inline]
-pub const fn abi_decoder_config() -> alloy::sol_types::abi::AbiDecoderConfig {
-    alloy::sol_types::abi::AbiDecoderConfig::new().memory_limit(ABI_DECODER_MEMORY_LIMIT)
+pub const fn abi_decoder_config_for_spec(
+    spec: TempoHardfork,
+) -> alloy::sol_types::abi::AbiDecoderConfig {
+    alloy::sol_types::abi::AbiDecoderConfig::new()
+        .memory_limit(ABI_DECODER_MEMORY_LIMIT)
+        .strict(spec.is_t11())
 }
 
 pub mod typed {
@@ -262,7 +267,9 @@ macro_rules! dispatch {
                             |data| {
                                 <Calls as alloy::sol_types::SolInterface>::abi_decode_with_config(
                                     data,
-                                    $crate::dispatch::abi_decoder_config(),
+                                    $crate::dispatch::abi_decoder_config_for_spec(
+                                        $crate::storage::StorageCtx.spec(),
+                                    ),
                                 )
                             },
                             |$call| match $match_call {

--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -19,12 +19,15 @@ use revm::{
     context::journaled_state::JournalLoadError,
     precompile::{PrecompileError, PrecompileHalt, PrecompileOutput, PrecompileResult},
 };
-use tempo_contracts::precompiles::{
-    AccountKeychainError, AddrRegistryError, CurrentCommitteeError, FeeManagerError, NonceError,
-    ReceivePolicyGuardError, RolesAuthError, SignatureVerifierError, StablecoinDEXError,
-    StorageCreditsError, TIP20ChannelReserveError, TIP20FactoryError, TIP403RegistryError,
-    TIPFeeAMMError, UnknownFunctionSelector, ValidatorConfigError, ValidatorConfigV2Error,
-    ZoneFactoryError,
+use tempo_contracts::{
+    TempoHardfork,
+    precompiles::{
+        AccountKeychainError, AddrRegistryError, CurrentCommitteeError, FeeManagerError,
+        NonceError, ReceivePolicyGuardError, RolesAuthError, SignatureVerifierError,
+        StablecoinDEXError, StorageCreditsError, TIP20ChannelReserveError, TIP20FactoryError,
+        TIP403RegistryError, TIPFeeAMMError, UnknownFunctionSelector, ValidatorConfigError,
+        ValidatorConfigV2Error, ZoneFactoryError,
+    },
 };
 
 /// Top-level error type for all Tempo precompile operations
@@ -299,12 +302,15 @@ pub fn add_errors_to_registry<T: SolInterface>(
         registry.insert(
             selector.into(),
             Box::new(move |data: &[u8]| {
-                T::abi_decode_with_config(data, crate::dispatch::abi_decoder_config())
-                    .ok()
-                    .map(|error| DecodedTempoPrecompileError {
-                        error: converter(error),
-                        revert_bytes: data,
-                    })
+                T::abi_decode_with_config(
+                    data,
+                    crate::dispatch::abi_decoder_config_for_spec(TempoHardfork::latest()),
+                )
+                .ok()
+                .map(|error| DecodedTempoPrecompileError {
+                    error: converter(error),
+                    revert_bytes: data,
+                })
             }),
         );
     }


### PR DESCRIPTION
Updates Alloy Core to v1.7.2 and enables strict ABI decoding for precompile calldata at T11. Registered precompile errors use the latest hardfork configuration.