### PR TITLE
Enable private Cyclops audit comments

### DIFF
--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -41,7 +41,9 @@ jobs:
       github.event.issue.pull_request &&
       (
         startsWith(github.event.comment.body, 'cyclops audit') ||
+        startsWith(github.event.comment.body, 'cyclops private audit') ||
         startsWith(github.event.comment.body, '@decofe cyclops audit') ||
+        startsWith(github.event.comment.body, '@decofe cyclops private audit') ||
         startsWith(github.event.comment.body, 'derek audit')
       )
     runs-on: ubuntu-latest
@@ -51,9 +53,9 @@ jobs:
       pull-requests: read
     steps:
       - name: Handle audit command
-        uses: tempoxyz/gh-actions/actions/pr-audit-comment@183a02178c660ce295e9a262edc5857cb7135f06
+        uses: tempoxyz/gh-actions/actions/pr-audit-comment@4bf4080e1262b19a9b8e0e4d16ee4ba07d23edf9
         with:
-          command-regex: '^(?:@decofe\s+)?(?:cyclops\s+audit|derek\s+audit)\b'
+          command-regex: '^(?:@decofe\s+)?(?:cyclops\s+(?:private\s+)?audit|derek\s+audit)\b'
           permission-check-mode: association
           allowed-associations: OWNER,MEMBER
           allow-same-author: "true"

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -53,7 +53,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Handle audit command
-        uses: tempoxyz/gh-actions/actions/pr-audit-comment@4bf4080e1262b19a9b8e0e4d16ee4ba07d23edf9
+        uses: tempoxyz/gh-actions/actions/pr-audit-comment@7741a8658354abd422dd1b941d07f809682ca96d
         with:
           command-regex: '^(?:@decofe\s+)?(?:cyclops\s+(?:private\s+)?audit|derek\s+audit)\b'
           permission-check-mode: association


### PR DESCRIPTION
Accepts `cyclops private audit` (including `fast`, `super-fast`, `perf`, and `note=...`) and pins the shared parser implementation at merged gh-actions commit `7741a8658354abd422dd1b941d07f809682ca96d`.