### PR TITLE
fix(cli): include consensus in snapshot commands by default

### DIFF
--- a/bin/tempo/src/snapshot_download.rs
+++ b/bin/tempo/src/snapshot_download.rs
@@ -32,7 +32,7 @@ pub(crate) struct Args {
     /// Skip encoding consensus state. This will pass-through directly to Reth.
     #[arg(
         long,
-        default_value_t = true,
+        default_value_t = false,
         default_missing_value = "true",
         hide = true,
         num_args = 0..=1,
@@ -480,6 +480,20 @@ mod tests {
         let help = Args::command().render_long_help().to_string();
 
         assert!(!help.contains("--skip-consensus"));
+    }
+
+    #[test]
+    fn args_defaults_to_include_consensus() {
+        let args = Args::try_parse_from([
+            "tempo",
+            "--manifest-url",
+            "https://snap/manifest.json",
+            "--datadir",
+            "/d",
+        ])
+        .unwrap();
+
+        assert!(!args.skip_consensus);
     }
 
     #[test]

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -53,7 +53,7 @@ pub(crate) struct Args {
     /// Skip encoding consensus state. This will pass-through directly to Reth.
     #[arg(
         long,
-        default_value_t = true,
+        default_value_t = false,
         default_missing_value = "true",
         hide = true,
         num_args = 0..=1,
@@ -396,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn args_defaults_to_skip_consensus() {
+    fn args_defaults_to_include_consensus() {
         let args = Args::try_parse_from([
             "tempo",
             "--source-datadir",
@@ -406,7 +406,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert!(args.skip_consensus);
+        assert!(!args.skip_consensus);
     }
 
     #[test]


### PR DESCRIPTION
Backports #7154 so the FlatMPT image includes consensus data in the normal snapshot restore workflow.

Prompted by: @laibe