### PR TITLE
docs(tip-1104): specify primitive account upgrades

### DIFF
--- a/tips/tip-1104.md
+++ b/tips/tip-1104.md
@@ -407,6 +407,134 @@ existing authorization method.
 
 # Tooling
 
+## Upgrade UX
+
+Wallets must present upgrade as an explicit one-way security ceremony, not as an
+ordinary settings change. The flow has the following stages.
+
+### 1. Check Eligibility
+
+Before accepting a configuration, the wallet must verify against the same block:
+
+- the connected primitive signer recovers to the account being upgraded;
+- the TIP-1061 commitment slot is zero;
+- the account has no EVM code or EIP-7702 delegation;
+- the account is on a network where this TIP and TIP-1061 are active; and
+- the account can pay or sponsor the upgrade transaction.
+
+The wallet should reconstruct known AccountKeychain keys from canonical events or
+an indexer and show their status, expiry, admin authority, call scope, and spending
+limits. If complete enumeration cannot be proven, the UI must say that undiscovered
+delegated keys may remain active. Eligibility must be rechecked immediately before
+submission.
+
+### 2. Build the Owner Policy
+
+The user selects owner addresses, weights, and threshold. The wallet must sort the
+owners canonically, validate the policy under TIP-1061, derive the deterministic
+upgrade salt, and display the resulting commitment.
+
+The original root key requires an explicit choice:
+
+- **Retire completely:** omit the root address from the owner set. After upgrade,
+  the key has no authority.
+- **Retain as an owner:** include the root address with an explicit weight. The key
+  can then contribute only an account-bound owner approval and cannot submit a bare
+  primitive transaction.
+
+The UI must not silently include the root address. It must also identify whether
+the proposed policy can be satisfied without that key.
+
+### 3. Prove Owner Readiness
+
+Before enabling submission, the wallet must demonstrate control of enough proposed
+owners to meet the threshold. Primitive owners sign a non-broadcast readiness
+challenge bound to the chain ID, account, proposed commitment, and expiry. A nested
+multisig owner must supply a valid current TIP-1061 witness for the same challenge.
+
+```text
+upgrade_readiness_digest = keccak256(
+  "tempo:multisig:upgrade-readiness" ||
+  uint256(chain_id) ||
+  account ||
+  upgrade_commitment ||
+  uint64(expiry)
+)
+```
+
+The readiness proof is a wallet safety check, not onchain authorization. The root
+key alone authorizes `upgradeAccount`; readiness signatures must never be attached
+to or accepted by the precompile. Wallets should additionally simulate a
+TIP-1061-authorized transaction with the proposed configuration using a state
+override containing the proposed commitment.
+
+### 4. Review the Irreversible Transition
+
+The final confirmation must show:
+
+- the unchanged account address and network;
+- the complete sorted owner policy and human-readable quorum examples;
+- whether the root is retired or retained as a weighted owner;
+- known access keys that will remain active, with admin keys highlighted;
+- the exact 32-byte commitment;
+- estimated upgrade gas and the ongoing commitment-read cost;
+- that arbitrary-address upgrades do not gain TIP-1061's counterfactual cross-chain
+  recovery property; and
+- a plain warning that there is no downgrade or root-key recovery path.
+
+The primary confirmation copy should state: **After this transaction finalizes,
+bare signatures from this account's current key will no longer work.**
+
+### 5. Submit the Upgrade
+
+The wallet constructs a transaction whose only top-level call is
+`upgradeAccount(threshold, owners)`. The outer signature must come directly from
+the primitive root; an access key, admin key, multisig wrapper, or contract wallet
+must not be offered as a signer. The wallet must not batch transfers, approvals,
+key changes, or application calls with the upgrade.
+
+While pending, the UI must retain the current primitive mode and prevent submitting
+a second upgrade. Replacement transactions may change fees but must preserve the
+exact call data; changing the policy requires cancelling or replacing the pending
+transaction with an ordinary non-upgrade transaction, then restarting readiness
+checks.
+
+### 6. Verify Finalization
+
+Receipt success alone is insufficient. Before switching the account UI to
+configurable mode, the wallet must:
+
+1. find the canonical `AccountUpgraded` event for the account;
+2. read `config_slot(account)` at the receipt block and require the expected
+   commitment;
+3. wait for the wallet's configured finality threshold;
+4. read the commitment again from the finalized canonical block; and
+5. verify that a TIP-1061 quorum can authorize a simulated transaction.
+
+If the transaction reverts, the account remains primitive and the UI must report
+the first precompile error. If a reorg removes the upgrade, the UI returns to
+pending or primitive mode based on canonical state and must not rely on the orphaned
+event.
+
+### 7. Operate the Upgraded Account
+
+After finalization, the wallet uses TIP-1061 signatures for direct transactions and
+the existing keychain envelope for access-key transactions. It must retain or be
+able to reconstruct the complete configuration witness from the upgrade event;
+the onchain commitment alone cannot recover the owners.
+
+The old root signer should be labeled **retired** and hidden from direct-send flows.
+If it remains an explicit owner, it appears only inside the quorum-signing flow.
+Owner rotation uses TIP-1061 `updateConfig`; access-key review and revocation use
+the existing AccountKeychain interfaces.
+
+Wallet state should expose `Eligible`, `Collecting readiness proofs`, `Ready to
+upgrade`, `Pending`, `Finalizing`, `Configurable`, `Failed`, and `Reorged` states so
+automation does not infer completion from a submitted transaction or unfinalized
+event.
+
+## SDK and RPC Requirements
+
 Wallets and SDKs must add:
 
 - deterministic `upgrade_salt(account)` and upgrade-commitment helpers;

--- a/tips/tip-1104.md
+++ b/tips/tip-1104.md
@@ -1,0 +1,478 @@
+---
+id: TIP-1104
+title: Primitive Account Upgrade to Configurable Account
+description: Lets an existing primitive account irreversibly retire its root key and adopt a TIP-1061 configuration without changing address.
+authors: Georgios Konstantopoulos (@gakonst)
+status: Draft
+related: TIP-0001, TIP-1011, TIP-1020, TIP-1049, TIP-1053, TIP-1061
+protocolVersion: TBD
+---
+
+# TIP-1104: Primitive Account Upgrade to Configurable Account
+
+## Abstract
+
+This TIP lets an existing primitive account irreversibly become a TIP-1061
+configurable account without changing its address. The account's final primitive
+transaction commits an initial owner configuration. After that commitment is
+stored, bare signatures from the original root key are rejected and the account
+is controlled by its owner quorum and any active AccountKeychain access keys.
+
+The upgrade reuses TIP-1061's single configuration-commitment slot and full
+configuration witnesses. No owner rows are stored. Because any primitive address
+may upgrade, consensus must read the commitment for every address presented as a
+primitive authority; this is the unavoidable state lookup that distinguishes an
+ordinary account from one whose root key has been retired.
+
+## Motivation
+
+TIP-1061 creates configurable accounts at counterfactually derived addresses. It
+does not let an existing primitive account retain its address while disabling its
+root key. Users who already have balances, allowances, roles, names, or application
+history at an address must otherwise move each asset and relationship to a new
+account, and some state cannot be moved at all.
+
+An existing account should be able to make one final root-authorized transition to
+quorum control. The transition must preserve the account address and application
+state, must not create a second path for the retired root key, and must not persist
+the full owner set.
+
+## Assumptions
+
+- TIP-1061 is active and provides multisig signatures, configuration witnesses,
+  configuration commitments, `updateConfig`, and AccountKeychain integration.
+- A nonzero TIP-1061 configuration commitment uniquely binds the complete
+  configuration supplied as a witness, up to Keccak-256 collision resistance.
+- The upgrade is irreversible. Restoring primitive-root authority requires making
+  the root address an explicit owner in a later configuration; it does not restore
+  bare primitive signatures.
+- Consensus can identify the outer signature kind and AccountKeychain transaction
+  key before executing the native multisig precompile.
+- An account with EVM code or EIP-7702 delegation is not a primitive account for
+  this TIP and must remove that code or delegation before upgrading.
+- Existing AccountKeychain access keys are independent delegated authorities and
+  remain active after upgrade unless separately revoked.
+
+If TIP-1061's commitment encoding or witness validation changes, this TIP must use
+the same active encoding and validation rules. Implementations must not maintain a
+second owner-config format.
+
+## Threat Model
+
+- **Primitive root key.** The root key is fully trusted until the upgrade commits.
+  A compromised root may race the intended upgrade or choose an attacker-controlled
+  configuration. Normal nonce ordering and transaction finality are the defenses.
+- **Configuration witnesses.** Submitters may provide malformed, stale, oversized,
+  cyclic, or insufficient owner configurations and approvals. TIP-1061 validation
+  and limits apply unchanged.
+- **Access keys.** Existing ordinary and admin access keys may still act after the
+  root is retired, subject to their existing expiry, scope, spending-limit, and
+  admin rules. Upgrade tooling must surface them before confirmation.
+- **Fee payers and authorization-list authorities.** A retired primitive key must
+  not remain usable indirectly in another protocol role.
+- **RPC and transaction-pool caches.** Cached zero commitments may become stale
+  after an upgrade or reorg. Consensus uses block-position state; pools must
+  revalidate affected transactions.
+- **Hash collisions.** Forging a witness for a stored commitment is outside scope
+  under Keccak-256 collision resistance.
+
+---
+
+# Specification
+
+## Terminology
+
+- **Primitive account:** an account authorized by a bare
+  `TempoSignature::Primitive` whose recovered address is the account.
+- **Root key:** the primitive key whose recovered address is the account address.
+- **Upgraded account:** an address upgraded by this TIP and carrying a nonzero
+  TIP-1061 configuration commitment.
+- **Root retirement:** rejection of the root key's bare primitive signature after
+  upgrade. The key may still be named explicitly as an owner and sign inside a
+  TIP-1061 multisig witness.
+
+## Upgrade Configuration
+
+The first configuration of an upgraded account uses TIP-1061's existing
+`MultisigConfig` and commitment formula. It has version `1` and a deterministic
+salt bound to the existing account:
+
+```text
+UPGRADED_ACCOUNT_SALT_DOMAIN = "tempo:multisig:upgrade"
+
+upgrade_salt(account) = keccak256(
+  UPGRADED_ACCOUNT_SALT_DOMAIN ||
+  account
+)
+
+upgrade_config = MultisigConfig {
+  salt: upgrade_salt(account),
+  version: 1,
+  threshold,
+  owners
+}
+
+upgrade_commitment = config_commitment(upgrade_config)
+```
+
+The domain is encoded as its exact ASCII bytes without a length prefix. `account`
+is encoded as 20 bytes. The commitment uses TIP-1061's exact active commitment
+encoding.
+
+Rules:
+
+- The upgrade configuration must satisfy all active TIP-1061 owner, ordering,
+  weight, threshold, nesting, and size rules.
+- `upgrade_commitment` must be nonzero.
+- The account address is not derived from `upgrade_config`; the existing address is
+  retained.
+- Version `1` distinguishes an upgraded account from TIP-1061's counterfactual
+  version-`0` configuration.
+- Later `updateConfig` calls must preserve `upgrade_salt(account)` and increment the
+  version exactly as specified by TIP-1061.
+- The original root address may appear as an owner. If omitted, it has no authority
+  after upgrade. If included, it contributes only through an account-bound
+  TIP-1061 owner approval.
+
+## Storage
+
+This TIP reuses TIP-1061's configuration slot:
+
+```text
+config_slot(account) = mapping_slot(account, 0)
+
+storage[config_slot(account)] = upgrade_commitment
+```
+
+Rules:
+
+- Upgrade must create exactly one nonzero 32-byte configuration commitment and
+  must not persist the threshold, owners, weights, salt, or version elsewhere.
+- The slot must be zero before upgrade and nonzero afterward.
+- The commitment must never be cleared. Configuration updates replace it with a
+  nonzero commitment under TIP-1061.
+- Failed or reverted upgrades must leave the slot unchanged.
+- Existing AccountKeychain rows are not copied, deleted, or rewritten.
+
+## Native Multisig Precompile
+
+TIP-1061's `INativeMultisig` interface is extended with `upgradeAccount`:
+
+```solidity
+interface INativeMultisigUpgrade {
+    struct MultisigOwner {
+        address owner;
+        uint8 weight;
+    }
+
+    /// @notice Irreversibly retires msg.sender's primitive root key and installs
+    ///         the first configurable-account owner commitment.
+    /// @dev Must be the only top-level call in a transaction directly authorized
+    ///      by msg.sender's primitive root key. Existing AccountKeychain access
+    ///      keys remain active. The installed configuration has deterministic
+    ///      salt upgrade_salt(msg.sender) and version 1.
+    /// @param threshold Minimum total owner weight required by TIP-1061.
+    /// @param owners Strictly ascending weighted owner addresses.
+    /// @return commitment The nonzero TIP-1061 configuration commitment stored
+    ///         for msg.sender.
+    function upgradeAccount(
+        uint8 threshold,
+        MultisigOwner[] calldata owners
+    ) external returns (bytes32 commitment);
+
+    /// @notice Emitted after an existing primitive account retires its root key.
+    /// @param account Account whose address and application state are retained.
+    /// @param commitment Installed TIP-1061 configuration commitment.
+    /// @param salt Deterministic upgrade salt bound to account.
+    /// @param threshold Minimum owner weight required for authorization.
+    /// @param owners Complete initial owner configuration.
+    event AccountUpgraded(
+        address indexed account,
+        bytes32 indexed commitment,
+        bytes32 salt,
+        uint8 threshold,
+        MultisigOwner[] owners
+    );
+
+    /// @notice The caller is not directly authorized by its primitive root key.
+    error PrimitiveRootRequired();
+
+    /// @notice The transaction contains a top-level call other than upgradeAccount.
+    error UpgradeMustBeOnlyCall();
+
+    /// @notice The account already has a nonzero configuration commitment.
+    error AccountAlreadyConfigurable();
+
+    /// @notice The account has EVM code or EIP-7702 delegation.
+    error AccountHasCode();
+
+    /// @notice The proposed TIP-1061 configuration is invalid.
+    error InvalidConfig();
+}
+```
+
+The protocol must expose a transaction-local authorization mode to the precompile.
+It is `PrimitiveRoot` only when the outer transaction signature is a primitive
+signature recovering to `tx.from`, with no AccountKeychain transaction key.
+Simulation overrides must not manufacture this mode unless they also provide and
+validate the corresponding primitive signature.
+
+`upgradeAccount` validation proceeds in this order:
+
+1. Require that this is the only top-level call in `tx.calls`.
+2. Require `msg.sender == tx.origin == tx.from`.
+3. Require transaction-local authorization mode `PrimitiveRoot` and a zero
+   AccountKeychain transaction key.
+4. Require empty EVM code and no EIP-7702 delegation at `msg.sender`.
+5. Read `config_slot(msg.sender)` and require zero.
+6. Derive `salt = upgrade_salt(msg.sender)` and construct version-`1` config from
+   `threshold` and `owners`.
+7. Validate the complete configuration under TIP-1061.
+8. Compute the TIP-1061 commitment and require it is nonzero.
+9. Write the commitment to `config_slot(msg.sender)`.
+10. Emit `AccountUpgraded` with the full configuration.
+11. Return the commitment.
+
+The upgrade transaction uses ordinary nonce and fee validation. Its primitive
+signature commits to the complete `upgradeAccount` calldata through the existing
+transaction signing hash. No additional owner approvals are required: the root key
+is the account authority until the commitment write succeeds.
+
+The single-call restriction makes the transition boundary explicit. The
+transaction performs no application call under ambiguous pre- and post-upgrade
+authority. A revert at any point reverts the commitment and event.
+
+## Root-Key Rejection
+
+After signature recovery and before accepting an address as a primitive authority,
+consensus must read its TIP-1061 configuration commitment. A nonzero commitment
+means bare primitive authority is retired.
+
+The check applies to:
+
+- an outer `TempoSignature::Primitive` sender;
+- a primitive signature authorizing `SignedKeyAuthorization` for its account;
+- a primitive fee-payer signature;
+- a primitive EIP-7702 or Tempo authorization-list authority;
+- any other protocol path that treats a recovered primitive address as direct
+  authority rather than as a TIP-1061 owner approval.
+
+On a nonzero commitment, these paths must reject with `RootKeyRetired(account)`.
+The check does not apply to a primitive signature nested as an owner approval in a
+valid TIP-1061 witness. That approval is bound to the configurable-account digest
+and contributes only its configured weight.
+
+AccountKeychain transactions remain valid because the access key, not the retired
+root, supplies authority. AccountKeychain mutators continue to require a valid
+quorum or an active admin access key under their existing rules. An access key must
+not call `updateConfig` or `upgradeAccount` for its parent.
+
+## Configuration Authorization After Upgrade
+
+An upgraded account uses TIP-1061's initialized/current witness path immediately:
+
+```text
+signature = 0x05 || rlp([
+  account,
+  upgrade_config,
+  owner_signatures
+])
+```
+
+Validation must:
+
+1. Read the nonzero commitment at `config_slot(account)`.
+2. Validate and hash the complete configuration witness.
+3. Require the witness commitment to equal the stored commitment.
+4. Verify the TIP-1061 owner quorum over the account-bound digest using version
+   `1`, or the later stored version after updates.
+
+The version-`0` derivation path must not authorize an upgraded account after its
+commitment becomes nonzero.
+
+## Existing Access Keys
+
+Upgrade does not revoke or change existing AccountKeychain state. In particular:
+
+- active ordinary keys remain active under existing restrictions;
+- active admin keys retain key-management authority but cannot change the owner
+  configuration;
+- revoked keys remain revoked;
+- expiry, scopes, spending limits, and authorization witnesses are unchanged.
+
+Wallets must enumerate or otherwise surface known access keys before presenting an
+upgrade confirmation. If the keychain does not support complete enumeration, the
+wallet must state that undiscovered delegated authority may remain. Users who want
+quorum-only control must revoke unwanted keys before upgrading.
+
+## Transaction Pool and Block Ordering
+
+An upgrade affects every later transaction in the same block. After the commitment
+write, primitive transactions involving the account in any authority role listed
+above are invalid, even if they entered the pool before the upgrade.
+
+Pools must index transactions by recovered primitive authority roles and revalidate
+or evict them when an `AccountUpgraded` event or corresponding commitment change is
+observed. Reorg handling must restore transactions only after validation against
+the new canonical state.
+
+## Gas Accounting
+
+Each primitive authority check is charged using the active precompile storage-read
+schedule. A transaction with several roles may warm and reuse the same slot under
+the normal access rules, but it must still perform each consensus-required check.
+
+`upgradeAccount` charges:
+
+- one warm or cold read of `config_slot(msg.sender)` as applicable;
+- one zero-to-nonzero SSTORE under the active storage and state-gas schedule;
+- exact Keccak gas for `upgrade_salt` and the TIP-1061 commitment preimages;
+- calldata and processing costs for validating all owners;
+- exact event gas for `AccountUpgraded`.
+
+Ordinary primitive transactions therefore acquire one commitment read. This TIP
+does not claim that the lookup is free or avoidable: without reading authenticated
+state, an old primitive signature is indistinguishable from one produced before
+root retirement.
+
+## Backwards Compatibility
+
+- Account addresses, balances, nonces, token balances, allowances, roles, and
+  application state are unchanged by upgrade.
+- Existing transaction encodings are unchanged.
+- Before activation, `upgradeAccount` is unavailable and primitive authority keeps
+  its previous behavior.
+- After activation, accounts with a zero commitment keep their previous primitive
+  behavior.
+- Accounts with a nonzero TIP-1061 commitment reject bare primitive authority,
+  including accounts upgraded by this TIP.
+- Existing TIP-1061 counterfactual accounts continue to use their existing initial
+  and current witness rules.
+- Contracts and EIP-7702 delegated accounts cannot use this upgrade path.
+
+## Alternatives Considered
+
+### Keep the Root Key Active
+
+Allowing an existing EOA to add quorum authorization while preserving bare root
+authorization avoids the global commitment read, but the root remains a unilateral
+bypass. This does not satisfy root retirement.
+
+### Store a Marker in the AccountKeychain
+
+A dedicated root-disabled row in AccountKeychain still requires a state read for
+every primitive authority and adds a second state item. Reusing TIP-1061's nonzero
+commitment is smaller and avoids inconsistent markers.
+
+### Store a Marker in EVM Bytecode or EIP-7702 Delegation
+
+Code is already visible through the sender account load and could avoid the
+commitment read for ordinary EOAs. It changes `EXTCODESIZE`/`EXTCODEHASH`, EIP-3607
+behavior, safe-token receiver behavior, and calls to the upgraded address. EIP-7702
+also defines delegation rather than root retirement. These application-visible
+semantic changes are not acceptable for an address-preserving upgrade.
+
+### Extend the Core Account Leaf
+
+Adding an authorization-mode field to the Ethereum account leaf would make the
+marker available with the existing account read. It changes account RLP, state-root
+construction, proofs, snapshots, database formats, and interoperability. That cost
+is disproportionate to this feature.
+
+### Reserve a Nonce or Balance Bit
+
+Encoding root retirement in nonce or balance state interferes with transaction
+ordering, CREATE address derivation, balance semantics, proofs, and RPC output. It
+also introduces exceptional masking rules throughout the EVM.
+
+### Add a New Transaction or Signature Form
+
+An upgraded account can use a new form, but old primitive signatures remain valid
+unless validation consults state. A wire-format distinction alone cannot revoke an
+existing authorization method.
+
+## Success Criteria
+
+- An existing primitive account upgrades without changing its address or
+  application-visible state.
+- After finalization, bare root signatures fail in every direct protocol authority
+  role while a valid TIP-1061 quorum succeeds.
+- Existing AccountKeychain access keys behave identically before and after upgrade.
+- Exactly one persistent 32-byte configuration commitment is created.
+- Reverted upgrades create no state or event.
+- Same-block ordering, transaction-pool eviction, and reorg tests demonstrate that
+  no stale root-authorized transaction executes after the commitment write.
+- Benchmarks report the throughput and witness impact of the added commitment read
+  on ordinary primitive transfers before the TIP advances beyond Draft.
+
+# Tooling
+
+Wallets and SDKs must add:
+
+- deterministic `upgrade_salt(account)` and upgrade-commitment helpers;
+- an `upgradeAccount` transaction builder and simulator;
+- confirmation UI that states the transition is irreversible and lists the owner
+  quorum, whether the old root remains an explicit owner, and known active access
+  keys;
+- current authorization-mode reporting based on the TIP-1061 commitment;
+- errors that distinguish `RootKeyRetired` from an invalid primitive signature;
+- configuration reconstruction from `AccountUpgraded`, subsequent TIP-1061 update
+  events, and full witnesses.
+
+RPC implementations should expose the existing TIP-1061 commitment getter and may
+add a derived view returning `Primitive` or `Configurable`. A zero commitment alone
+does not identify a counterfactual TIP-1061 account, so such a view must not claim
+that every zero-commitment address is primitive without additional context.
+
+# Observability
+
+Implementations must emit `AccountUpgraded` exactly once for each successful
+upgrade. Operators should track:
+
+- successful upgrades and reverted upgrade attempts by error class;
+- `RootKeyRetired` rejections by authority role;
+- commitment-read latency and cache-hit rate on primitive transaction validation;
+- pool evictions caused by upgrades;
+- configuration update failures for upgraded accounts.
+
+The event answers which account upgraded, which commitment became authoritative,
+and which owner configuration tooling must index. Metrics must not include raw
+signatures or other sensitive payloads.
+
+# Invariants
+
+1. **Address preservation.** Upgrade must not change the account address or any
+   application state outside the TIP-1061 commitment slot.
+2. **Single-slot state.** Upgrade stores exactly one nonzero commitment and no owner
+   rows.
+3. **Irreversibility.** Once nonzero, the commitment can change only to another
+   valid nonzero TIP-1061 commitment and can never be cleared.
+4. **Root retirement.** No bare primitive signature for an upgraded address may act
+   as sender, key-authorizer, fee payer, authorization-list authority, or other
+   direct protocol authority.
+5. **Owner use of the old key.** The old key may contribute only when explicitly
+   configured as an owner and signing the account-bound TIP-1061 digest.
+6. **Direct upgrade authority.** Only the current primitive root, through a direct
+   single-call transaction with zero keychain transaction key, may upgrade.
+7. **Atomicity.** Failed or reverted upgrade transactions leave the commitment,
+   authorization mode, and events unchanged.
+8. **Configuration validity.** The installed and all later configurations satisfy
+   TIP-1061 and preserve `upgrade_salt(account)`.
+9. **Version monotonicity.** Upgrade installs version `1`; later updates increment
+   the version by exactly one.
+10. **Access-key continuity.** Upgrade neither grants, revokes, nor changes any
+    AccountKeychain key or restriction.
+11. **Block-position authorization.** Every transaction is validated against the
+    commitment in effect at its exact block position.
+12. **No code-bearing upgrade.** Contracts and EIP-7702 delegated accounts cannot
+    upgrade through this path.
+13. **No wire-format change.** Existing primitive, keychain, and multisig encodings
+    remain byte-identical.
+
+Critical tests must cover successful upgrade with and without the old root in the
+new owner set; invalid and zero commitments; malformed, duplicate, unsorted, and
+unreachable owner configurations; nested owners; all direct primitive authority
+roles; existing ordinary/admin/revoked/expired access keys; same-block root
+transactions before and after upgrade; reverted upgrade; duplicate upgrade; reorgs;
+pool eviction; code-bearing and delegated accounts; fee sponsorship; configuration
+rotation; and RPC simulation.


### PR DESCRIPTION
Adds an irreversible primitive-account upgrade that reuses TIP-1061’s single configuration commitment while preserving the existing address and AccountKeychain state.

Specifies root-key rejection across direct authority roles and documents the unavoidable commitment-read tradeoff.

Prompted by: @gakonst