### PR TITLE
refactor(evm): remove validator set execution context

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1373,7 +1373,6 @@ async fn validate_block(
         .new_payload(TempoExecutionData {
             block,
             block_access_list,
-            validator_set: None,
         })
         .await
         .wrap_err("failed sending new-payload request to execution layer to validate block")?;
@@ -1657,8 +1656,6 @@ async fn forward_finalized(
         .new_payload(TempoExecutionData {
             block: execution_block,
             block_access_list,
-            // can be omitted for finalized blocks
-            validator_set: None,
         })
         .await
         .wrap_err(
@@ -1718,7 +1715,6 @@ async fn forward_notarized(
             .new_payload(TempoExecutionData {
                 block,
                 block_access_list,
-                validator_set: None,
             })
             .await
             .wrap_err(

--- a/crates/consensus/src/follow/executor/actor.rs
+++ b/crates/consensus/src/follow/executor/actor.rs
@@ -312,8 +312,6 @@ async fn submit_new_payload<TContext: Pacer, E: ExecutionEngine + ?Sized>(
         .new_payload(TempoExecutionData {
             block,
             block_access_list,
-            // can be omitted for finalized blocks
-            validator_set: None,
         })
         .pace(context, Duration::from_millis(20))
         .await

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -25,7 +25,6 @@ tempo-precompiles.workspace = true
 tempo-primitives = { workspace = true, features = ["reth"] }
 tempo-revm.workspace = true
 
-commonware-cryptography.workspace = true
 commonware-codec.workspace = true
 
 reth-consensus.workspace = true
@@ -58,6 +57,7 @@ alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 alloy-signer.workspace = true
 alloy-sol-types.workspace = true
 commonware-consensus.workspace = true
+commonware-cryptography.workspace = true
 commonware-math.workspace = true
 commonware-utils.workspace = true
 criterion.workspace = true

--- a/crates/evm/benches/common/mod.rs
+++ b/crates/evm/benches/common/mod.rs
@@ -407,7 +407,6 @@ where
         },
         general_gas_limit: 10_000_000_000,
         shared_gas_limit: 0,
-        validator_set: None,
         consensus_context: None,
         subblock_fee_recipients: Default::default(),
     };

--- a/crates/evm/src/assemble.rs
+++ b/crates/evm/src/assemble.rs
@@ -37,7 +37,6 @@ impl TempoBlockAssembler {
                     inner,
                     general_gas_limit,
                     shared_gas_limit,
-                    validator_set: _,
                     consensus_context,
                     subblock_fee_recipients: _,
                 },
@@ -190,7 +189,6 @@ mod tests {
             },
             general_gas_limit,
             shared_gas_limit,
-            validator_set: None,
             consensus_context: None,
             subblock_fee_recipients: HashMap::new(),
         };
@@ -301,7 +299,6 @@ mod tests {
             },
             general_gas_limit,
             shared_gas_limit,
-            validator_set: None,
             consensus_context: Some(ctx),
             subblock_fee_recipients: HashMap::new(),
         };
@@ -383,7 +380,6 @@ mod tests {
             },
             general_gas_limit,
             shared_gas_limit,
-            validator_set: None,
             consensus_context: None,
             subblock_fee_recipients: HashMap::new(),
         };

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -14,18 +14,14 @@ use alloy_evm::{
 use alloy_primitives::{Address, B256, Bytes, U256};
 use alloy_rlp::Decodable;
 use alloy_sol_types::SolCall;
-use commonware_codec::{DecodeExt, ReadExt};
-use commonware_cryptography::{
-    Verifier,
-    ed25519::{PublicKey, Signature},
-};
+use commonware_codec::ReadExt;
 use reth_evm::block::StateDB;
 use reth_revm::{
     Inspector,
     context::result::{ExecutionResult, ResultAndState},
     state::{Account, Bytecode, EvmState, EvmStorageSlot, TransactionId},
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use tempo_chainspec::{TempoChainSpec, hardfork::TempoHardforks};
 use tempo_contracts::precompiles::{
     ADDRESS_REGISTRY_ADDRESS, CURRENT_COMMITTEE_ADDRESS, ICurrentCommittee, INITIAL_FACTORY_OWNER,
@@ -34,8 +30,7 @@ use tempo_contracts::precompiles::{
     initial_zone_factory_state, t12_zone_factory_state,
 };
 use tempo_primitives::{
-    SubBlock, SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType,
-    subblock::PartialValidatorKey,
+    SubBlockMetadata, TempoReceipt, TempoTxEnvelope, TempoTxType, subblock::PartialValidatorKey,
 };
 use tempo_revm::{TempoHaltReason, evm::TempoContext};
 use tracing::trace;
@@ -172,13 +167,11 @@ pub struct TempoBlockExecutor<'a, DB: Database, I> {
 
     section: BlockSection,
     seen_subblocks: Vec<(PartialValidatorKey, Vec<TempoTxEnvelope>)>,
-    validator_set: Option<Vec<B256>>,
     subblock_fee_recipients: HashMap<PartialValidatorKey, Address>,
     extra_data: Bytes,
 
     pub(crate) replay_state: StorageActionReplayState,
 
-    shared_gas_limit: u64,
     non_shared_gas_left: u64,
     non_payment_gas_left: u64,
     incentive_gas_used: u64,
@@ -196,10 +189,8 @@ where
     ) -> Self {
         Self {
             incentive_gas_used: 0,
-            validator_set: ctx.validator_set,
             non_payment_gas_left: ctx.general_gas_limit,
             non_shared_gas_left: evm.block().gas_limit.saturating_sub(ctx.shared_gas_limit),
-            shared_gas_limit: ctx.shared_gas_limit,
             extra_data: ctx.inner.extra_data.clone(),
             inner: EthBlockExecutor::new(
                 evm,
@@ -393,7 +384,7 @@ where
             }
 
             let mut buf = metadata_input;
-            let Ok(metadata) = Vec::<SubBlockMetadata>::decode(&mut buf) else {
+            let Ok(_) = Vec::<SubBlockMetadata>::decode(&mut buf) else {
                 return Err(BlockValidationError::msg(
                     "invalid subblocks metadata system transaction",
                 ));
@@ -405,8 +396,6 @@ where
                 ));
             }
 
-            self.validate_shared_gas(&metadata)?;
-
             seen_subblocks_signatures = true;
         } else {
             return Err(BlockValidationError::msg("invalid system transaction"));
@@ -415,98 +404,6 @@ where
         Ok(BlockSection::System {
             seen_subblocks_signatures,
         })
-    }
-
-    pub(crate) fn validate_shared_gas(
-        &self,
-        metadata: &[SubBlockMetadata],
-    ) -> Result<(), BlockValidationError> {
-        // Skip incentive gas validation if validator set context is not available.
-        let Some(validator_set) = &self.validator_set else {
-            return Ok(());
-        };
-        let gas_per_subblock = self
-            .shared_gas_limit
-            .checked_div(validator_set.len() as u64)
-            .expect("validator set must not be empty");
-
-        let mut incentive_gas = 0;
-        let mut seen = HashSet::new();
-        let mut next_non_empty = 0;
-        for metadata in metadata {
-            if !validator_set.contains(&metadata.validator) {
-                return Err(BlockValidationError::msg("invalid subblock validator"));
-            }
-
-            if !seen.insert(metadata.validator) {
-                return Err(BlockValidationError::msg(
-                    "only one subblock per validator is allowed",
-                ));
-            }
-
-            let transactions = if let Some((validator, txs)) =
-                self.seen_subblocks.get(next_non_empty)
-                && validator.matches(metadata.validator)
-            {
-                next_non_empty += 1;
-                txs.clone()
-            } else {
-                Vec::new()
-            };
-
-            let reserved_gas = transactions
-                .iter()
-                .map(|tx| {
-                    core::cmp::min(
-                        tx.gas_limit(),
-                        self.inner.evm.cfg.tx_gas_limit_cap.unwrap_or(u64::MAX),
-                    )
-                })
-                .sum::<u64>();
-
-            let signature_hash = SubBlock {
-                version: metadata.version,
-                fee_recipient: metadata.fee_recipient,
-                parent_hash: self.inner.ctx.parent_hash,
-                transactions: transactions.clone(),
-            }
-            .signature_hash();
-
-            let Ok(validator) = PublicKey::decode(&mut metadata.validator.as_ref()) else {
-                return Err(BlockValidationError::msg("invalid subblock validator"));
-            };
-
-            let Ok(signature) = Signature::decode(&mut metadata.signature.as_ref()) else {
-                return Err(BlockValidationError::msg(
-                    "invalid subblock signature encoding",
-                ));
-            };
-
-            // TODO: Add namespace?
-            if !validator.verify(&[], signature_hash.as_slice(), &signature) {
-                return Err(BlockValidationError::msg("invalid subblock signature"));
-            }
-
-            if reserved_gas > gas_per_subblock {
-                return Err(BlockValidationError::msg(
-                    "subblock gas used exceeds gas per subblock",
-                ));
-            }
-
-            incentive_gas += gas_per_subblock - reserved_gas;
-        }
-
-        if next_non_empty != self.seen_subblocks.len() {
-            return Err(BlockValidationError::msg(
-                "failed to map all non-empty subblocks to metadata",
-            ));
-        }
-
-        if incentive_gas < self.incentive_gas_used {
-            return Err(BlockValidationError::msg("incentive gas limit exceeded"));
-        }
-
-        Ok(())
     }
 
     /// Pre-validate a transaction before execution.
@@ -773,18 +670,6 @@ where
     fn finish(
         mut self,
     ) -> Result<(Self::Evm, BlockExecutionResult<Self::Receipt>), BlockExecutionError> {
-        let seen_subblock_signatures = match self.section {
-            BlockSection::System {
-                seen_subblocks_signatures,
-            } => seen_subblocks_signatures,
-            _ => false,
-        };
-
-        // Post T4, if subblocks metadata transaction was not seen, imply empty metadata.
-        if !seen_subblock_signatures && self.evm().cfg.spec.is_t4() {
-            self.validate_shared_gas(&[])?;
-        }
-
         self.apply_current_committee_system_call()?;
 
         let amsterdam_eip8037_enabled = self.evm().cfg.enable_amsterdam_eip8037;
@@ -835,11 +720,6 @@ where
         txs: Vec<TempoTxEnvelope>,
     ) {
         self.seen_subblocks.push((proposer, txs));
-    }
-
-    /// Set incentive gas used for testing gas limit validation.
-    pub(crate) fn set_incentive_gas_used_for_test(&mut self, gas: u64) {
-        self.incentive_gas_used = gas;
     }
 
     /// Get the current section for assertions.
@@ -1164,214 +1044,6 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_shared_gas() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .build(&mut db, &chainspec);
-
-        let metadata = vec![create_valid_subblock_metadata(B256::ZERO, &signer)];
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_validate_shared_gas_set_does_not_contain_validator() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let different_validator = B256::repeat_byte(0x42); // Not the signer's key
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![different_validator])
-            .build(&mut db, &chainspec);
-
-        let metadata = vec![create_valid_subblock_metadata(B256::ZERO, &signer)];
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "invalid subblock validator"
-        );
-    }
-
-    #[test]
-    fn test_validate_shared_gas_more_than_one_subblock_per_validator() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .build(&mut db, &chainspec);
-
-        // Same validator appears twice
-        let m = create_valid_subblock_metadata(B256::ZERO, &signer);
-        let metadata = vec![m.clone(), m];
-
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "only one subblock per validator is allowed"
-        );
-    }
-
-    #[test]
-    fn test_validate_shared_gas_invalid_signature_encoding() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .build(&mut db, &chainspec);
-
-        // Create metadata with invalid signature encoding
-        let metadata = vec![SubBlockMetadata {
-            version: SubBlockVersion::V1,
-            validator: validator_key,
-            fee_recipient: Address::ZERO,
-            signature: Bytes::from_static(&[0x01, 0x02, 0x03]),
-        }];
-
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "invalid subblock signature encoding"
-        );
-    }
-
-    #[test]
-    fn test_validate_shared_gas_invalid_signature() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .build(&mut db, &chainspec);
-
-        // Create metadata with wrong signature
-        let wrong_signer = PrivateKey::from_seed(1);
-        let subblock = tempo_primitives::SubBlock {
-            version: SubBlockVersion::V1,
-            parent_hash: B256::ZERO,
-            fee_recipient: Address::ZERO,
-            transactions: vec![],
-        };
-        let signature_hash = subblock.signature_hash();
-        let wrong_signature = wrong_signer.sign(&[], signature_hash.as_slice());
-
-        let metadata = vec![SubBlockMetadata {
-            version: SubBlockVersion::V1,
-            validator: validator_key, // Correct validator
-            fee_recipient: Address::ZERO,
-            signature: Bytes::copy_from_slice(wrong_signature.as_ref()), // Wrong signature
-        }];
-
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "invalid subblock signature"
-        );
-    }
-
-    #[test]
-    fn test_validate_shared_gas_gas_used_exceeds_gas_per_subblock() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-        let tx = create_legacy_tx();
-        let proposer = PartialValidatorKey::from_slice(&validator_key[..15]);
-
-        // Create subblock with transactions included
-        let subblock = tempo_primitives::SubBlock {
-            version: SubBlockVersion::V1,
-            parent_hash: B256::ZERO,
-            fee_recipient: Address::ZERO,
-            transactions: vec![tx.clone()],
-        };
-
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .with_shared_gas_limit(100) // Low shared gas limit
-            .with_seen_subblock(proposer, vec![tx])
-            .build(&mut db, &chainspec);
-        let signature_hash = subblock.signature_hash();
-        let signature = signer.sign(&[], signature_hash.as_slice());
-
-        let metadata = vec![SubBlockMetadata {
-            version: SubBlockVersion::V1,
-            validator: validator_key,
-            fee_recipient: Address::ZERO,
-            signature: Bytes::copy_from_slice(signature.as_ref()),
-        }];
-
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "subblock gas used exceeds gas per subblock"
-        );
-    }
-
-    #[test]
-    fn test_validate_shared_gas_unexpected_subblock_len() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-
-        // Add a seen subblock from a different validator that won't match metadata
-        let different_key = B256::repeat_byte(0x99);
-        let different_proposer = PartialValidatorKey::from_slice(&different_key[..15]);
-
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .with_seen_subblock(different_proposer, vec![])
-            .build(&mut db, &chainspec);
-
-        // Metadata has validator_key but seen_subblocks has different_key
-        let metadata = vec![create_valid_subblock_metadata(B256::ZERO, &signer)];
-
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "failed to map all non-empty subblocks to metadata"
-        );
-    }
-
-    #[test]
-    fn test_validate_shared_gas_limit_exceeded() {
-        let chainspec = test_chainspec();
-        let mut db = State::builder().with_bundle_update().build();
-        let signer = PrivateKey::from_seed(0);
-        let validator_key = B256::from_slice(&signer.public_key());
-
-        // Set incentive_gas_used higher than available incentive gas
-        let executor = TestExecutorBuilder::default()
-            .with_validator_set(vec![validator_key])
-            .with_incentive_gas_used(100_000_000)
-            .build(&mut db, &chainspec);
-
-        let metadata = vec![create_valid_subblock_metadata(B256::ZERO, &signer)];
-
-        let result = executor.validate_shared_gas(&metadata);
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "incentive gas limit exceeded"
-        );
-    }
-
-    #[test]
     fn test_is_payment_uses_v2_from_t5() {
         let tx = create_tip20_empty_calldata_tx();
         assert!(
@@ -1656,40 +1328,6 @@ mod tests {
 
         let result = executor.finish();
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_finish_t4_without_metadata_passes_when_incentive_gas_is_zero() {
-        let chainspec = DEV.clone();
-        let mut db = State::builder().with_bundle_update().build();
-        let mut executor = TestExecutorBuilder::default()
-            .with_parent_beacon_block_root(B256::ZERO)
-            .with_validator_set(vec![B256::repeat_byte(0x01)])
-            .build(&mut db, &chainspec);
-
-        executor.inner.evm.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T4;
-        executor.apply_pre_execution_changes().unwrap();
-
-        assert!(executor.finish().is_ok());
-    }
-
-    #[test]
-    fn test_finish_t4_without_metadata_rejects_incentive_gas() {
-        let chainspec = DEV.clone();
-        let mut db = State::builder().with_bundle_update().build();
-        let mut executor = TestExecutorBuilder::default()
-            .with_parent_beacon_block_root(B256::ZERO)
-            .with_validator_set(vec![B256::repeat_byte(0x01)])
-            .with_incentive_gas_used(1)
-            .build(&mut db, &chainspec);
-
-        executor.inner.evm.cfg.spec = tempo_chainspec::hardfork::TempoHardfork::T4;
-        executor.apply_pre_execution_changes().unwrap();
-
-        match executor.finish() {
-            Err(err) => assert_eq!(err.to_string(), "incentive gas limit exceeded"),
-            Ok(_) => panic!("finish should fail when T4 block has incentive gas without metadata"),
-        }
     }
 
     #[test]

--- a/crates/evm/src/context.rs
+++ b/crates/evm/src/context.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use alloy_evm::eth::EthBlockExecutionCtx;
-use alloy_primitives::{Address, B256};
+use alloy_primitives::Address;
 use reth_evm::NextBlockEnvAttributes;
 use tempo_primitives::{TempoConsensusContext, subblock::PartialValidatorKey};
 
@@ -15,13 +15,6 @@ pub struct TempoBlockExecutionCtx<'a> {
     pub general_gas_limit: u64,
     /// Shared gas limit for the block.
     pub shared_gas_limit: u64,
-    /// Validator set for the block.
-    ///
-    /// Only set for un-finalized blocks coming from consensus layer.
-    ///
-    /// When this is set to `None`, no validation of subblock signatures is performed.
-    /// Make sure to always set this field when executing blocks from untrusted sources
-    pub validator_set: Option<Vec<B256>>,
     /// Consensus metadata for the block. `None` for pre-fork blocks.
     pub consensus_context: Option<TempoConsensusContext>,
     /// Mapping from a subblock validator public key to the fee recipient configured.

--- a/crates/evm/src/engine.rs
+++ b/crates/evm/src/engine.rs
@@ -25,13 +25,8 @@ impl ConfigureEngineEvm<TempoExecutionData> for TempoEvmConfig {
         let TempoExecutionData {
             block,
             block_access_list: _,
-            validator_set,
         } = payload;
-        let mut context = self.context_for_block(block)?;
-
-        context.validator_set = validator_set.clone();
-
-        Ok(context)
+        self.context_for_block(block)
     }
 
     fn tx_iterator_for_payload(
@@ -224,7 +219,6 @@ mod tests {
         let payload = TempoExecutionData {
             block: block.into(),
             block_access_list: None,
-            validator_set: None,
         };
 
         let result = evm_config.tx_iterator_for_payload(&payload);
@@ -254,12 +248,9 @@ mod tests {
 
         let system_tx = create_subblock_metadata_tx(chainspec.chain().id(), 1);
         let block = create_test_block(vec![system_tx]);
-        let validator_set = Some(vec![B256::repeat_byte(0x01), B256::repeat_byte(0x02)]);
-
         let payload = TempoExecutionData {
             block: block.into(),
             block_access_list: None,
-            validator_set: validator_set.clone(),
         };
 
         let result = evm_config.context_for_payload(&payload);
@@ -270,7 +261,6 @@ mod tests {
         // Verify context fields
         assert_eq!(context.general_gas_limit, 10_000_000);
         assert_eq!(context.shared_gas_limit, 3_000_000);
-        assert_eq!(context.validator_set, validator_set);
         assert!(context.subblock_fee_recipients.is_empty());
     }
 
@@ -285,7 +275,6 @@ mod tests {
         let payload = TempoExecutionData {
             block: block.clone().into(),
             block_access_list: None,
-            validator_set: None,
         };
 
         let result = evm_config.evm_env_for_payload(&payload);

--- a/crates/evm/src/lib.rs
+++ b/crates/evm/src/lib.rs
@@ -304,8 +304,6 @@ impl ConfigureEvm for TempoEvmConfig {
             },
             general_gas_limit: block.header().general_gas_limit,
             shared_gas_limit: block.header().shared_gas_limit,
-            // Not available when we only have a block body.
-            validator_set: None,
             consensus_context: block.header().consensus_context,
             subblock_fee_recipients,
         })
@@ -331,8 +329,6 @@ impl ConfigureEvm for TempoEvmConfig {
             },
             general_gas_limit: attributes.general_gas_limit,
             shared_gas_limit: attributes.shared_gas_limit,
-            // Fine to not validate during block building.
-            validator_set: None,
             consensus_context: attributes.consensus_context,
             subblock_fee_recipients: Default::default(),
         })
@@ -589,8 +585,6 @@ mod tests {
         // Verify context fields
         assert_eq!(context.general_gas_limit, 10_000_000);
         assert_eq!(context.shared_gas_limit, 3_000_000);
-        assert!(context.validator_set.is_none());
-
         // Verify subblock_fee_recipients was extracted from metadata
         let partial_key = PartialValidatorKey::from_slice(&validator_key[..15]);
         assert_eq!(
@@ -676,7 +670,6 @@ mod tests {
         // Verify context fields from attributes
         assert_eq!(context.general_gas_limit, 12_000_000);
         assert_eq!(context.shared_gas_limit, 4_000_000);
-        assert!(context.validator_set.is_none());
         assert_eq!(context.inner.parent_hash, parent.hash());
         assert_eq!(
             context.inner.parent_beacon_block_root,

--- a/crates/evm/src/test_utils.rs
+++ b/crates/evm/src/test_utils.rs
@@ -51,7 +51,6 @@ pub(crate) struct TestExecutorBuilder {
     pub(crate) parent_hash: B256,
     pub(crate) general_gas_limit: u64,
     pub(crate) shared_gas_limit: u64,
-    pub(crate) validator_set: Option<Vec<B256>>,
     pub(crate) parent_beacon_block_root: Option<B256>,
     pub(crate) subblock_fee_recipients: HashMap<PartialValidatorKey, Address>,
     /// Sets `cfg_env.enable_amsterdam_eip8037` to gate TIP-1016 behavior in tests.
@@ -61,7 +60,6 @@ pub(crate) struct TestExecutorBuilder {
     // Test state to seed into the executor after creation
     pub(crate) initial_section: Option<BlockSection>,
     pub(crate) initial_seen_subblocks: Vec<(PartialValidatorKey, Vec<TempoTxEnvelope>)>,
-    pub(crate) initial_incentive_gas_used: u64,
 }
 
 impl Default for TestExecutorBuilder {
@@ -72,7 +70,6 @@ impl Default for TestExecutorBuilder {
             parent_hash: B256::ZERO,
             general_gas_limit: 10_000_000,
             shared_gas_limit: 10_000_000,
-            validator_set: None,
             parent_beacon_block_root: None,
             subblock_fee_recipients: HashMap::new(),
             amsterdam_eip8037_enabled: false,
@@ -80,7 +77,6 @@ impl Default for TestExecutorBuilder {
             extra_data: Bytes::new(),
             initial_section: None,
             initial_seen_subblocks: Vec::new(),
-            initial_incentive_gas_used: 0,
         }
     }
 }
@@ -103,16 +99,6 @@ impl TestExecutorBuilder {
 
     pub(crate) fn with_spec(mut self, spec: TempoHardfork) -> Self {
         self.spec = spec;
-        self
-    }
-
-    pub(crate) fn with_validator_set(mut self, validators: Vec<B256>) -> Self {
-        self.validator_set = Some(validators);
-        self
-    }
-
-    pub(crate) fn with_shared_gas_limit(mut self, limit: u64) -> Self {
-        self.shared_gas_limit = limit;
         self
     }
 
@@ -146,12 +132,6 @@ impl TestExecutorBuilder {
         txs: Vec<TempoTxEnvelope>,
     ) -> Self {
         self.initial_seen_subblocks.push((proposer, txs));
-        self
-    }
-
-    /// Set the initial incentive gas used (for testing gas limit validation).
-    pub(crate) fn with_incentive_gas_used(mut self, gas: u64) -> Self {
-        self.initial_incentive_gas_used = gas;
         self
     }
 
@@ -193,7 +173,6 @@ impl TestExecutorBuilder {
             },
             general_gas_limit: self.general_gas_limit,
             shared_gas_limit: self.shared_gas_limit,
-            validator_set: self.validator_set,
             consensus_context: None,
             subblock_fee_recipients: self.subblock_fee_recipients,
         };
@@ -207,10 +186,6 @@ impl TestExecutorBuilder {
         for (proposer, txs) in self.initial_seen_subblocks {
             executor.add_seen_subblock_for_test(proposer, txs);
         }
-        if self.initial_incentive_gas_used > 0 {
-            executor.set_incentive_gas_used_for_test(self.initial_incentive_gas_used);
-        }
-
         executor
     }
 }

--- a/crates/node/src/engine.rs
+++ b/crates/node/src/engine.rs
@@ -26,7 +26,6 @@ impl PayloadValidator<TempoPayloadTypes> for TempoEngineValidator {
         let TempoExecutionData {
             block,
             block_access_list: _,
-            validator_set: _,
         } = payload;
         Ok(block.into_sealed_block())
     }

--- a/crates/payload/types/src/lib.rs
+++ b/crates/payload/types/src/lib.rs
@@ -6,7 +6,7 @@
 mod attrs;
 mod budget;
 
-use alloy_primitives::{B256, Bytes};
+use alloy_primitives::Bytes;
 pub use attrs::TempoPayloadAttributes;
 pub use budget::{
     MarshalPersistEstimator, ValidationLatencyEstimate, ValidationLatencyEstimator,
@@ -121,7 +121,6 @@ impl TempoBuiltPayload {
         TempoExecutionData {
             block,
             block_access_list,
-            validator_set: None,
         }
     }
 }
@@ -158,8 +157,6 @@ pub struct TempoExecutionData {
     pub block: SealedOrRecoveredBlock<Block>,
     /// RLP-encoded EIP-7928 block access list, when supplied with the payload.
     pub block_access_list: Option<Bytes>,
-    /// Validator set active at the time this block was built.
-    pub validator_set: Option<Vec<B256>>,
 }
 
 /// Serde helper for preserving the legacy plain block JSON shape.
@@ -273,7 +270,6 @@ impl PayloadTypes for TempoPayloadTypes {
         TempoExecutionData {
             block: block.into(),
             block_access_list: bal,
-            validator_set: None,
         }
     }
 }
@@ -348,8 +344,7 @@ mod tests {
                     "transactionsRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
                 }
             },
-            "block_access_list": null,
-            "validator_set": null
+            "block_access_list": null
         });
 
         let execution_data: TempoExecutionData = serde_json::from_value(fixture.clone()).unwrap();


### PR DESCRIPTION
Removes the remaining `validator_set` execution-context plumbing and now-dead validator-dependent pre-T4 subblock validation. Keeps the T4 incentive-gas guard introduced on #7449.

Stacked on #7449.

Prompted by: @SuperFluffy