### PR TITLE
docs(tip-1105): add T11 pricing hardening meta TIP

### DIFF
--- a/tips/tip-1091.md
+++ b/tips/tip-1091.md
@@ -92,10 +92,13 @@ Zone creation selects independent initial enforcement modes for account access
 `allowedAccounts` and `zoneGateways` lists prepopulate roles even while their
 corresponding mode is open. An empty closed or enforced role set denies all such
 access until the admin assigns a role or changes the mode. The shared messenger
-MUST NOT be an allowed account, and an address MUST NOT appear in both lists.
-Duplicate and zero-address entries are permitted. The factory initializes
-allowed accounts with the `Account` role and zone gateways with the
-`CallbackGateway` role in the new portal.
+MUST NOT be an allowed account. Before T11, an address MUST NOT appear in both
+lists; duplicate entries within either list and zero-address entries are
+permitted. At T11, every address across `allowedAccounts`, `zoneGateways`, and
+`sequencers` MUST be unique, while zero-address entries remain permitted for
+`allowedAccounts` and `zoneGateways`. The factory initializes allowed accounts
+with the `Account` role and zone gateways with the `CallbackGateway` role in the
+new portal.
 
 Each zone portal is installed at:
 

--- a/tips/tip-1100.md
+++ b/tips/tip-1100.md
@@ -37,4 +37,5 @@ T11 onward: words * 30
 
 The charge applies to all Tempo precompiles and all input bytes, including the
 function selector. If the caller has insufficient gas, execution MUST halt with
-out-of-gas before decoding. T11 does not change any other precompile gas charge.
+out-of-gas before decoding. This per-word charge is independent of the T11
+duplicate-validation charges specified by [TIP-1105](./tip-1105.md).

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -30,7 +30,6 @@ behavior, they are grouped here as one coordinated rollout alongside [TIP-1100](
 
 **PRs**: [#7298](https://github.com/tempoxyz/tempo/pull/7298),
 [#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
-[#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
 
 At T11, AccountKeychain call-scope validation copies target and selector keys into contiguous
 vectors, sorts them, and rejects equal adjacent values. Recipient duplicate checks use the same

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -3,7 +3,7 @@ id: TIP-1105
 title: T11 Pricing Hardening Meta TIP
 description: Meta TIP collecting precompile decoding and duplicate-validation pricing hardenings gated behind the T11 hardfork.
 authors: Arsenii Kulikov (@klkvr)
-status: Draft
+status: Approved
 related: TIP-1100
 protocolVersion: T11
 ---

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -26,25 +26,18 @@ behavior, they are grouped here as one coordinated rollout alongside [TIP-1100](
 
 # Changes
 
-## 1. Improve duplicate validation
+## 1. Price duplicate validation
 
-**Pricing hardening**: [#7298](https://github.com/tempoxyz/tempo/pull/7298) · **Author**: @klkvr
+**Pricing hardenings**: [#7298](https://github.com/tempoxyz/tempo/pull/7298),
+[#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
 
 At T11, AccountKeychain call-scope validation copies target and selector keys into contiguous
 vectors, sorts them, and rejects equal adjacent values. Recipient duplicate checks use the same
-sort-and-scan strategy. This makes work predictable for adversarial duplicate placement while
-preserving the historical pre-T11 validation path.
-
-## 2. Meter duplicate validation
-
-**Pricing hardening**: [#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
-
-T11 charges 20 gas for every value processed by a metered duplicate check. The charge is deducted
-before sorting and applies to AccountKeychain targets, selectors, and recipients as well as the
+sort-and-scan strategy. T11 charges 20 gas for every value processed by these checks, including the
 combined ZoneFactory role lists. Insufficient gas halts before sorting; pre-T11 duplicate checks
-retain their historical gas and validation behavior.
+retain their historical validation and gas behavior.
 
-## 3. Require strict ABI decoding
+## 2. Require strict ABI decoding
 
 **Pricing hardening**: [#7444](https://github.com/tempoxyz/tempo/pull/7444) · **Author**: @klkvr
 

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -28,7 +28,8 @@ behavior, they are grouped here as one coordinated rollout alongside [TIP-1100](
 
 ## 1. Sort scope keys during validation
 
-**Pricing hardenings**: [#7298](https://github.com/tempoxyz/tempo/pull/7298),
+**PRs**: [#7298](https://github.com/tempoxyz/tempo/pull/7298),
+[#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
 [#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
 
 At T11, AccountKeychain call-scope validation copies target and selector keys into contiguous
@@ -39,7 +40,7 @@ retain their historical validation and gas behavior.
 
 ## 2. Require strict ABI decoding
 
-**Pricing hardening**: [#7444](https://github.com/tempoxyz/tempo/pull/7444) · **Author**: @klkvr
+**PRs**: [#7444](https://github.com/tempoxyz/tempo/pull/7444) · **Author**: @klkvr
 
 At T11, every Tempo precompile dispatcher enables Alloy's strict ABI decoder while retaining the
 existing 16 MiB decoder memory limit. Strict decoding validates token values and requires canonical

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -12,96 +12,43 @@ protocolVersion: T11
 
 ## Abstract
 
-This meta TIP collects three precompile pricing hardenings that activate at T11.
-Together they bound or explicitly charge input-dependent ABI decoding and duplicate-validation
-work while preserving pre-T11 behavior for historical reexecution.
+This meta TIP collects precompile pricing hardenings that activate at T11. Together they bound or
+explicitly charge input-dependent ABI decoding and duplicate-validation work while preserving
+legacy behavior before T11.
 
 ## Motivation
 
-Precompile calldata can encode large dynamic collections whose decoding and validation cost is not
-fully represented by storage operations or other execution charges. Attackers can choose inputs
-that maximize allocation, sorting, or repeated validation work while paying too little gas for the
-node resources consumed.
-
-T11 coordinates stricter canonical decoding, a more predictable duplicate-detection algorithm,
-and an explicit per-item duplicate-validation charge. These pricing hardenings complement
-[TIP-1100](./tip-1100.md), which raises the general per-word precompile input charge.
-
-## Assumptions
-
-- TIP-1100 activates at the same T11 boundary.
-- Alloy Core 1.7.2 strict decoding rejects non-canonical ABI encodings deterministically.
-- Pre-T11 blocks continue to execute with their historical decoding, validation-order, and gas
-  behavior.
-
-## Threat Model
-
-Untrusted callers may submit maximum-size precompile inputs and adversarial dynamic-array layouts
-to maximize decoder allocation and duplicate-validation work. Validators and RPC nodes are assumed
-to execute the same hardfork-aware decoder and gas schedule.
+T11 hardens precompile pricing against calldata that maximizes decoding, allocation, or
+duplicate-validation work. Because these changes affect gas costs and hardfork-gated execution
+behavior, they are grouped here as one coordinated rollout alongside [TIP-1100](./tip-1100.md).
 
 ---
 
 # Changes
 
-## 1. Sort duplicate-validation keys
+## 1. Improve duplicate validation
 
-**Pricing hardening PR**: [#7298](https://github.com/tempoxyz/tempo/pull/7298)
+**Pricing hardening**: [#7298](https://github.com/tempoxyz/tempo/pull/7298) · **Author**: @klkvr
 
 At T11, AccountKeychain call-scope validation copies target and selector keys into contiguous
 vectors, sorts them, and rejects equal adjacent values. Recipient duplicate checks use the same
-sort-and-scan strategy. The pre-T11 `HashSet` paths and validation order remain unchanged where
-required for historical reexecution.
-
-This makes the work performed for adversarial duplicate placement predictable and avoids repeated
-hash-table operations on large scope collections. Duplicate targets, selectors, and recipients
-continue to revert with `InvalidCallScope`.
+sort-and-scan strategy. This makes work predictable for adversarial duplicate placement while
+preserving the historical pre-T11 validation path.
 
 ## 2. Meter duplicate validation
 
-**Pricing hardening PR**: [#7447](https://github.com/tempoxyz/tempo/pull/7447)
+**Pricing hardening**: [#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr
 
 T11 charges 20 gas for every value processed by a metered duplicate check. The charge is deducted
-before sorting, and insufficient gas halts execution with out-of-gas.
-
-The charge applies independently to:
-
-- AccountKeychain scope targets;
-- selector rules for each target;
-- recipient lists for each selector rule; and
-- the combined ZoneFactory allowed-account, gateway, and sequencer role lists.
-
-ZoneFactory uses the same metered sort-and-scan validation at T11 and rejects an address duplicated
-within or across its role lists with `InvalidClosedLoopConfig`. Before T11, duplicate-validation
-metering contributes zero additional gas and the historical validation path remains active.
+before sorting and applies to AccountKeychain targets, selectors, and recipients as well as the
+combined ZoneFactory role lists. Insufficient gas halts before sorting; pre-T11 duplicate checks
+retain their historical gas and validation behavior.
 
 ## 3. Require strict ABI decoding
 
-**Pricing hardening PR**: [#7444](https://github.com/tempoxyz/tempo/pull/7444)
+**Pricing hardening**: [#7444](https://github.com/tempoxyz/tempo/pull/7444) · **Author**: @klkvr
 
 At T11, every Tempo precompile dispatcher enables Alloy's strict ABI decoder while retaining the
 existing 16 MiB decoder memory limit. Strict decoding validates token values and requires canonical
 dynamic-data layout: gaps, overlaps, trailing data, and non-zero padding are rejected before
-dispatch.
-
-Pre-T11 calls retain permissive decoding for historical compatibility. Registered precompile error
-decoding uses the latest hardfork configuration so tooling interprets revert data under the current
-strict rules.
-
-# Tooling
-
-Call builders must emit canonical ABI encodings. Existing Solidity and Alloy encoders already do
-so; no interface or command changes are required.
-
-# Observability
-
-No new events are required. Non-canonical calldata and duplicate inputs are visible as reverted
-precompile calls, while underpriced duplicate-validation work may halt with out-of-gas.
-
-# Invariants
-
-1. Pre-T11 blocks retain their historical decoding results, validation order, and gas charges.
-2. At T11, non-canonical ABI calldata cannot reach precompile dispatch.
-3. At T11, every metered duplicate check deducts 20 gas per processed value before sorting.
-4. Duplicate-validation charges use checked arithmetic and fail with out-of-gas on overflow.
-5. Duplicate targets, selectors, recipients, or ZoneFactory roles cannot bypass validation.
+dispatch. Pre-T11 calls retain permissive decoding for historical compatibility.

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -26,7 +26,7 @@ behavior, they are grouped here as one coordinated rollout alongside [TIP-1100](
 
 # Changes
 
-## 1. Price duplicate validation
+## 1. Sort scope keys during validation
 
 **Pricing hardenings**: [#7298](https://github.com/tempoxyz/tempo/pull/7298),
 [#7447](https://github.com/tempoxyz/tempo/pull/7447) · **Author**: @klkvr

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -1,0 +1,107 @@
+---
+id: TIP-1105
+title: T11 Pricing Hardening Meta TIP
+description: Meta TIP collecting precompile decoding and duplicate-validation pricing hardenings gated behind the T11 hardfork.
+authors: Arsenii Kulikov (@klkvr)
+status: Draft
+related: TIP-1100
+protocolVersion: T11
+---
+
+# TIP-1105: T11 Pricing Hardening Meta TIP
+
+## Abstract
+
+This meta TIP collects three precompile pricing hardenings that activate at T11.
+Together they bound or explicitly charge input-dependent ABI decoding and duplicate-validation
+work while preserving pre-T11 behavior for historical reexecution.
+
+## Motivation
+
+Precompile calldata can encode large dynamic collections whose decoding and validation cost is not
+fully represented by storage operations or other execution charges. Attackers can choose inputs
+that maximize allocation, sorting, or repeated validation work while paying too little gas for the
+node resources consumed.
+
+T11 coordinates stricter canonical decoding, a more predictable duplicate-detection algorithm,
+and an explicit per-item duplicate-validation charge. These pricing hardenings complement
+[TIP-1100](./tip-1100.md), which raises the general per-word precompile input charge.
+
+## Assumptions
+
+- TIP-1100 activates at the same T11 boundary.
+- Alloy Core 1.7.2 strict decoding rejects non-canonical ABI encodings deterministically.
+- Pre-T11 blocks continue to execute with their historical decoding, validation-order, and gas
+  behavior.
+
+## Threat Model
+
+Untrusted callers may submit maximum-size precompile inputs and adversarial dynamic-array layouts
+to maximize decoder allocation and duplicate-validation work. Validators and RPC nodes are assumed
+to execute the same hardfork-aware decoder and gas schedule.
+
+---
+
+# Changes
+
+## 1. Sort duplicate-validation keys
+
+**Pricing hardening PR**: [#7298](https://github.com/tempoxyz/tempo/pull/7298)
+
+At T11, AccountKeychain call-scope validation copies target and selector keys into contiguous
+vectors, sorts them, and rejects equal adjacent values. Recipient duplicate checks use the same
+sort-and-scan strategy. The pre-T11 `HashSet` paths and validation order remain unchanged where
+required for historical reexecution.
+
+This makes the work performed for adversarial duplicate placement predictable and avoids repeated
+hash-table operations on large scope collections. Duplicate targets, selectors, and recipients
+continue to revert with `InvalidCallScope`.
+
+## 2. Meter duplicate validation
+
+**Pricing hardening PR**: [#7447](https://github.com/tempoxyz/tempo/pull/7447)
+
+T11 charges 20 gas for every value processed by a metered duplicate check. The charge is deducted
+before sorting, and insufficient gas halts execution with out-of-gas.
+
+The charge applies independently to:
+
+- AccountKeychain scope targets;
+- selector rules for each target;
+- recipient lists for each selector rule; and
+- the combined ZoneFactory allowed-account, gateway, and sequencer role lists.
+
+ZoneFactory uses the same metered sort-and-scan validation at T11 and rejects an address duplicated
+within or across its role lists with `InvalidClosedLoopConfig`. Before T11, duplicate-validation
+metering contributes zero additional gas and the historical validation path remains active.
+
+## 3. Require strict ABI decoding
+
+**Pricing hardening PR**: [#7444](https://github.com/tempoxyz/tempo/pull/7444)
+
+At T11, every Tempo precompile dispatcher enables Alloy's strict ABI decoder while retaining the
+existing 16 MiB decoder memory limit. Strict decoding validates token values and requires canonical
+dynamic-data layout: gaps, overlaps, trailing data, and non-zero padding are rejected before
+dispatch.
+
+Pre-T11 calls retain permissive decoding for historical compatibility. Registered precompile error
+decoding uses the latest hardfork configuration so tooling interprets revert data under the current
+strict rules.
+
+# Tooling
+
+Call builders must emit canonical ABI encodings. Existing Solidity and Alloy encoders already do
+so; no interface or command changes are required.
+
+# Observability
+
+No new events are required. Non-canonical calldata and duplicate inputs are visible as reverted
+precompile calls, while underpriced duplicate-validation work may halt with out-of-gas.
+
+# Invariants
+
+1. Pre-T11 blocks retain their historical decoding results, validation order, and gas charges.
+2. At T11, non-canonical ABI calldata cannot reach precompile dispatch.
+3. At T11, every metered duplicate check deducts 20 gas per processed value before sorting.
+4. Duplicate-validation charges use checked arithmetic and fail with out-of-gas on overflow.
+5. Duplicate targets, selectors, recipients, or ZoneFactory roles cannot bypass validation.

--- a/tips/tip-1105.md
+++ b/tips/tip-1105.md
@@ -33,9 +33,10 @@ behavior, they are grouped here as one coordinated rollout alongside [TIP-1100](
 
 At T11, AccountKeychain call-scope validation copies target and selector keys into contiguous
 vectors, sorts them, and rejects equal adjacent values. Recipient duplicate checks use the same
-sort-and-scan strategy. T11 charges 20 gas for every value processed by these checks, including the
-combined ZoneFactory role lists. Insufficient gas halts before sorting; pre-T11 duplicate checks
-retain their historical validation and gas behavior.
+sort-and-scan strategy. ZoneFactory rejects duplicate addresses within or across its
+allowed-account, gateway, and sequencer role lists. T11 charges 20 gas for every value processed by
+these checks; insufficient gas halts before sorting. Pre-T11 duplicate checks retain their
+historical validation and gas behavior.
 
 ## 2. Require strict ABI decoding
 


### PR DESCRIPTION
Groups the T11 pricing hardenings from #7298, #7444, and #7447 under a single meta TIP. Documents strict ABI decoding, deterministic duplicate detection, and per-item metering while preserving pre-T11 behavior.

Prompted by: @klkvr