### PR TITLE
docs(tip-1061): store config hash in account leaf

### DIFF
--- a/.changelog/native-multisig.md
+++ b/.changelog/native-multisig.md
@@ -1,11 +1,9 @@
 ---
 tempo-alloy: minor
-tempo-contracts: minor
-tempo-precompiles: minor
 tempo-primitives: minor
 tempo-evm: minor
 tempo-revm: minor
 tempo-node: minor
 ---
 
-Activates counterfactual native multisig accounts at T12, including a new multisig precompile, signature-carried configuration witnesses, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Initial account identity uses a dedicated cross-chain CREATE2 recovery factory that is reserved on Tempo, while owner updates persist one configuration commitment slot.
+Activates counterfactual native multisig accounts at T12, including signature-carried configuration witnesses and updates, and `MultisigSignature` validation across the EVM, transaction pool, and RPC layers. Initial account identity uses a dedicated cross-chain CREATE2 recovery factory that is reserved on Tempo, while owner updates persist one configuration hash in the account leaf.

--- a/tips/tip-1061.md
+++ b/tips/tip-1061.md
@@ -24,9 +24,9 @@ Today, these needs typically require a contract wallet or external account abstr
 
 ## Assumptions
 
-- T12 activates consensus acceptance and validation of multisig signatures, the native multisig precompile, and the signed key authorization changes together.
+- T12 activates consensus acceptance and validation of multisig signatures, account-leaf configuration hashes, and the signed key authorization changes together.
 - The existing Tempo transaction, key authorization, and sponsorship digests bind the fields documented by their respective TIPs. Multisig authorization inherits those digest guarantees and adds the account and configuration version bindings defined below.
-- Only the native multisig precompile can modify multisig configuration commitments.
+- Only successful transactions directly authorized by the applicable owner quorum can modify an account's multisig configuration hash.
 - Account keychain validation continues to enforce access-key expiry, scope, spending limits, and admin permissions. Multisig authorization does not weaken those restrictions.
 - Cross-chain recovery is an asset-recovery mechanism controlled by the initial owner configuration. It does not synchronize later Tempo configuration updates or make the address a general-purpose multisig identity on other chains.
 
@@ -136,6 +136,18 @@ pub struct MultisigSignature {
 
     /// Ordered primitive or nested multisig account owner signatures.
     pub signatures: Vec<TempoSignature>,
+
+    /// Optional owner update applied after successful transaction execution.
+    pub config_update: Option<MultisigConfigUpdate>,
+}
+
+/// A replacement owner policy. The salt is preserved and the version is incremented implicitly.
+pub struct MultisigConfigUpdate {
+    /// Minimum total owner weight required after the update.
+    pub threshold: u8,
+
+    /// Strictly ascending replacement owners.
+    pub owners: Vec<MultisigOwner>,
 }
 ```
 
@@ -154,10 +166,11 @@ Rules:
 A type `0x05` multisig signature MUST be encoded as:
 
 ```text
-0x05 || rlp([account, config, signatures])
+0x05 || rlp([account, config, signatures, config_update])
 
 config = rlp([salt, version, threshold, owners])
 owner  = rlp([owner, weight])
+config_update = rlp([]) | rlp([threshold, owners])
 ```
 
 Rules:
@@ -166,6 +179,7 @@ Rules:
 - Transactions carrying type `0x05` MUST be rejected before T12. Generic wire-format decoders MAY parse the type without hardfork context, but consensus validation MUST NOT accept it before T12.
 - `signatures` MUST contain 1 to `MAX_MULTISIG_SIGNATURES` owner signatures, each using the existing `TempoSignature` byte encoding. Decoders MUST reject an empty list before intrinsic gas is computed.
 - Decoders MUST reject malformed encodings, trailing fields, limit violations, and excessive nesting.
+- An empty `config_update` list means no update. A nonempty list MUST contain exactly `threshold` and `owners`.
 - When `config.version == 0`, `account` MUST be derived from `config.salt`, `config.threshold`, and `config.owners`, and its persisted configuration commitment MUST be zero.
 - When `config.version > 0`, the stored commitment for `account` MUST be nonzero and equal the commitment of `config`.
 - Initial and current signatures MAY appear as nested owner or key authorization signatures when their respective commitment-state rules hold.
@@ -219,7 +233,7 @@ Rules:
 - The derived address MUST be nonzero and outside virtual, active-precompile, TIP-20, and ZonePortal namespaces.
 - Configuration updates MUST preserve the salt and replace the current threshold and owners without changing the account address.
 - Version `0` MUST identify only the initial derived configuration and MUST NOT be persisted. Updated configurations MUST use monotonically increasing nonzero versions.
-- A configuration update whose commitment equals zero MUST revert with `InvalidConfig`; zero is reserved to mean that the account still uses its initial derived configuration.
+- A configuration update whose commitment equals zero MUST be rejected; zero is reserved to mean that the account still uses its initial derived configuration.
 
 ## Authorization
 
@@ -230,17 +244,20 @@ multisig_digest = keccak256(
   "tempo:multisig:signature" ||
   inner_digest ||
   account ||
-  uint64(config_version)
+  uint64(config_version) ||
+  next_config_hash
 )
 ```
+
+`next_config_hash` is zero when `config_update` is absent. Otherwise it is the configuration hash of a configuration that preserves the current salt, increments the current version by one, and uses the update's threshold and owners.
 
 The account binding prevents an owner signature from being reused for another multisig account or as an ordinary primitive signature. The configuration version prevents an owner signature from becoming valid again after later owner updates.
 
 Rules:
 
-- The digest MUST encode `config_version` as an eight-byte, big-endian integer. Initial authorization MUST use version `0`; current authorization MUST use the version in the committed witness.
+- The digest MUST encode `config_version` as an eight-byte, big-endian integer and `next_config_hash` as 32 raw bytes. Initial authorization MUST use version `0`; current authorization MUST use the version in the committed witness.
 - `inner_digest` MUST be `tx.signature_hash()` when direct or the parent's multisig account digest when nested.
-- Owner signatures MUST be owner-ordered, belong to the applicable configuration, and reach threshold on the final item.
+- Owner signatures MUST be owner-ordered, belong to the applicable configuration, and reach threshold on the final item. Every owner signature at a node signs the same digest, including that node's `next_config_hash`.
 - Validation MUST reject missing quorum, duplicate or unsorted owners, cycles, and any owner signature submitted after quorum is reached.
 - Stateless recovery MUST validate the shape, including version-0 account derivation, and return `account` without proving commitment equality, membership, or quorum.
 - Stateful validation MUST compare the witness with the account's block-position commitment and complete quorum verification before the account is treated as authorized.
@@ -252,111 +269,48 @@ Initial transactions authorize counterfactual accounts without establishing mult
 Rules:
 
 - `tx.from`, `tx.origin`, and top-level `msg.sender` MUST equal the account; one authorization MUST cover the call batch.
-- An initial transaction MAY repeat while the account's commitment remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state. Ordinary nonce validation and consumption apply; balance and storage MUST NOT prevent authorization.
+- An initial transaction MAY repeat while the account leaf's `config_hash` remains zero and MUST NOT require a zero protocol nonce or write multisig configuration state unless it carries `config_update`. Ordinary nonce validation and consumption apply; balance and storage MUST NOT prevent authorization.
 - Authorization lists MUST reject `TempoSignature::Multisig` entries statelessly.
-- Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a multisig-commitment read. Address collisions with derived multisig accounts are outside this TIP's security scope.
-- Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a multisig-commitment read.
+- Primitive authorization-list signatures authenticate their authority directly and MUST NOT require a separate configuration lookup. Address collisions with derived multisig accounts are outside this TIP's security scope.
+- Keychain-signed authorization-list entries MUST retain the existing T0 behavior: they are skipped, MUST NOT install delegation, and MUST NOT require a separate configuration lookup.
 - Subblock transactions MUST NOT use multisig outer or key authorization signatures.
 - Sponsorship MUST use existing sponsored signing hashes.
 - Pools MUST revalidate transactions carrying an initial or current signature for an account, or naming it as `key_authorization.key_id`, whenever that account's commitment changes, including after reorgs.
+- A successful transaction carrying `config_update` MUST replace the account leaf's `config_hash` after its calls complete.
 
-## Storage
+## Account Leaf Storage
 
-The multisig account precompile stores one commitment per account; signatures and update events carry full configurations. `pad32` encodes an address or unsigned integer as a 32-byte, big-endian, left-zero-padded value. `mapping_slot` returns the Keccak-256 result as a big-endian `uint256`.
+Tempo extends the state-trie account value with one optional `config_hash` field. Implementations MUST encode the account leaf as follows:
 
 ```text
-mapping_slot(key, base) = keccak256(pad32(key) || pad32(base))
-
-config_slot(account) = mapping_slot(account, 0)
-
-storage[config_slot(account)] = config_commitment
+unconfigured_account = rlp([nonce, balance, storage_root, code_hash])
+configured_account   = rlp([nonce, balance, storage_root, code_hash, config_hash])
 ```
 
 Rules:
 
-- Mapping base slot `0` MUST hold the configuration commitment with the key order above. This TIP MUST NOT store owner arrays or direct owner-weight rows.
-- A zero slot means no configuration update has occurred. It does not prove that the address is not a counterfactual multisig account.
-- A nonzero slot MUST contain the current configuration commitment and MUST never return to zero.
+- `config_hash == 0` MUST use the four-field legacy encoding. This preserves existing state roots and account-leaf encodings for accounts that do not use configurable accounts.
+- A nonzero `config_hash` MUST be encoded as the fifth field and MUST equal the current configuration commitment.
+- The field is part of the account leaf and therefore of the state root, account proofs, execution witnesses, snapshots, and block access lists.
+- Implementations MUST retrieve `config_hash` with the account record. Validation MUST NOT perform a separate contract-storage or precompile-storage lookup.
+- This TIP MUST NOT persist owner arrays or direct owner-weight rows.
+- Zero means no configuration update has occurred. It does not prove that the address is not a counterfactual multisig account.
+- Once nonzero, `config_hash` MUST never return to zero.
 
-## Native Multisig Precompile
+## Configuration Updates
 
-A dedicated precompile exposes account derivation, commitment reads, and owner updates:
-
-```solidity
-interface INativeMultisig {
-    struct MultisigOwner {
-        address owner;
-        uint8 weight;
-    }
-
-    struct MultisigConfig {
-        bytes32 salt;
-        uint64 version;
-        uint8 threshold;
-        MultisigOwner[] owners;
-    }
-
-    /// Derives an account address from an initial configuration.
-    /// Reverts when the configuration or derived address is invalid.
-    function deriveAccount(
-        bytes32 salt,
-        uint8 threshold,
-        MultisigOwner[] calldata owners
-    ) external pure returns (address account);
-
-    /// Returns the persisted configuration commitment, or zero before the first update.
-    function getConfigCommitment(
-        address account
-    ) external view returns (bytes32 commitment);
-
-    /// Commits to msg.sender's next configuration after proving its current configuration.
-    /// Requires direct owner-quorum authorization and a top-level batch call.
-    function updateConfig(
-        MultisigConfig calldata current,
-        uint8 threshold,
-        MultisigOwner[] calldata owners
-    ) external;
-
-    event MultisigConfigUpdated(
-        address indexed account,
-        bytes32 salt,
-        uint64 version,
-        uint8 threshold,
-        MultisigOwner[] owners
-    );
-
-    error InvalidAccount();
-    error InvalidConfig();
-    error InvalidThreshold();
-    error InvalidMultisigOwner();
-    error InvalidWeight();
-    error TooManyOwners();
-    error DuplicateOwner();
-    error InvalidOwnerOrder();
-    error UnauthorizedMultisigCaller();
-}
-```
-
-Configuration updates are authorized by the applicable initial or current owner quorum.
+A direct multisig signature MAY carry `config_update`. No precompile, contract call, or additional authorization signature is used. The current quorum binds the update through `next_config_hash` in `multisig_digest`.
 
 Rules:
 
-- The precompile MUST be deployed at `0xAACC000000000000000000000000000000000000` from T12.
-- `deriveAccount` MUST use the account identity formula above and enforce the initial configuration and address constraints without reading account state.
-- `getConfigCommitment` MUST return the exact commitment slot, including zero before the first update.
-- `updateConfig` MUST be a direct top-level call with `msg.sender == tx.origin` and a zero keychain transaction key.
-- When `current.version == 0`, `current` MUST derive `msg.sender` and its commitment slot MUST be zero. Otherwise, its commitment MUST match the slot at call time.
-- The new configuration MUST preserve `current.salt` and use `current.version + 1`.
-- `updateConfig` MUST NOT accept a separate authorization signature.
-- Configuration validation MUST return the first applicable error in this order:
-  - `InvalidMultisigOwner` for an empty owner list.
-  - `TooManyOwners` above `MAX_MULTISIG_OWNERS`.
-  - `InvalidThreshold` when the threshold is zero.
-  - For each owner: `InvalidMultisigOwner` for the zero address or the multisig account itself, `InvalidWeight` for zero weight, `DuplicateOwner` when equal to the previous owner, or `InvalidOwnerOrder` when below it.
-  - `InvalidWeight` when the weight sum overflows or exceeds `u8::MAX`.
-  - `InvalidThreshold` when the threshold exceeds the weight reachable from the eight highest-weight owners.
-- Address derivation MUST return `InvalidAccount` when the derived address is zero or reserved.
-- `updateConfig` MUST return `UnauthorizedMultisigCaller` for an indirect call, `msg.sender != tx.origin`, a nonzero keychain transaction key, or a transaction not directly authorized by the applicable initial or current owner quorum.
+- Only the outer transaction signature MAY carry `config_update`. Nested owner signatures, key authorization signatures, keychain signatures, and fee-payer signatures MUST NOT update configuration.
+- A transaction carrying `config_update` MUST use a direct `TempoSignature::Multisig` outer signature and a zero keychain transaction key.
+- When `config.version == 0`, `config` MUST derive `account` and the account leaf's `config_hash` MUST be zero. Otherwise, the hash of `config` MUST match the nonzero account-leaf field at the transaction's block position.
+- The next configuration MUST preserve `config.salt`, use `config.version + 1`, and use the threshold and owners carried by `config_update`.
+- The next configuration MUST satisfy the same owner, weight, ordering, and threshold rules as any other configuration, and its hash MUST be nonzero.
+- Configuration validation MUST report the first applicable error in this order: empty owners, too many owners, zero threshold, invalid owner, invalid weight, duplicate owner, invalid owner order, weight overflow, then unreachable threshold.
+- The update MUST be applied only after all transaction calls complete successfully. A rejected or reverted transaction MUST leave `config_hash` unchanged.
+- The update is atomic with the transaction's other state changes. Owners explicitly authorize both the transaction calls through `inner_digest` and the replacement configuration through `next_config_hash`.
 
 ## Cross-chain Recovery
 
@@ -392,7 +346,7 @@ A multisig account can delegate ordinary or admin authority through the existing
 The owner quorum authorizes a key authorization with this digest:
 
 ```text
-multisig_digest(key_authorization.signature_hash(), account, config_version)
+multisig_digest(key_authorization.signature_hash(), account, config_version, ZERO_HASH)
 ```
 
 #### Signed Key Authorization Encoding
@@ -435,7 +389,7 @@ Rules:
 - Access key transactions MUST use the V2 envelope, execute as the account under stored restrictions, and skip the parent quorum.
 - Access key transactions MUST reject a parent with a nonzero multisig commitment and EVM code or EIP-7702 delegation.
 - Stateless TIP-1020 `recover` and `verify` MUST reject bare multisig account signatures.
-- Access keys MUST NOT call `updateConfig` for their parent.
+- Access-key, nested-owner, and key-authorization signatures MUST encode `config_update` as absent.
 - Only a direct multisig account signature with a zero keychain transaction key MAY replace the parent's owner set.
 
 ## Gas
@@ -444,7 +398,6 @@ Multisig account authorization is charged as regular intrinsic gas. Costs scale 
 
 | Component | Gas |
 |---|---:|
-| Per-node configuration commitment read | 2,100 |
 | Nested-node account code/delegation check | 2,600 |
 | `full_primitive_cost(secp256k1)` | 3,000 |
 | `full_primitive_cost(P256)` | 8,000 |
@@ -474,11 +427,10 @@ config_proof_hash_cost(config) =
 The recursive authorization charge is:
 
 ```text
-witness_bytes(signature) = rlp(account) || rlp(config)
+witness_bytes(signature) = rlp(account) || rlp(config) || rlp(config_update)
 
 node(signature) =
-    2,100
-  + calldata_gas(witness_bytes(signature))
+    calldata_gas(witness_bytes(signature))
   + config_proof_hash_cost(signature.config)
   + multisig_digest_hash_cost
   + sum(full_primitive_cost(owner) or 2,600 + node(nested_owner))
@@ -494,13 +446,12 @@ direct_multisig_surcharge =
 key_authorization_multisig_surcharge =
   node(key_authorization.signature)
 
-commitment_gating_surcharge =
-  gas consumed by required multisig-commitment reads for:
-  - each newly authorized access-key ID
-  - a keychain caller with code or delegation
+config_update_write_cost =
+  20,000  if the prior config_hash is zero
+   5,000  otherwise
 ```
 
-Commitment reads are charged per node even when the slot is reused or cached. The witness calldata charge scales with complete configuration parsing and validation. There are no owner-row or owner-weight storage reads.
+The account's configuration hash is obtained from the account leaf already loaded for sender or owner validation, so there is no separate configuration-read charge. The witness calldata charge scales with complete configuration parsing and validation. There are no owner-row or owner-weight storage reads.
 
 Each nested node adds one cold account access for checking that the nested multisig owner has no bytecode or EIP-7702 delegation. Implementations only need the account's code hash and MUST NOT load its bytecode for this check.
 
@@ -508,7 +459,7 @@ The direct subtraction accounts for the secp256k1 transaction signature already 
 
 When a signed key authorization uses a multisig signature, its existing signature-verification term uses `key_authorization_multisig_surcharge`. It is charged independently of the outer signature and receives no 3,000 gas subtraction.
 
-Initial use writes no multisig state. Configuration updates use the active warm SSTORE schedule for the slot's transaction-original and current values.
+Initial use writes no multisig state. Configuration updates charge the zero-to-nonzero or nonzero-to-nonzero account-metadata write cost above and never receive a clearing refund.
 
 Rules:
 
@@ -519,10 +470,9 @@ Rules:
 - The 3,000 gas subtraction MUST apply once at the outer account node, never to nested nodes or key authorization sidecars.
 - Direct multisig authorization MUST NOT add the account keychain's 900 gas processing buffer.
 - Every initial and current node MUST charge its exact witness bytes once. WebAuthn data gas MUST continue to be charged only by `full_primitive_cost`.
-- Initial authorization MUST NOT charge any configuration-storage write.
-- State-dependent role restrictions MUST add `commitment_gating_surcharge` to intrinsic gas.
-- `deriveAccount` MUST add `account_derivation_hash_cost(config)` to its normal precompile execution costs.
-- `updateConfig` MUST add `config_proof_hash_cost(current) + config_commitment_hash_cost(next)`, exactly one warm configuration-slot read and write under the active precompile storage schedule, plus its event and normal precompile execution costs.
+- Initial authorization without `config_update` MUST NOT charge any configuration write.
+- A signature carrying `config_update` MUST add `config_commitment_hash_cost(next)` and `config_update_write_cost`.
+- Account derivation performed by RPC or tooling MUST use the exact formula, but does not contribute execution gas unless validation requires it.
 
 ## Tooling
 
@@ -530,23 +480,25 @@ Wallets, SDKs, RPCs, and indexers need to expose multisig accounts across addres
 
 Rules:
 
-- Tooling MUST support the T12 configuration witness encoding, signed key authorization shape, current configuration commitment and version, and precompile ABI and events; address derivation SHOULD use `deriveAccount`.
+- Tooling MUST support the T12 configuration witness and update encoding, signed key authorization shape, and current account-leaf configuration hash and version; address derivation MUST use the formula in [Account Identity](#account-identity).
 - Recovery tooling MUST verify the Safe Singleton Factory runtime, dedicated factory runtime, and wallet init-code hash before presenting a chain as supported, and MUST report whether the initial configuration has a direct secp256k1 recovery quorum.
 
 ## Observability
 
-Multisig signatures and owner-update events expose enough data to reconstruct an account's configuration history.
+Successful multisig transactions carrying configuration updates expose enough data to reconstruct an account's configuration history.
 
 Rules:
 
 - The initial configuration MUST be reconstructed from a version-0 multisig signature; the account address and zero commitment do not reveal it.
-- A successful owner update MUST emit `MultisigConfigUpdated(account, salt, version, threshold, owners)`.
-- The initial configuration uses version `0`; the first owner-update event uses version `1`, and each later event increments it by one.
+- Indexers MUST treat an update as final only when the carrying transaction succeeds and the resulting account leaf contains the expected `config_hash`.
+- The initial configuration uses version `0`; the first successful update uses version `1`, and each later update increments it by one.
 - Account keychain paths MUST retain their existing events.
 
 ## Examples
 
 These examples illustrate the canonical signing flows and main authorization edge cases. They add no normative rules.
+
+`ZERO_HASH` below denotes 32 zero bytes and therefore no configuration update.
 
 ### Initial Configuration
 
@@ -579,7 +531,8 @@ tx = transaction(
 digest = multisig_digest(
   tx.signature_hash(),
   account,
-  0
+  0,
+  ZERO_HASH
 )
 
 tx.signature =
@@ -589,7 +542,8 @@ tx.signature =
     [
       sign(alice_key, digest),
       sign(bob_key, digest)
-    ]
+    ],
+    []
   ])
 
 execute(tx)
@@ -611,7 +565,8 @@ tx = transaction(
 digest = multisig_digest(
   tx.signature_hash(),
   account,
-  config.version
+  config.version,
+  ZERO_HASH
 )
 
 tx.signature =
@@ -621,7 +576,8 @@ tx.signature =
     [
       sign(alice_key, digest),
       sign(bob_key, digest)
-    ]
+    ],
+    []
   ])
 
 execute(tx)
@@ -643,14 +599,16 @@ tx = transaction(
 parent_digest = multisig_digest(
   tx.signature_hash(),
   parent_account,
-  parent_config.version
+  parent_config.version,
+  ZERO_HASH
 )
 
 // Bind the parent digest to the child multisig account.
 child_digest = multisig_digest(
   parent_digest,
   child_account,
-  child_config.version
+  child_config.version,
+  ZERO_HASH
 )
 
 alice_signature = sign(alice_key, child_digest)
@@ -661,7 +619,8 @@ child_owner_signature =
   0x05 || rlp([
     child_account,
     child_config,
-    [alice_signature, bob_signature]
+    [alice_signature, bob_signature],
+    []
   ])
 
 // Attach the parent's multisig account signature.
@@ -669,7 +628,8 @@ tx.signature =
   0x05 || rlp([
     parent_account,
     parent_config,
-    [child_owner_signature]
+    [child_owner_signature],
+    []
   ])
 
 execute(tx)
@@ -694,7 +654,8 @@ tx = transaction(
 digest = multisig_digest(
   tx.signature_hash(),
   account,
-  config.version
+  config.version,
+  ZERO_HASH
 )
 
 alice_signature = sign(alice_key, digest)
@@ -704,7 +665,8 @@ tx.signature =
   0x05 || rlp([
     account,
     config,
-    [alice_signature, bob_signature]
+    [alice_signature, bob_signature],
+    []
   ])
 
 // Select the fee token and authorize payment for this account.
@@ -732,7 +694,8 @@ tx.fee_payer_signature = sign_secp256k1(fee_payer_key, fee_payer_digest)
 digest = multisig_digest(
   tx.signature_hash(),
   account,
-  config.version
+  config.version,
+  ZERO_HASH
 )
 
 alice_signature = sign(alice_key, digest)
@@ -742,7 +705,8 @@ tx.signature =
   0x05 || rlp([
     account,
     config,
-    [alice_signature, bob_signature]
+    [alice_signature, bob_signature],
+    []
   ])
 ```
 
@@ -761,7 +725,7 @@ owners = [
 ]
 
 // Ref: Authorization formula
-digest = multisig_digest(tx.signature_hash(), account, config.version)
+digest = multisig_digest(tx.signature_hash(), account, config.version, ZERO_HASH)
 
 alice_signature = sign(alice_key, digest)
 bob_signature   = sign(bob_key, digest)
@@ -811,7 +775,8 @@ key_authorization = KeyAuthorization(
 key_authorization_digest = multisig_digest(
   key_authorization.signature_hash(),
   account,
-  0
+  0,
+  ZERO_HASH
 )
 
 key_authorization_signature =
@@ -821,7 +786,8 @@ key_authorization_signature =
     [
       sign(alice_key, key_authorization_digest),
       sign(bob_key, key_authorization_digest)
-    ]
+    ],
+    []
   ])
 
 // Include the signed key authorization in the initial transaction.
@@ -884,7 +850,8 @@ key_authorization = KeyAuthorization(
 key_authorization_digest = multisig_digest(
   key_authorization.signature_hash(),
   account,
-  0
+  0,
+  ZERO_HASH
 )
 
 // The key authorization independently carries the initial witness.
@@ -895,7 +862,8 @@ key_authorization_signature =
     [
       sign(alice_key, key_authorization_digest),
       sign(bob_key, key_authorization_digest)
-    ]
+    ],
+    []
   ])
 
 initial_tx = transaction(
@@ -913,7 +881,8 @@ initial_tx = transaction(
 initial_digest = multisig_digest(
   initial_tx.signature_hash(),
   account,
-  0
+  0,
+  ZERO_HASH
 )
 
 initial_tx.signature =
@@ -923,7 +892,8 @@ initial_tx.signature =
     [
       sign(alice_key, initial_digest),
       sign(bob_key, initial_digest)
-    ]
+    ],
+    []
   ])
 
 execute(initial_tx)
@@ -956,25 +926,31 @@ The applicable initial or current quorum authorizes an owner update, which prese
 Assume Alice and Bob are both required. They replace themselves with Carol:
 
 ```text
-// Build a top-level owner update.
+// Build the transaction and replacement owner policy.
 rotate_tx = transaction(
   from = account,
-  calls = [
-    // Ref: Native Multisig Precompile
-    updateConfig(
-      current = config,
-      threshold = 1,
-      owners = [[carol_address, 1]]
-    )
-  ]
+  calls = [...]
+)
+config_update = multisig_config_update(
+  threshold = 1,
+  owners = [[carol_address, 1]]
 )
 
-// The initial owners authorize the first update with version 0.
+next_config = multisig_config(
+  salt = config.salt,
+  version = 1,
+  threshold = config_update.threshold,
+  owners = config_update.owners
+)
+next_config_hash = config_commitment(next_config)
+
+// The initial owners authorize both the calls and the first update.
 // Ref: Authorization formula
 rotate_digest = multisig_digest(
   rotate_tx.signature_hash(),
   account,
-  0
+  0,
+  next_config_hash
 )
 
 rotate_tx.signature =
@@ -984,7 +960,8 @@ rotate_tx.signature =
     [
       sign(alice_key, rotate_digest),
       sign(bob_key, rotate_digest)
-    ]
+    ],
+    [config_update.threshold, config_update.owners]
   ])
 
 execute(rotate_tx)
@@ -996,23 +973,19 @@ next_tx = transaction(
 )
 
 // Ref: Authorization formula
-next_config = multisig_config(
-  salt = config.salt,
-  version = 1,
-  threshold = 1,
-  owners = [[carol_address, 1]]
-)
 next_digest = multisig_digest(
   next_tx.signature_hash(),
   account,
-  next_config.version
+  next_config.version,
+  ZERO_HASH
 )
 
 next_tx.signature =
   0x05 || rlp([
     account,
     next_config,
-    [sign(carol_key, next_digest)]
+    [sign(carol_key, next_digest)],
+    []
   ])
 ```
 
@@ -1029,10 +1002,10 @@ Rules:
 
 Rules:
 
-- **Stable identity.** Initial authorization MUST satisfy `tx.from == multisig_address`, where `multisig_address` is the canonical CREATE2 recovery address. `updateConfig` MUST NOT change the address.
+- **Stable identity.** Initial authorization MUST satisfy `tx.from == multisig_address`, where `multisig_address` is the canonical CREATE2 recovery address. A configuration update MUST NOT change the address.
 - **Witness selection.** A zero commitment MUST accept only the derived initial witness; a nonzero commitment MUST accept only a matching current witness.
 - **Configuration validity.** Configurations MUST satisfy all owner, weight, total-weight, and threshold limits above, and MUST NOT include their own account as an owner.
-- **Single-slot state.** Multisig configuration storage MUST contain only the current commitment and MUST NOT persist owner rows.
+- **Single-field state.** The account leaf MUST contain at most one nonzero configuration hash and MUST NOT persist owner rows.
 - **No account code.** A multisig account MUST NOT have EVM bytecode or EIP-7702 delegation code.
 - **Owner signatures.** Owner signatures MUST be primitive over the current digest or nested with the parent digest as `inner_digest`. Every nested multisig signature MUST carry and validate its own initial or current witness. Keychain signatures MUST NOT be accepted as owner signatures.
 - **Owner set membership.** Recovered or nested owner addresses MUST be sorted and belong to the applicable owner configuration.
@@ -1042,9 +1015,8 @@ Rules:
 - **Signature contexts.** Multisig signatures MUST be outer, nested owner, or key authorization signatures.
 - **Key authorization.** Transactions MAY carry `key_authorization`. A multisig key authorization MUST independently carry an initial or current witness and match `key_authorization.account`.
 - **Account keychain access.** Multisig accounts MAY own access keys. Multisig signatures MUST NOT authorize keychain access. Access keys MUST NOT replace parent owner sets.
-- **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a multisig-commitment read.
-- **Config update frame.** `updateConfig` MUST run in a protocol-created top-level frame for one `tx.calls` entry.
-- **Config update identity.** `updateConfig` MUST require direct outer-quorum authorization for `msg.sender` and a zero keychain transaction key.
-- **No config update signature.** `updateConfig` MUST NOT accept an additional signature parameter.
+- **Fee payer.** When `fee_payer_signature` is present, it MUST be secp256k1. Its recovered address is treated as a primitive identity and MUST NOT require a separate configuration lookup.
+- **Config update identity.** A configuration update MUST require direct outer-quorum authorization for the account and a zero keychain transaction key.
+- **Config update binding.** Every owner approval at the outer node MUST bind the same nonzero `next_config_hash`, and the update MUST be applied only after successful execution.
 - **Recovery binding.** A canonical recovery wallet MUST deploy at `multisig_address` and accept only an initial configuration that re-derives its bound `account_salt`.
 - **Recovery authority.** Baseline cross-chain recovery MUST remain bound to the initial owner configuration and MUST NOT be represented as current Tempo authorization after an owner update.


### PR DESCRIPTION
## Summary
- remove the native multisig precompile and its storage mapping
- store the nonzero configuration hash as an optional fifth account-leaf RLP field while preserving legacy four-field encoding for zero
- carry quorum-bound configuration updates in the outer multisig signature and apply them after successful execution
- remove the separate commitment-read charge and price account-metadata writes directly

Stacked on [#7242](https://github.com/tempoxyz/tempo/pull/7242). The account-leaf implementation is prototyped in [alloy-rs/trie#156](https://github.com/alloy-rs/trie/pull/156), [paradigmxyz/reth-core#45](https://github.com/paradigmxyz/reth-core/pull/45), and [paradigmxyz/reth#26991](https://github.com/paradigmxyz/reth/pull/26991).

## Validation
- `git diff --check`
- confirmed the branch merge-base is the current #7242 head
- `forge test` is unavailable locally because upstream Foundry does not recognize Tempo hardfork `T10`

Prompted by: @legion2002