### PR TITLE
chore(deps): pin reth overlay optimizations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-evm"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b307a52f91f7f3aad56b5cb4f54e5eb17dd0b3f4b2c82823301499fe1c6fdaf"
+checksum = "7b6bd5f7e5ce9858bac99275e3f548c3b63bb3e5806da0142dc0b2f518d3ec4a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -4484,7 +4484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5003,8 +5003,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
 ]
 
 [[package]]
@@ -5709,7 +5709,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6098,7 +6098,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8983,8 +8983,8 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "reth-basic-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9010,8 +9010,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chain-state"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9041,8 +9041,8 @@ dependencies = [
 
 [[package]]
 name = "reth-chainspec"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9061,8 +9061,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9074,8 +9074,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-commands"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9159,8 +9159,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-runner"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9169,8 +9169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-cli-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9190,9 +9190,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0dd7f542fbcae0e490ebe13f3eababcc05547375246ff7f62700b533cf3f01"
+checksum = "d34b0b409ecf930ed3850e92bd9b4d4f8a8c397eef23e8ba5b1a1a02682a94bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9211,9 +9211,9 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs-derive"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
+checksum = "ebcb49ab084e764e7d20f710e2c9daa439380d0fc33f8bfee8c372bfdbc1f437"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9222,8 +9222,8 @@ dependencies = [
 
 [[package]]
 name = "reth-config"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9239,8 +9239,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9253,8 +9253,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-common"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9266,8 +9266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-consensus-debug-client"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9291,8 +9291,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9320,8 +9320,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9346,8 +9346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-common"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9376,8 +9376,8 @@ dependencies = [
 
 [[package]]
 name = "reth-db-models"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9391,8 +9391,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv4"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9416,8 +9416,8 @@ dependencies = [
 
 [[package]]
 name = "reth-discv5"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9440,8 +9440,8 @@ dependencies = [
 
 [[package]]
 name = "reth-dns-discovery"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9464,8 +9464,8 @@ dependencies = [
 
 [[package]]
 name = "reth-downloaders"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9501,8 +9501,8 @@ dependencies = [
 
 [[package]]
 name = "reth-e2e-test-utils"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9560,8 +9560,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ecies"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9587,8 +9587,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-local"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9610,8 +9610,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9637,8 +9637,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-tree"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9686,7 +9686,6 @@ dependencies = [
  "reth-trie-sparse",
  "revm",
  "schnellru",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9694,8 +9693,8 @@ dependencies = [
 
 [[package]]
 name = "reth-engine-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,8 +9723,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,8 +9741,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-downloader"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,8 +9757,8 @@ dependencies = [
 
 [[package]]
 name = "reth-era-utils"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,8 +9781,8 @@ dependencies = [
 
 [[package]]
 name = "reth-errors"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,8 +9792,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,8 +9820,8 @@ dependencies = [
 
 [[package]]
 name = "reth-eth-wire-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,8 +9843,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,8 +9884,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-cli"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,8 +9907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-consensus"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,8 +9923,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-engine-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,8 +9939,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,8 +9952,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,8 +9982,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,8 +9996,8 @@ dependencies = [
 
 [[package]]
 name = "reth-etl"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,8 +10006,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,8 +10032,8 @@ dependencies = [
 
 [[package]]
 name = "reth-evm-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,8 +10052,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-cache"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,8 +10070,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-errors"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,8 +10083,8 @@ dependencies = [
 
 [[package]]
 name = "reth-execution-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,8 +10102,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,8 +10140,8 @@ dependencies = [
 
 [[package]]
 name = "reth-exex-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,8 +10154,8 @@ dependencies = [
 
 [[package]]
 name = "reth-fs-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,8 +10164,8 @@ dependencies = [
 
 [[package]]
 name = "reth-invalid-block-hooks"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,8 +10190,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ipc"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,8 +10210,8 @@ dependencies = [
 
 [[package]]
 name = "reth-libmdbx"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,8 +10227,8 @@ dependencies = [
 
 [[package]]
 name = "reth-mdbx-sys"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,8 +10236,8 @@ dependencies = [
 
 [[package]]
 name = "reth-metrics"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "futures",
  "libc",
@@ -10251,8 +10250,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-banlist"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,8 +10259,8 @@ dependencies = [
 
 [[package]]
 name = "reth-net-nat"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,8 +10273,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,8 +10332,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,8 +10357,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-p2p"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,8 +10381,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-peers"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,8 +10396,8 @@ dependencies = [
 
 [[package]]
 name = "reth-network-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,8 +10410,8 @@ dependencies = [
 
 [[package]]
 name = "reth-nippy-jar"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10428,8 +10427,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10452,8 +10451,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10520,8 +10519,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-core"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10575,8 +10574,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethereum"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10624,8 +10623,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-ethstats"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10648,8 +10647,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-events"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10672,8 +10671,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-metrics"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "bytes",
  "eyre",
@@ -10701,8 +10700,8 @@ dependencies = [
 
 [[package]]
 name = "reth-node-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10713,8 +10712,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10737,8 +10736,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-builder-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10749,8 +10748,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-primitives"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10772,8 +10771,8 @@ dependencies = [
 
 [[package]]
 name = "reth-payload-validator"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10782,9 +10781,9 @@ dependencies = [
 
 [[package]]
 name = "reth-primitives-traits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a8d5b246650b23e6767a45e46334d352557f473e91c2ea7211cc29291cca"
+checksum = "9060738a07ca1b0d8ede3ce21d8187c57cc22ee9e2991b29cbbc663280f843cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10815,8 +10814,8 @@ dependencies = [
 
 [[package]]
 name = "reth-provider"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10865,8 +10864,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10892,8 +10891,8 @@ dependencies = [
 
 [[package]]
 name = "reth-prune-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10908,8 +10907,8 @@ dependencies = [
 
 [[package]]
 name = "reth-revm"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10923,8 +10922,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -10999,8 +10998,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11029,8 +11028,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-builder"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11072,8 +11071,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-convert"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11092,8 +11091,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-engine-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11123,8 +11122,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11170,8 +11169,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-eth-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11220,8 +11219,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-layer"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11236,8 +11235,8 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-server-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11252,9 +11251,9 @@ dependencies = [
 
 [[package]]
 name = "reth-rpc-traits"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b417a50d3fa9b58bb1a22e46fb47e0866006f24abffa1fbe75ae60116b5b2efa"
+checksum = "f410d6bff1fd059ebaec2edeff1326f103f61162158411325d78158f94b2b4a9"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -11267,8 +11266,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11319,8 +11318,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11347,8 +11346,8 @@ dependencies = [
 
 [[package]]
 name = "reth-stages-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11361,8 +11360,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11381,8 +11380,8 @@ dependencies = [
 
 [[package]]
 name = "reth-static-file-types"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11396,8 +11395,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-api"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11422,8 +11421,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-errors"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11439,8 +11438,8 @@ dependencies = [
 
 [[package]]
 name = "reth-storage-overlay"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11467,8 +11466,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tasks"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11488,8 +11487,8 @@ dependencies = [
 
 [[package]]
 name = "reth-testing-utils"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11504,8 +11503,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tokio-util"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11514,8 +11513,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "clap",
  "eyre",
@@ -11534,8 +11533,8 @@ dependencies = [
 
 [[package]]
 name = "reth-tracing-otlp"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11553,8 +11552,8 @@ dependencies = [
 
 [[package]]
 name = "reth-transaction-pool"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11596,8 +11595,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11622,8 +11621,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-common"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11650,8 +11649,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-db"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11666,8 +11665,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-parallel"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11683,7 +11682,6 @@ dependencies = [
  "reth-storage-errors",
  "reth-tasks",
  "reth-trie",
- "reth-trie-sparse",
  "revm",
  "thiserror 2.0.18",
  "tracing",
@@ -11691,8 +11689,8 @@ dependencies = [
 
 [[package]]
 name = "reth-trie-sparse"
-version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=9812056#98120568b6f1c133fbffefd0371e1af6413271ee"
+version = "2.5.2"
+source = "git+https://github.com/paradigmxyz/reth?rev=fc25ab4#fc25ab45e3aa4a3411dd13928c158e91ea4f11ba"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11703,8 +11701,6 @@ dependencies = [
  "reth-metrics",
  "reth-primitives-traits",
  "reth-trie-common",
- "serde",
- "serde_json",
  "slotmap",
  "smallvec",
  "strum",
@@ -11713,18 +11709,18 @@ dependencies = [
 
 [[package]]
 name = "reth-zstd-compressors"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80addacffc5df9398c55919f8993922d2b688f2aa5753708fdd658ca3cc63e39"
+checksum = "08f1ebb37e81a596ce16e81bec6a0c9accbdb914cf19b9190eff69ed00395900"
 dependencies = [
  "zstd",
 ]
 
 [[package]]
 name = "revm"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c7fcd426beab3b91300a6d0d5eb8d583c0fad0fba451126e19fd51443eca62"
+checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11741,9 +11737,9 @@ dependencies = [
 
 [[package]]
 name = "revm-bytecode"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537356bdec80dbc04e4e6bb688b3441ff7cf18eecdcf3cac23150633c46467f1"
+checksum = "c8d38e16b72ec1c836ec8490562bfb21003165ea8bc496086bf345680a6e6c41"
 dependencies = [
  "bitvec",
  "phf 0.14.0",
@@ -11753,9 +11749,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "42.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6512f05f83378e29b2b016fa5bd7f5a533e3625548be4113732e1a536c2564"
+checksum = "f85bce65cc8969955309d5c4c37a63612209c720d040f1982dda6b59e39ab059"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11770,9 +11766,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103fff818b10311034c0c11ff8760294ee0e3c320daab3c5717990fe8ee2617b"
+checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11786,9 +11782,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df72760eab0852100e748c7cb03ce0221626d60ac14534118c84c5cc894fb4c9"
+checksum = "31d764afa9a1c9278c05d40461b07319d21ccb39c1bdf0e9dde7e5ea7d9be53d"
 dependencies = [
  "alloy-eips",
  "derive_more",
@@ -11802,9 +11798,9 @@ dependencies = [
 
 [[package]]
 name = "revm-database-interface"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9286c059a11be1dee814cafdc3a3ade57521c8caa050785a52c19a9d894f400"
+checksum = "d2a27e4440c2ef4932afdaa28a1d1ac8601504c7030c1a387b5e307d07d864d1"
 dependencies = [
  "auto_impl",
  "either",
@@ -11816,9 +11812,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09126175c3fa482e71e80cc28c6bb17e681911e472b94d4f7f73dd6780411798"
+checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11835,9 +11831,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "42.0.1"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa55b208b52f0c083ea68147c78866eeecadd7c0071a614f477de316b60648e"
+checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
 dependencies = [
  "auto_impl",
  "either",
@@ -11853,9 +11849,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspectors"
-version = "0.42.2"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c136a072540987ee442e9824631835520b13e5756f20780a637ba2e11f9c28"
+checksum = "79b609cb78fcb3a8c10f3190847c9bb0223423cf46e2de30a61ea9e37a3e6736"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11873,9 +11869,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd310927437752ce4bac6997b385772823b84843f04c82e151993bec1265a5ed"
+checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11886,9 +11882,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "42.0.1"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2431091420999795df6a200b9f7933defe3d654710560a895e6bcabbd9954a5"
+checksum = "1e22eb3326b44ec0bc47a874966a562390e1613f1f0ba4dc4a1056e525e0f628"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -11912,9 +11908,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef5564c1bce219fd08beca43d4f39fdcbc19193fa4f604c0c6b58950a13194a"
+checksum = "f1f4ba1a5757fe4398262290422c371556fcebf236f762f7ed7ff2c56768a63c"
 dependencies = [
  "alloy-primitives",
  "once_cell",
@@ -11923,9 +11919,9 @@ dependencies = [
 
 [[package]]
 name = "revm-state"
-version = "42.0.0"
+version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4ae66db3abfcb565854dbfc95513bfa440b3dc390ddf8e50b0363d12a6fa79"
+checksum = "7cd02082cf1baca01e8bc17456c45136bdc66632395a98db1c1a2afe4c6ea87f"
 dependencies = [
  "alloy-eip7928",
  "bitflags 2.11.1",
@@ -12246,7 +12242,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -12326,7 +12322,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -13286,7 +13282,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -15369,7 +15365,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,74 +146,74 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9812056" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-codecs = { version = "0.7.0", default-features = false }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-primitives-traits = { version = "0.7.0", default-features = false }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9812056", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "fc25ab4", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "42.0.1", features = ["optional_fee_charge"], default-features = false }
-revm-inspectors = "0.42.2"
+revm = { version = "43.0.0", features = ["optional_fee_charge"], default-features = false }
+revm-inspectors = "0.43.0"
 
 alloy-json-abi = { version = "1.7.2", default-features = false }
 alloy-primitives = { version = "1.7.2", default-features = false }
@@ -224,7 +224,7 @@ alloy-consensus = { version = "2.4.1", default-features = false }
 alloy-contract = { version = "2.4.1", default-features = false }
 alloy-eip7928 = { version = "0.4.5", default-features = false }
 alloy-eips = { version = "2.4.1", default-features = false }
-alloy-evm = { version = "0.38.0", default-features = false }
+alloy-evm = { version = "0.39.0", default-features = false }
 alloy-genesis = { version = "2.4.1", default-features = false }
 alloy-hardforks = "0.4.7"
 alloy-json-rpc = "2.4.1"


### PR DESCRIPTION
Pins Reth to [paradigmxyz/reth#26990](https://github.com/paradigmxyz/reth/pull/26990) at `fc25ab45e3aa4a3411dd13928c158e91ea4f11ba` and aligns Tempo's direct compatibility crates with the upstream 2.5.2 dependency graph. Verified with `cargo +nightly fmt --all -- --check` and `cargo check -p tempo --locked`.

Prompted by: @mediocregopher