### PR TITLE
feat(consensus): track delivered blocks and add delivery/head walks to the tree

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -173,6 +173,9 @@ struct Metrics {
     /// the head; holds its last value while the pending head's height is
     /// unknown (its body has not arrived yet).
     convergence_depth: commonware_runtime::telemetry::metrics::Registered<Gauge>,
+    /// Number of blocks the execution layer accepted that are not on its
+    /// canonical chain.
+    uncanonicalized_blocks: commonware_runtime::telemetry::metrics::Registered<Gauge>,
 }
 
 impl Metrics {
@@ -202,11 +205,17 @@ impl Metrics {
             (negative after a re-anchor below the head)",
             Gauge::default(),
         );
+        let uncanonicalized_blocks = context.register(
+            "uncanonicalized_blocks",
+            "number of blocks the execution layer accepted that are not on its canonical chain",
+            Gauge::default(),
+        );
         Self {
             finalized_blocks_proposed_by_self,
             notarized_tree_blocks,
             finalization_lag,
             convergence_depth,
+            uncanonicalized_blocks,
         }
     }
 
@@ -218,6 +227,8 @@ impl Metrics {
         if let Some(depth) = depths.convergence_depth {
             self.convergence_depth.set(depth);
         }
+        self.uncanonicalized_blocks
+            .set(depths.uncanonicalized_blocks as i64);
     }
 }
 

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -1,10 +1,11 @@
 //! The notarized tree: the executor's record of the chain above the
-//! finalized tip, of the forkchoice state the execution layer last
-//! accepted, and of how far that state has converged onto the pending
-//! head's ancestry.
+//! finalized tip, of which of those blocks the execution layer has
+//! accepted, of the forkchoice state the execution layer last accepted,
+//! and of how far that state has converged onto the pending head's
+//! ancestry.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -22,20 +23,24 @@ use crate::consensus::{Digest, block::Block};
 mod tests;
 
 /// How long a notarized block the execution layer failed to process is
-/// withheld from forwarding before it becomes eligible for a retry.
+/// withheld from delivery and forkchoice updates before it becomes
+/// eligible for a retry.
 pub(super) const NOTARIZED_REJECTION_RETRY_DELAY: Duration = Duration::from_secs(10);
 
-/// A block known to the executor together with the validator set to validate
-/// it against.
+/// A block known to the executor together with what the execution layer
+/// has said about it.
 #[derive(Clone, Debug)]
 pub(super) struct BlockEntry {
     pub(super) block: Arc<Block>,
+    /// The execution layer accepted the block through a new-payload request.
+    delivered: bool,
     rejected_at: Option<SystemTime>,
 }
 
 impl BlockEntry {
-    /// Whether the block may be forwarded at `now`: it is not withheld by
-    /// a rejection younger than [`NOTARIZED_REJECTION_RETRY_DELAY`].
+    /// Whether the block may be delivered or made the head at `now`: it is
+    /// not withheld by a rejection younger than
+    /// [`NOTARIZED_REJECTION_RETRY_DELAY`].
     fn forwardable(&self, now: SystemTime) -> bool {
         self.rejected_at
             .is_none_or(|rejected_at| now >= rejected_at + NOTARIZED_REJECTION_RETRY_DELAY)
@@ -122,16 +127,30 @@ impl LocalState {
 /// there is no block above the anchor: the step is a bare forkchoice
 /// update repointing the head onto the tip.
 ///
+/// # Delivery and forkchoice are separate steps
+///
+/// [`Self::next_to_deliver`] hands out the next block whose parent the
+/// execution layer *knows* (accepted through a delivery or validation, or
+/// part of the tracked state) for a bare new-payload request.
+/// [`Self::next_head`] names the highest known block on the pending head's
+/// ancestry for a forkchoice update, so an update can never make the
+/// execution layer sync. Both walk the ancestry fresh on every query.
+///
 /// Recording methods only insert primary state (the pending head, the
-/// local state, and bodies, guarded against the finalized tip);
-/// [`Self::heal`], run by the actor once per event-loop iteration, prunes
-/// what the advancing finalized tip covers.
+/// local state, bodies and their delivery status, guarded against the
+/// finalized tip); [`Self::heal`], run by the actor once per event-loop
+/// iteration, prunes what the advancing finalized tip covers.
 #[derive(Debug)]
 pub(super) struct NotarizedTree {
     /// The latest observed finalized tip of the network: the tree's
     /// lower bound. The tree only records notarized blocks above this finalized
     /// tip.
     network_finalized_tip: (Round, Height, Digest),
+    /// The highest finalized block the execution layer accepted through a
+    /// new-payload request: the finalized side of the next forkchoice
+    /// update. Sits between `local_finalized_tip` and
+    /// `network_finalized_tip`.
+    delivered_finalized: (Height, Digest),
     /// The finalized tip as canonicalized on the execution layer: the
     /// finalized side of the last accepted forkchoice state. Trails
     /// `network_finalized_tip` until the finalization pipeline catches up,
@@ -163,6 +182,9 @@ pub(super) struct Depths {
     /// below the head; `None` while the pending head's body - and with it
     /// its height - is unknown.
     pub(super) convergence_depth: Option<i64>,
+    /// Number of held blocks the execution layer accepted that are not on
+    /// its canonical chain: delivered above the head, or on other branches.
+    pub(super) uncanonicalized_blocks: usize,
 }
 
 /// The next convergence step toward the pending head, returned by
@@ -224,6 +246,7 @@ impl NotarizedTree {
     ) -> Self {
         Self {
             network_finalized_tip,
+            delivered_finalized: local_state.finalized,
             local_finalized_tip: local_state.finalized,
             pending_head: PendingHead::finalized_tip(network_finalized_tip),
             local_head: local_state.head,
@@ -253,6 +276,18 @@ impl NotarizedTree {
                 .get(&self.pending_head.digest)
                 .map(|entry| entry.block.height())
         };
+        // The head's ancestry held by the tree is the canonical part.
+        let mut canonical = HashSet::new();
+        let mut digest = self.local_head.1;
+        while let Some(entry) = self.blocks.get(&digest) {
+            canonical.insert(digest);
+            digest = entry.block.parent_digest();
+        }
+        let uncanonicalized_blocks = self
+            .blocks
+            .iter()
+            .filter(|(digest, entry)| entry.delivered && !canonical.contains(digest))
+            .count();
         Depths {
             blocks: self.blocks.len(),
             finalization_lag: network_finalized_height
@@ -260,6 +295,7 @@ impl NotarizedTree {
                 .saturating_sub(self.local_finalized_tip.0.get()),
             convergence_depth: pending_height
                 .map(|height| height.get() as i64 - self.local_head.0.get() as i64),
+            uncanonicalized_blocks,
         }
     }
 
@@ -297,10 +333,14 @@ impl NotarizedTree {
                 }))
     }
 
-    /// Records a forkchoice state newly accepted by the execution layer.
+    /// Records an accepted forkchoice state. A finalized block the tree did
+    /// not see delivered (startup backfill) advances the delivered one too.
     pub(super) fn set_local_state(&mut self, local_state: LocalState) {
         self.local_head = local_state.head;
         self.local_finalized_tip = local_state.finalized;
+        if local_state.finalized.0 > self.delivered_finalized.0 {
+            self.delivered_finalized = local_state.finalized;
+        }
     }
 
     /// Records a consensus context's parent as the pending head of the
@@ -315,6 +355,8 @@ impl NotarizedTree {
     /// Records the body of a block unless the finalized tip covers its
     /// height. Such a stale block is expunged so that it is neither
     /// fetched nor forwarded again.
+    ///
+    /// Re-recording clears a rejection but keeps the delivery status.
     pub(super) fn record_block(&mut self, block: Arc<Block>) {
         if block.height() <= self.network_finalized_tip.1 {
             debug!(
@@ -325,10 +367,16 @@ impl NotarizedTree {
             self.remove(&block.digest());
             return;
         }
+        let digest = block.digest();
+        let delivered = self
+            .blocks
+            .get(&digest)
+            .is_some_and(|entry| entry.delivered);
         self.blocks.insert(
-            block.digest(),
+            digest,
             BlockEntry {
                 block,
+                delivered,
                 rejected_at: None,
             },
         );
@@ -348,11 +396,12 @@ impl NotarizedTree {
     /// traded for recovery speed, bounded by the advancing finalized tip,
     /// which sweeps everything it passes.
     pub(super) fn heal(&mut self) {
-        // `first_missing_ancestor` and `next_to_forward` bound their walks
-        // by the network's finalized tip, which is only correct while the
-        // locally canonicalized finalized tip does not run ahead of it. The
-        // marshal actor upholds this: it reports a finalized tip before
-        // delivering the finalized blocks covered by it.
+        // `first_missing_ancestor`, `next_to_forward`, `next_to_deliver` and
+        // `next_head` bound their walks by the network's finalized tip,
+        // which is only correct while the locally canonicalized finalized
+        // tip does not run ahead of it. The marshal actor upholds this: it
+        // reports a finalized tip before delivering the finalized blocks
+        // covered by it.
         debug_assert!(
             self.local_finalized_tip.0 <= self.network_finalized_tip.1,
             "the locally canonicalized finalized tip must never run ahead of \
@@ -375,10 +424,11 @@ impl NotarizedTree {
     /// Marks the block as rejected by the execution layer at `now`,
     /// excluding it from forwarding until
     /// [`NOTARIZED_REJECTION_RETRY_DELAY`] has elapsed or the entry is
-    /// expunged.
+    /// expunged, and revoking its delivery status.
     pub(super) fn mark_rejected(&mut self, digest: &Digest, now: SystemTime) {
         if let Some(entry) = self.blocks.get_mut(digest) {
             entry.rejected_at = Some(now);
+            entry.delivered = false;
         }
     }
 
@@ -488,5 +538,109 @@ impl NotarizedTree {
             digest = entry.block.parent_digest();
         }
         None
+    }
+}
+
+/// What the execution layer has, and the two walks that follow from it:
+/// the next block to deliver and the next block to make the head.
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "the scheduler switches from `next_to_forward` to these walks next"
+    )
+)]
+impl NotarizedTree {
+    /// The block consensus reported building on: the convergence target.
+    pub(super) fn pending_head(&self) -> Digest {
+        self.pending_head.digest
+    }
+
+    /// The highest finalized block the execution layer accepted: the
+    /// finalized target of the next forkchoice update.
+    pub(super) fn delivered_finalized(&self) -> (Height, Digest) {
+        self.delivered_finalized
+    }
+
+    /// Whether the execution layer has `digest`: the tracked head or
+    /// finalized block, the delivered finalized block, or a delivered entry.
+    pub(super) fn is_known(&self, digest: Digest) -> bool {
+        self.known_height(digest).is_some()
+    }
+
+    /// The height of `digest` if the execution layer has it.
+    pub(super) fn known_height(&self, digest: Digest) -> Option<Height> {
+        if self.local_head.1 == digest {
+            return Some(self.local_head.0);
+        }
+        if self.local_finalized_tip.1 == digest {
+            return Some(self.local_finalized_tip.0);
+        }
+        if self.delivered_finalized.1 == digest {
+            return Some(self.delivered_finalized.0);
+        }
+        self.blocks
+            .get(&digest)
+            .filter(|entry| entry.delivered)
+            .map(|entry| entry.block.height())
+    }
+
+    /// Records a finalized block the execution layer accepted; a no-op at
+    /// or below the tracked height.
+    pub(super) fn set_delivered_finalized(&mut self, height: Height, digest: Digest) {
+        if height > self.delivered_finalized.0 {
+            self.delivered_finalized = (height, digest);
+        }
+    }
+
+    /// Marks the block as accepted by the execution layer, clearing any
+    /// rejection.
+    pub(super) fn mark_delivered(&mut self, digest: &Digest) {
+        if let Some(entry) = self.blocks.get_mut(digest) {
+            entry.delivered = true;
+            entry.rejected_at = None;
+        }
+    }
+
+    /// The lowest block on the pending head's ancestry the execution layer
+    /// does not have but whose parent it has, if the ancestry is walkable
+    /// and no block on the way is withheld.
+    pub(super) fn next_to_deliver(&self, now: SystemTime) -> Option<Arc<Block>> {
+        let (_, finalized_height, _) = self.network_finalized_tip;
+
+        let mut candidate: Option<&BlockEntry> = None;
+        let mut digest = self.pending_head.digest;
+        while !self.is_known(digest) {
+            let entry = self.blocks.get(&digest)?;
+            if entry.block.height() <= finalized_height || !entry.forwardable(now) {
+                return None;
+            }
+            candidate = Some(entry);
+            digest = entry.block.parent_digest();
+        }
+        candidate.map(|entry| entry.block.clone())
+    }
+
+    /// The highest block on the pending head's ancestry the execution layer
+    /// has, if it is not the head already, the ancestry down to it is
+    /// walkable, and no block on the way is withheld. Bottoming out on the
+    /// finalized tip repoints onto it.
+    pub(super) fn next_head(&self, now: SystemTime) -> Option<(Height, Digest)> {
+        let (_, finalized_height, _) = self.network_finalized_tip;
+
+        let mut digest = self.pending_head.digest;
+        loop {
+            if digest == self.local_head.1 {
+                return None;
+            }
+            if let Some(height) = self.known_height(digest) {
+                return Some((height, digest));
+            }
+            let entry = self.blocks.get(&digest)?;
+            if entry.block.height() <= finalized_height || !entry.forwardable(now) {
+                return None;
+            }
+            digest = entry.block.parent_digest();
+        }
     }
 }

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -5,7 +5,7 @@
 //! ancestry.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -276,18 +276,17 @@ impl NotarizedTree {
                 .get(&self.pending_head.digest)
                 .map(|entry| entry.block.height())
         };
-        // The head's ancestry held by the tree is the canonical part.
-        let mut canonical = HashSet::new();
+        // Delivered blocks minus the delivered ones on the head's ancestry,
+        // which is the canonical part the tree holds.
+        let mut uncanonicalized_blocks =
+            self.blocks.values().filter(|entry| entry.delivered).count();
         let mut digest = self.local_head.1;
         while let Some(entry) = self.blocks.get(&digest) {
-            canonical.insert(digest);
+            if entry.delivered {
+                uncanonicalized_blocks -= 1;
+            }
             digest = entry.block.parent_digest();
         }
-        let uncanonicalized_blocks = self
-            .blocks
-            .iter()
-            .filter(|(digest, entry)| entry.delivered && !canonical.contains(digest))
-            .count();
         Depths {
             blocks: self.blocks.len(),
             finalization_lag: network_finalized_height

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -550,11 +550,6 @@ impl NotarizedTree {
     )
 )]
 impl NotarizedTree {
-    /// The block consensus reported building on: the convergence target.
-    pub(super) fn pending_head(&self) -> Digest {
-        self.pending_head.digest
-    }
-
     /// The highest finalized block the execution layer accepted: the
     /// finalized target of the next forkchoice update.
     pub(super) fn delivered_finalized(&self) -> (Height, Digest) {
@@ -621,10 +616,11 @@ impl NotarizedTree {
     }
 
     /// The highest block on the pending head's ancestry the execution layer
-    /// has, if it is not the head already, the ancestry down to it is
-    /// walkable, and no block on the way is withheld. Bottoming out on the
-    /// finalized tip repoints onto it.
-    pub(super) fn next_head(&self, now: SystemTime) -> Option<(Height, Digest)> {
+    /// has, if it is not the head already and the ancestry down to it is
+    /// walkable. A withheld block on the way does not matter: the head moves
+    /// onto what the execution layer accepted regardless. Bottoming out on
+    /// the finalized tip repoints onto it.
+    pub(super) fn next_head(&self) -> Option<(Height, Digest)> {
         let (_, finalized_height, _) = self.network_finalized_tip;
 
         let mut digest = self.pending_head.digest;
@@ -636,7 +632,7 @@ impl NotarizedTree {
                 return Some((height, digest));
             }
             let entry = self.blocks.get(&digest)?;
-            if entry.block.height() <= finalized_height || !entry.forwardable(now) {
+            if entry.block.height() <= finalized_height {
                 return None;
             }
             digest = entry.block.parent_digest();

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -97,6 +97,23 @@ fn forwarded(tree: &mut NotarizedTree, block: &Block) {
     tree.set_local_state(local_state);
 }
 
+/// The digest of the next block to deliver, if any.
+fn next_delivery(tree: &NotarizedTree, now: SystemTime) -> Option<Digest> {
+    tree.next_to_deliver(now).map(|block| block.digest())
+}
+
+/// Simulates the completed delivery of `block`: the execution layer
+/// accepted its new-payload request.
+fn delivered(tree: &mut NotarizedTree, block: &Block) {
+    tree.mark_delivered(&block.digest());
+}
+
+/// Simulates full convergence onto `block`: delivered, then made the head.
+fn converged(tree: &mut NotarizedTree, block: &Block) {
+    delivered(tree, block);
+    forwarded(tree, block);
+}
+
 #[test]
 fn forwards_chain_on_top_of_finalized_tip_in_order() {
     let finalized = Digest(B256::repeat_byte(0xff));
@@ -554,8 +571,11 @@ fn depths_measure_backlogs() {
     assert_eq!(depths.blocks, 0);
     assert_eq!(depths.finalization_lag, 0);
     assert_eq!(depths.convergence_depth, Some(0));
+    assert_eq!(depths.uncanonicalized_blocks, 0);
 
     // Two recorded blocks, the pending head two above the local head.
+    // Recorded bodies are not uncanonicalized until delivered; delivered
+    // ones are until the head passes them.
     let a = block(1, 11, finalized);
     let b = block(2, 12, a.digest());
     record(&mut tree, &a);
@@ -563,6 +583,12 @@ fn depths_measure_backlogs() {
     let depths = tree.depths();
     assert_eq!(depths.blocks, 2);
     assert_eq!(depths.convergence_depth, Some(2));
+    assert_eq!(depths.uncanonicalized_blocks, 0);
+    delivered(&mut tree, &a);
+    delivered(&mut tree, &b);
+    assert_eq!(tree.depths().uncanonicalized_blocks, 2);
+    forwarded(&mut tree, &a);
+    assert_eq!(tree.depths().uncanonicalized_blocks, 1);
 
     // A pending head without a body has no known height.
     let c = block(3, 13, b.digest());
@@ -784,4 +810,228 @@ fn reaffirmed_finalized_tip_needs_no_fetch() {
     tree.set_pending_head(round(2), finalized);
 
     assert_eq!(tree.first_missing_ancestor(), None);
+}
+
+#[test]
+fn delivers_chain_on_top_of_finalized_tip_bottom_up() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    let a = block(1, 11, finalized);
+    let b = block(2, 12, a.digest());
+    record(&mut tree, &a);
+    record(&mut tree, &b);
+
+    // Only the block directly above a known block can be delivered; there
+    // is no known block to move the head onto yet.
+    assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
+    assert_eq!(tree.next_head(T0), None);
+
+    // Once a is delivered, b is deliverable and a is the highest known
+    // block on the path: the head can already move onto it.
+    delivered(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), a.digest())));
+
+    // With the whole path delivered, one forkchoice update covers it.
+    delivered(&mut tree, &b);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+
+    forwarded(&mut tree, &b);
+    assert_eq!(tree.next_head(T0), None);
+}
+
+#[test]
+fn fork_extends_from_the_nearest_known_block() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    // F - N0 - N1 - N2 is converged onto in full ...
+    let n0 = block(1, 11, finalized);
+    let n1 = block(2, 12, n0.digest());
+    let n2 = block(3, 13, n1.digest());
+    record(&mut tree, &n0);
+    record(&mut tree, &n1);
+    record(&mut tree, &n2);
+    delivered(&mut tree, &n0);
+    delivered(&mut tree, &n1);
+    converged(&mut tree, &n2);
+    assert_eq!(next_delivery(&tree, T0), None);
+
+    // ... when F - N0 - N1' - N3 becomes the canonical chain. The report
+    // arrives before the bodies; delivery stalls until the ancestry
+    // is walkable.
+    let n1p = block(4, 12, n0.digest());
+    let n3 = block(5, 13, n1p.digest());
+    report_parent(&mut tree, &n3);
+    tree.heal();
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
+
+    // N3's body arrives, but its parent N1' is still missing: the
+    // ancestry does not reach down to a block the execution layer has.
+    tree.record_block(n3.clone().into());
+    tree.heal();
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
+
+    // N1' arrives via the fetch machinery, completing the ancestry. The
+    // head (N2) sits off the new canonical path, but the trunk block N0 is
+    // known to the execution layer: the fork branch is delivered from
+    // directly above it, and the head can be moved back onto N0 meanwhile.
+    tree.record_block(n1p.clone().into());
+    tree.heal();
+    assert_eq!(next_delivery(&tree, T0), Some(n1p.digest()));
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), n0.digest())));
+    delivered(&mut tree, &n1p);
+    assert_eq!(next_delivery(&tree, T0), Some(n3.digest()));
+    delivered(&mut tree, &n3);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(13), n3.digest())));
+}
+
+/// A head stranded on an abandoned notarized branch while consensus
+/// re-anchors on the (already delivered) finalized tip itself: there is
+/// nothing to deliver, and the head target is the tip.
+#[test]
+fn next_head_repoints_a_stranded_head_onto_the_finalized_tip() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    // No convergence step while the head sits on the finalized tip.
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
+
+    // A block is notarized and converged onto, then its view nullifies
+    // and the network abandons it; consensus re-anchors on the finalized
+    // tip.
+    let abandoned = block(1, 11, finalized);
+    record(&mut tree, &abandoned);
+    converged(&mut tree, &abandoned);
+    tree.set_pending_head(round(0), finalized);
+    tree.heal();
+    assert_eq!(tree.pending_head(), finalized);
+
+    // There is no block to deliver; the head target is the tip.
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), Some((Height::new(10), finalized)));
+
+    // The repoint forkchoice update is accepted: the head is back on the
+    // tip and there is nothing left to do.
+    let local_state = tree.local_state().update_head(Height::new(10), finalized);
+    tree.set_local_state(local_state);
+    assert_eq!(tree.next_head(T0), None);
+}
+
+/// No head target while the finalized-block delivery for the tip is still
+/// outstanding: the tip cannot be named before the execution layer has it.
+#[test]
+fn next_head_waits_for_the_finalized_tip_delivery() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    let a1 = block(1, 11, finalized);
+    record(&mut tree, &a1);
+    converged(&mut tree, &a1);
+
+    // A sibling of the converged block finalizes; its delivery has not
+    // arrived yet. A report re-anchoring on it must not name it.
+    let b1 = block(2, 11, finalized);
+    tree.set_network_finalized_tip(round(2), Height::new(11), b1.digest());
+    tree.set_pending_head(round(2), b1.digest());
+    tree.heal();
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
+
+    // The delivery lands: the head target is the finalized block ...
+    tree.set_delivered_finalized(Height::new(11), b1.digest());
+    assert_eq!(tree.next_head(T0), Some((Height::new(11), b1.digest())));
+
+    // ... and once the forkchoice update rebased the head, there is
+    // nothing left to repoint.
+    let local_state = tree
+        .local_state()
+        .update_finalized(Height::new(11), b1.digest())
+        .update_head(Height::new(11), b1.digest());
+    tree.set_local_state(local_state);
+    assert_eq!(tree.next_head(T0), None);
+}
+
+/// Blocks the execution layer knows: the canonicalized state, the
+/// delivered finalized block, and delivered notarized blocks - not
+/// recorded bodies the execution layer has not seen.
+#[test]
+fn known_blocks_are_the_canonicalized_state_and_delivered_blocks() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+    assert_eq!(tree.known_height(finalized), Some(Height::new(10)));
+
+    // A recorded body is not known until delivered.
+    let a = block(1, 11, finalized);
+    record(&mut tree, &a);
+    assert!(!tree.is_known(a.digest()));
+    delivered(&mut tree, &a);
+    assert_eq!(tree.known_height(a.digest()), Some(Height::new(11)));
+
+    // Re-recording the body keeps the delivery status.
+    tree.record_block(a.clone().into());
+    assert!(tree.is_known(a.digest()));
+
+    // A delivered finalized block is known before it is canonicalized.
+    let f = block(2, 11, finalized);
+    tree.set_network_finalized_tip(round(2), Height::new(11), f.digest());
+    tree.heal();
+    assert!(!tree.is_known(f.digest()));
+    tree.set_delivered_finalized(Height::new(11), f.digest());
+    assert_eq!(tree.known_height(f.digest()), Some(Height::new(11)));
+    assert_eq!(
+        tree.delivered_finalized(),
+        (Height::new(11), f.digest()),
+        "the delivered finalized block is the next finalized target",
+    );
+
+    // Canonicalizing a finalized block the tree did not see delivered
+    // (the startup backfill) advances the delivered finalized block too.
+    let g = block(3, 12, f.digest());
+    tree.set_network_finalized_tip(round(3), Height::new(12), g.digest());
+    tree.heal();
+    tree.set_local_state(LocalState {
+        head: (Height::new(12), g.digest()),
+        finalized: (Height::new(12), g.digest()),
+    });
+    assert_eq!(tree.delivered_finalized(), (Height::new(12), g.digest()));
+    assert!(tree.is_known(g.digest()));
+}
+
+/// A rejection revokes the block's delivery status: the execution layer
+/// refused it, so it is delivered anew - after the retry delay - before it
+/// is named again.
+#[test]
+fn rejection_revokes_delivery() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    let a = block(1, 11, finalized);
+    let b = block(2, 12, a.digest());
+    record(&mut tree, &a);
+    record(&mut tree, &b);
+    delivered(&mut tree, &a);
+    delivered(&mut tree, &b);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+
+    // b is rejected: unknown again and withheld, which also withholds the
+    // head move onto its known parent.
+    tree.mark_rejected(&b.digest(), T0);
+    assert!(!tree.is_known(b.digest()));
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(T0), None);
+
+    // After the delay, b is delivered again, and a fresh acceptance clears
+    // the rejection.
+    let retry = T0 + NOTARIZED_REJECTION_RETRY_DELAY;
+    assert_eq!(next_delivery(&tree, retry), Some(b.digest()));
+    assert_eq!(tree.next_head(retry), Some((Height::new(11), a.digest())));
+    delivered(&mut tree, &b);
+    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
 }

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -825,21 +825,21 @@ fn delivers_chain_on_top_of_finalized_tip_bottom_up() {
     // Only the block directly above a known block can be delivered; there
     // is no known block to move the head onto yet.
     assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 
     // Once a is delivered, b is deliverable and a is the highest known
     // block on the path: the head can already move onto it.
     delivered(&mut tree, &a);
     assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
-    assert_eq!(tree.next_head(T0), Some((Height::new(11), a.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(11), a.digest())));
 
     // With the whole path delivered, one forkchoice update covers it.
     delivered(&mut tree, &b);
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(12), b.digest())));
 
     forwarded(&mut tree, &b);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 }
 
 #[test]
@@ -867,14 +867,14 @@ fn fork_extends_from_the_nearest_known_block() {
     report_parent(&mut tree, &n3);
     tree.heal();
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 
     // N3's body arrives, but its parent N1' is still missing: the
     // ancestry does not reach down to a block the execution layer has.
     tree.record_block(n3.clone().into());
     tree.heal();
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 
     // N1' arrives via the fetch machinery, completing the ancestry. The
     // head (N2) sits off the new canonical path, but the trunk block N0 is
@@ -883,12 +883,12 @@ fn fork_extends_from_the_nearest_known_block() {
     tree.record_block(n1p.clone().into());
     tree.heal();
     assert_eq!(next_delivery(&tree, T0), Some(n1p.digest()));
-    assert_eq!(tree.next_head(T0), Some((Height::new(11), n0.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(11), n0.digest())));
     delivered(&mut tree, &n1p);
     assert_eq!(next_delivery(&tree, T0), Some(n3.digest()));
     delivered(&mut tree, &n3);
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), Some((Height::new(13), n3.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(13), n3.digest())));
 }
 
 /// A head stranded on an abandoned notarized branch while consensus
@@ -901,7 +901,7 @@ fn next_head_repoints_a_stranded_head_onto_the_finalized_tip() {
 
     // No convergence step while the head sits on the finalized tip.
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 
     // A block is notarized and converged onto, then its view nullifies
     // and the network abandons it; consensus re-anchors on the finalized
@@ -911,17 +911,16 @@ fn next_head_repoints_a_stranded_head_onto_the_finalized_tip() {
     converged(&mut tree, &abandoned);
     tree.set_pending_head(round(0), finalized);
     tree.heal();
-    assert_eq!(tree.pending_head(), finalized);
 
     // There is no block to deliver; the head target is the tip.
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), Some((Height::new(10), finalized)));
+    assert_eq!(tree.next_head(), Some((Height::new(10), finalized)));
 
     // The repoint forkchoice update is accepted: the head is back on the
     // tip and there is nothing left to do.
     let local_state = tree.local_state().update_head(Height::new(10), finalized);
     tree.set_local_state(local_state);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 }
 
 /// No head target while the finalized-block delivery for the tip is still
@@ -942,11 +941,11 @@ fn next_head_waits_for_the_finalized_tip_delivery() {
     tree.set_pending_head(round(2), b1.digest());
     tree.heal();
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 
     // The delivery lands: the head target is the finalized block ...
     tree.set_delivered_finalized(Height::new(11), b1.digest());
-    assert_eq!(tree.next_head(T0), Some((Height::new(11), b1.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(11), b1.digest())));
 
     // ... and once the forkchoice update rebased the head, there is
     // nothing left to repoint.
@@ -955,7 +954,7 @@ fn next_head_waits_for_the_finalized_tip_delivery() {
         .update_finalized(Height::new(11), b1.digest())
         .update_head(Height::new(11), b1.digest());
     tree.set_local_state(local_state);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), None);
 }
 
 /// Blocks the execution layer knows: the canonicalized state, the
@@ -1018,20 +1017,19 @@ fn rejection_revokes_delivery() {
     record(&mut tree, &b);
     delivered(&mut tree, &a);
     delivered(&mut tree, &b);
-    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(12), b.digest())));
 
-    // b is rejected: unknown again and withheld, which also withholds the
-    // head move onto its known parent.
+    // b is rejected: unknown again and withheld. The head still moves onto
+    // its accepted parent.
     tree.mark_rejected(&b.digest(), T0);
     assert!(!tree.is_known(b.digest()));
     assert_eq!(next_delivery(&tree, T0), None);
-    assert_eq!(tree.next_head(T0), None);
+    assert_eq!(tree.next_head(), Some((Height::new(11), a.digest())));
 
     // After the delay, b is delivered again, and a fresh acceptance clears
     // the rejection.
     let retry = T0 + NOTARIZED_REJECTION_RETRY_DELAY;
     assert_eq!(next_delivery(&tree, retry), Some(b.digest()));
-    assert_eq!(tree.next_head(retry), Some((Height::new(11), a.digest())));
     delivered(&mut tree, &b);
-    assert_eq!(tree.next_head(T0), Some((Height::new(12), b.digest())));
+    assert_eq!(tree.next_head(), Some((Height::new(12), b.digest())));
 }


### PR DESCRIPTION
Prepares the notarized tree for delivering blocks and updating the
forkchoice state in separate steps. Nothing in the actor uses the new
walks yet; the scheduler switches over next.

Each block entry records whether the execution layer accepted it through
a new-payload request (`mark_delivered`); a rejection revokes that and
re-recording a body keeps it. `delivered_finalized` is the highest
finalized block the execution layer accepted, the finalized target of the
next forkchoice update; canonicalizing a finalized block the tree did not
see delivered (startup backfill) advances it too.

`is_known` / `known_height` answer whether the execution layer has a
block: the tracked head or finalized block, the delivered finalized
block, or a delivered entry. `next_to_deliver` walks the pending head's
ancestry down to the lowest block above a known one; `next_head` names
the highest known block on that ancestry, bottoming out on the finalized
tip for a repoint. Both stop at withheld blocks.

`Depths.uncanonicalized_blocks` counts delivered entries off the tracked
head's ancestry and is published as `executor_uncanonicalized_blocks`.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
