### PR TITLE
refactor(consensus): trust the marshal actor's finalized delivery order

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1120,11 +1120,17 @@ where
                 self.pending_consensus_request = Some((round, ConsensusRequest::Verify(request)));
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
-                // Builds are registered via a forkchoice update naming the
-                // parent as the head, so the build runs once the execution
-                // layer's head is there, waits while convergence is about to
-                // get there, and is dropped otherwise.
-                if self.notarized_tree.is_local_head(build.digest) {
+                // Consensus builds on the pending head it reported. The build
+                // runs once the execution layer's head is there, waits while
+                // convergence is about to get there, and is dropped otherwise.
+                let pending_head = self.notarized_tree.pending_head();
+                if build.digest != pending_head {
+                    info!(
+                        %pending_head,
+                        build.parent = %build.digest,
+                        "build is not on the pending head, dropping it",
+                    );
+                } else if self.notarized_tree.is_local_head(pending_head) {
                     let target = self.notarized_tree.local_state();
                     let fut = execute_forkchoice(
                         self.execution_node.clone(),
@@ -1134,7 +1140,7 @@ where
                     );
                     self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
                     return Ok(());
-                } else if self.is_convergence_target(build.digest) {
+                } else if self.is_convergence_target(pending_head) {
                     // Reschedules the request; the actor will not spin on
                     // `start_next_execution_request` as long as it remains
                     // scheduled before the select! in the select-loop (some

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1,8 +1,7 @@
 //! Drives the actual execution forwarding blocks and setting forkchoice state.
 //!
 //! This agent ingests (monotonically) increasing finalized blocks from the
-//! marshal actor and forwards them to the execution layer as `newPayload` +
-//! `forkchoiceUpdated` pairs.
+//! marshal actor and forwards them to the execution layer.
 //!
 //! In addition, the agent:
 //!
@@ -10,26 +9,27 @@
 //! 2. drives the execution layer toward that notarized head,
 //! 3. and validates and builds blocks.
 //!
-//! The notarization and finalization pipelines are strictly separate:
-//! the marshal actor informs the executor of the finalized network tip.
-//! Notarizations then are strictly above that finalized network tip. If the
-//! executor is at the finalized network tip, then the executor will forward
-//! the (notarized) child to the execution layer.
+//! # Delivery and forkchoice are separate steps
+//!
+//! `newPayload` delivers a block body and never moves the head; notarized
+//! blocks, finalized blocks, and validation probes are all deliveries.
+//! `forkchoiceUpdated` moves the head and the finalized block, on a later
+//! iteration, and only ever names blocks the execution layer has answered
+//! `VALID` for. One update covers everything delivered since the last one.
+//! Finalized blocks are acknowledged to the marshal actor once the update
+//! finalizing them is accepted, and finality work is scheduled ahead of
+//! notarized convergence.
 //!
 //! Requests to verify or build blocks work in a similar manner: a request to
-//! verify or build a block on top of some `$PARENT` will only pass if the the
-//! local tracked tip is at `$PARENT`.
+//! verify or build a block on top of some `$PARENT` will only pass if the
+//! execution layer is known to have `$PARENT`.
 //!
-//! # Notarizations are retried, everything else is fatal
+//! # Notarized deliveries are retried, everything else is fatal
 //!
-//! A notarized block rejected by the execution layer is retried while it
-//! remains above the network finalized tip. Once that tip advances to or past
-//! the block's height, the notarized block is ejected. In contrast, an
-//! `INVALID` finalized block is a hard failure that shuts down the node.
-//!
-//! Forkchoice updates only ever name blocks the execution layer has already
-//! accepted, so an update not answered `VALID` means the executor's view of
-//! the execution layer has diverged from it: the node shuts down.
+//! A rejected notarized delivery is retried while the block stays above the
+//! finalized tip. An `INVALID` finalized block is fatal, and so is any
+//! forkchoice update not answered `VALID`: the executor's view of the
+//! execution layer has diverged from it.
 
 use std::{
     collections::VecDeque,
@@ -82,7 +82,7 @@ use crate::{
 mod tests;
 
 mod notarized_tree;
-use notarized_tree::{LocalState, NextToForward, NotarizedTree};
+use notarized_tree::{LocalState, NotarizedTree};
 
 /// How often to probe whether the execution layer is ready to process blocks.
 const EXECUTION_LAYER_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
@@ -115,8 +115,13 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// Armed only when no execution-layer work is active or queued.
     fcu_heartbeat_timer: OptionFuture<BoxFuture<'static, ()>>,
 
-    /// Finalized blocks waiting to be forwarded to the execution layer.
+    /// Finalized blocks waiting to be delivered to the execution layer.
     pending_finalizations: VecDeque<FinalizedBlockRequest>,
+
+    /// Finalized blocks the execution layer has accepted, waiting for the
+    /// forkchoice update that finalizes them before they are acknowledged
+    /// to the marshal actor. In height order.
+    pending_acknowledgements: VecDeque<FinalizedBlockRequest>,
 
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
@@ -269,7 +274,7 @@ where
         // blocks from the floor, so the tracked state must start there for
         // the re-delivery to line up; the already-finalized blocks are
         // acknowledged without involving the execution layer (see
-        // [`forward_finalized`]).
+        // [`Self::handle_finalized_delivered`]).
         let finalized = if finalized_floor.get() < execution_finalized_num_hash.number {
             let digest = execution_node
                 .canonical_block_hash(finalized_floor.get())
@@ -312,6 +317,7 @@ where
             fcu_heartbeat_timer: OptionFuture::none(),
 
             pending_finalizations: VecDeque::new(),
+            pending_acknowledgements: VecDeque::new(),
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -452,10 +458,10 @@ where
     }
 
     /// Interprets the answer of a finished execution task: this is the one
-    /// place where answers are turned into decisions - what to withhold,
-    /// what to acknowledge, and what is fatal. There is only one task at a
-    /// time, so the tracked state at completion is the state the task ran on
-    /// top of.
+    /// place where answers are turned into decisions - what to mark
+    /// delivered, what to withhold, what to acknowledge, and what is fatal.
+    /// There is only one task at a time, so the tracked state at completion
+    /// is the state the task ran on top of.
     #[instrument(
         parent = &finished.span,
         skip_all,
@@ -477,54 +483,58 @@ where
         let ExecutionTaskFinished { outcome, .. } = finished;
         match outcome {
             ExecutionTaskOutcome::Validated { request, status } => {
+                // A failed validation is logged by the handler; it is not
+                // fatal, consensus treats it as a rejected proposal.
                 let _logged = self.handle_validated(request, status);
-                Ok(())
             }
-            ExecutionTaskOutcome::Delivered {
-                digest,
-                target,
-                status,
-                response,
-            } => self.handle_delivered(digest, target, status, response),
-            ExecutionTaskOutcome::FinalizedDelivered {
-                request,
-                target,
-                status,
-                response,
-            } => self.handle_finalized_delivered(request, target, status, response),
+            ExecutionTaskOutcome::Delivered { digest, status } => {
+                // A withheld delivery is logged by the handler; it is retried.
+                let _logged = self.handle_delivered(digest, status);
+            }
+            ExecutionTaskOutcome::FinalizedDelivered { request, status } => {
+                self.handle_finalized_delivered(request, status)?
+            }
             ExecutionTaskOutcome::Forkchoice {
                 target,
                 build,
                 response,
-            } => self.handle_forkchoice_response(target, build, response),
+            } => self.handle_forkchoice_response(target, build, response)?,
         }
+        Ok(())
     }
 
     /// Resolves a validation request from the execution layer's answer.
-    /// `VALID` and `INVALID` are verdicts; `SYNCING` (unknown parent),
-    /// `ACCEPTED`, and transport errors fail the request by dropping its
-    /// channel and are returned as errors. Gaps are repaired by
-    /// convergence, not on this path.
+    /// `VALID` and `INVALID` are verdicts, and the block is marked delivered
+    /// or withheld accordingly; `SYNCING` (unknown parent), `ACCEPTED`, and
+    /// transport errors fail the request by dropping its channel and are
+    /// returned as errors, without touching the tree: they say nothing about
+    /// the block. Gaps are repaired by convergence, not on this path.
     #[instrument(skip_all, err(level = Level::WARN))]
     fn handle_validated(
-        &self,
+        &mut self,
         request: Option<VerifyBlockRequest>,
         status: eyre::Result<(PayloadStatusEnum, Duration)>,
     ) -> eyre::Result<()> {
-        let Some(VerifyBlockRequest {
-            cause, response, ..
-        }) = request
-        else {
+        let Some(request) = request else {
             return Ok(());
         };
+        let digest = request.block.digest();
+        let VerifyBlockRequest {
+            cause, response, ..
+        } = request;
         let _entered = cause.enter();
+        let now = self.context.current();
         let verdict = match status {
-            Ok((PayloadStatusEnum::Valid, duration)) => Some(duration),
+            Ok((PayloadStatusEnum::Valid, duration)) => {
+                self.notarized_tree.mark_delivered(&digest);
+                Some(duration)
+            }
             Ok((PayloadStatusEnum::Invalid { validation_error }, _)) => {
                 info!(
                     validation_error,
                     "execution layer returned that the block was invalid"
                 );
+                self.notarized_tree.mark_rejected(&digest, now);
                 None
             }
             Ok((PayloadStatusEnum::Syncing, _)) => {
@@ -552,88 +562,12 @@ where
         Ok(())
     }
 
-    /// `VALID` delivers the notarized block and the forkchoice update that
-    /// followed, if any, moves the tracked state. Anything else withholds the
-    /// block for the retry delay so that it is not retried in a tight loop;
-    /// the finalization pipeline remains the fatal-on-failure backstop.
-    #[instrument(skip_all, fields(%digest), err)]
-    fn handle_delivered(
-        &mut self,
-        digest: Digest,
-        target: LocalState,
-        status: eyre::Result<PayloadStatusEnum>,
-        response: Option<eyre::Result<ForkchoiceUpdated>>,
-    ) -> eyre::Result<()> {
-        match status {
-            Ok(PayloadStatusEnum::Valid) => {}
-            Ok(status) => {
-                warn!(
-                    %status,
-                    "execution layer did not accept the notarized block; withholding it",
-                );
-                let now = self.context.current();
-                self.notarized_tree.mark_rejected(&digest, now);
-                return Ok(());
-            }
-            Err(error) => {
-                warn!(%error, "failed delivering notarized block; withholding it");
-                let now = self.context.current();
-                self.notarized_tree.mark_rejected(&digest, now);
-                return Ok(());
-            }
-        }
-        self.handle_forkchoice_response(target, None, response)
-    }
-
-    /// A non-`VALID` answer is fatal. Otherwise the forkchoice update that
-    /// followed, if any, moves the tracked state onto the finalized block,
-    /// which is then acknowledged to the marshal actor.
-    #[instrument(
-        skip_all,
-        fields(
-            block.digest = %request.block.digest(),
-            block.height = %request.block.height(),
-        ),
-        err,
-    )]
-    fn handle_finalized_delivered(
-        &mut self,
-        request: FinalizedBlockRequest,
-        target: LocalState,
-        status: eyre::Result<PayloadStatusEnum>,
-        response: Option<eyre::Result<ForkchoiceUpdated>>,
-    ) -> eyre::Result<()> {
-        let block = request.block.as_ref();
-        match status {
-            Ok(PayloadStatusEnum::Valid) => {}
-            Ok(status) => {
-                bail!(
-                    "payload status of finalized block `{}` at height `{}` was \
-                    not valid: {status}",
-                    block.digest(),
-                    block.height(),
-                );
-            }
-            Err(error) => {
-                return Err(error.wrap_err(format!(
-                    "failed delivering finalized block `{}` at height `{}`",
-                    block.digest(),
-                    block.height(),
-                )));
-            }
-        }
-        self.handle_forkchoice_response(target, None, response)?;
-        self.acknowledge(request);
-        Ok(())
-    }
-
-    /// An accepted forkchoice update becomes the tracked state, and so does
-    /// a stale one that was not submitted (`None`): the execution layer is
-    /// past that finality already and the tracked state catches up. A
-    /// rejected update is fatal: every target named is a block the
-    /// execution layer accepted, so the executor's view of the execution
-    /// layer has diverged from it. A build the update carried is driven to
-    /// completion.
+    /// An accepted forkchoice update becomes the tracked state (mutated only
+    /// here), and so does a stale one that was not submitted (`None`). A
+    /// rejected one is fatal: every target named is a block the execution
+    /// layer accepted, so the executor's view of the execution layer has
+    /// diverged from it. Finalized blocks the update covers are
+    /// acknowledged; a build it carried is driven to completion.
     fn handle_forkchoice_response(
         &mut self,
         target: LocalState,
@@ -660,6 +594,7 @@ where
                 info!("tracked finality is below the execution layer's; dropping the build");
             }
             self.notarized_tree.set_local_state(target);
+            self.acknowledge_finalized();
             return Ok(());
         };
         let diverged = || {
@@ -676,6 +611,7 @@ where
         }
 
         self.notarized_tree.set_local_state(target);
+        self.acknowledge_finalized();
 
         // Dropping the build's response channel signals the failure to the
         // subscriber.
@@ -697,6 +633,130 @@ where
         Ok(())
     }
 
+    /// `VALID` makes the notarized block known to the execution layer.
+    /// Anything else withholds it for the retry delay so that it is not
+    /// retried in a tight loop; the finalization pipeline remains the
+    /// fatal-on-failure backstop.
+    #[instrument(skip_all, fields(%digest), err(level = Level::WARN))]
+    fn handle_delivered(
+        &mut self,
+        digest: Digest,
+        status: eyre::Result<PayloadStatusEnum>,
+    ) -> eyre::Result<()> {
+        match status {
+            Ok(PayloadStatusEnum::Valid) => {
+                self.notarized_tree.mark_delivered(&digest);
+                Ok(())
+            }
+            Ok(status) => {
+                let now = self.context.current();
+                self.notarized_tree.mark_rejected(&digest, now);
+                bail!(
+                    "execution layer did not accept the notarized block; withholding it: {status}"
+                )
+            }
+            Err(error) => {
+                let now = self.context.current();
+                self.notarized_tree.mark_rejected(&digest, now);
+                Err(error.wrap_err("failed delivering notarized block; withholding it"))
+            }
+        }
+    }
+
+    /// A non-`VALID` answer is fatal. Otherwise the block becomes the next
+    /// finalized target and is acknowledged once the forkchoice update
+    /// finalizing it lands - or right away if the execution layer already
+    /// finalized it (a re-delivery).
+    #[instrument(
+        skip_all,
+        fields(
+            block.digest = %request.block.digest(),
+            block.height = %request.block.height(),
+        ),
+        err,
+    )]
+    fn handle_finalized_delivered(
+        &mut self,
+        request: FinalizedBlockRequest,
+        status: eyre::Result<PayloadStatusEnum>,
+    ) -> eyre::Result<()> {
+        let block = request.block.as_ref();
+        debug_assert!(
+            block.height() >= self.notarized_tree.delivered_finalized().0,
+            "finalized blocks are delivered in height order",
+        );
+        match status {
+            Ok(PayloadStatusEnum::Valid) => {}
+            Ok(status) => {
+                bail!(
+                    "payload status of finalized block `{}` at height `{}` was \
+                    not valid: {status}",
+                    block.digest(),
+                    block.height(),
+                );
+            }
+            Err(error) => {
+                return Err(error.wrap_err(format!(
+                    "failed delivering finalized block `{}` at height `{}`",
+                    block.digest(),
+                    block.height(),
+                )));
+            }
+        }
+
+        self.notarized_tree
+            .set_delivered_finalized(block.height(), block.digest());
+        if block.height() <= self.notarized_tree.local_state().finalized.0 {
+            // NOTE: this block is already final on the execution layer. This
+            // can happen if marshal is anchored below the EL and delivers
+            // finalized blocks the EL already knows about. In this case, it
+            // makes sense to ACK immediately rather than wait for an FCU
+            // sweep.
+            // The execution layer confirms it is the block it finalized at
+            // this height before it is acknowledged.
+            let canonical = self
+                .execution_node
+                .canonical_block_hash(block.height().get())
+                .wrap_err_with(|| {
+                    format!(
+                        "failed reading canonical execution block hash at finalized block \
+                        height `{}`",
+                        block.height(),
+                    )
+                })?;
+            ensure!(
+                canonical == Some(block.digest().0),
+                "re-delivered finalized block `{}` at height `{}` conflicts with the \
+                execution layer's canonical block `{canonical:?}` at the same height, which \
+                the execution layer already considers final",
+                block.digest(),
+                block.height(),
+            );
+            self.acknowledge(request);
+        } else {
+            self.pending_acknowledgements.push_back(request);
+        }
+        Ok(())
+    }
+
+    /// Acknowledges the queued blocks the execution layer reports as
+    /// finalized. Its own marker is the reference, not the tracked state:
+    /// an update whose head is a canonical ancestor is answered `VALID`
+    /// without the marker moving. Deliveries are in chain order, so height
+    /// identifies them.
+    fn acknowledge_finalized(&mut self) {
+        let finalized = self.execution_node.finalized_num_hash().number;
+        while let Some(request) = self.pending_acknowledgements.front() {
+            if request.block.height().get() > finalized {
+                break;
+            }
+            let Some(request) = self.pending_acknowledgements.pop_front() else {
+                break;
+            };
+            self.acknowledge(request);
+        }
+    }
+
     /// Acknowledges a block the execution layer finalized to the marshal actor.
     fn acknowledge(&self, request: FinalizedBlockRequest) {
         let FinalizedBlockRequest {
@@ -713,6 +773,11 @@ where
         {
             self.metrics.finalized_blocks_proposed_by_self.inc();
         }
+        info!(
+            block.digest = %block.digest(),
+            block.height = %block.height(),
+            "finalized block is final on the execution layer; acknowledging it",
+        );
         acknowledgment.acknowledge();
     }
 
@@ -742,6 +807,10 @@ where
         Ok(())
     }
 
+    /// Climbs from the tracked finalized state to the finalized floor
+    /// before entering the loop, through the regular finalization tasks
+    /// and their outcome handling, awaited in place. One forkchoice update
+    /// at the floor finalizes the delivered blocks.
     #[instrument(skip_all, err)]
     async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
         let start = self.notarized_tree.local_state().finalized.0.get() + 1;
@@ -770,10 +839,9 @@ where
                 block: Arc::new(block),
                 acknowledgment: ack,
             };
-
-            // The block goes through the regular finalization task and its
-            // outcome handling, awaited in place.
-            self.start_finalization(request)?;
+            self.check_finalized_delivery_order(request.block.as_ref())?;
+            let fut = execute_finalization(self.execution_node.clone(), request);
+            self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Finalize, fut));
             let finished = (&mut self.execution_task).await;
             self.handle_execution_task_finished(finished)
                 .wrap_err_with(|| {
@@ -782,8 +850,18 @@ where
                         to execution layer"
                     )
                 })?;
-        }
 
+            if height == end && self.start_forkchoice_update()? {
+                let finished = (&mut self.execution_task).await;
+                self.handle_execution_task_finished(finished)
+                    .wrap_err_with(|| {
+                        format!(
+                            "failed finalizing backfilled finalized block at height `{height}` \
+                            on the execution layer"
+                        )
+                    })?;
+            }
+        }
         Ok(())
     }
 
@@ -810,6 +888,8 @@ where
         }
     }
 
+    /// Re-affirms the tracked forkchoice state, unless the scheduler finds
+    /// real work to do first.
     #[instrument(skip_all)]
     fn send_forkchoice_update_heartbeat(&mut self) -> eyre::Result<()> {
         // The heartbeat timer is only armed while no other execution-layer
@@ -965,23 +1045,23 @@ where
         }
     }
 
-    /// Returns if the convergence machinery is expected to imminently make
-    /// `digest` available to the execution layer.
-    ///
-    /// There are 2 options:
-    ///
-    /// 1. either the block is already queued, or
-    /// 2. we expect the block to be scheduled next.
-    ///
-    /// Point 2 allows for marshal to deliver the next finalized block
-    /// just-in-time.
+    /// Whether `digest` is queued for delivery or is the next thing
+    /// convergence does, so that a request waiting on it is held rather
+    /// than failed.
     fn is_convergence_target(&self, digest: Digest) -> bool {
         self.pending_finalizations
             .iter()
             .any(|request| request.block.digest() == digest)
-            || self.notarized_tree.converges_imminently(digest)
+            || self
+                .notarized_tree
+                .converges_imminently(digest, self.context.current())
     }
 
+    /// Picks the next execution task: consensus request, finalized
+    /// deliveries, the forkchoice update finalizing them, notarized
+    /// deliveries, the forkchoice update moving the head. Finality goes
+    /// first so a long notarized run never holds up acknowledgements;
+    /// deliveries go before the update so one update covers a whole run.
     #[instrument(
         skip_all,
         fields(
@@ -1005,11 +1085,8 @@ where
         // imminently.
         match self.pending_consensus_request.take() {
             Some((round, ConsensusRequest::Verify(request))) => {
-                if self
-                    .notarized_tree
-                    .is_local_notarized_or_finalized_tip(request.block.parent_digest())
-                    || !self.is_convergence_target(request.block.parent_digest())
-                {
+                let parent = request.block.parent_digest();
+                if self.notarized_tree.is_known(parent) || !self.is_convergence_target(parent) {
                     let fut = execute_validation(self.execution_node.clone(), request);
                     self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Verify, fut));
                     return Ok(());
@@ -1023,9 +1100,10 @@ where
                 self.pending_consensus_request = Some((round, ConsensusRequest::Verify(request)));
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
-                // Builds are registered via FCU setting the head hash to the
-                // parent. So running it with the head anywhere else would fight
-                // notarized-chain convergence.
+                // Builds are registered via a forkchoice update naming the
+                // parent as the head, so the build runs once the execution
+                // layer's head is there, waits while convergence is about to
+                // get there, and is dropped otherwise.
                 if self.notarized_tree.is_local_head(build.digest) {
                     let target = self.notarized_tree.local_state();
                     let fut = execute_forkchoice(
@@ -1036,13 +1114,13 @@ where
                     );
                     self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
                     return Ok(());
-                }
-                // Reschedules the request; the actor will not spin on
-                // `start_next_execution_request` as long as it remains
-                // scheduled before the select! in the select-loop (some other
-                // event needs to take place first; ideally the result of the
-                // convergence target we are falling through to).
-                if self.is_convergence_target(build.digest) {
+                } else if self.is_convergence_target(build.digest) {
+                    // Reschedules the request; the actor will not spin on
+                    // `start_next_execution_request` as long as it remains
+                    // scheduled before the select! in the select-loop (some
+                    // other event needs to take place first; ideally the
+                    // result of the convergence target we are falling through
+                    // to).
                     self.pending_consensus_request =
                         Some((round, ConsensusRequest::Build { cause, build }));
                 } else {
@@ -1056,43 +1134,106 @@ where
             None => {}
         }
 
-        if let Some(step) = self.notarized_tree.next_to_forward(self.context.current()) {
-            let target = self
-                .notarized_tree
-                .local_state()
-                .update_head(step.height(), step.digest());
-            let fut = match step {
-                NextToForward::Block(block) => {
-                    execute_notarization(self.execution_node.clone(), block, target).boxed()
-                }
-                NextToForward::Repoint(..) => {
-                    execute_forkchoice(self.execution_node.clone(), Span::current(), target, None)
-                        .boxed()
-                }
-            };
-            self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Notarize, fut));
+        // Finalizations are delivered in order and acknowledged so that the
+        // marshal actor can make progress. Every finalized block is
+        // delivered, whether or not the execution layer is thought to know
+        // it: a known block is answered `VALID` from its caches without
+        // being executed again.
+        if let Some(request) = self.pending_finalizations.pop_front() {
+            self.check_finalized_delivery_order(request.block.as_ref())?;
+            let fut = execute_finalization(self.execution_node.clone(), request);
+            self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Finalize, fut));
             return Ok(());
         }
 
-        // Finalizations are forwarded in order and acknowledged so that the
-        // marshal actor can make progress.
-        if let Some(request) = self.pending_finalizations.pop_front() {
-            self.start_finalization(request)?;
+        // With the finalized queue drained, delivered finalized blocks that
+        // await their acknowledgement are locked in before notarized
+        // convergence continues. The update takes the head target that is
+        // known at this point along.
+        if !self.pending_acknowledgements.is_empty() && self.start_forkchoice_update()? {
+            return Ok(());
+        }
+
+        if let Some(block) = self.notarized_tree.next_to_deliver(self.context.current()) {
+            let fut = execute_delivery(self.execution_node.clone(), block);
+            self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Deliver, fut));
+            return Ok(());
+        }
+
+        self.start_forkchoice_update()?;
+        Ok(())
+    }
+
+    /// Finalized blocks are delivered in order, at or above the tracked
+    /// finalized block: a delivery below it is a protocol violation, and a
+    /// different block at its height means two blocks were finalized at the
+    /// same height.
+    fn check_finalized_delivery_order(&self, block: &Block) -> eyre::Result<()> {
+        let (finalized_height, finalized_digest) = self.notarized_tree.local_state().finalized;
+        ensure!(
+            block.height() >= finalized_height,
+            "finalized block with digest `{}` at height `{}` is below the \
+            executor's tracked finalized block `{finalized_digest}` at height \
+            `{finalized_height}`; finalized blocks must only ever be delivered \
+            at or on top of the tracked state",
+            block.digest(),
+            block.height(),
+        );
+        if block.height() == finalized_height {
+            ensure!(
+                block.digest() == finalized_digest,
+                "finalized block with digest `{}` at height `{}` conflicts with \
+                the executor's tracked finalized block `{finalized_digest}` at the \
+                same height; two different blocks must never be finalized at the \
+                same height",
+                block.digest(),
+                block.height(),
+            );
         }
         Ok(())
     }
 
-    /// Starts forwarding a finalized block: a new-payload request followed by
-    /// the forkchoice update finalizing it.
-    fn start_finalization(&mut self, request: FinalizedBlockRequest) -> eyre::Result<()> {
-        let target = finalization_target(
-            &self.execution_node,
-            self.notarized_tree.local_state(),
-            request.block.as_ref(),
-        )?;
-        let fut = execute_finalization(self.execution_node.clone(), request, target);
-        self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Finalize, fut));
-        Ok(())
+    /// Starts the forkchoice update onto the next target, if any; returns
+    /// whether it did.
+    fn start_forkchoice_update(&mut self) -> eyre::Result<bool> {
+        let Some(target) = self.next_forkchoice_target()? else {
+            return Ok(false);
+        };
+        let fut = execute_forkchoice(self.execution_node.clone(), Span::current(), target, None);
+        self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Forkchoice, fut));
+        Ok(true)
+    }
+
+    /// The next forkchoice state, if it differs from the tracked one: the
+    /// delivered finalized block, and the highest delivered block on the
+    /// pending head's ancestry. A head the tree cannot place is checked
+    /// against the canonical chain and moved onto the finalized block if it
+    /// does not descend from it.
+    fn next_forkchoice_target(&self) -> eyre::Result<Option<LocalState>> {
+        let local = self.notarized_tree.local_state();
+        let (finalized_height, finalized_digest) = self.notarized_tree.delivered_finalized();
+        let mut target = local.update_finalized(finalized_height, finalized_digest);
+        if let Some((height, digest)) = self.notarized_tree.next_head() {
+            target = target.update_head(height, digest);
+        }
+
+        if target.finalized != local.finalized && target.head == local.head {
+            let canonical_hash = self
+                .execution_node
+                .canonical_block_hash(finalized_height.get())
+                .wrap_err_with(|| {
+                    format!(
+                        "failed reading canonical execution block hash at finalized \
+                        block height `{finalized_height}`",
+                    )
+                })?;
+            let head_descends_from_finalized = canonical_hash == Some(finalized_digest.0);
+            if !head_descends_from_finalized {
+                target = target.update_head(finalized_height, finalized_digest);
+            }
+        }
+
+        Ok((target != local).then_some(target))
     }
 }
 
@@ -1230,8 +1371,9 @@ enum ExecutionTaskType {
     Heartbeat,
     Verify,
     Build,
-    Notarize,
+    Deliver,
     Finalize,
+    Forkchoice,
 }
 
 impl ExecutionTaskType {
@@ -1240,8 +1382,9 @@ impl ExecutionTaskType {
             Self::Heartbeat => "heartbeat",
             Self::Verify => "verify",
             Self::Build => "build",
-            Self::Notarize => "notarize",
+            Self::Deliver => "deliver",
             Self::Finalize => "finalize",
+            Self::Forkchoice => "forkchoice",
         }
     }
 }
@@ -1277,10 +1420,10 @@ struct ExecutionTaskFinished {
 impl ExecutionTaskFinished {
     fn target(&self) -> Option<LocalState> {
         match &self.outcome {
-            ExecutionTaskOutcome::Validated { .. } => None,
-            ExecutionTaskOutcome::Delivered { target, .. }
-            | ExecutionTaskOutcome::FinalizedDelivered { target, .. }
-            | ExecutionTaskOutcome::Forkchoice { target, .. } => Some(*target),
+            ExecutionTaskOutcome::Forkchoice { target, .. } => Some(*target),
+            ExecutionTaskOutcome::Validated { .. }
+            | ExecutionTaskOutcome::Delivered { .. }
+            | ExecutionTaskOutcome::FinalizedDelivered { .. } => None,
         }
     }
 }
@@ -1306,7 +1449,7 @@ impl Future for ExecutionTask {
     }
 }
 
-/// What an execution task got back from the execution layer, reported
+/// What an execution task got back from its single engine call, reported
 /// uninterpreted; [`Actor::handle_execution_task_finished`] decides.
 enum ExecutionTaskOutcome {
     /// The request travels back for its verdict; `None` if the subscriber
@@ -1315,24 +1458,17 @@ enum ExecutionTaskOutcome {
         request: Option<VerifyBlockRequest>,
         status: eyre::Result<(PayloadStatusEnum, Duration)>,
     },
-    /// A notarized block was delivered. `response` answers the forkchoice
-    /// update onto `target` that followed a `VALID` delivery; `None` if none
-    /// was submitted (the delivery failed, or the update was stale).
+    /// A notarized block was delivered through a bare new-payload request.
     Delivered {
         digest: Digest,
-        target: LocalState,
         status: eyre::Result<PayloadStatusEnum>,
-        response: Option<eyre::Result<ForkchoiceUpdated>>,
     },
-    /// The request travels back for its acknowledgement. `response` as for
-    /// [`Self::Delivered`].
+    /// The request travels back for its acknowledgement.
     FinalizedDelivered {
         request: FinalizedBlockRequest,
-        target: LocalState,
         status: eyre::Result<PayloadStatusEnum>,
-        response: Option<eyre::Result<ForkchoiceUpdated>>,
     },
-    /// The raw answer to a bare forkchoice update, together with the build
+    /// The raw answer to a forkchoice update, together with the build
     /// subscriber it carried; `None` if the update was stale and not
     /// submitted.
     Forkchoice {
@@ -1361,16 +1497,9 @@ struct StartPayloadJob {
     response: oneshot::Sender<TempoBuiltPayload>,
 }
 
-/// Submits a forkchoice update onto `target`, with the build's payload
-/// attributes if the build is still wanted.
-///
-/// The caller dispatches a build only when the execution layer's head
-/// already is the parent (see [`Actor::start_next_execution_task`]), so
-/// the forkchoice update re-affirms the head instead of moving it; the
-/// Engine API requires the update regardless, because builds can only be
-/// registered through forkchoice updates. The update is still submitted
-/// when the build is dropped as canceled below - a no-op re-affirmation,
-/// doubling as a head refresh (heartbeats rely on this).
+/// Submits a forkchoice update targeting `target`, with the build's payload
+/// attributes if the build is still wanted. A no-op update is submitted
+/// regardless (heartbeats rely on this).
 #[instrument(
     skip_all,
     parent = &cause,
@@ -1419,9 +1548,7 @@ async fn execute_forkchoice(
     }
 }
 
-/// Delivers a finalized block through a new-payload request and, if the
-/// delivery was `VALID`, follows up with the forkchoice update finalizing
-/// it.
+/// Delivers a finalized block through a bare new-payload request.
 #[instrument(
     skip_all,
     parent = &request.cause,
@@ -1433,27 +1560,13 @@ async fn execute_forkchoice(
 async fn execute_finalization(
     execution_node: impl ExecutionLayer,
     request: FinalizedBlockRequest,
-    target: LocalState,
 ) -> ExecutionTaskOutcome {
     // The validator set can be omitted for finalized blocks.
     let status = deliver_block(&execution_node, request.block.clone(), None).await;
-    let response = match &status {
-        Ok(PayloadStatusEnum::Valid) => {
-            submit_forkchoice_update(&execution_node, request.cause.clone(), target, None).await
-        }
-        _ => None,
-    };
-    ExecutionTaskOutcome::FinalizedDelivered {
-        request,
-        target,
-        status,
-        response,
-    }
+    ExecutionTaskOutcome::FinalizedDelivered { request, status }
 }
 
-/// Delivers a notarized block through a new-payload request and, if the
-/// delivery was `VALID`, follows up with the forkchoice update moving the
-/// head onto it.
+/// Delivers a notarized block through a bare new-payload request.
 #[instrument(
     skip_all,
     fields(
@@ -1461,25 +1574,13 @@ async fn execute_finalization(
         block.height = %block.height(),
     ),
 )]
-async fn execute_notarization(
+async fn execute_delivery(
     execution_node: impl ExecutionLayer,
     block: Arc<Block>,
-    target: LocalState,
 ) -> ExecutionTaskOutcome {
     let digest = block.digest();
     let status = deliver_block(&execution_node, block, None).await;
-    let response = match &status {
-        Ok(PayloadStatusEnum::Valid) => {
-            submit_forkchoice_update(&execution_node, Span::current(), target, None).await
-        }
-        _ => None,
-    };
-    ExecutionTaskOutcome::Delivered {
-        digest,
-        target,
-        status,
-        response,
-    }
+    ExecutionTaskOutcome::Delivered { digest, status }
 }
 
 /// Probes the execution layer with the block to validate and hands the
@@ -1559,6 +1660,58 @@ async fn deliver_block(
     Ok(payload_status.status)
 }
 
+/// Whether `target` finalizes below the execution layer's own finality, so
+/// that submitting it would move finality backwards. The tracked state
+/// trails execution-layer finality after a snapshot restore until the
+/// marshal actor's re-deliveries catch up; a tracked finalized block the
+/// execution layer's canonical chain contradicts is fatal.
+fn is_stale_forkchoice(
+    execution_node: &impl ExecutionLayer,
+    target: LocalState,
+) -> eyre::Result<bool> {
+    let execution_finalized = execution_node.finalized_num_hash();
+    if execution_finalized.number < target.finalized.0.get() {
+        return Ok(false);
+    }
+    let canonical_digest = execution_node
+        .canonical_block_hash(target.finalized.0.get())
+        .wrap_err_with(|| {
+            format!(
+                "failed reading canonical execution block hash at the tracked \
+                finalized height `{}`",
+                target.finalized.0,
+            )
+        })?
+        .ok_or_else(|| {
+            eyre!(
+                "no canonical execution block hash at the tracked finalized height \
+                `{}`, even though it is at or below the execution layer's finalized \
+                height `{}`",
+                target.finalized.0,
+                execution_finalized.number,
+            )
+        })?;
+    ensure!(
+        canonical_digest == target.finalized.1.0,
+        "tracked finalized block `{}` at height `{}` conflicts with the execution \
+        layer's canonical block `{canonical_digest}` at the same height, which the \
+        execution layer already considers final; two different blocks must never be \
+        finalized at the same height",
+        target.finalized.1,
+        target.finalized.0,
+    );
+    if execution_finalized.number > target.finalized.0.get() {
+        debug!(
+            execution_finalized_height = execution_finalized.number,
+            execution_finalized_hash = %execution_finalized.hash,
+            "tracked finalized state is below the execution layer's finalized tip; \
+            skipping the forkchoice update",
+        );
+        return Ok(true);
+    }
+    Ok(false)
+}
+
 /// Drives a payload build on the execution layer to completion.
 ///
 /// Resolves the payload registered under `payload_id` from the execution
@@ -1628,7 +1781,8 @@ async fn run_payload_job(
 
 /// Submits the forkchoice update unless it is stale (see
 /// [`is_stale_forkchoice`]), in which case nothing is sent and `None` is
-/// returned. A failing stale check is reported like a failed update.
+/// returned. A failing stale check is reported like a failed update; the
+/// response is returned raw.
 #[instrument(
     skip_all,
     parent = &cause,
@@ -1662,7 +1816,6 @@ async fn submit_forkchoice_update(
             )));
         }
     };
-
     if fcu_response.is_invalid() {
         warn!(
             payload_status = %fcu_response.payload_status,
@@ -1674,125 +1827,5 @@ async fn submit_forkchoice_update(
             "execution layer reported FCU status",
         );
     }
-
-    if !fcu_response.is_valid() {
-        return Some(
-            Err(Report::msg(fcu_response.payload_status))
-                .wrap_err("forkchoice-update was not valid"),
-        );
-    }
-
     Some(Ok(fcu_response))
-}
-
-/// Whether `target` finalizes below the execution layer's own finality, so
-/// that submitting it would move finality backwards. The tracked state
-/// trails execution-layer finality after a snapshot restore until the
-/// marshal actor's re-deliveries catch up; a tracked finalized block the
-/// execution layer's canonical chain contradicts is fatal.
-fn is_stale_forkchoice(
-    execution_node: &impl ExecutionLayer,
-    target: LocalState,
-) -> eyre::Result<bool> {
-    let execution_finalized = execution_node.finalized_num_hash();
-    if execution_finalized.number < target.finalized.0.get() {
-        return Ok(false);
-    }
-    let canonical_digest = execution_node
-        .canonical_block_hash(target.finalized.0.get())
-        .wrap_err_with(|| {
-            format!(
-                "failed reading canonical execution block hash at the tracked \
-                finalized height `{}`",
-                target.finalized.0,
-            )
-        })?
-        .ok_or_else(|| {
-            eyre!(
-                "no canonical execution block hash at the tracked finalized height \
-                `{}`, even though it is at or below the execution layer's finalized \
-                height `{}`",
-                target.finalized.0,
-                execution_finalized.number,
-            )
-        })?;
-    ensure!(
-        canonical_digest == target.finalized.1.0,
-        "tracked finalized block `{}` at height `{}` conflicts with the execution \
-        layer's canonical block `{canonical_digest}` at the same height, which the \
-        execution layer already considers final; two different blocks must never be \
-        finalized at the same height",
-        target.finalized.1,
-        target.finalized.0,
-    );
-    if execution_finalized.number > target.finalized.0.get() {
-        debug!(
-            execution_finalized_height = execution_finalized.number,
-            execution_finalized_hash = %execution_finalized.hash,
-            "tracked finalized state is below the execution layer's finalized tip; \
-            skipping the forkchoice update",
-        );
-        return Ok(true);
-    }
-    Ok(false)
-}
-
-fn finalization_target(
-    execution_node: &impl ExecutionLayer,
-    canonicalized: LocalState,
-    block: &Block,
-) -> eyre::Result<LocalState> {
-    // All blocks (finalized and notarized) arrive in the EL via the executor
-    // actor. There is no pipeline sync and no other way to drive the EL
-    // forward at this point.
-    //
-    // The tracked finalized state starts at the lower of the execution
-    // layer's finalized tip and the consensus finalized floor - the lowest
-    // point the marshal delivers finalized blocks from. A delivery below the
-    // tracked state is therefore a protocol violation.
-    //
-    // Under normal operation, all blocks arrive in sequence. Only at startup
-    // does the marshal actor forward a block at the height of the finalized
-    // floor (this can include genesis).
-    ensure!(
-        block.height() >= canonicalized.finalized.0,
-        "finalized block with digest `{}` at height `{}` is below the \
-        executor's tracked finalized block `{}` at height `{}`; finalized \
-        blocks must only ever be delivered at or on top of the tracked state",
-        block.digest(),
-        block.height(),
-        canonicalized.finalized.1,
-        canonicalized.finalized.0,
-    );
-
-    if block.height() == canonicalized.finalized.0 {
-        ensure!(
-            block.digest() == canonicalized.finalized.1,
-            "finalized block with digest `{}` at height `{}` conflicts with \
-            the executor's tracked finalized block `{}` at the same height; \
-            two different blocks must never be finalized at the same height",
-            block.digest(),
-            block.height(),
-            canonicalized.finalized.1,
-        );
-        return Ok(canonicalized);
-    }
-
-    let canonical_hash = execution_node
-        .canonical_block_hash(block.height().get())
-        .wrap_err_with(|| {
-            format!(
-                "failed reading canonical execution block hash at finalized block height `{}`",
-                block.height(),
-            )
-        })?;
-    let head_descends_from_finalized = canonical_hash == Some(block.digest().0);
-
-    Ok(if head_descends_from_finalized {
-        canonicalized.update_finalized(block.height(), block.digest())
-    } else {
-        canonicalized
-            .update_finalized(block.height(), block.digest())
-            .update_head(block.height(), block.digest())
-    })
 }

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -87,6 +87,13 @@ use notarized_tree::{LocalState, NotarizedTree};
 /// How often to probe whether the execution layer is ready to process blocks.
 const EXECUTION_LAYER_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
+/// How many `VALID` new-payload answers - validations, notarized and
+/// finalized deliveries alike - are collected before a forkchoice update is
+/// forced. The execution layer persists and prunes relative to its
+/// canonical head, so blocks delivered ahead of the update that
+/// canonicalizes them stay in memory.
+const DELIVERIES_PER_FORKCHOICE_UPDATE: usize = 8;
+
 pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     context: ContextCell<TContext>,
 
@@ -122,6 +129,10 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// forkchoice update that finalizes them before they are acknowledged
     /// to the marshal actor. In height order.
     pending_acknowledgements: VecDeque<FinalizedBlockRequest>,
+
+    /// Blocks delivered since the last forkchoice update, see
+    /// [`DELIVERIES_PER_FORKCHOICE_UPDATE`].
+    deliveries_since_forkchoice: usize,
 
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
@@ -318,6 +329,7 @@ where
 
             pending_finalizations: VecDeque::new(),
             pending_acknowledgements: VecDeque::new(),
+            deliveries_since_forkchoice: 0,
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -527,6 +539,7 @@ where
         let verdict = match status {
             Ok((PayloadStatusEnum::Valid, duration)) => {
                 self.notarized_tree.mark_delivered(&digest);
+                self.deliveries_since_forkchoice += 1;
                 Some(duration)
             }
             Ok((PayloadStatusEnum::Invalid { validation_error }, _)) => {
@@ -646,6 +659,7 @@ where
         match status {
             Ok(PayloadStatusEnum::Valid) => {
                 self.notarized_tree.mark_delivered(&digest);
+                self.deliveries_since_forkchoice += 1;
                 Ok(())
             }
             Ok(status) => {
@@ -706,6 +720,7 @@ where
 
         self.notarized_tree
             .set_delivered_finalized(block.height(), block.digest());
+        self.deliveries_since_forkchoice += 1;
         if block.height() <= self.notarized_tree.local_state().finalized.0 {
             // NOTE: this block is already final on the execution layer. This
             // can happen if marshal is anchored below the EL and delivers
@@ -809,8 +824,9 @@ where
 
     /// Climbs from the tracked finalized state to the finalized floor
     /// before entering the loop, through the regular finalization tasks
-    /// and their outcome handling, awaited in place. One forkchoice update
-    /// at the floor finalizes the delivered blocks.
+    /// and their outcome handling, awaited in place. Every
+    /// [`DELIVERIES_PER_FORKCHOICE_UPDATE`] delivered blocks, and at the
+    /// floor, a forkchoice update finalizes them.
     #[instrument(skip_all, err)]
     async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
         let start = self.notarized_tree.local_state().finalized.0.get() + 1;
@@ -851,7 +867,10 @@ where
                     )
                 })?;
 
-            if height == end && self.start_forkchoice_update()? {
+            if (self.deliveries_since_forkchoice >= DELIVERIES_PER_FORKCHOICE_UPDATE
+                || height == end)
+                && self.start_forkchoice_update()?
+            {
                 let finished = (&mut self.execution_task).await;
                 self.handle_execution_task_finished(finished)
                     .wrap_err_with(|| {
@@ -1057,9 +1076,10 @@ where
                 .converges_imminently(digest, self.context.current())
     }
 
-    /// Picks the next execution task: consensus request, finalized
-    /// deliveries, the forkchoice update finalizing them, notarized
-    /// deliveries, the forkchoice update moving the head. Finality goes
+    /// Picks the next execution task: consensus request, the forkchoice
+    /// update forced by a long run of deliveries, finalized deliveries, the
+    /// forkchoice update finalizing them, notarized deliveries, the
+    /// forkchoice update moving the head. Finality goes
     /// first so a long notarized run never holds up acknowledgements;
     /// deliveries go before the update so one update covers a whole run.
     #[instrument(
@@ -1134,6 +1154,14 @@ where
             None => {}
         }
 
+        // Too many blocks delivered since the last forkchoice update: lock
+        // them in before delivering more.
+        if self.deliveries_since_forkchoice >= DELIVERIES_PER_FORKCHOICE_UPDATE
+            && self.start_forkchoice_update()?
+        {
+            return Ok(());
+        }
+
         // Finalizations are delivered in order and acknowledged so that the
         // marshal actor can make progress. Every finalized block is
         // delivered, whether or not the execution layer is thought to know
@@ -1196,6 +1224,9 @@ where
     /// Starts the forkchoice update onto the next target, if any; returns
     /// whether it did.
     fn start_forkchoice_update(&mut self) -> eyre::Result<bool> {
+        // Whatever was delivered is either covered by the update below or
+        // cannot be canonicalized by any update.
+        self.deliveries_since_forkchoice = 0;
         let Some(target) = self.next_forkchoice_target()? else {
             return Ok(false);
         };

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -134,6 +134,12 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// [`DELIVERIES_PER_FORKCHOICE_UPDATE`].
     deliveries_since_forkchoice: usize,
 
+    /// The round of the newest consensus context whose parent was recorded
+    /// as the pending head. Reports come from concurrently running proposal
+    /// and verification handlers and can arrive out of order; an older
+    /// round's report must not supersede a newer one.
+    pending_head_reported_in: Round,
+
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
     /// slot because a node either verifies or proposes in a round, never
@@ -330,6 +336,7 @@ where
             pending_finalizations: VecDeque::new(),
             pending_acknowledgements: VecDeque::new(),
             deliveries_since_forkchoice: 0,
+            pending_head_reported_in: finalized_tip.0,
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -997,6 +1004,15 @@ where
         fields(digest = %context.parent.1),
     )]
     fn record_pending_head(&mut self, context: Context<Digest, PublicKey>) {
+        if context.round < self.pending_head_reported_in {
+            debug!(
+                round = %context.round,
+                newest = %self.pending_head_reported_in,
+                "ignoring pending head report from an older round",
+            );
+            return;
+        }
+        self.pending_head_reported_in = context.round;
         self.notarized_tree.set_pending_head(
             Round::new(context.round.epoch(), context.parent.0),
             context.parent.1,

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -687,7 +687,8 @@ where
     /// A non-`VALID` answer is fatal. Otherwise the block becomes the next
     /// finalized target and is acknowledged once the forkchoice update
     /// finalizing it lands - or right away if the execution layer already
-    /// finalized it (a re-delivery).
+    /// finalized it (a re-delivery). The marshal actor delivers the
+    /// finalized chain in order; that order is trusted, not checked.
     #[instrument(
         skip_all,
         fields(
@@ -862,7 +863,6 @@ where
                 block: Arc::new(block),
                 acknowledgment: ack,
             };
-            self.check_finalized_delivery_order(request.block.as_ref())?;
             let fut = execute_finalization(self.execution_node.clone(), request);
             self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Finalize, fut));
             let finished = (&mut self.execution_task).await;
@@ -1190,7 +1190,6 @@ where
         // it: a known block is answered `VALID` from its caches without
         // being executed again.
         if let Some(request) = self.pending_finalizations.pop_front() {
-            self.check_finalized_delivery_order(request.block.as_ref())?;
             let fut = execute_finalization(self.execution_node.clone(), request);
             self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Finalize, fut));
             return Ok(());
@@ -1211,35 +1210,6 @@ where
         }
 
         self.start_forkchoice_update()?;
-        Ok(())
-    }
-
-    /// Finalized blocks are delivered in order, at or above the tracked
-    /// finalized block: a delivery below it is a protocol violation, and a
-    /// different block at its height means two blocks were finalized at the
-    /// same height.
-    fn check_finalized_delivery_order(&self, block: &Block) -> eyre::Result<()> {
-        let (finalized_height, finalized_digest) = self.notarized_tree.local_state().finalized;
-        ensure!(
-            block.height() >= finalized_height,
-            "finalized block with digest `{}` at height `{}` is below the \
-            executor's tracked finalized block `{finalized_digest}` at height \
-            `{finalized_height}`; finalized blocks must only ever be delivered \
-            at or on top of the tracked state",
-            block.digest(),
-            block.height(),
-        );
-        if block.height() == finalized_height {
-            ensure!(
-                block.digest() == finalized_digest,
-                "finalized block with digest `{}` at height `{}` conflicts with \
-                the executor's tracked finalized block `{finalized_digest}` at the \
-                same height; two different blocks must never be finalized at the \
-                same height",
-                block.digest(),
-                block.height(),
-            );
-        }
         Ok(())
     }
 

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -189,6 +189,13 @@ pub(super) struct Depths {
 
 /// The next convergence step toward the pending head, returned by
 /// [`NotarizedTree::next_to_forward`].
+#[cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "superseded by `next_to_deliver` and `next_head`; removed next"
+    )
+)]
 #[derive(Debug)]
 pub(super) enum NextToForward {
     /// Forward this block: a new-payload request followed by a forkchoice
@@ -199,6 +206,10 @@ pub(super) enum NextToForward {
     Repoint(Height, Digest),
 }
 
+#[expect(
+    dead_code,
+    reason = "superseded by `next_to_deliver` and `next_head`; removed next"
+)]
 impl NextToForward {
     /// The digest of the block the step converges the head onto.
     pub(super) fn digest(&self) -> Digest {
@@ -299,6 +310,10 @@ impl NotarizedTree {
     }
 
     /// Returns if `digest` is at the head or finalized tip of the tracked EL state.
+    #[expect(
+        dead_code,
+        reason = "superseded by `next_to_deliver` and `next_head`; removed next"
+    )]
     pub(super) fn is_local_notarized_or_finalized_tip(&self, digest: Digest) -> bool {
         self.local_head.1 == digest || self.local_finalized_tip.1 == digest
     }
@@ -308,28 +323,16 @@ impl NotarizedTree {
         self.local_head.1 == digest
     }
 
-    /// Whether convergence is expected to make `digest` known to the
-    /// execution layer imminently (or if the execution layer is already
-    /// converged).
-    ///
-    /// These are the conditions:
-    ///
-    /// 1. `digest` is the local finalized tip or head, or
-    /// 2. `digest` is the network finalized tip, and the network finalized
-    ///    tip is the next block to be delivered (known fact: marshal only
-    ///    delivers finalized tips if a certificate and block are available).
-    /// 3. `digest` is the pending head, its body is in hand, and it sits
-    ///    directly on a converged anchor - the local head, or the local
-    ///    finalized tip for a fork switch replayed from the tip. One
-    ///    forward step remains either way.
-    pub(super) fn converges_imminently(&self, digest: Digest) -> bool {
-        self.is_local_notarized_or_finalized_tip(digest)
+    /// Whether `digest` is the next thing convergence does: the head target
+    /// of the next forkchoice update, the next block to deliver, or the next
+    /// finalized block the marshal actor delivers.
+    pub(super) fn converges_imminently(&self, digest: Digest, now: SystemTime) -> bool {
+        self.next_head().is_some_and(|(_, head)| head == digest)
+            || self
+                .next_to_deliver(now)
+                .is_some_and(|block| block.digest() == digest)
             || (self.network_finalized_tip.2 == digest
-                && self.local_finalized_tip.0.next() == self.network_finalized_tip.1)
-            || (self.pending_head.digest == digest
-                && self.blocks.get(&digest).is_some_and(|entry| {
-                    self.is_local_notarized_or_finalized_tip(entry.block.parent_digest())
-                }))
+                && self.delivered_finalized.0.next() == self.network_finalized_tip.1)
     }
 
     /// Records an accepted forkchoice state. A finalized block the tree did
@@ -477,6 +480,13 @@ impl NotarizedTree {
     /// *NOTE:* This digest right now only works for the finalized tip.
     ///
     /// **FIXME:** Allow for repointing to any ancestor.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "superseded by `next_to_deliver` and `next_head`; removed next"
+        )
+    )]
     pub(super) fn next_to_forward(&self, now: SystemTime) -> Option<NextToForward> {
         if self.local_finalized_tip.0 < self.network_finalized_tip.1 {
             return None;
@@ -542,15 +552,12 @@ impl NotarizedTree {
 
 /// What the execution layer has, and the two walks that follow from it:
 /// the next block to deliver and the next block to make the head.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "the scheduler switches from `next_to_forward` to these walks next"
-    )
-)]
 impl NotarizedTree {
     /// The block consensus reported building on: the convergence target.
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "the build gate switches to the pending head next")
+    )]
     pub(super) fn pending_head(&self) -> Digest {
         self.pending_head.digest
     }

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -445,10 +445,6 @@ impl NotarizedTree {
 /// the next block to deliver and the next block to make the head.
 impl NotarizedTree {
     /// The block consensus reported building on: the convergence target.
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "the build gate switches to the pending head next")
-    )]
     pub(super) fn pending_head(&self) -> Digest {
         self.pending_head.digest
     }

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -96,8 +96,9 @@ impl LocalState {
     }
 }
 
-/// Tracks notarized blocks at the tip of the chain and returns which block can
-/// be forwarded to the EL next.
+/// Tracks notarized blocks at the tip of the chain and returns which block
+/// can be delivered to the execution layer next, and which block the
+/// execution layer's head can be moved onto.
 ///
 /// The canonical target is `pending_head`: the parent of the most recent
 /// consensus context. This is expected to be reported by the simplex engine via
@@ -117,15 +118,6 @@ impl LocalState {
 ///
 /// The tree holds data strictly above the finalized *network* tip,
 /// which it tracks itself: recording and pruning are guarded against it.
-///
-/// The tree is self-canonicalizing: [`Self::next_to_forward`] walks the
-/// pending head's ancestry down to the nearest *anchor* the execution
-/// layer provably has - its own head, or the network's finalized tip -
-/// and hands out the block directly above it, derived fresh on every
-/// query. There is no cached convergence state that could go stale
-/// against a fork. When the pending head is the finalized tip itself,
-/// there is no block above the anchor: the step is a bare forkchoice
-/// update repointing the head onto the tip.
 ///
 /// # Delivery and forkchoice are separate steps
 ///
@@ -153,8 +145,7 @@ pub(super) struct NotarizedTree {
     delivered_finalized: (Height, Digest),
     /// The finalized tip as canonicalized on the execution layer: the
     /// finalized side of the last accepted forkchoice state. Trails
-    /// `network_finalized_tip` until the finalization pipeline catches up,
-    /// which forwarding is gated on.
+    /// `delivered_finalized` until the forkchoice update lands.
     local_finalized_tip: (Height, Digest),
     /// The pending head reported by the most recent consensus context: the
     /// tip of the canonical path the execution layer's head is converged
@@ -185,47 +176,6 @@ pub(super) struct Depths {
     /// Number of held blocks the execution layer accepted that are not on
     /// its canonical chain: delivered above the head, or on other branches.
     pub(super) uncanonicalized_blocks: usize,
-}
-
-/// The next convergence step toward the pending head, returned by
-/// [`NotarizedTree::next_to_forward`].
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "superseded by `next_to_deliver` and `next_head`; removed next"
-    )
-)]
-#[derive(Debug)]
-pub(super) enum NextToForward {
-    /// Forward this block: a new-payload request followed by a forkchoice
-    /// update making it the head.
-    Block(Arc<Block>),
-    /// Repoint the head onto the already-known finalized tip with a bare
-    /// forkchoice update; there is no block to deliver.
-    Repoint(Height, Digest),
-}
-
-#[expect(
-    dead_code,
-    reason = "superseded by `next_to_deliver` and `next_head`; removed next"
-)]
-impl NextToForward {
-    /// The digest of the block the step converges the head onto.
-    pub(super) fn digest(&self) -> Digest {
-        match self {
-            Self::Block(block) => block.digest(),
-            Self::Repoint(_, digest) => *digest,
-        }
-    }
-
-    /// The height of the block the step converges the head onto.
-    pub(super) fn height(&self) -> Height {
-        match self {
-            Self::Block(block) => block.height(),
-            Self::Repoint(height, _) => *height,
-        }
-    }
 }
 
 /// The parent of the most recent consensus context: the notarized block
@@ -309,15 +259,6 @@ impl NotarizedTree {
         }
     }
 
-    /// Returns if `digest` is at the head or finalized tip of the tracked EL state.
-    #[expect(
-        dead_code,
-        reason = "superseded by `next_to_deliver` and `next_head`; removed next"
-    )]
-    pub(super) fn is_local_notarized_or_finalized_tip(&self, digest: Digest) -> bool {
-        self.local_head.1 == digest || self.local_finalized_tip.1 == digest
-    }
-
     /// Returns if `digest` is at the head of the tracked EL state.
     pub(super) fn is_local_head(&self, digest: Digest) -> bool {
         self.local_head.1 == digest
@@ -398,12 +339,11 @@ impl NotarizedTree {
     /// traded for recovery speed, bounded by the advancing finalized tip,
     /// which sweeps everything it passes.
     pub(super) fn heal(&mut self) {
-        // `first_missing_ancestor`, `next_to_forward`, `next_to_deliver` and
-        // `next_head` bound their walks by the network's finalized tip,
-        // which is only correct while the locally canonicalized finalized
-        // tip does not run ahead of it. The marshal actor upholds this: it
-        // reports a finalized tip before delivering the finalized blocks
-        // covered by it.
+        // `first_missing_ancestor`, `next_to_deliver` and `next_head` bound
+        // their walks by the network's finalized tip, which is only correct
+        // while the locally canonicalized finalized tip does not run ahead
+        // of it. The marshal actor upholds this: it reports a finalized tip
+        // before delivering the finalized blocks covered by it.
         debug_assert!(
             self.local_finalized_tip.0 <= self.network_finalized_tip.1,
             "the locally canonicalized finalized tip must never run ahead of \
@@ -466,55 +406,6 @@ impl NotarizedTree {
                 %digest,
                 "ignoring finalized tip that does not advance the tracked one",
             );
-        }
-    }
-
-    /// Returns the next convergence step toward the pending head.
-    ///
-    /// Returns a block if it is directly above the anchor (this can be
-    /// the local head or local finalized tip).
-    ///
-    /// Returns just a digest if the execution layer is to be re-pointed to the
-    /// an ancestor of the current local head.
-    ///
-    /// *NOTE:* This digest right now only works for the finalized tip.
-    ///
-    /// **FIXME:** Allow for repointing to any ancestor.
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "superseded by `next_to_deliver` and `next_head`; removed next"
-        )
-    )]
-    pub(super) fn next_to_forward(&self, now: SystemTime) -> Option<NextToForward> {
-        if self.local_finalized_tip.0 < self.network_finalized_tip.1 {
-            return None;
-        }
-        let (_, finalized_height, finalized_digest) = self.network_finalized_tip;
-
-        let mut child: Option<&BlockEntry> = None;
-        let mut digest = self.pending_head.digest;
-        while digest != self.local_head.1 && digest != finalized_digest {
-            let entry = self.blocks.get(&digest)?;
-            if entry.block.height() <= finalized_height {
-                return None;
-            }
-            child = Some(entry);
-            digest = entry.block.parent_digest();
-        }
-        match child {
-            Some(entry) => entry
-                .forwardable(now)
-                .then(|| NextToForward::Block(entry.block.clone())),
-            // If the anchor is the local finalized tip and the notarized branch
-            // is stranded, repoint to the finalized tip.
-            //
-            // NOTE: This works because we short-circuit on
-            // `local_finalized < network_finalized`. If we did not do that,
-            // this would potentially trigger a SYNCING.
-            None => (digest == finalized_digest && self.local_head.1 != finalized_digest)
-                .then_some(NextToForward::Repoint(finalized_height, finalized_digest)),
         }
     }
 

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -7,7 +7,7 @@ use commonware_consensus::{CertifiableBlock as _, Heightable as _};
 
 use std::time::{Duration, SystemTime};
 
-use super::{LocalState, NOTARIZED_REJECTION_RETRY_DELAY, NextToForward, NotarizedTree};
+use super::{LocalState, NOTARIZED_REJECTION_RETRY_DELAY, NotarizedTree};
 use crate::consensus::{Digest, block::Block};
 
 /// The reference "now" for tree queries; tests state rejection times
@@ -75,18 +75,6 @@ fn record(tree: &mut NotarizedTree, block: &Block) {
     tree.heal();
 }
 
-/// The next block to forward, if any; panics if the next convergence step
-/// is a repoint instead of a block.
-fn next_block(tree: &NotarizedTree, now: SystemTime) -> Option<std::sync::Arc<Block>> {
-    match tree.next_to_forward(now) {
-        Some(NextToForward::Block(block)) => Some(block),
-        Some(NextToForward::Repoint(height, digest)) => {
-            panic!("expected a block to forward, got a repoint to `{digest}` at `{height}`")
-        }
-        None => None,
-    }
-}
-
 /// Simulates the completed forward of `block`: the execution layer
 /// accepted it as its new head, and the resulting forkchoice state is
 /// reported back into the tree.
@@ -115,27 +103,6 @@ fn converged(tree: &mut NotarizedTree, block: &Block) {
 }
 
 #[test]
-fn forwards_chain_on_top_of_finalized_tip_in_order() {
-    let finalized = Digest(B256::repeat_byte(0xff));
-    let mut tree = empty_tree(finalized);
-
-    let a = block(1, 11, finalized);
-    let b = block(2, 12, a.digest());
-    record(&mut tree, &a);
-    record(&mut tree, &b);
-
-    let next = next_block(&tree, T0).expect("chain start");
-    assert_eq!(next.digest(), a.digest());
-
-    forwarded(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain continues");
-    assert_eq!(next.digest(), b.digest());
-
-    forwarded(&mut tree, &b);
-    assert!(next_block(&tree, T0).is_none());
-}
-
-#[test]
 fn sibling_notarized_in_later_round_supersedes() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
@@ -143,63 +110,16 @@ fn sibling_notarized_in_later_round_supersedes() {
     let a1 = block(1, 11, finalized);
     let a2 = block(2, 11, finalized);
     record(&mut tree, &a1);
-    // The stale sibling was forwarded and become the head ...
-    forwarded(&mut tree, &a1);
+    // The stale sibling was converged onto and became the head ...
+    converged(&mut tree, &a1);
 
     // ... but a report of its sibling redefines the canonical path; the
     // walk anchors at the finalized tip, and the superseding sibling is
-    // forwarded next.
+    // delivered next and then made the head.
     record(&mut tree, &a2);
-    let next = next_block(&tree, T0).expect("supersede fork");
-    assert_eq!(next.digest(), a2.digest());
-}
-
-#[test]
-fn fork_replays_from_the_nearest_anchor() {
-    let finalized = Digest(B256::repeat_byte(0xff));
-    let mut tree = empty_tree(finalized);
-
-    // F - N0 - N1 - N2 is forwarded in full ...
-    let n0 = block(1, 11, finalized);
-    let n1 = block(2, 12, n0.digest());
-    let n2 = block(3, 13, n1.digest());
-    record(&mut tree, &n0);
-    record(&mut tree, &n1);
-    record(&mut tree, &n2);
-    forwarded(&mut tree, &n2);
-    assert!(next_block(&tree, T0).is_none());
-
-    // ... when F - N0 - N1' - N3 becomes the canonical chain. The report
-    // arrives before the bodies; forwarding stalls until the ancestry
-    // is walkable.
-    let n1p = block(4, 12, n0.digest());
-    let n3 = block(5, 13, n1p.digest());
-    report_parent(&mut tree, &n3);
-    tree.heal();
-    assert!(next_block(&tree, T0).is_none());
-
-    // N3's body arrives, but its parent N1' is still missing: the
-    // ancestry does not reach down to a block the execution layer has.
-    tree.record_block(n3.clone().into());
-    tree.heal();
-    assert!(next_block(&tree, T0).is_none());
-
-    // N1' arrives via the fetch machinery, completing the ancestry. The
-    // head (N2) sits off the new canonical path and is no anchor, so the
-    // walk runs to the finalized tip and the path is replayed from there:
-    // the trunk block N0 - already known to the execution layer, which
-    // answers it from its caches - comes first, then the fork branch.
-    tree.record_block(n1p.clone().into());
-    tree.heal();
-
-    let next = next_block(&tree, T0).expect("trunk replay");
-    assert_eq!(next.digest(), n0.digest());
-    forwarded(&mut tree, &n0);
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), n1p.digest());
-    forwarded(&mut tree, &n1p);
-    let next = next_block(&tree, T0).expect("fork tip");
-    assert_eq!(next.digest(), n3.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(a2.digest()));
+    delivered(&mut tree, &a2);
+    assert_eq!(tree.next_head(), Some((Height::new(11), a2.digest())));
 }
 
 #[test]
@@ -207,12 +127,13 @@ fn fork_during_ancestor_fetch_keeps_the_fetch_target() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // F - N1 - N2 is forwarded in full ...
+    // F - N1 - N2 is converged onto in full ...
     let n1 = block(1, 11, finalized);
     let n2 = block(2, 12, n1.digest());
     record(&mut tree, &n1);
     record(&mut tree, &n2);
-    forwarded(&mut tree, &n2);
+    delivered(&mut tree, &n1);
+    converged(&mut tree, &n2);
 
     // ... when the chain forks to F - N3 - N4. N3's report arrives first
     // (from the context preceding N4's validation) and becomes the
@@ -230,24 +151,25 @@ fn fork_during_ancestor_fetch_keeps_the_fetch_target() {
     tree.heal();
 
     // ... and the fetch target is unchanged — N3, re-derived from N4's
-    // context — so the in-flight fetch for N3 is kept, and forwarding
+    // context — so the in-flight fetch for N3 is kept, and delivery
     // stalls on the gap meanwhile.
     assert_eq!(tree.first_missing_ancestor(), Some((round(3), n3.digest())),);
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
 
     // The landed fetch delivers N3's body, completing the ancestry down
-    // to the finalized tip - the anchor while the head sits on the
-    // orphaned branch.
+    // to the finalized tip - the nearest known block while the head sits
+    // on the orphaned branch.
     tree.record_block(n3.clone().into());
     tree.heal();
 
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), n3.digest());
-    forwarded(&mut tree, &n3);
-    let next = next_block(&tree, T0).expect("fork tip");
-    assert_eq!(next.digest(), n4.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(n3.digest()));
+    delivered(&mut tree, &n3);
+    assert_eq!(next_delivery(&tree, T0), Some(n4.digest()));
+    delivered(&mut tree, &n4);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(), Some((Height::new(12), n4.digest())));
     forwarded(&mut tree, &n4);
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(tree.next_head(), None);
 }
 
 #[test]
@@ -263,16 +185,15 @@ fn heads_off_the_canonical_path_are_no_anchor() {
     record(&mut tree, &b2);
 
     // A head off the canonical path (b1 was superseded by b2) is no
-    // anchor: the walk runs to the finalized tip, and the path is
-    // replayed from there - the common parent a first (a cached no-op
-    // for the execution layer), then the superseding sibling.
-    forwarded(&mut tree, &a);
-    forwarded(&mut tree, &b1);
-    let next = next_block(&tree, T0).expect("replayed parent");
-    assert_eq!(next.digest(), a.digest());
-    forwarded(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain continues");
-    assert_eq!(next.digest(), b2.digest());
+    // anchor: the superseding sibling is delivered on top of the common
+    // parent a, which the execution layer knows, and the head - until b2
+    // is delivered - can only be moved back onto a.
+    delivered(&mut tree, &a);
+    converged(&mut tree, &b1);
+    assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
+    assert_eq!(tree.next_head(), Some((Height::new(11), a.digest())));
+    delivered(&mut tree, &b2);
+    assert_eq!(tree.next_head(), Some((Height::new(12), b2.digest())));
 }
 
 #[test]
@@ -288,8 +209,9 @@ fn missing_body_caps_the_chain() {
     report_parent(&mut tree, &b);
     record(&mut tree, &c);
 
-    forwarded(&mut tree, &a);
-    assert!(next_block(&tree, T0).is_none());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(), None);
 }
 
 #[test]
@@ -375,7 +297,7 @@ fn finalized_tip_never_regresses() {
     record(&mut tree, &b);
     tree.set_network_finalized_tip(round(1), Height::new(11), a.digest());
     tree.heal();
-    forwarded(&mut tree, &b);
+    converged(&mut tree, &b);
 
     // A tip below the tracked one (replayed on startup) is ignored: the
     // boundary, the tree's data, and the local head stay untouched.
@@ -445,11 +367,11 @@ fn validation_cached_ancestors_complete_the_ancestry_without_a_fetch() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // The old fork F - A is forwarded in full ...
+    // The old fork F - A is converged onto in full ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
-    forwarded(&mut tree, &a);
-    assert!(next_block(&tree, T0).is_none());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), None);
 
     // ... while the winning fork's ancestor B1 is cached by its validation
     // — a body without any report; it is never named a pending head.
@@ -466,14 +388,11 @@ fn validation_cached_ancestors_complete_the_ancestry_without_a_fetch() {
     tree.heal();
     assert_eq!(tree.first_missing_ancestor(), None);
 
-    // ... but the heal pass walks the ancestry and re-roots the stranded
-    // meet down to the fork point, and the fork branch is forwarded
-    // from its start.
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), b1.digest());
-    forwarded(&mut tree, &b1);
-    let next = next_block(&tree, T0).expect("fork tip");
-    assert_eq!(next.digest(), b2.digest());
+    // ... but the walk down the ancestry finds the fork point at the
+    // finalized tip, and the fork branch is delivered from its start.
+    assert_eq!(next_delivery(&tree, T0), Some(b1.digest()));
+    delivered(&mut tree, &b1);
+    assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
 }
 
 #[test]
@@ -481,12 +400,13 @@ fn finalized_tip_reroots_a_head_stranded_on_an_orphaned_branch() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // The fork F - A1 - A2 is reported and forwarded in full ...
+    // The fork F - A1 - A2 is reported and converged onto in full ...
     let a1 = block(1, 11, finalized);
     let a2 = block(2, 12, a1.digest());
     record(&mut tree, &a1);
     record(&mut tree, &a2);
-    forwarded(&mut tree, &a2);
+    delivered(&mut tree, &a1);
+    converged(&mut tree, &a2);
 
     // ... when the network finalizes B1, A1's sibling, orphaning the
     // branch the head sits on. The heal pass re-sets the fork's pending
@@ -497,74 +417,26 @@ fn finalized_tip_reroots_a_head_stranded_on_an_orphaned_branch() {
     tree.heal();
     assert_eq!(tree.pending_head.digest, b1.digest());
 
-    // The finalization pipeline delivers B1; the head - sitting on the
-    // orphaned branch - is rebased onto it (mirroring
-    // `forward_finalized`), which also reopens the forwarding gate.
+    // Nothing can be named while B1 is undelivered; its delivery through
+    // the finalization pipeline makes it the head target (a repoint) ...
+    assert_eq!(tree.next_head(), None);
+    tree.set_delivered_finalized(Height::new(11), b1.digest());
+    assert_eq!(tree.next_head(), Some((Height::new(11), b1.digest())));
+
+    // ... and the accepted forkchoice update rebases the stranded head.
     let local_state = tree
         .local_state()
         .update_finalized(Height::new(11), b1.digest())
         .update_head(Height::new(11), b1.digest());
     tree.set_local_state(local_state);
+    assert_eq!(tree.next_head(), None);
 
-    // The next report builds on B2: the rebased head B1 anchors the
-    // walk, so B2 is forwarded without any fetch.
+    // The next report builds on B2: the rebased head B1 is known, so B2
+    // is delivered without any fetch.
     report_parent(&mut tree, &b2);
     tree.record_block(b2.clone().into());
     tree.heal();
-    let next = next_block(&tree, T0).expect("fork branch");
-    assert_eq!(next.digest(), b2.digest());
-}
-
-/// The deferral predicate for consensus requests: a parent converges
-/// imminently when the execution layer already has it (head or finalized
-/// tip), or when it is the pending head, its body in hand, one forward
-/// step above a converged anchor - and does not when it is further out,
-/// its body needs a fetch, or it belongs to a superseded report.
-/// The deferral predicate for consensus requests: a block is imminent when
-/// it is the next block to deliver or the next head target, and not when it
-/// is further out, its body needs a fetch, or it is already converged.
-#[test]
-fn convergence_is_imminent_for_the_next_delivery_or_head_target() {
-    let finalized = Digest(B256::repeat_byte(0xff));
-    let mut tree = empty_tree(finalized);
-
-    // The converged finalized tip is nothing convergence still does;
-    // callers check for known blocks first.
-    assert!(!tree.converges_imminently(finalized, T0));
-
-    // A pending head whose recorded body sits directly on a known block
-    // (here the finalized tip) is the next delivery ...
-    let a = block(1, 11, finalized);
-    record(&mut tree, &a);
-    assert!(tree.converges_imminently(a.digest(), T0));
-
-    // ... but two deliveries away is not imminent: a needs a delivery
-    // first. The delivery alone suffices; the head need not move.
-    let b = block(2, 12, a.digest());
-    record(&mut tree, &b);
-    assert!(!tree.converges_imminently(b.digest(), T0));
-    delivered(&mut tree, &a);
-    assert!(tree.converges_imminently(b.digest(), T0));
-    // The delivered a is the next head target: imminent as well.
-    assert!(tree.converges_imminently(a.digest(), T0));
-
-    // A pending head whose body is not in hand needs a fetch first: the
-    // report alone does not make it imminent.
-    let c = block(3, 13, b.digest());
-    report_parent(&mut tree, &c);
-    tree.heal();
-    assert!(!tree.converges_imminently(c.digest(), T0));
-
-    // A sibling fork one step above the finalized tip is imminent even
-    // though it is not the head's child: it is delivered directly on top
-    // of the tip.
-    let a2 = block(4, 11, finalized);
-    record(&mut tree, &a2);
-    assert!(tree.converges_imminently(a2.digest(), T0));
-
-    // A withheld block is not delivered next.
-    tree.mark_rejected(&a2.digest(), T0);
-    assert!(!tree.converges_imminently(a2.digest(), T0));
+    assert_eq!(next_delivery(&tree, T0), Some(b2.digest()));
 }
 
 /// The tree's convergence measures: block-body count, the undelivered
@@ -605,7 +477,8 @@ fn depths_measure_backlogs() {
     assert_eq!(tree.depths().convergence_depth, None);
 
     // A re-anchor below the head measures negative.
-    forwarded(&mut tree, &b);
+    delivered(&mut tree, &a);
+    converged(&mut tree, &b);
     tree.set_pending_head(round(4), a.digest());
     assert_eq!(tree.depths().convergence_depth, Some(-1));
 
@@ -640,103 +513,38 @@ fn next_finalized_delivery_is_imminent() {
     assert!(tree.converges_imminently(above.digest(), T0));
 }
 
-/// A head stranded on an abandoned notarized branch while consensus
-/// re-anchors on the (already forwarded) finalized tip itself: the walk in
-/// `next_to_forward` cannot reach an anchor - it only hands out blocks
-/// strictly above one - so `repoint_to_finalized_tip` must take over and
-/// report the tip to repoint the head onto.
-#[test]
-fn stranded_head_is_repointed_onto_the_finalized_tip() {
-    let finalized = Digest(B256::repeat_byte(0xff));
-    let mut tree = empty_tree(finalized);
-
-    // No convergence step while the head sits on the finalized tip.
-    assert!(tree.next_to_forward(T0).is_none());
-
-    // A block is notarized and forwarded, then its view nullifies and the
-    // network abandons it; consensus re-anchors on the finalized tip.
-    let abandoned = block(1, 11, finalized);
-    record(&mut tree, &abandoned);
-    forwarded(&mut tree, &abandoned);
-    tree.set_pending_head(round(0), finalized);
-    tree.heal();
-
-    // There is no block above the anchor to hand out; the step is the
-    // repoint.
-    let Some(NextToForward::Repoint(height, digest)) = tree.next_to_forward(T0) else {
-        panic!("stranded head must be repointed");
-    };
-    assert_eq!((height, digest), (Height::new(10), finalized));
-
-    // The repoint forkchoice update is accepted: the head is back on the
-    // tip and there is nothing left to do.
-    let local_state = tree.local_state().update_head(height, digest);
-    tree.set_local_state(local_state);
-    assert_eq!(tree.local_state().head, (Height::new(10), finalized));
-    assert!(tree.next_to_forward(T0).is_none());
-}
-
-/// No repoint while the finalized-block delivery for the tip is still
-/// outstanding: the finalization pipeline moves the head then.
-#[test]
-fn no_repoint_while_the_finalized_tip_delivery_is_outstanding() {
-    let finalized = Digest(B256::repeat_byte(0xff));
-    let mut tree = empty_tree(finalized);
-
-    let a1 = block(1, 11, finalized);
-    record(&mut tree, &a1);
-    forwarded(&mut tree, &a1);
-
-    // A sibling of the forwarded block finalizes; its delivery has not
-    // arrived yet. A report re-anchoring on it must not trigger a repoint.
-    let b1 = block(2, 11, finalized);
-    tree.set_network_finalized_tip(round(2), Height::new(11), b1.digest());
-    tree.set_pending_head(round(2), b1.digest());
-    tree.heal();
-    assert!(tree.next_to_forward(T0).is_none());
-
-    // The delivery lands (mirroring `forward_finalized`), rebasing the
-    // head; there is nothing left to repoint.
-    let local_state = tree
-        .local_state()
-        .update_finalized(Height::new(11), b1.digest())
-        .update_head(Height::new(11), b1.digest());
-    tree.set_local_state(local_state);
-    assert!(tree.next_to_forward(T0).is_none());
-}
-
 #[test]
 fn reported_parents_supersede_by_report_order_not_notarization_order() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // X and its child Y are forwarded in full ...
+    // X and its child Y are converged onto in full ...
     let x = block(1, 11, finalized);
     let y = block(2, 12, x.digest());
     record(&mut tree, &x);
     record(&mut tree, &y);
-    forwarded(&mut tree, &y);
-    assert!(next_block(&tree, T0).is_none());
+    delivered(&mut tree, &x);
+    converged(&mut tree, &y);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(), None);
 
     // ... but Y never certifies, and a later context reports the *older*
-    // X as the parent being built on. With the head still on Y - not on
-    // X's ancestry - the walk anchors at the finalized tip and hands out
-    // X itself, so that its forkchoice update repoints the head.
+    // X as the parent being built on. X is known to the execution layer:
+    // nothing is delivered, the head is repointed onto X directly.
     report_parent(&mut tree, &x);
     tree.heal();
-    let next = next_block(&tree, T0).expect("repoint to older parent");
-    assert_eq!(next.digest(), x.digest());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(), Some((Height::new(11), x.digest())));
     // Once the head is X, there is nothing left to do.
     forwarded(&mut tree, &x);
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(tree.next_head(), None);
 
     // A context building on Y again re-roots forward: Y is the pending
-    // head once more and, with the head on X, is simply the next block
-    // to forward.
+    // head once more and, being known, simply the next head.
     report_parent(&mut tree, &y);
     tree.heal();
-    let next = next_block(&tree, T0).expect("flip back");
-    assert_eq!(next.digest(), y.digest());
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(), Some((Height::new(12), y.digest())));
 }
 
 #[test]
@@ -744,29 +552,28 @@ fn head_reported_while_the_ancestry_was_unwalkable_is_found() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // A is picked up for forwarding ...
+    // A is picked up for delivery ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain start");
-    assert_eq!(next.digest(), a.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
 
-    // ... and while the forward is in flight, B's report arrives without
-    // its body. The completed forward makes A the head, but the pending
+    // ... and while the delivery is in flight, B's report arrives without
+    // its body. The completed delivery makes A known, but the pending
     // head's ancestry is not walkable yet, so nothing can be handed out.
     let b = block(2, 12, a.digest());
     report_parent(&mut tree, &b);
     tree.heal();
-    forwarded(&mut tree, &a);
-    assert!(next_block(&tree, T0).is_none());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), None);
+    assert_eq!(tree.next_head(), None);
 
-    // B's body closes the gap: the head A - derived fresh as the anchor
-    // - is found, and B is the next block to forward. (A cached
+    // B's body closes the gap: the known A - derived fresh as the anchor
+    // - is found, and B is the next block to deliver. (A cached
     // convergence position would have missed A's head report while the
     // ancestry was unwalkable and re-selected A forever.)
     tree.record_block(b.clone().into());
     tree.heal();
-    let next = next_block(&tree, T0).expect("gap closed");
-    assert_eq!(next.digest(), b.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
 }
 
 #[test]
@@ -779,28 +586,28 @@ fn rejected_blocks_are_withheld_until_the_retry_delay_elapses() {
     record(&mut tree, &a);
     record(&mut tree, &b);
 
-    // The rejected candidate halts forwarding until the retry delay has
+    // The rejected candidate halts delivery until the retry delay has
     // fully elapsed.
     tree.mark_rejected(&a.digest(), T0);
-    assert!(next_block(&tree, T0).is_none());
+    assert_eq!(next_delivery(&tree, T0), None);
     let just_before_retry = T0 + NOTARIZED_REJECTION_RETRY_DELAY - Duration::from_millis(1);
-    assert!(next_block(&tree, just_before_retry).is_none());
-    let next = next_block(&tree, T0 + NOTARIZED_REJECTION_RETRY_DELAY).expect("rejection expired");
-    assert_eq!(next.digest(), a.digest());
+    assert_eq!(next_delivery(&tree, just_before_retry), None);
+    assert_eq!(
+        next_delivery(&tree, T0 + NOTARIZED_REJECTION_RETRY_DELAY),
+        Some(a.digest())
+    );
 
     // Re-recording the body clears the timestamp.
     tree.mark_rejected(&a.digest(), T0);
     tree.record_block(a.clone().into());
     tree.heal();
-    let next = next_block(&tree, T0).expect("timestamp cleared");
-    assert_eq!(next.digest(), a.digest());
+    assert_eq!(next_delivery(&tree, T0), Some(a.digest()));
 
     // Blocks above the rejected one are unaffected once the head is
     // past it.
     tree.mark_rejected(&a.digest(), T0);
-    forwarded(&mut tree, &a);
-    let next = next_block(&tree, T0).expect("chain continues");
-    assert_eq!(next.digest(), b.digest());
+    converged(&mut tree, &a);
+    assert_eq!(next_delivery(&tree, T0), Some(b.digest()));
 }
 
 #[test]
@@ -1039,4 +846,51 @@ fn rejection_revokes_delivery() {
     assert_eq!(next_delivery(&tree, retry), Some(b.digest()));
     delivered(&mut tree, &b);
     assert_eq!(tree.next_head(), Some((Height::new(12), b.digest())));
+}
+
+/// The deferral predicate for consensus requests: a block is imminent when
+/// it is the next block to deliver or the next head target, and not when it
+/// is further out, its body needs a fetch, or it is already converged.
+#[test]
+fn convergence_is_imminent_for_the_next_delivery_or_head_target() {
+    let finalized = Digest(B256::repeat_byte(0xff));
+    let mut tree = empty_tree(finalized);
+
+    // The converged finalized tip is nothing convergence still does;
+    // callers check for known blocks first.
+    assert!(!tree.converges_imminently(finalized, T0));
+
+    // A pending head whose recorded body sits directly on a known block
+    // (here the finalized tip) is the next delivery ...
+    let a = block(1, 11, finalized);
+    record(&mut tree, &a);
+    assert!(tree.converges_imminently(a.digest(), T0));
+
+    // ... but two deliveries away is not imminent: a needs a delivery
+    // first. The delivery alone suffices; the head need not move.
+    let b = block(2, 12, a.digest());
+    record(&mut tree, &b);
+    assert!(!tree.converges_imminently(b.digest(), T0));
+    delivered(&mut tree, &a);
+    assert!(tree.converges_imminently(b.digest(), T0));
+    // The delivered a is the next head target: imminent as well.
+    assert!(tree.converges_imminently(a.digest(), T0));
+
+    // A pending head whose body is not in hand needs a fetch first: the
+    // report alone does not make it imminent.
+    let c = block(3, 13, b.digest());
+    report_parent(&mut tree, &c);
+    tree.heal();
+    assert!(!tree.converges_imminently(c.digest(), T0));
+
+    // A sibling fork one step above the finalized tip is imminent even
+    // though it is not the head's child: it is delivered directly on top
+    // of the tip.
+    let a2 = block(4, 11, finalized);
+    record(&mut tree, &a2);
+    assert!(tree.converges_imminently(a2.digest(), T0));
+
+    // A withheld block is not delivered next.
+    tree.mark_rejected(&a2.digest(), T0);
+    assert!(!tree.converges_imminently(a2.digest(), T0));
 }

--- a/crates/consensus/src/executor/actor/notarized_tree/tests.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/tests.rs
@@ -520,42 +520,51 @@ fn finalized_tip_reroots_a_head_stranded_on_an_orphaned_branch() {
 /// tip), or when it is the pending head, its body in hand, one forward
 /// step above a converged anchor - and does not when it is further out,
 /// its body needs a fetch, or it belongs to a superseded report.
+/// The deferral predicate for consensus requests: a block is imminent when
+/// it is the next block to deliver or the next head target, and not when it
+/// is further out, its body needs a fetch, or it is already converged.
 #[test]
-fn convergence_is_imminent_only_one_step_from_an_anchor() {
+fn convergence_is_imminent_for_the_next_delivery_or_head_target() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // The delivered finalized tip is converged already.
-    assert!(tree.converges_imminently(finalized));
+    // The converged finalized tip is nothing convergence still does;
+    // callers check for known blocks first.
+    assert!(!tree.converges_imminently(finalized, T0));
 
-    // A pending head whose recorded body sits directly on the head (here
-    // still the finalized tip) is one forward step away ...
+    // A pending head whose recorded body sits directly on a known block
+    // (here the finalized tip) is the next delivery ...
     let a = block(1, 11, finalized);
     record(&mut tree, &a);
-    assert!(tree.converges_imminently(a.digest()));
+    assert!(tree.converges_imminently(a.digest(), T0));
 
-    // ... but two steps away is not imminent: b needs a forwarded first.
+    // ... but two deliveries away is not imminent: a needs a delivery
+    // first. The delivery alone suffices; the head need not move.
     let b = block(2, 12, a.digest());
     record(&mut tree, &b);
-    assert!(!tree.converges_imminently(b.digest()));
-    forwarded(&mut tree, &a);
-    assert!(tree.converges_imminently(b.digest()));
-    // The superseded a stays imminent only because the head sits on it.
-    assert!(tree.converges_imminently(a.digest()));
+    assert!(!tree.converges_imminently(b.digest(), T0));
+    delivered(&mut tree, &a);
+    assert!(tree.converges_imminently(b.digest(), T0));
+    // The delivered a is the next head target: imminent as well.
+    assert!(tree.converges_imminently(a.digest(), T0));
 
     // A pending head whose body is not in hand needs a fetch first: the
     // report alone does not make it imminent.
     let c = block(3, 13, b.digest());
     report_parent(&mut tree, &c);
     tree.heal();
-    assert!(!tree.converges_imminently(c.digest()));
+    assert!(!tree.converges_imminently(c.digest(), T0));
 
     // A sibling fork one step above the finalized tip is imminent even
-    // though it is not the head's child: the replay from the tip anchor
-    // hands it out directly.
+    // though it is not the head's child: it is delivered directly on top
+    // of the tip.
     let a2 = block(4, 11, finalized);
     record(&mut tree, &a2);
-    assert!(tree.converges_imminently(a2.digest()));
+    assert!(tree.converges_imminently(a2.digest(), T0));
+
+    // A withheld block is not delivered next.
+    tree.mark_rejected(&a2.digest(), T0);
+    assert!(!tree.converges_imminently(a2.digest(), T0));
 }
 
 /// The tree's convergence measures: block-body count, the undelivered
@@ -612,26 +621,23 @@ fn next_finalized_delivery_is_imminent() {
     let finalized = Digest(B256::repeat_byte(0xff));
     let mut tree = empty_tree(finalized);
 
-    // One above the local finalized tip: the marshal's next dispatch is
-    // the tip itself.
+    // One above the delivered finalized block: the marshal's next
+    // dispatch is the tip itself.
     let next = block(1, 11, finalized);
     tree.set_network_finalized_tip(round(1), Height::new(11), next.digest());
     tree.heal();
-    assert!(tree.converges_imminently(next.digest()));
+    assert!(tree.converges_imminently(next.digest(), T0));
 
     // Two above: an undelivered block sits below the tip.
     let above = block(2, 12, next.digest());
     tree.set_network_finalized_tip(round(2), Height::new(12), above.digest());
     tree.heal();
-    assert!(!tree.converges_imminently(above.digest()));
+    assert!(!tree.converges_imminently(above.digest(), T0));
 
-    // The gap closes as deliveries land.
-    let local_state = tree
-        .local_state()
-        .update_finalized(Height::new(11), next.digest())
-        .update_head(Height::new(11), next.digest());
-    tree.set_local_state(local_state);
-    assert!(tree.converges_imminently(above.digest()));
+    // The gap closes as deliveries land - before the forkchoice update
+    // finalizing them.
+    tree.set_delivered_finalized(Height::new(11), next.digest());
+    assert!(tree.converges_imminently(above.digest(), T0));
 }
 
 /// A head stranded on an abandoned notarized branch while consensus

--- a/crates/consensus/src/executor/actor/tests/backfill.rs
+++ b/crates/consensus/src/executor/actor/tests/backfill.rs
@@ -105,14 +105,9 @@ fn backfill_then_converges_onto_a_notarized_extension() {
         assert_eq!(h.execution.new_payloads(), vec![d1, d2, d3, d4]);
         assert_eq!(
             h.execution.fcus(),
-            vec![
-                STARTUP_FCU,
-                (d1, d1, false),
-                (d2, d2, false),
-                (d3, d2, false),
-                (d4, d2, false),
-            ],
-            "notarized convergence must preserve the backfilled finalized boundary",
+            vec![STARTUP_FCU, (d2, d2, false), (d4, d2, false)],
+            "the backfill finalizes the floor with one update, and notarized \
+            convergence must preserve that boundary",
         );
         assert_eq!(h.execution.finalized(), Some((2, d2)));
     });
@@ -316,8 +311,9 @@ fn snapshot_restore_replays_below_execution_finality_without_forkchoice_updates(
             })
             .start(&context);
 
-        // Re-delivery of the block at the floor: acknowledged, but no
-        // forkchoice update is submitted for the stale state.
+        // Re-delivery of the block at the floor: delivered (the execution
+        // layer answers from its caches) and acknowledged on that answer;
+        // no forkchoice update is submitted for the stale state.
         h.deliver_finalized(b1)
             .await
             .expect("the re-delivered block should be acknowledged");

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -239,6 +239,37 @@ fn build_on_a_head_the_network_finalized_past_is_dropped() {
 }
 
 #[test_traced]
+fn late_pending_head_report_from_an_older_round_is_ignored() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // Two validated siblings; consensus moves on to build on b1.
+        let a1 = make_block(1, 1, GENESIS);
+        let b1 = make_block(2, 1, GENESIS);
+        let (da1, db1) = (a1.digest(), b1.digest());
+        for (view, block) in [(1, a1), (2, b1)] {
+            h.verify(round(view), block)
+                .await
+                .expect("verification should complete")
+                .expect("block should be valid");
+        }
+        h.report_pending_head(4, 2, db1);
+        h.wait_until(|| h.execution.head() == db1).await;
+
+        // A report from an older context arrives late (the handlers run
+        // concurrently). It must not move the pending head back onto a1
+        // and cost the node its proposal on b1.
+        h.report_pending_head(3, 1, da1);
+        let proposal = make_block(5, 2, db1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(5), db1)
+            .await
+            .expect("the build on the current pending head must complete");
+        assert_eq!(h.execution.head(), db1);
+    });
+}
+
+#[test_traced]
 fn queued_build_is_dropped_when_finality_advances_past_its_parent() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -11,7 +11,8 @@ use tempo_payload_types::TempoPayloadAttributes;
 use tempo_primitives::TempoConsensusContext;
 
 use super::harness::{
-    ElCall, ForkchoiceStateExt as _, GENESIS, Harness, built_payload, make_block, round,
+    ElCall, ForkchoiceStateExt as _, GENESIS, Harness, STARTUP_FCU, built_payload, make_block,
+    round,
 };
 use crate::consensus::Digest;
 
@@ -221,20 +222,13 @@ fn build_canceled_while_queued_still_reaffirms_the_head() {
         h.deliver_finalized(b1)
             .await
             .expect("finalized block should be acknowledged");
-        h.wait_until(|| {
-            h.execution
-                .fcus()
-                .iter()
-                .filter(|(head, ..)| *head == d1)
-                .count()
-                >= 2
-        })
-        .await;
 
-        assert!(
-            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
-            "the canceled build must not submit attributes; the FCU degrades \
-            to a bare head re-affirmation",
+        h.wait_until(|| h.execution.fcus().len() == 3).await;
+        assert_eq!(
+            h.execution.fcus(),
+            vec![STARTUP_FCU, (d1, d1, false), (d1, d1, false)],
+            "the canceled build must not submit attributes; its FCU degrades \
+            to a bare re-affirmation of the head",
         );
         assert!(h.execution.pending_payload_jobs().is_empty());
     });

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -176,6 +176,69 @@ fn build_on_an_unknown_parent_is_dropped() {
 }
 
 #[test_traced]
+fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // a1 is known to the execution layer through its validation, but
+        // consensus never reports it as the pending head: a build on top of
+        // it is not what consensus builds on.
+        let a1 = make_block(1, 1, GENESIS);
+        let da1 = a1.digest();
+        h.verify(round(1), a1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+
+        let rx = h.build(round(2), da1);
+        rx.await
+            .expect_err("a build whose parent the head will not reach must fail");
+        assert!(
+            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
+            "no build may be registered off the pending head's path",
+        );
+    });
+}
+
+#[test_traced]
+fn build_on_a_head_the_network_finalized_past_is_dropped() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+
+        // The head sits on notarized a1.
+        let a1 = make_block(1, 1, GENESIS);
+        let da1 = a1.digest();
+        h.verify(round(1), a1)
+            .await
+            .expect("a1 should validate")
+            .expect("a1 should be valid");
+        h.report_pending_head(2, 1, da1);
+        h.wait_until(|| h.execution.head() == da1).await;
+
+        // The network finalizes b1 on another branch. The tip report alone
+        // re-anchors the pending head onto the tip, so a1 is no longer what
+        // consensus builds on: the build is dropped before the finalized
+        // block is even delivered, and no payload is registered on the
+        // abandoned head.
+        let b1 = make_block(3, 1, GENESIS);
+        let db1 = b1.digest();
+        h.deliver_tip(round(3), 1, db1);
+        h.build(round(4), da1)
+            .await
+            .expect_err("the build on the abandoned head must fail");
+        assert!(
+            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
+            "no payload may be registered on the abandoned head",
+        );
+
+        h.deliver_finalized(b1)
+            .await
+            .expect("b1 should be acknowledged");
+        assert_eq!(h.execution.head(), db1);
+    });
+}
+
+#[test_traced]
 fn queued_build_is_dropped_when_finality_advances_past_its_parent() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -83,6 +83,45 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
 }
 
 #[test_traced]
+fn long_delivery_runs_are_locked_in_every_few_blocks() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // Ten notarized blocks above genesis, all bodies fetched tip-down.
+        let mut blocks = Vec::new();
+        let mut parent = GENESIS;
+        for height in 1..=10 {
+            let block = make_block(height, height, parent);
+            parent = block.digest();
+            blocks.push(block);
+        }
+        let digests = blocks.iter().map(|b| b.digest()).collect::<Vec<_>>();
+        h.report_pending_head(11, 10, digests[9]);
+        for block in blocks.iter().rev() {
+            h.wait_until(|| {
+                h.marshal
+                    .fulfill_subscription(block.digest(), block.clone())
+            })
+            .await;
+        }
+
+        // The run is delivered bottom-up, with a forkchoice update forced
+        // after every eight deliveries so that the execution layer never
+        // holds more than that many uncanonicalized blocks.
+        h.wait_until(|| h.execution.head() == digests[9]).await;
+        assert_eq!(h.execution.new_payloads(), digests);
+        assert_eq!(
+            h.execution.fcus(),
+            vec![
+                STARTUP_FCU,
+                (digests[7], GENESIS, false),
+                (digests[9], GENESIS, false),
+            ],
+        );
+    });
+}
+
+#[test_traced]
 fn dropped_body_fetch_is_retried() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -72,16 +72,12 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
         assert_eq!(
             h.execution.new_payloads(),
             vec![d1, d2, d3],
-            "blocks are forwarded bottom-up",
+            "blocks are delivered bottom-up",
         );
         assert_eq!(
             h.execution.fcus(),
-            vec![
-                STARTUP_FCU,
-                (d1, GENESIS, false),
-                (d2, GENESIS, false),
-                (d3, GENESIS, false)
-            ],
+            vec![STARTUP_FCU, (d3, GENESIS, false)],
+            "one forkchoice update moves the head across the whole delivered run",
         );
     });
 }
@@ -224,9 +220,8 @@ fn rejected_notarized_fcu_is_fatal() {
         let h = Harness::start_at_genesis(&context);
 
         // The forkchoice update names a block the execution layer accepted
-        // through its new-payload request. A rejection means the executor's
-        // view of the execution layer has diverged from it: the node shuts
-        // down.
+        // through its delivery. A rejection means the executor's view of the
+        // execution layer has diverged from it: the node shuts down.
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.execution.script_fcu(
@@ -494,7 +489,10 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
         let fetches = h.marshal.subscribe_log().len();
 
         // Flip back to branch B: both bodies are still resident, so the
-        // re-convergence must not fetch anything.
+        // re-convergence must not fetch anything. The execution layer
+        // already knows the branch, so the head is repointed onto it with a
+        // bare forkchoice update.
+        let payloads_before = h.execution.new_payloads();
         h.report_pending_head(5, 2, d2);
         h.wait_until(|| h.execution.head() == d2).await;
         assert_eq!(
@@ -502,7 +500,12 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
             fetches,
             "flip-flopping between branches must reuse resident bodies",
         );
-        assert_eq!(h.execution.new_payloads().last(), Some(&d2));
+        assert_eq!(
+            h.execution.new_payloads(),
+            payloads_before,
+            "a branch the execution layer knows is not delivered again",
+        );
+        assert_eq!(h.execution.fcus().last(), Some(&(d2, GENESIS, false)));
     });
 }
 

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -1,7 +1,8 @@
 //! Scenario tests for the finalization pipeline: finalized blocks arriving
-//! from the marshal actor are forwarded to the execution layer as
-//! `newPayload` + `forkchoiceUpdated` pairs, in order, and acknowledged
-//! only once the execution layer accepted them.
+//! from the marshal actor are delivered to the execution layer through
+//! `newPayload` in order, finalized through a subsequent
+//! `forkchoiceUpdated` that may cover several deliveries, and acknowledged
+//! only once that forkchoice update has been accepted.
 
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
 use commonware_macros::test_traced;
@@ -12,6 +13,7 @@ use super::harness::{
     ElCall, ForkchoiceStateExt as _, GENESIS, Harness, HarnessOptions, STARTUP_FCU,
     STARTUP_FCU_CALL, make_block, make_block_with_proposer, round,
 };
+use crate::consensus::Digest;
 
 fn finalized_blocks_proposed_by_self(h: &Harness) -> u64 {
     h.metrics()
@@ -57,19 +59,31 @@ fn finalized_blocks_are_forwarded_in_order() {
         let b3 = make_block(3, 3, b2.digest());
         let digests = [b1.digest(), b2.digest(), b3.digest()];
 
+        // Hold the first delivery open so that the later blocks queue up
+        // behind it, as they do when the execution layer is catching up.
+        let release_first = h
+            .execution
+            .script_delayed_new_payload(digests[0], Ok(PayloadStatusEnum::Valid));
         h.deliver_tip(round(3), 3, b3.digest());
         let w1 = h.deliver_finalized(b1);
         let w2 = h.deliver_finalized(b2);
         let w3 = h.deliver_finalized(b3);
+        h.wait_until(|| h.execution.new_payloads() == vec![digests[0]])
+            .await;
+        release_first
+            .send(())
+            .expect("first delivery should still be gated");
         w1.await.expect("first block should be acknowledged");
         w2.await.expect("second block should be acknowledged");
         w3.await.expect("third block should be acknowledged");
 
         assert_eq!(h.execution.new_payloads(), digests);
-        let expected_fcus = std::iter::once(STARTUP_FCU)
-            .chain(digests.map(|digest| (digest, digest, false)))
-            .collect::<Vec<_>>();
-        assert_eq!(h.execution.fcus(), expected_fcus);
+        assert_eq!(
+            h.execution.fcus(),
+            vec![STARTUP_FCU, (digests[2], digests[2], false)],
+            "queued finalized blocks are delivered back to back and finalized \
+            by a single forkchoice update",
+        );
         assert_eq!(h.execution.finalized(), Some((3, digests[2])));
     });
 }
@@ -181,16 +195,46 @@ fn new_payload_transport_error_is_fatal() {
     });
 }
 
+/// Converges the head onto `a1 -> a2` (branch A) through validations and
+/// pending-head reports, then reports an unknown block as the pending head
+/// so that the pending head's ancestry is not walkable: the forkchoice step
+/// cannot derive the head from the tree and must consult the execution
+/// layer's canonical chain when finality advances.
+async fn converge_on_branch_a_with_unwalkable_pending_head(h: &Harness) -> (Digest, Digest) {
+    let a1 = make_block(1, 1, GENESIS);
+    let a2 = make_block(2, 2, a1.digest());
+    let (da1, da2) = (a1.digest(), a2.digest());
+    for (view, block, digest) in [(1, a1, da1), (2, a2, da2)] {
+        h.verify(round(view), block)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+        h.report_pending_head(view + 1, view, digest);
+        h.wait_until(|| h.execution.head() == digest).await;
+    }
+
+    let unknown = make_block(4, 3, da2).digest();
+    h.report_pending_head(5, 4, unknown);
+    h.wait_until(|| h.marshal.open_subscriptions() == vec![(unknown, round(4))])
+        .await;
+    (da1, da2)
+}
+
 #[test_traced]
 fn canonical_block_lookup_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
+        let (_, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+        let fcus_before = h.execution.fcus();
 
-        let b1 = make_block(1, 1, GENESIS);
+        // b1 finalizes below the head on another branch. Whether the head
+        // descends from it is read from the canonical chain; the read
+        // failing must not let the finalization through.
+        let b1 = make_block(3, 1, GENESIS);
         h.execution
             .script_canonical_block_hash(1, Err("database unavailable"));
 
-        h.deliver_tip(round(1), 1, b1.digest());
+        h.deliver_tip(round(3), 1, b1.digest());
         h.deliver_finalized(b1)
             .await
             .expect_err("a canonical lookup failure must not acknowledge the finalized block");
@@ -198,8 +242,55 @@ fn canonical_block_lookup_error_is_fatal() {
         h.actor
             .await
             .expect("actor should shut down cleanly on a canonical lookup error");
-        assert!(h.execution.new_payloads().is_empty());
-        assert_eq!(h.execution.fcus(), vec![STARTUP_FCU]);
+        assert_eq!(
+            h.execution.fcus(),
+            fcus_before,
+            "no forkchoice update may follow the failed lookup",
+        );
+        assert_eq!(h.execution.head(), da2);
+    });
+}
+
+#[test_traced]
+fn finalizing_below_a_head_on_another_branch_moves_the_head() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+        let (_, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+
+        // b1 finalizes at height 1 on branch B while the head is a2 at
+        // height 2 on branch A. The head does not descend from the
+        // finalized block, so it is moved onto it.
+        let b1 = make_block(3, 1, GENESIS);
+        let db1 = b1.digest();
+        h.deliver_tip(round(3), 1, db1);
+        h.deliver_finalized(b1)
+            .await
+            .expect("the finalized branch should be acknowledged");
+
+        assert_eq!(h.execution.fcus().last(), Some(&(db1, db1, false)));
+        assert_eq!(h.execution.head(), db1);
+        assert_eq!(h.execution.finalized(), Some((1, db1)));
+        assert_ne!(da2, db1);
+    });
+}
+
+#[test_traced]
+fn finalizing_below_a_descending_head_keeps_the_head() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+        let (da1, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+
+        // a1 finalizes below the head a2 while the pending head's ancestry
+        // is not walkable. The canonical chain shows that the head descends
+        // from a1, so only finality moves.
+        h.deliver_tip(round(3), 1, da1);
+        h.deliver_finalized(make_block(1, 1, GENESIS))
+            .await
+            .expect("the finalized ancestor should be acknowledged");
+
+        assert_eq!(h.execution.fcus().last(), Some(&(da2, da1, false)));
+        assert_eq!(h.execution.head(), da2);
+        assert_eq!(h.execution.finalized(), Some((1, da1)));
     });
 }
 
@@ -341,14 +432,11 @@ fn redelivered_finalized_block_at_the_tracked_state_is_acknowledged() {
                     finalized: d1,
                     with_attrs: false,
                 },
+                // The redelivery is delivered again - the execution layer
+                // answers from its caches - and acknowledged on that answer;
+                // the block is final already, so no forkchoice update follows.
                 ElCall::NewPayload(d1),
-                ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false,
-                },
             ],
-            "a redelivery is re-checked and re-affirmed before acknowledgment",
         );
         assert_eq!(h.execution.finalized(), Some((1, d1)),);
     });

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -354,33 +354,6 @@ fn forkchoice_update_transport_error_is_fatal() {
 }
 
 #[test_traced]
-fn finalized_block_below_the_tracked_state_is_fatal() {
-    deterministic::Runner::default().start(|context| async move {
-        let mut h = Harness::start_at_genesis(&context);
-
-        let b1 = make_block(1, 1, GENESIS);
-        let b2 = make_block(2, 2, b1.digest());
-        h.deliver_tip(round(2), 2, b2.digest());
-        h.deliver_finalized(b1.clone())
-            .await
-            .expect("first block should be acknowledged");
-        h.deliver_finalized(b2)
-            .await
-            .expect("second block should be acknowledged");
-
-        // Delivering a block below the tracked finalized height violates
-        // the in-order delivery protocol.
-        h.deliver_finalized(b1)
-            .await
-            .expect_err("a block below the tracked finalized state must not be acknowledged");
-
-        h.actor
-            .await
-            .expect("actor should shut down cleanly on a fatal error");
-    });
-}
-
-#[test_traced]
 fn conflicting_finalized_block_at_the_tracked_height_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
@@ -391,8 +364,9 @@ fn conflicting_finalized_block_at_the_tracked_height_is_fatal() {
             .await
             .expect("first block should be acknowledged");
 
-        // A different block finalized at the same height means consensus
-        // failed fundamentally.
+        // A different block at the height the execution layer already
+        // finalized means consensus failed fundamentally; the execution
+        // layer's canonical chain is what the re-delivery is checked against.
         let conflicting = make_block(9, 1, GENESIS);
         h.deliver_finalized(conflicting)
             .await

--- a/crates/consensus/src/executor/actor/tests/metrics.rs
+++ b/crates/consensus/src/executor/actor/tests/metrics.rs
@@ -141,3 +141,37 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         assert_eq!(h.execution.head(), d3);
     });
 }
+
+#[test_traced]
+fn uncanonicalized_blocks_tracks_delivered_blocks_off_the_canonical_chain() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+        assert_eq!(gauge(&h, "uncanonicalized_blocks"), 0);
+
+        // A validated block is known to the execution layer but not its
+        // head yet.
+        let b1 = make_block(1, 1, GENESIS);
+        let d1 = b1.digest();
+        h.verify(round(1), b1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 1)
+            .await;
+
+        // Moving the head onto it canonicalizes it.
+        h.report_pending_head(2, 1, d1);
+        h.wait_until(|| h.execution.head() == d1).await;
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 0)
+            .await;
+
+        // A validated sibling stays on a side branch.
+        let a1 = make_block(3, 1, GENESIS);
+        h.verify(round(3), a1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 1)
+            .await;
+    });
+}

--- a/crates/consensus/src/executor/actor/tests/metrics.rs
+++ b/crates/consensus/src/executor/actor/tests/metrics.rs
@@ -2,7 +2,6 @@
 //! tree unit tests cover the arithmetic; these tests prove that the actor
 //! publishes the measures after processing real messages and EL outcomes.
 
-use alloy_rpc_types_engine::PayloadStatusEnum;
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 
@@ -117,8 +116,9 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
 
         let b1 = make_block(1, 1, GENESIS);
         let b2 = make_block(2, 2, b1.digest());
-        let (d1, d2) = (b1.digest(), b2.digest());
-        for (view, block, digest) in [(1, b1, d1), (2, b2, d2)] {
+        let b3 = make_block(3, 3, b2.digest());
+        let (d1, d2, d3) = (b1.digest(), b2.digest(), b3.digest());
+        for (view, block, digest) in [(1, b1, d1), (2, b2, d2), (3, b3, d3)] {
             h.verify(round(view), block)
                 .await
                 .expect("verification should complete")
@@ -128,22 +128,16 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         }
         h.wait_until(|| gauge(&h, "convergence_depth") == 0).await;
 
-        // Re-anchor onto a1, a sibling of b1 at height 1 the execution layer
-        // rejects: the block is withheld, so the pending head stays at
-        // height 1 while the accepted local head remains b2 at height 2, and
-        // the signed distance is observable.
+        // Re-anchor onto a2 on a side branch at height 2 while its parent
+        // a1 is missing: the ancestry is not walkable, so the head stays at
+        // b3 and the signed distance is observable.
         let a1 = make_block(4, 1, GENESIS);
-        let da1 = a1.digest();
-        h.execution.script_new_payload(
-            da1,
-            Ok(PayloadStatusEnum::Invalid {
-                validation_error: "re-anchor rejected by test".into(),
-            }),
-        );
-        h.report_pending_head(5, 4, da1);
-        h.wait_until(|| h.marshal.fulfill_subscription(da1, a1.clone()))
+        let a2 = make_block(5, 2, a1.digest());
+        let da2 = a2.digest();
+        h.report_pending_head(6, 5, da2);
+        h.wait_until(|| h.marshal.fulfill_subscription(da2, a2.clone()))
             .await;
         h.wait_until(|| gauge(&h, "convergence_depth") == -1).await;
-        assert_eq!(h.execution.head(), d2);
+        assert_eq!(h.execution.head(), d3);
     });
 }

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -391,50 +391,6 @@ fn finality_is_locked_in_before_notarized_convergence() {
 }
 
 #[test_traced]
-fn slow_marshal_fetch_does_not_block_building() {
-    deterministic::Runner::default().start(|context| async move {
-        let h = Harness::start_at_genesis(&context);
-
-        // Leave the missing pending head's marshal subscription unresolved.
-        let pending = make_block(1, 1, GENESIS);
-        let pending_digest = pending.digest();
-        h.report_pending_head(2, 1, pending_digest);
-        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(1))])
-            .await;
-
-        // A proposal build on the known local head must be registered and
-        // delivered independently of the pending body fetch.
-        let proposal = make_block(3, 1, GENESIS);
-        let proposal_digest = proposal.digest();
-        h.execution.script_built_payload(built_payload(&proposal));
-        let build = h.build(round(3), GENESIS);
-        futures::pin_mut!(build);
-        let deadline = h.run_for(Duration::from_millis(100));
-        futures::pin_mut!(deadline);
-        let payload = match futures::future::select(build, deadline).await {
-            Either::Left((payload, _deadline)) => {
-                payload.expect("build should complete while the fetch is pending")
-            }
-            Either::Right(((), _build)) => {
-                panic!("the pending marshal fetch blocked building")
-            }
-        };
-
-        let (block, _) = payload.into_execution_payload();
-        assert_eq!(block.hash(), proposal_digest.0);
-        assert!(
-            h.execution.fcus().contains(&(GENESIS, GENESIS, true)),
-            "the attribute-carrying build FCU must reach the execution layer",
-        );
-        assert_eq!(
-            h.marshal.open_subscriptions(),
-            vec![(pending_digest, round(1))],
-            "building must not cancel or consume the independent body fetch",
-        );
-    });
-}
-
-#[test_traced]
 fn heartbeats_are_disarmed_while_work_is_active_or_queued() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::builder()

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -1,6 +1,6 @@
 //! Scenario tests for the actor's scheduling invariants: one execution-layer
-//! task at a time, consensus requests before convergence before
-//! finalization, the FCU heartbeat, and shutdown.
+//! task at a time, consensus requests before finality work before notarized
+//! convergence, the FCU heartbeat, and shutdown.
 
 use std::time::Duration;
 
@@ -49,50 +49,6 @@ fn slow_marshal_fetch_does_not_block_validation() {
             h.marshal.open_subscriptions(),
             vec![(pending_digest, round(1))],
             "validation must not cancel or consume the independent body fetch",
-        );
-    });
-}
-
-#[test_traced]
-fn slow_marshal_fetch_does_not_block_building() {
-    deterministic::Runner::default().start(|context| async move {
-        let h = Harness::start_at_genesis(&context);
-
-        // Leave the missing pending head's marshal subscription unresolved.
-        let pending = make_block(1, 1, GENESIS);
-        let pending_digest = pending.digest();
-        h.report_pending_head(2, 1, pending_digest);
-        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(1))])
-            .await;
-
-        // A proposal build on the known local head must be registered and
-        // delivered independently of the pending body fetch.
-        let proposal = make_block(3, 1, GENESIS);
-        let proposal_digest = proposal.digest();
-        h.execution.script_built_payload(built_payload(&proposal));
-        let build = h.build(round(3), GENESIS);
-        futures::pin_mut!(build);
-        let deadline = h.run_for(Duration::from_millis(100));
-        futures::pin_mut!(deadline);
-        let payload = match futures::future::select(build, deadline).await {
-            Either::Left((payload, _deadline)) => {
-                payload.expect("build should complete while the fetch is pending")
-            }
-            Either::Right(((), _build)) => {
-                panic!("the pending marshal fetch blocked building")
-            }
-        };
-
-        let (block, _) = payload.into_execution_payload();
-        assert_eq!(block.hash(), proposal_digest.0);
-        assert!(
-            h.execution.fcus().contains(&(GENESIS, GENESIS, true)),
-            "the attribute-carrying build FCU must reach the execution layer",
-        );
-        assert_eq!(
-            h.marshal.open_subscriptions(),
-            vec![(pending_digest, round(1))],
-            "building must not cancel or consume the independent body fetch",
         );
     });
 }
@@ -280,15 +236,14 @@ fn one_execution_task_at_a_time_and_consensus_requests_win_the_next_slot() {
             vec![
                 STARTUP_FCU_CALL,
                 ElCall::NewPayload(d1),
-                ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false
-                },
-                // The validation of b2 runs before b2's finalization: its
-                // new-payload probe is not followed by a forkchoice update.
+                // The validation of b2 runs before b2's finalization and
+                // before the forkchoice update finalizing b1: its
+                // new-payload probe wins the slot as soon as it is free.
                 ElCall::NewPayload(d2),
+                // b2 was pruned from the tree by the tip covering it, so its
+                // finalization delivers it again ...
                 ElCall::NewPayload(d2),
+                // ... and one forkchoice update finalizes both blocks.
                 ElCall::Fcu {
                     head: d2,
                     finalized: d2,
@@ -354,14 +309,16 @@ fn consensus_work_takes_priority_over_ready_convergence() {
             vec![
                 STARTUP_FCU_CALL,
                 ElCall::NewPayload(d1),
+                // Both operations were ready when the delivery of b1
+                // released the slot, but latency-critical consensus work
+                // ran first. Finality is locked in next, before notarized
+                // convergence delivers b2 and moves the head onto it.
+                ElCall::NewPayload(candidate_digest),
                 ElCall::Fcu {
                     head: d1,
                     finalized: d1,
                     with_attrs: false,
                 },
-                // Both operations were ready when finalization released the
-                // slot, but latency-critical consensus work ran first.
-                ElCall::NewPayload(candidate_digest),
                 ElCall::NewPayload(d2),
                 ElCall::Fcu {
                     head: d2,
@@ -374,68 +331,105 @@ fn consensus_work_takes_priority_over_ready_convergence() {
 }
 
 #[test_traced]
-fn convergence_takes_priority_over_queued_finalization() {
+fn finality_is_locked_in_before_notarized_convergence() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
-        let d1 = b1.digest();
+        let b2 = make_block(2, 2, b1.digest());
+        let (d1, d2) = (b1.digest(), b2.digest());
         let release_finalization = h
             .execution
             .script_delayed_new_payload(d1, Ok(PayloadStatusEnum::Valid));
-        h.execution
-            .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
-        h.deliver_tip(round(1), 1, d1);
-        let first_finalization = h.deliver_finalized(b1.clone());
+        h.deliver_tip(round(2), 2, d2);
+        let w1 = h.deliver_finalized(b1);
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
             .await;
 
-        // Make convergence onto b2 ready above the finalized boundary.
-        let b2 = make_block(2, 2, d1);
-        let d2 = b2.digest();
-        h.report_pending_head(3, 2, d2);
-        h.wait_until(|| h.marshal.fulfill_subscription(d2, b2.clone()))
+        // Make convergence onto the notarized n3 ready above the finalized
+        // boundary while the first finalized delivery still owns the slot,
+        // and queue the second finalized block behind it.
+        let n3 = make_block(3, 3, d2);
+        let d3 = n3.digest();
+        h.report_pending_head(4, 3, d3);
+        h.wait_until(|| h.marshal.fulfill_subscription(d3, n3.clone()))
             .await;
         h.run_for(Duration::from_millis(10)).await;
-
-        // Queue a valid finalization redelivery. Once the first delivery
-        // advances local finality to b1, this and convergence are both ready.
-        let redelivery = h.deliver_finalized(b1);
+        let w2 = h.deliver_finalized(b2);
         h.run_for(Duration::from_millis(10)).await;
 
         release_finalization
             .send(())
             .expect("finalization should still be gated");
-        first_finalization
-            .await
-            .expect("first delivery should be acknowledged");
-        redelivery.await.expect("redelivery should be acknowledged");
+        w1.await.expect("first block should be acknowledged");
+        w2.await.expect("second block should be acknowledged");
+        h.wait_until(|| h.execution.head() == d3).await;
 
         assert_eq!(
             h.execution.calls(),
             vec![
                 STARTUP_FCU_CALL,
                 ElCall::NewPayload(d1),
-                ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false,
-                },
-                // Convergence wins the newly available slot.
+                // The queued finalized range is drained and locked in with
+                // one forkchoice update before the notarized block is
+                // delivered, even though n3 was ready first.
                 ElCall::NewPayload(d2),
                 ElCall::Fcu {
                     head: d2,
-                    finalized: d1,
+                    finalized: d2,
                     with_attrs: false,
                 },
-                // Only then is the queued finalization redelivery handled.
-                ElCall::NewPayload(d1),
+                ElCall::NewPayload(d3),
                 ElCall::Fcu {
-                    head: d2,
-                    finalized: d1,
+                    head: d3,
+                    finalized: d2,
                     with_attrs: false,
                 },
             ],
+        );
+    });
+}
+
+#[test_traced]
+fn slow_marshal_fetch_does_not_block_building() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // Leave the missing pending head's marshal subscription unresolved.
+        let pending = make_block(1, 1, GENESIS);
+        let pending_digest = pending.digest();
+        h.report_pending_head(2, 1, pending_digest);
+        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(1))])
+            .await;
+
+        // A proposal build on the known local head must be registered and
+        // delivered independently of the pending body fetch.
+        let proposal = make_block(3, 1, GENESIS);
+        let proposal_digest = proposal.digest();
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(3), GENESIS);
+        futures::pin_mut!(build);
+        let deadline = h.run_for(Duration::from_millis(100));
+        futures::pin_mut!(deadline);
+        let payload = match futures::future::select(build, deadline).await {
+            Either::Left((payload, _deadline)) => {
+                payload.expect("build should complete while the fetch is pending")
+            }
+            Either::Right(((), _build)) => {
+                panic!("the pending marshal fetch blocked building")
+            }
+        };
+
+        let (block, _) = payload.into_execution_payload();
+        assert_eq!(block.hash(), proposal_digest.0);
+        assert!(
+            h.execution.fcus().contains(&(GENESIS, GENESIS, true)),
+            "the attribute-carrying build FCU must reach the execution layer",
+        );
+        assert_eq!(
+            h.marshal.open_subscriptions(),
+            vec![(pending_digest, round(1))],
+            "building must not cancel or consume the independent body fetch",
         );
     });
 }


### PR DESCRIPTION
The marshal actor delivers finalized blocks in height order, and two different blocks finalized at one height are a consensus failure, not something the executor can catch. Drop the delivery-order checks (`check_finalized_delivery_order`): a delivery below the tracked finalized block and a different block at its height are no longer fatal on their own.

What remains: a `debug_assert!` on height order in `handle_finalized_delivered`, and the digest check of a re-delivered block against the execution layer's canonical block at that height, which is where a conflicting finalized block still shuts the node down. `finalized_block_below_the_tracked_state_is_fatal` goes with the check.