### PR TITLE
chore(bench): disable Samply for public nightly benchmarks

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -29,7 +29,7 @@ on:
       samply:
         description: "Enable samply profiling"
         required: false
-        default: true
+        default: false
         type: boolean
 
 permissions: {}
@@ -175,7 +175,7 @@ jobs:
       run-type: ${{ matrix.run_type }}
       run-pairs: "1"
       clickhouse-run: feature-1
-      samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply == false && 'false' || 'true' }}
+      samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply }}
     secrets:
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}

--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -175,7 +175,7 @@ jobs:
       run-type: ${{ matrix.run_type }}
       run-pairs: "1"
       clickhouse-run: feature-1
-      samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply }}
+      samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply && 'true' || 'false' }}
     secrets:
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}
       GRAFANA_TEMPO: ${{ secrets.GRAFANA_TEMPO }}


### PR DESCRIPTION
Disables Samply for scheduled public e2e benchmarks so profiling overhead does not affect published throughput. Manual dispatches can still opt in.

Validation: `git diff --check`; workflow parsed successfully with PyYAML.

Prompted by: @mediocregopher