### PR TITLE
docs(tip-1106): allow expiring nonce discriminators

### DIFF
--- a/tips/tip-1106.md
+++ b/tips/tip-1106.md
@@ -33,34 +33,6 @@ uniqueness without changing the transaction encoding or adding protocol state.
 The alternative is to add a new salt field to the Tempo transaction type. That would require a new
 encoding and duplicate functionality already provided by the encoded `nonce` field.
 
-## Assumptions
-
-- Tempo transaction signing and transaction encodings continue to commit to the `nonce` field.
-- Expiring nonce replay protection continues to use the transaction hash or a sender-scoped hash
-  derived from the signable transaction payload, depending on the active protocol version.
-- Applications that require distinct hashes choose distinct discriminator values or vary another
-  committed field. The protocol does not allocate discriminator values or guarantee their
-  uniqueness.
-- Existing expiring nonce transactions with `nonce = 0` remain valid after activation. A non-zero
-  expiring nonce transaction submitted before activation remains invalid.
-
-If an implementation omits `nonce` from a signing or replay-protection hash, the uniqueness
-property in this TIP does not hold and that implementation is non-conforming.
-
-## Threat Model
-
-- **Transaction sender:** May choose any discriminator, including reusing a value. Reuse is safe,
-  but identical signable payloads retain identical replay-protection identifiers and are treated as
-  the same transaction.
-- **Wallet or relayer:** Is responsible for choosing distinct discriminator values when distinct
-  transactions are required. A malicious or faulty generator can cause local hash collisions by
-  reusing the complete signable payload, but cannot bypass signature checks or replay protection.
-- **Block producer and node operator:** Must not interpret the discriminator as a sequential nonce,
-  read or update 2D nonce state for it, or accept the same replay-protection identifier twice.
-- **Fee payer:** Cannot create a distinct replayable transaction solely by changing sponsorship
-  data that is excluded from the sender's signable payload; the existing sender-scoped replay
-  protection remains unchanged.
-
 ---
 
 # Specification
@@ -101,26 +73,3 @@ values and document whether those values are random, monotonic, or caller-suppli
 
 RPC estimation and transaction submission MUST apply the fork-gated validation rule. Existing
 wire formats and JSON-RPC field types do not change.
-
-# Observability
-
-N/A. The change adds no new state transition or event. Existing invalid-transaction metrics and
-logs are sufficient, but implementations SHOULD preserve a distinct pre-activation rejection
-reason for a non-zero expiring nonce so cross-fork submission failures remain diagnosable.
-
-# Invariants
-
-| ID | Invariant | Critical cases |
-|----|-----------|----------------|
-| **D1** | Full range accepted | At and after activation, expiring transactions with `nonce` equal to `0`, `1`, and `uint64.max` pass nonce validation. |
-| **D2** | Pre-activation compatibility | Before activation, `nonce = 0` passes and every non-zero value is rejected. |
-| **D3** | Hash separation | Two otherwise identical expiring transactions with different `nonce` values have different signing, transaction, and replay-protection hashes. |
-| **D4** | Replay protection | Repeating the same complete expiring transaction remains a replay and cannot execute twice within its replay-protection lifetime. |
-| **D5** | No ordering | Transactions with discriminator values `2`, `0`, and `1` may execute in any order or in the same block. |
-| **D6** | No nonce state mutation | Successful and reverted expiring transactions do not change the sender's protocol nonce or any 2D nonce solely because of the discriminator. |
-| **D7** | Sponsorship invariance | Changing only fee-payer data excluded from the sender's signable payload does not create a new replay-protection identifier. |
-| **D8** | Encoding compatibility | Existing `nonce = 0` expiring transactions retain their current encoding and hash. |
-
-Tests MUST cover the boundary values, both sides of the activation boundary, identical payloads
-with equal and unequal discriminators, multiple discriminators from one sender in a block, replay
-attempts, reverted execution, and sponsored transactions.

--- a/tips/tip-1106.md
+++ b/tips/tip-1106.md
@@ -1,0 +1,126 @@
+---
+id: TIP-1106
+title: Expiring Nonce Discriminators
+description: Allows the nonce field of an expiring nonce transaction to distinguish otherwise identical transactions.
+authors: Alexey Shekhirin (@shekhirin)
+status: Draft
+related: TIP-1009, TIP-1000, Transactions
+protocolVersion: TBD
+---
+
+# TIP-1106: Expiring Nonce Discriminators
+
+## Abstract
+
+This TIP allows the `nonce` field of an expiring nonce transaction to contain any `uint64` value,
+rather than requiring zero. In expiring nonce mode the field is an opaque discriminator, not a
+sequential nonce. Two otherwise identical transactions can therefore choose different values and
+produce different signing, transaction, and replay-protection hashes.
+
+## Motivation
+
+[TIP-1009](./tip-1009.md) requires every expiring nonce transaction to set `nonce = 0`. As a result,
+two transactions from the same sender with identical calls, validity bounds, fee parameters, and
+other signable fields have the same signing payload. This is useful for deduplication, but prevents
+an application from intentionally creating distinct instances of the same operation within one
+validity window.
+
+Applications can vary another signed field, such as `validBefore`, but doing so changes that
+field's actual semantics and may not be possible when transactions are produced concurrently.
+Using the existing `nonce` field as an opaque discriminator provides an explicit source of
+uniqueness without changing the transaction encoding or adding protocol state.
+
+The alternative is to add a new salt field to the Tempo transaction type. That would require a new
+encoding and duplicate functionality already provided by the encoded `nonce` field.
+
+## Assumptions
+
+- Tempo transaction signing and transaction encodings continue to commit to the `nonce` field.
+- Expiring nonce replay protection continues to use the transaction hash or a sender-scoped hash
+  derived from the signable transaction payload, depending on the active protocol version.
+- Applications that require distinct hashes choose distinct discriminator values or vary another
+  committed field. The protocol does not allocate discriminator values or guarantee their
+  uniqueness.
+- Existing expiring nonce transactions with `nonce = 0` remain valid after activation. A non-zero
+  expiring nonce transaction submitted before activation remains invalid.
+
+If an implementation omits `nonce` from a signing or replay-protection hash, the uniqueness
+property in this TIP does not hold and that implementation is non-conforming.
+
+## Threat Model
+
+- **Transaction sender:** May choose any discriminator, including reusing a value. Reuse is safe,
+  but identical signable payloads retain identical replay-protection identifiers and are treated as
+  the same transaction.
+- **Wallet or relayer:** Is responsible for choosing distinct discriminator values when distinct
+  transactions are required. A malicious or faulty generator can cause local hash collisions by
+  reusing the complete signable payload, but cannot bypass signature checks or replay protection.
+- **Block producer and node operator:** Must not interpret the discriminator as a sequential nonce,
+  read or update 2D nonce state for it, or accept the same replay-protection identifier twice.
+- **Fee payer:** Cannot create a distinct replayable transaction solely by changing sponsorship
+  data that is excluded from the sender's signable payload; the existing sender-scoped replay
+  protection remains unchanged.
+
+---
+
+# Specification
+
+At the activation protocol version, replace TIP-1009's `nonce == 0` validity requirement with the
+following rule:
+
+> When `nonceKey == TEMPO_EXPIRING_NONCE_KEY`, `nonce` MAY be any value in the transaction field's
+> existing `uint64` range. The value is an opaque transaction discriminator and has no ordering or
+> state-transition semantics.
+
+For an expiring nonce transaction:
+
+1. Validation MUST NOT compare `nonce` with the sender's protocol nonce or a 2D nonce.
+2. Execution MUST NOT increment, initialize, read, or write protocol or 2D nonce state as a result
+   of the discriminator value.
+3. `nonce` MUST remain included in the existing transaction signing payload and transaction
+   encoding.
+4. The replay-protection identifier MUST continue to commit to the complete signable payload,
+   including `nonce`, and to the sender where required by the active protocol version.
+5. All other TIP-1009 requirements, including `nonceKey`, validity-window checks, replay checks,
+   circular-buffer behavior, and gas charging, remain unchanged.
+
+Consequently, for two valid expiring nonce transactions that differ only in `nonce`, their signing
+hashes, signed transaction hashes, and replay-protection identifiers MUST differ. No new state or
+storage layout is introduced.
+
+The rule is fork-gated. Before activation, an expiring nonce transaction with `nonce != 0` MUST be
+rejected according to TIP-1009. At and after activation, both zero and non-zero values MUST be
+accepted.
+
+# Tooling
+
+Transaction builders, RPC helpers, and fillers MUST stop overriding an explicitly supplied
+expiring `nonce` with zero after activation. Helpers MAY continue to use zero by default. Helpers
+intended to create distinct otherwise identical transactions SHOULD assign distinct `uint64`
+values and document whether those values are random, monotonic, or caller-supplied.
+
+RPC estimation and transaction submission MUST apply the fork-gated validation rule. Existing
+wire formats and JSON-RPC field types do not change.
+
+# Observability
+
+N/A. The change adds no new state transition or event. Existing invalid-transaction metrics and
+logs are sufficient, but implementations SHOULD preserve a distinct pre-activation rejection
+reason for a non-zero expiring nonce so cross-fork submission failures remain diagnosable.
+
+# Invariants
+
+| ID | Invariant | Critical cases |
+|----|-----------|----------------|
+| **D1** | Full range accepted | At and after activation, expiring transactions with `nonce` equal to `0`, `1`, and `uint64.max` pass nonce validation. |
+| **D2** | Pre-activation compatibility | Before activation, `nonce = 0` passes and every non-zero value is rejected. |
+| **D3** | Hash separation | Two otherwise identical expiring transactions with different `nonce` values have different signing, transaction, and replay-protection hashes. |
+| **D4** | Replay protection | Repeating the same complete expiring transaction remains a replay and cannot execute twice within its replay-protection lifetime. |
+| **D5** | No ordering | Transactions with discriminator values `2`, `0`, and `1` may execute in any order or in the same block. |
+| **D6** | No nonce state mutation | Successful and reverted expiring transactions do not change the sender's protocol nonce or any 2D nonce solely because of the discriminator. |
+| **D7** | Sponsorship invariance | Changing only fee-payer data excluded from the sender's signable payload does not create a new replay-protection identifier. |
+| **D8** | Encoding compatibility | Existing `nonce = 0` expiring transactions retain their current encoding and hash. |
+
+Tests MUST cover the boundary values, both sides of the activation boundary, identical payloads
+with equal and unequal discriminators, multiple discriminators from one sender in a block, replay
+attempts, reverted execution, and sponsored transactions.


### PR DESCRIPTION
Defines the expiring transaction nonce as an opaque discriminator so otherwise identical transactions can produce distinct hashes without adding encoding or state. Keeps zero valid, preserves replay protection, and specifies fork-gated validation and tooling behavior.

Prompted by: @shekhirin