### PR TITLE
fix(consensus): make rejected forkchoice updates fatal

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -20,12 +20,16 @@
 //! verify or build a block on top of some `$PARENT` will only pass if the the
 //! local tracked tip is at `$PARENT`.
 //!
-//! # Notarizations are retried, finalizations are fatal
+//! # Notarizations are retried, everything else is fatal
 //!
 //! A notarized block rejected by the execution layer is retried while it
 //! remains above the network finalized tip. Once that tip advances to or past
 //! the block's height, the notarized block is ejected. In contrast, an
 //! `INVALID` finalized block is a hard failure that shuts down the node.
+//!
+//! Forkchoice updates only ever name blocks the execution layer has already
+//! accepted, so an update not answered `VALID` means the executor's view of
+//! the execution layer has diverged from it: the node shuts down.
 
 use std::{
     collections::VecDeque,
@@ -35,7 +39,7 @@ use std::{
 
 use alloy_primitives::B256;
 
-use alloy_rpc_types_engine::{PayloadId, PayloadStatusEnum};
+use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatusEnum};
 use commonware_consensus::{
     Heightable as _,
     marshal::Update,
@@ -1082,7 +1086,8 @@ enum ExecutionTaskOutcome {
         /// execution layer and that still needs to be driven to completion.
         payload_job: Option<StartPayloadJob>,
     },
-    /// A notarized block could not be forwarded and should be retried later.
+    /// The new-payload request for a notarized block failed; the block is
+    /// retried later.
     NotarizedBlockRejected {
         digest: Digest,
         target: LocalState,
@@ -1125,7 +1130,17 @@ async fn execute_heartbeat(
     canonicalized: LocalState,
     cause: Span,
 ) -> ExecutionTaskOutcome {
-    if let Err(error) = submit_forkchoice_update(
+    match is_stale_forkchoice(&execution_node, canonicalized) {
+        Ok(false) => {}
+        Ok(true) => {
+            return ExecutionTaskOutcome::Completed {
+                canonicalized: None,
+                payload_job: None,
+            };
+        }
+        Err(error) => return ExecutionTaskOutcome::Fatal { error },
+    }
+    match submit_forkchoice_update(
         &execution_node,
         cause,
         canonicalized,
@@ -1134,11 +1149,13 @@ async fn execute_heartbeat(
     )
     .await
     {
-        warn!(%error, "forkchoice update heartbeat failed");
-    }
-    ExecutionTaskOutcome::Completed {
-        canonicalized: None,
-        payload_job: None,
+        Ok(_) => ExecutionTaskOutcome::Completed {
+            canonicalized: None,
+            payload_job: None,
+        },
+        Err(error) => ExecutionTaskOutcome::Fatal {
+            error: error.wrap_err("forkchoice update heartbeat failed"),
+        },
     }
 }
 
@@ -1179,6 +1196,20 @@ async fn execute_build(
 
     let (attributes, payload_response) = build_attributes.unzip();
 
+    match is_stale_forkchoice(&execution_node, canonicalized) {
+        Ok(false) => {}
+        Ok(true) => {
+            // Dropping the response channel signals the failure to the
+            // subscriber.
+            info!("tracked finality is below the execution layer's; dropping the build");
+            return ExecutionTaskOutcome::Completed {
+                canonicalized: None,
+                payload_job: None,
+            };
+        }
+        Err(error) => return ExecutionTaskOutcome::Fatal { error },
+    }
+
     // The forkchoice update is submitted even if it would not change the
     // forkchoice state: the execution layer treats it as a no-op (the FCU
     // heartbeat relies on this).
@@ -1193,8 +1224,8 @@ async fn execute_build(
     )
     .await
     {
-        Ok(payload_id) => {
-            let payload_job = match (payload_response, payload_id) {
+        Ok(fcu_response) => {
+            let payload_job = match (payload_response, fcu_response.payload_id) {
                 (Some(response), Some(payload_id)) => Some(StartPayloadJob {
                     cause,
                     payload_id,
@@ -1211,15 +1242,11 @@ async fn execute_build(
                 payload_job,
             }
         }
-        Err(error) => {
-            // Dropping the response channels signals the failure to the
-            // subscribers; the cause is only logged here.
-            warn!(%error, "forkchoice update failed");
-            ExecutionTaskOutcome::Completed {
-                canonicalized: None,
-                payload_job: None,
-            }
-        }
+        // Dropping the response channel signals the failure to the
+        // subscriber.
+        Err(error) => ExecutionTaskOutcome::Fatal {
+            error: error.wrap_err("forkchoice update registering the payload build failed"),
+        },
     }
 }
 
@@ -1265,22 +1292,45 @@ async fn execute_notarization(
     validator_set: Option<Vec<B256>>,
 ) -> ExecutionTaskOutcome {
     let digest = step.digest();
-    let is_repoint = matches!(step, NextToForward::Repoint(..));
     let target = on_top_of.update_head(step.height(), digest);
-    match forward_notarized(execution_node, on_top_of, target, step, validator_set).await {
+    if let NextToForward::Block(block) = step
+        && forward_notarized(&execution_node, block, validator_set)
+            .await
+            .is_err()
+    {
+        // The cause is logged by `forward_notarized`.
+        return ExecutionTaskOutcome::NotarizedBlockRejected { digest, target };
+    }
+
+    // The forkchoice update is skipped when it would not change anything or
+    // when the tracked finality trails the execution layer's, but the state
+    // is reported either way so that the tree's tracked state stays
+    // consistent.
+    let canonicalized = async {
+        if target != on_top_of && !is_stale_forkchoice(&execution_node, target)? {
+            submit_forkchoice_update(
+                &execution_node,
+                Span::current(),
+                target,
+                None,
+                ForkchoiceUpdateKind::Canonicalize {
+                    head_or_finalized: HeadOrFinalized::Head,
+                },
+            )
+            .await?;
+        }
+        eyre::Ok(target)
+    }
+    .await;
+    match canonicalized {
         Ok(canonicalized) => ExecutionTaskOutcome::Completed {
             canonicalized: Some(canonicalized),
             payload_job: None,
         },
-        // A failed repoint is fatal: the target is expected to be an ancestor
-        // of the current canonical chain. Anything but success means that CL
-        // and EL disagree.
-        Err(error) if is_repoint => ExecutionTaskOutcome::Fatal {
+        Err(error) => ExecutionTaskOutcome::Fatal {
             error: error
-                .wrap_err("failed repointing the execution layer's head onto the finalized tip"),
+                .wrap_err("failed moving the execution layer's head onto the notarized block"),
         },
-        // The cause is logged by `forward_notarized`.
-        Err(_logged) => ExecutionTaskOutcome::NotarizedBlockRejected { digest, target },
     }
 }
 
@@ -1495,62 +1545,7 @@ async fn submit_forkchoice_update(
     canonicalized: LocalState,
     attrs: Option<TempoPayloadAttributes>,
     kind: ForkchoiceUpdateKind,
-) -> eyre::Result<Option<PayloadId>> {
-    // The execution layer's finalized tip only ever advances. The tracked
-    // state can trail the execution layer's finality: it starts at the
-    // consensus finalized floor, which can sit below the execution layer's
-    // finalized tip after a snapshot restore, and only catches up as the
-    // marshal re-delivers the already-finalized blocks.
-    //
-    // Whenever the execution layer's finality is at or ahead of the tracked
-    // finalized block, that block must lie on the execution layer's
-    // canonical chain - anything else means two conflicting blocks were
-    // finalized. A forkchoice state whose finalized block is strictly below
-    // the execution layer's own is stale in its entirety and is not
-    // submitted. Callers treat the skip as a no-op; a payload-build request
-    // affected by it fails through the missing payload ID.
-    if let execution_finalized = execution_node.finalized_num_hash()
-        && execution_finalized.number >= canonicalized.finalized.0.get()
-    {
-        let canonical_digest = execution_node
-            .canonical_block_hash(canonicalized.finalized.0.get())
-            .wrap_err_with(|| {
-                format!(
-                    "failed reading canonical execution block hash at the tracked \
-                    finalized height `{}`",
-                    canonicalized.finalized.0,
-                )
-            })?
-            .ok_or_else(|| {
-                eyre!(
-                    "no canonical execution block hash at the tracked \
-                    finalized height `{}`, even though it is at or below the \
-                    execution layer's finalized height `{}`",
-                    canonicalized.finalized.0,
-                    execution_finalized.number,
-                )
-            })?;
-        ensure!(
-            canonical_digest == canonicalized.finalized.1.0,
-            "tracked finalized block `{}` at height `{}` conflicts with the \
-            execution layer's canonical block `{canonical_digest}` at the same \
-            height, which the execution layer already considers final; two \
-            different blocks must never be finalized at the same height",
-            canonicalized.finalized.1,
-            canonicalized.finalized.0,
-        );
-
-        if execution_finalized.number > canonicalized.finalized.0.get() {
-            debug!(
-                execution_finalized_height = execution_finalized.number,
-                execution_finalized_hash = %execution_finalized.hash,
-                "tracked finalized state is below the execution layer's \
-                finalized tip; skipping the forkchoice update",
-            );
-            return Ok(None);
-        }
-    }
-
+) -> eyre::Result<ForkchoiceUpdated> {
     let fcu_response = execution_node
         .fork_choice_updated(canonicalized.to_forkchoice_state(), attrs)
         .await
@@ -1573,7 +1568,59 @@ async fn submit_forkchoice_update(
             .wrap_err("forkchoice-update was not valid");
     }
 
-    Ok(fcu_response.payload_id)
+    Ok(fcu_response)
+}
+
+/// Whether `target` finalizes below the execution layer's own finality, so
+/// that submitting it would move finality backwards. The tracked state
+/// trails execution-layer finality after a snapshot restore until the
+/// marshal actor's re-deliveries catch up; a tracked finalized block the
+/// execution layer's canonical chain contradicts is fatal.
+fn is_stale_forkchoice(
+    execution_node: &impl ExecutionLayer,
+    target: LocalState,
+) -> eyre::Result<bool> {
+    let execution_finalized = execution_node.finalized_num_hash();
+    if execution_finalized.number < target.finalized.0.get() {
+        return Ok(false);
+    }
+    let canonical_digest = execution_node
+        .canonical_block_hash(target.finalized.0.get())
+        .wrap_err_with(|| {
+            format!(
+                "failed reading canonical execution block hash at the tracked \
+                finalized height `{}`",
+                target.finalized.0,
+            )
+        })?
+        .ok_or_else(|| {
+            eyre!(
+                "no canonical execution block hash at the tracked finalized height \
+                `{}`, even though it is at or below the execution layer's finalized \
+                height `{}`",
+                target.finalized.0,
+                execution_finalized.number,
+            )
+        })?;
+    ensure!(
+        canonical_digest == target.finalized.1.0,
+        "tracked finalized block `{}` at height `{}` conflicts with the execution \
+        layer's canonical block `{canonical_digest}` at the same height, which the \
+        execution layer already considers final; two different blocks must never be \
+        finalized at the same height",
+        target.finalized.1,
+        target.finalized.0,
+    );
+    if execution_finalized.number > target.finalized.0.get() {
+        debug!(
+            execution_finalized_height = execution_finalized.number,
+            execution_finalized_hash = %execution_finalized.hash,
+            "tracked finalized state is below the execution layer's finalized tip; \
+            skipping the forkchoice update",
+        );
+        return Ok(true);
+    }
+    Ok(false)
 }
 
 fn finalization_target(
@@ -1679,16 +1726,20 @@ async fn forward_finalized(
         "payload status of finalized block was not valid: {payload_status}"
     );
 
-    submit_forkchoice_update(
-        &execution_node,
-        cause.clone(),
-        target,
-        None,
-        ForkchoiceUpdateKind::Canonicalize {
-            head_or_finalized: HeadOrFinalized::Finalized,
-        },
-    )
-    .await?;
+    // The tracked state still folds the target when the update is stale, so
+    // the re-deliveries catch it up with the execution layer's finality.
+    if !is_stale_forkchoice(&execution_node, target)? {
+        submit_forkchoice_update(
+            &execution_node,
+            cause.clone(),
+            target,
+            None,
+            ForkchoiceUpdateKind::Canonicalize {
+                head_or_finalized: HeadOrFinalized::Finalized,
+            },
+        )
+        .await?;
+    }
 
     if let Some(public_key) = public_key.as_ref()
         && consensus_context.is_some_and(|context| context.proposer.to_inner() == *public_key)
@@ -1701,7 +1752,8 @@ async fn forward_finalized(
     Ok(target)
 }
 
-/// Drives convergence of the EL to the pending notarized tip.
+/// Delivers a notarized block to the execution layer via a new-payload
+/// request.
 ///
 /// The caller is responsible for only forwarding blocks that link to the
 /// canonicalized state, so the new-payload request must come back valid;
@@ -1709,55 +1761,34 @@ async fn forward_finalized(
 #[instrument(
     skip_all,
     fields(
-        block.digest = %step.digest(),
-        block.height = %step.height(),
+        block.digest = %block.digest(),
+        block.height = %block.height(),
     ),
     err(level = Level::WARN),
 )]
 async fn forward_notarized(
-    execution_node: impl ExecutionLayer,
-    on_top_of: LocalState,
-    target: LocalState,
-    step: NextToForward,
+    execution_node: &impl ExecutionLayer,
+    block: Arc<Block>,
     validator_set: Option<Vec<B256>>,
-) -> eyre::Result<LocalState> {
-    if let NextToForward::Block(block) = step {
-        let (block, block_access_list) = Arc::unwrap_or_clone(block).into_parts();
-        let payload_status = execution_node
-            .new_payload(TempoExecutionData {
-                block,
-                block_access_list,
-                validator_set,
-            })
-            .await
-            .wrap_err(
-                "failed sending new-payload request to execution engine to \
-                forward notarized block",
-            )?;
-        ensure!(
-            payload_status.is_valid(),
-            "payload status of notarized block was neither valid nor invalid \
-            (likely syncing): `{payload_status}`",
-        );
-    }
-
-    // The forkchoice update is skipped when it would not change anything,
-    // but the state is reported either way so that the tree's tracked
-    // state stays consistent.
-    if target == on_top_of {
-        return Ok(target);
-    }
-    submit_forkchoice_update(
-        &execution_node,
-        Span::current(),
-        target,
-        None,
-        ForkchoiceUpdateKind::Canonicalize {
-            head_or_finalized: HeadOrFinalized::Head,
-        },
-    )
-    .await?;
-    Ok(target)
+) -> eyre::Result<()> {
+    let (block, block_access_list) = Arc::unwrap_or_clone(block).into_parts();
+    let payload_status = execution_node
+        .new_payload(TempoExecutionData {
+            block,
+            block_access_list,
+            validator_set,
+        })
+        .await
+        .wrap_err(
+            "failed sending new-payload request to execution engine to \
+            forward notarized block",
+        )?;
+    ensure!(
+        payload_status.is_valid(),
+        "payload status of notarized block was neither valid nor invalid \
+        (likely syncing): `{payload_status}`",
+    );
+    Ok(())
 }
 
 /// Marker to indicate whether the head hash or finalized hash should be updated.

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1190,7 +1190,10 @@ async fn execute_build(
         .as_ref()
         .is_some_and(|(_, response)| response.is_canceled())
     {
-        info!("dropping payload build request: the subscriber went away while it was queued");
+        info!(
+            "dropping payload build request: subscriber went away while \
+            awaiting execution"
+        );
         build_attributes.take();
     }
 
@@ -1199,8 +1202,6 @@ async fn execute_build(
     match is_stale_forkchoice(&execution_node, canonicalized) {
         Ok(false) => {}
         Ok(true) => {
-            // Dropping the response channel signals the failure to the
-            // subscriber.
             info!("tracked finality is below the execution layer's; dropping the build");
             return ExecutionTaskOutcome::Completed {
                 canonicalized: None,
@@ -1294,11 +1295,9 @@ async fn execute_notarization(
     let digest = step.digest();
     let target = on_top_of.update_head(step.height(), digest);
     if let NextToForward::Block(block) = step
-        && forward_notarized(&execution_node, block, validator_set)
-            .await
-            .is_err()
-    {
         // The cause is logged by `forward_notarized`.
+        && let Err(_) = forward_notarized(&execution_node, block, validator_set).await
+    {
         return ExecutionTaskOutcome::NotarizedBlockRejected { digest, target };
     }
 
@@ -1785,8 +1784,7 @@ async fn forward_notarized(
         )?;
     ensure!(
         payload_status.is_valid(),
-        "payload status of notarized block was neither valid nor invalid \
-        (likely syncing): `{payload_status}`",
+        "payload status of notarized block was not VALID: `{payload_status}`",
     );
     Ok(())
 }

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -344,10 +344,12 @@ fn aborted_payload_job_fails_the_build_without_shutdown() {
 }
 
 #[test_traced]
-fn rejected_build_forkchoice_update_fails_the_build_without_shutdown() {
+fn rejected_build_forkchoice_update_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
+        // The build re-affirms the tracked state; a rejection means the
+        // execution layer disagrees with the executor about that state.
         h.execution.script_fcu(
             ForkchoiceState::from_finalized_head(GENESIS, GENESIS),
             Ok(PayloadStatusEnum::Invalid {
@@ -357,18 +359,15 @@ fn rejected_build_forkchoice_update_fails_the_build_without_shutdown() {
         let rx = h.build(round(1), GENESIS);
         rx.await.expect_err("the failed FCU must fail the build");
 
-        // Build failures are not fatal for the executor.
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(2), b1)
+        h.actor
             .await
-            .expect("verification should complete");
-        assert!(verdict.is_some());
+            .expect("actor should shut down cleanly on a rejected build forkchoice update");
+        assert!(h.execution.pending_payload_jobs().is_empty());
     });
 }
 
 #[test_traced]
-fn forkchoice_update_transport_error_fails_the_build_without_shutdown() {
+fn build_forkchoice_update_transport_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
@@ -380,14 +379,10 @@ fn forkchoice_update_transport_error_fails_the_build_without_shutdown() {
         rx.await
             .expect_err("an FCU transport error must fail the build");
 
-        // Build transport failures are request-local. The actor remains
-        // available for later consensus work.
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(2), b1)
+        h.actor
             .await
-            .expect("verification should complete after the FCU transport error");
-        assert!(verdict.is_some());
+            .expect("actor should shut down cleanly on a build forkchoice transport error");
+        assert!(h.execution.pending_payload_jobs().is_empty());
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -219,10 +219,14 @@ fn new_payload_transport_error_is_withheld_then_retried() {
 }
 
 #[test_traced]
-fn rejected_notarized_fcu_does_not_advance_the_tracked_state() {
+fn rejected_notarized_fcu_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
+        // The forkchoice update names a block the execution layer accepted
+        // through its new-payload request. A rejection means the executor's
+        // view of the execution layer has diverged from it: the node shuts
+        // down.
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution.script_fcu(
@@ -235,79 +239,44 @@ fn rejected_notarized_fcu_does_not_advance_the_tracked_state() {
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
-        h.wait_until(|| h.execution.fcus().len() == 2).await;
-        h.run_for(Duration::from_millis(10)).await;
 
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a rejected forkchoice update");
         assert!(
             h.execution.knows_block(d1),
             "the successful new-payload call must leave the block known to the EL",
         );
+        assert_eq!(h.execution.fcus().len(), 2);
         assert_eq!(
             h.execution.head(),
             GENESIS,
             "the rejected FCU must not move the EL head",
         );
-
-        // Re-anchor consensus on genesis. If the actor had advanced its own
-        // tracked head despite the rejected FCU, it would now issue a repoint.
-        h.report_pending_head(3, 0, GENESIS);
-        let candidate = make_block(3, 1, GENESIS);
-        assert!(
-            h.verify(round(3), candidate)
-                .await
-                .expect("the actor should continue serving validation")
-                .is_some(),
-        );
-        h.run_for(Duration::from_millis(10)).await;
-        assert_eq!(
-            h.execution.fcus().len(),
-            2,
-            "the actor and EL must agree that the head remained at genesis",
-        );
     });
 }
 
 #[test_traced]
-fn rejected_notarized_fcu_is_withheld_then_retried() {
+fn notarized_fcu_transport_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
-        // An FCU rejection uses the shared notarized-block retry mechanism:
-        // the block is withheld for the rejection delay, and heartbeats drive
-        // the scheduler until it becomes eligible to be forwarded again.
-        let h = Harness::builder()
-            .harness_options(HarnessOptions {
-                fcu_heartbeat_interval: Duration::from_millis(200),
-                ..Default::default()
-            })
-            .start(&context);
+        let h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
-        let state = ForkchoiceState::from_finalized_head(GENESIS, d1);
         h.execution.script_fcu(
-            state,
-            Ok(PayloadStatusEnum::Invalid {
-                validation_error: "transient".into(),
-            }),
+            ForkchoiceState::from_finalized_head(GENESIS, d1),
+            Err("connection closed"),
         );
-        h.execution.script_fcu(state, Ok(PayloadStatusEnum::Valid));
 
         h.report_pending_head(2, 1, d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
-        h.wait_until(|| h.execution.new_payloads() == vec![d1])
-            .await;
 
-        h.run_for(Duration::from_secs(5)).await;
-        assert_eq!(
-            h.execution.new_payloads(),
-            vec![d1],
-            "a rejected FCU must not trigger a tight convergence retry",
-        );
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a forkchoice transport error");
+        assert_eq!(h.execution.new_payloads(), vec![d1]);
         assert_eq!(h.execution.head(), GENESIS);
-
-        h.run_for(Duration::from_secs(4)).await;
-        h.wait_until(|| h.execution.head() == d1).await;
-        assert_eq!(h.execution.new_payloads(), vec![d1, d1]);
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/metrics.rs
+++ b/crates/consensus/src/executor/actor/tests/metrics.rs
@@ -2,11 +2,11 @@
 //! tree unit tests cover the arithmetic; these tests prove that the actor
 //! publishes the measures after processing real messages and EL outcomes.
 
-use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
+use alloy_rpc_types_engine::PayloadStatusEnum;
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 
-use super::harness::{ForkchoiceStateExt as _, GENESIS, Harness, make_block, round};
+use super::harness::{GENESIS, Harness, make_block, round};
 
 fn gauge(h: &Harness, name: &str) -> i64 {
     let name = format!("executor_{name}");
@@ -128,16 +128,21 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         }
         h.wait_until(|| gauge(&h, "convergence_depth") == 0).await;
 
-        // Keep the re-anchor from completing so the signed distance remains
-        // observable: the pending head is b1 at height 1 while the accepted
-        // local head remains b2 at height 2.
-        h.execution.script_fcu(
-            ForkchoiceState::from_finalized_head(GENESIS, d1),
+        // Re-anchor onto a1, a sibling of b1 at height 1 the execution layer
+        // rejects: the block is withheld, so the pending head stays at
+        // height 1 while the accepted local head remains b2 at height 2, and
+        // the signed distance is observable.
+        let a1 = make_block(4, 1, GENESIS);
+        let da1 = a1.digest();
+        h.execution.script_new_payload(
+            da1,
             Ok(PayloadStatusEnum::Invalid {
                 validation_error: "re-anchor rejected by test".into(),
             }),
         );
-        h.report_pending_head(4, 1, d1);
+        h.report_pending_head(5, 4, da1);
+        h.wait_until(|| h.marshal.fulfill_subscription(da1, a1.clone()))
+            .await;
         h.wait_until(|| gauge(&h, "convergence_depth") == -1).await;
         assert_eq!(h.execution.head(), d2);
     });

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -536,7 +536,7 @@ fn heartbeat_timer_is_rearmed_after_work_finishes() {
 }
 
 #[test_traced]
-fn idle_actor_sends_forkchoice_heartbeats_and_survives_their_failure() {
+fn idle_actor_sends_forkchoice_heartbeats() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::builder()
             .harness_options(HarnessOptions {
@@ -559,23 +559,37 @@ fn idle_actor_sends_forkchoice_heartbeats_and_survives_their_failure() {
                 .all(|fcu| *fcu == (GENESIS, GENESIS, false)),
             "heartbeats re-affirm the tracked state",
         );
-
-        // Failing heartbeats are logged, not fatal.
-        h.execution.reject_all_fcus(true);
-        h.run_for(Duration::from_secs(1)).await;
-        h.execution.reject_all_fcus(false);
-
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(1), b1)
-            .await
-            .expect("the actor must still be serving requests");
-        assert!(verdict.is_some());
     });
 }
 
 #[test_traced]
-fn idle_actor_survives_heartbeat_transport_error() {
+fn rejected_heartbeat_is_fatal() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::builder()
+            .harness_options(HarnessOptions {
+                fcu_heartbeat_interval: Duration::from_millis(300),
+                ..Default::default()
+            })
+            .start(&context);
+
+        // A heartbeat re-affirms the state the execution layer last
+        // accepted. Rejecting it means the execution layer no longer agrees
+        // with the executor about its own state. (The startup readiness
+        // probe must pass first.)
+        h.wait_until(|| h.execution.fcus().len() == 1).await;
+        h.execution.reject_all_fcus(true);
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a rejected heartbeat");
+        assert_eq!(
+            h.execution.fcus(),
+            vec![STARTUP_FCU, (GENESIS, GENESIS, false)]
+        );
+    });
+}
+
+#[test_traced]
+fn heartbeat_transport_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::builder()
             .harness_options(HarnessOptions {
@@ -585,25 +599,14 @@ fn idle_actor_survives_heartbeat_transport_error() {
             .start(&context);
         let state = ForkchoiceState::from_finalized_head(GENESIS, GENESIS);
         h.execution.script_fcu(state, Err("connection closed"));
-        h.execution.script_fcu(state, Ok(PayloadStatusEnum::Valid));
 
-        h.wait_until(|| h.execution.fcus().len() == 3).await;
+        h.actor
+            .await
+            .expect("actor should shut down cleanly on a heartbeat transport error");
         assert_eq!(
             h.execution.fcus(),
-            vec![
-                STARTUP_FCU,
-                (GENESIS, GENESIS, false),
-                (GENESIS, GENESIS, false),
-            ],
-            "a failed heartbeat must not stop the explicitly accepted next heartbeat",
+            vec![STARTUP_FCU, (GENESIS, GENESIS, false)]
         );
-
-        let b1 = make_block(1, 1, GENESIS);
-        let verdict = h
-            .verify(round(1), b1)
-            .await
-            .expect("actor must keep serving after a heartbeat transport error");
-        assert!(verdict.is_some());
     });
 }
 

--- a/crates/consensus/src/executor/mod.rs
+++ b/crates/consensus/src/executor/mod.rs
@@ -2,19 +2,24 @@
 use std::{future::Future, sync::Arc};
 
 use alloy_primitives::B256;
-use alloy_rpc_types_engine::{ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus};
+use alloy_rpc_types_engine::{
+    ForkchoiceState, ForkchoiceUpdateError, ForkchoiceUpdated, PayloadId, PayloadStatus,
+    PayloadStatusEnum,
+};
 use commonware_consensus::{
     marshal::core::DigestFallback,
     types::{Height, Round},
 };
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{Clock, Metrics, Spawner};
+use reth_engine_primitives::BeaconForkChoiceUpdateError;
 use reth_ethereum::{chainspec::EthChainSpec as _, rpc::eth::primitives::BlockNumHash};
 use reth_node_builder::PayloadKind;
 use reth_provider::{BlockHashReader as _, BlockReader as _, BlockSource};
 use tempo_node::{TempoExecutionData, TempoFullNode};
 use tempo_payload_types::{TempoBuiltPayload, TempoPayloadAttributes};
 use tokio::sync::oneshot;
+use tracing::warn;
 
 mod actor;
 mod ingress;
@@ -90,7 +95,9 @@ pub(crate) trait ExecutionLayer: Clone + Send + Sync + 'static {
     ) -> impl Future<Output = eyre::Result<PayloadStatus>> + Send + 'static;
 
     /// Updates the execution layer's head and finalized blocks, optionally
-    /// registering a payload build.
+    /// registering a payload build. Payload attributes rejected after the
+    /// state was applied come back as `VALID` without a payload id: the
+    /// update succeeded, the build did not start.
     fn fork_choice_updated(
         &self,
         state: ForkchoiceState,
@@ -189,10 +196,26 @@ impl ExecutionLayer for Arc<TempoFullNode> {
     ) -> impl Future<Output = eyre::Result<ForkchoiceUpdated>> + Send + 'static {
         let engine = self.add_ons_handle.beacon_engine_handle.clone();
         async move {
-            engine
-                .fork_choice_updated(state, attributes)
-                .await
-                .map_err(Into::into)
+            match engine.fork_choice_updated(state, attributes).await {
+                Ok(response) => Ok(response),
+                // The engine applies the forkchoice state before it validates
+                // the payload attributes, so this error means the state is
+                // in place and only the build was refused.
+                Err(BeaconForkChoiceUpdateError::ForkchoiceUpdateError(
+                    ForkchoiceUpdateError::UpdatedInvalidPayloadAttributes,
+                )) => {
+                    warn!(
+                        head_block_hash = %state.head_block_hash,
+                        "execution layer applied the forkchoice state but rejected the \
+                        payload attributes; the build is lost",
+                    );
+                    Ok(ForkchoiceUpdated::new(PayloadStatus::new(
+                        PayloadStatusEnum::Valid,
+                        Some(state.head_block_hash),
+                    )))
+                }
+                Err(error) => Err(error.into()),
+            }
         }
     }
 


### PR DESCRIPTION
Any forkchoice update the execution layer does not answer `VALID`, or that fails in transport, now shuts the executor down: heartbeat, build, notarized and finalized updates alike. Every update names blocks the execution layer already accepted, so a rejection means the executor's view of the execution layer has diverged from it. Only a rejected new-payload request for a notarized block is still withheld and retried.

The stale-finality guard moves out of `submit_forkchoice_update` to the call sites: where the tracked finality trails the execution layer's (snapshot restore), the heartbeat is skipped, the build is dropped, and notarized and finalized forwarding fold the target into the tracked state without an engine call, as before. `submit_forkchoice_update` always submits and returns the raw response.

`forward_notarized` now only delivers the block; the forkchoice update follows in `execute_notarization` so its failure can be told apart from the delivery's. The repoint special case goes away with it.