### PR TITLE
chore(bench): tune nightly persistence settings

### DIFF
--- a/.github/workflows/bench-e2e-scheduled.yml
+++ b/.github/workflows/bench-e2e-scheduled.yml
@@ -175,6 +175,8 @@ jobs:
       run-type: ${{ matrix.run_type }}
       run-pairs: "1"
       clickhouse-run: feature-1
+      baseline-env: ${{ matrix.run_type == 'nightly' && 'RETH_ENGINE_PERSISTENCE_THRESHOLD=50 RETH_ENGINE_NUM_STATE_MASKING_BLOCKS=40' || '' }}
+      feature-env: ${{ matrix.run_type == 'nightly' && 'RETH_ENGINE_PERSISTENCE_THRESHOLD=50 RETH_ENGINE_NUM_STATE_MASKING_BLOCKS=40' || '' }}
       samply: ${{ github.event_name == 'workflow_dispatch' && inputs.samply && 'true' || 'false' }}
     secrets:
       TEMPO_TELEMETRY_URL: ${{ secrets.TEMPO_TELEMETRY_URL }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -55,8 +55,8 @@ target "tempo" {
 target "tempo-nightly" {
   inherits = ["tempo"]
   args = {
-    RETH_ENGINE_PERSISTENCE_THRESHOLD = "30"
-    RETH_ENGINE_NUM_STATE_MASKING_BLOCKS = "20"
+    RETH_ENGINE_PERSISTENCE_THRESHOLD = "50"
+    RETH_ENGINE_NUM_STATE_MASKING_BLOCKS = "40"
   }
   tags = ["${REGISTRY}/tempo:nightly", "docker.io/tempoxyz/tempo:nightly"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -55,8 +55,8 @@ target "tempo" {
 target "tempo-nightly" {
   inherits = ["tempo"]
   args = {
-    RETH_ENGINE_PERSISTENCE_THRESHOLD = "50"
-    RETH_ENGINE_NUM_STATE_MASKING_BLOCKS = "40"
+    RETH_ENGINE_PERSISTENCE_THRESHOLD = "30"
+    RETH_ENGINE_NUM_STATE_MASKING_BLOCKS = "20"
   }
   tags = ["${REGISTRY}/tempo:nightly", "docker.io/tempoxyz/tempo:nightly"]
 }


### PR DESCRIPTION
Passes `RETH_ENGINE_PERSISTENCE_THRESHOLD=50` and `RETH_ENGINE_NUM_STATE_MASKING_BLOCKS=40` to both benchmark sides when the scheduled workflow resolves a nightly run. Release runs retain their existing environment.

Validation: actionlint 1.7.12, PyYAML parsing, and `git diff --check`.

Prompted by: @mediocregopher