### PR TITLE
fix(tip_fee_manager): restrict distributeFees to the validator

### DIFF
--- a/crates/contracts/src/precompiles/tip_fee_manager.rs
+++ b/crates/contracts/src/precompiles/tip_fee_manager.rs
@@ -44,6 +44,7 @@ crate::sol! {
         error InvalidToken();
         error InsufficientFeeTokenBalance();
         error CannotChangeWithinBlock();
+        error Unauthorized();
     }
 }
 

--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -487,10 +487,6 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
 
     let root = MnemonicBuilder::from_phrase(TEST_MNEMONIC).build()?;
     let root_addr = root.address();
-    let attacker = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
-        .index(1)?
-        .build()?;
-    let attacker_addr = attacker.address();
     let validator = MnemonicBuilder::from_phrase(TEST_MNEMONIC)
         .index(2)?
         .build()?;
@@ -505,16 +501,12 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
     let provider = ProviderBuilder::new()
         .wallet(root.clone())
         .connect_http(setup.http_url.clone());
-    let attacker_provider = ProviderBuilder::new()
-        .wallet(attacker)
-        .connect_http(setup.http_url.clone());
     let validator_provider = ProviderBuilder::new()
         .wallet(validator)
         .connect_http(setup.http_url.clone());
     let fee_token = setup_test_token(provider.clone(), root_addr).await?;
     let fee_token_addr = *fee_token.address();
     let root_fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
-    let attacker_fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, attacker_provider);
     let validator_fee_manager =
         IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, validator_provider.clone());
     let validator_fee_token = ITIP20::new(fee_token_addr, validator_provider);
@@ -522,7 +514,7 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
     let credit_seed_amount = U256::from(1234u64);
 
     let path_usd = ITIP20::new(PATH_USD_ADDRESS, provider.clone());
-    for recipient in [attacker_addr, validator_addr, user_addr, credit_source_addr] {
+    for recipient in [validator_addr, user_addr, credit_source_addr] {
         let receipt = path_usd
             .transfer(recipient, U256::from(10_000_000_000u64))
             .send()
@@ -645,7 +637,7 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
     );
     let fee_manager_credit_before_distribute =
         credits.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await?;
-    let distribute_receipt = attacker_fee_manager
+    let distribute_receipt = validator_fee_manager
         .distributeFees(validator_addr, fee_token_addr)
         .gas(2_000_000)
         .send()
@@ -1009,9 +1001,8 @@ async fn test_tip1060_distribute_fees_receive_policy_guard_creations_are_account
         "fee token guard custody must start empty before the blocked distribution"
     );
 
-    let distribute_receipt = root_fee_manager
+    let distribute_receipt = validator_fee_manager
         .distributeFees(validator_addr, fee_token_addr)
-        .nonce(provider.get_transaction_count(root_addr).await?)
         .gas(2_000_000)
         .send()
         .await?

--- a/crates/node/tests/it/tip_fee_manager.rs
+++ b/crates/node/tests/it/tip_fee_manager.rs
@@ -9,7 +9,7 @@ use alloy::{
     },
     sol_types::SolEvent,
 };
-use alloy_eips::{BlockId, Encodable2718};
+use alloy_eips::Encodable2718;
 use alloy_network::{AnyReceiptEnvelope, EthereumWallet};
 use alloy_primitives::{Address, Signature, U256, address};
 use alloy_rpc_types_eth::TransactionRequest;
@@ -28,20 +28,42 @@ use tempo_primitives::{
 async fn test_set_user_token() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
 
-    let setup = TestNodeBuilder::new().build_http_only().await?;
+    let validator_wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC)
+        .index(9)?
+        .build()?;
+    let validator = validator_wallet.address();
+    let dynamic_validator = std::sync::Arc::new(std::sync::Mutex::new(validator));
+    let setup = TestNodeBuilder::new()
+        .with_dynamic_validator(dynamic_validator)
+        .build_http_only()
+        .await?;
     let http_url = setup.http_url;
 
     let wallet = MnemonicBuilder::from_phrase(crate::utils::TEST_MNEMONIC).build()?;
     let user_address = wallet.address();
-    let provider = ProviderBuilder::new().wallet(wallet).connect_http(http_url);
+    let provider = ProviderBuilder::new()
+        .wallet(wallet)
+        .connect_http(http_url.clone());
+    let validator_provider = ProviderBuilder::new()
+        .wallet(validator_wallet)
+        .connect_http(http_url);
 
     // Create test tokens
     let user_token = setup_test_token(provider.clone(), user_address).await?;
     let validator_token = ITIP20::new(PATH_USD_ADDRESS, &provider);
     let fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, provider.clone());
+    let validator_fee_manager = IFeeManager::new(TIP_FEE_MANAGER_ADDRESS, validator_provider);
 
     user_token
         .mint(user_address, U256::from(1e10))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Fund the validator so it can pay gas for distributeFees claims
+    validator_token
+        .transfer(validator, U256::from(10_000_000_000u64))
         .send()
         .await?
         .get_receipt()
@@ -53,13 +75,6 @@ async fn test_set_user_token() -> eyre::Result<()> {
         fee_manager.userTokens(user_address).call().await?,
         expected_default_token
     );
-
-    let validator = provider
-        .get_block(BlockId::latest())
-        .await?
-        .unwrap()
-        .header
-        .beneficiary;
 
     let validator_balance_before = validator_token.balanceOf(validator).call().await?;
 
@@ -96,8 +111,8 @@ async fn test_set_user_token() -> eyre::Result<()> {
         expected_cost * U256::from(9970) / U256::from(10000)
     );
 
-    // Distribute fees to validator (this distributes ALL accumulated fees for this token)
-    fee_manager
+    // Only the validator may claim accumulated fees
+    validator_fee_manager
         .distributeFees(validator, *validator_token.address())
         .send()
         .await?
@@ -120,7 +135,7 @@ async fn test_set_user_token() -> eyre::Result<()> {
     assert_eq!(current_token, *user_token.address());
 
     // Fees from setUserToken tx also accumulated
-    fee_manager
+    validator_fee_manager
         .distributeFees(validator, *validator_token.address())
         .send()
         .await?
@@ -161,7 +176,7 @@ async fn test_set_user_token() -> eyre::Result<()> {
 
     // Distribute fees before checking validator balance
     let validator_balance_before = validator_token.balanceOf(validator).call().await?;
-    fee_manager
+    validator_fee_manager
         .distributeFees(validator, *validator_token.address())
         .send()
         .await?

--- a/crates/precompiles/src/tip_fee_manager/dispatch.rs
+++ b/crates/precompiles/src/tip_fee_manager/dispatch.rs
@@ -33,8 +33,8 @@ impl Precompile for TipFeeManager {
                         self.set_validator_token(s, c, beneficiary)
                     }),
                     setUserToken(call) => mutate_void(call, msg_sender, |s, c| self.set_user_token(s, c)),
-                    distributeFees(call) => mutate_void(call, msg_sender, |_, c| {
-                        self.distribute_fees(c.validator, c.token)
+                    distributeFees(call) => mutate_void(call, msg_sender, |s, c| {
+                        self.distribute_fees(s, c.validator, c.token)
                     })
 
                 }

--- a/crates/precompiles/src/tip_fee_manager/mod.rs
+++ b/crates/precompiles/src/tip_fee_manager/mod.rs
@@ -288,16 +288,31 @@ impl TipFeeManager {
     /// Transfers a validator's accumulated fee balance to their address via [`TIP20Token`] and
     /// zeroes the ledger. No-ops when the balance is zero.
     ///
+    /// Only the validator themselves may claim their fees (`sender == validator`), matching the
+    /// caller-is-subject pattern used by [`Self::set_validator_token`] / [`Self::set_user_token`].
+    ///
     /// # Errors
+    /// - `Unauthorized` — `sender` is not `validator`
     /// - `InvalidToken` — `token` does not have a valid TIP-20 prefix
-    pub fn distribute_fees(&mut self, validator: Address, token: Address) -> Result<()> {
-        // collect_fee_pre_tx creates FeeManager balance slots for free; do not convert them into storage credits.
-        StorageCtx.set_tip1060_storage_credit_minting(false);
+    pub fn distribute_fees(
+        &mut self,
+        sender: Address,
+        validator: Address,
+        token: Address,
+    ) -> Result<()> {
+        if sender != validator {
+            return Err(FeeManagerError::unauthorized().into());
+        }
 
         let amount = self.collected_fees[validator][token].read()?;
         if amount.is_zero() {
             return Ok(());
         }
+
+        // collect_fee_pre_tx creates FeeManager balance slots for free; do not convert them into
+        // storage credits. Only set the flag once we know there is a non-zero transfer to perform.
+        StorageCtx.set_tip1060_storage_credit_minting(false);
+
         self.collected_fees[validator][token].write(U256::ZERO)?;
 
         // Transfer fees to validator
@@ -1015,7 +1030,7 @@ mod tests {
             assert_eq!(collected, U256::ZERO);
 
             // distribute_fees should be a no-op
-            let result = fee_manager.distribute_fees(validator, token.address());
+            let result = fee_manager.distribute_fees(validator, validator, token.address());
             assert!(result.is_ok(), "Should succeed even with zero balance");
 
             // Validator balance should still be zero
@@ -1062,9 +1077,9 @@ mod tests {
                 tip20_token.balance_of(ITIP20::balanceOfCall { account: validator })?;
             assert_eq!(balance_before, U256::ZERO);
 
-            // Distribute fees
+            // Distribute fees (caller must be the validator)
             let mut fee_manager = TipFeeManager::new();
-            fee_manager.distribute_fees(validator, token.address())?;
+            fee_manager.distribute_fees(validator, validator, token.address())?;
 
             // Verify validator received the fees
             let tip20_token = TIP20Token::from_address(token.address())?;
@@ -1076,6 +1091,45 @@ mod tests {
             let fee_manager = TipFeeManager::new();
             let remaining = fee_manager.collected_fees[validator][token.address()].read()?;
             assert_eq!(remaining, U256::ZERO);
+
+            Ok(())
+        })
+    }
+
+    /// Only the validator may claim their accumulated fees; unrelated EOAs are rejected.
+    #[test]
+    fn test_distribute_fees_rejects_unauthorized_caller() -> eyre::Result<()> {
+        let mut storage = HashMapStorageProvider::new(1);
+        let admin = Address::random();
+        let validator = Address::random();
+        let attacker = Address::random();
+
+        StorageCtx::enter(&mut storage, || {
+            let token = TIP20Setup::create("TestToken", "TEST", admin)
+                .with_issuer(admin)
+                .with_mint(TIP_FEE_MANAGER_ADDRESS, U256::from(1000))
+                .apply()?;
+
+            let mut fee_manager = TipFeeManager::new();
+            let fee_amount = U256::from(500);
+            fee_manager.collected_fees[validator][token.address()].write(fee_amount)?;
+
+            let result = fee_manager.distribute_fees(attacker, validator, token.address());
+            assert_eq!(
+                result,
+                Err(TempoPrecompileError::FeeManagerError(
+                    FeeManagerError::unauthorized()
+                ))
+            );
+
+            // Fees must remain uncleared when the call is rejected
+            let remaining = fee_manager.collected_fees[validator][token.address()].read()?;
+            assert_eq!(remaining, fee_amount);
+
+            let tip20_token = TIP20Token::from_address(token.address())?;
+            let balance =
+                tip20_token.balance_of(ITIP20::balanceOfCall { account: validator })?;
+            assert_eq!(balance, U256::ZERO);
 
             Ok(())
         })

--- a/tips/verify/test/invariants/FeeAMM.t.sol
+++ b/tips/verify/test/invariants/FeeAMM.t.sol
@@ -1036,7 +1036,8 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
 
     /// @notice Handler for distributing collected fees
     /// @dev On tempo-foundry, fees are only collected via protocol tx execution
-    ///      This handler tests the distribution mechanism when fees exist
+    ///      This handler tests the distribution mechanism when fees exist.
+    ///      Only the validator may call distributeFees (access control).
     /// @param seed Seed for selecting a pending fee entry
     function distributeFees(uint256 seed) external {
         // Select from tracked pending fees to avoid discarded runs
@@ -1045,6 +1046,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
         uint256 collectedBefore = amm.collectedFees(validator, token);
         uint256 validatorBalanceBefore = ITIP20(token).balanceOf(validator);
 
+        vm.prank(validator);
         try amm.distributeFees(validator, token) {
             _removePendingFee(validator, token);
 
@@ -2466,6 +2468,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
                 address token = address(_tokens[t]);
                 uint256 pending = amm.collectedFees(validator, token);
                 if (pending > 0) {
+                    vm.prank(validator);
                     try amm.distributeFees(validator, token) {
                         distributedAfterUnblacklist += pending;
                     } catch (bytes memory reason) {
@@ -2485,6 +2488,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
             // pathUSD fees
             uint256 pendingPathUSD = amm.collectedFees(validator, address(pathUSD));
             if (pendingPathUSD > 0) {
+                vm.prank(validator);
                 try amm.distributeFees(validator, address(pathUSD)) {
                     distributedAfterUnblacklist += pendingPathUSD;
                 } catch (bytes memory reason) {
@@ -2561,6 +2565,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
                 address token = address(_tokens[t]);
                 uint256 pendingFees = amm.collectedFees(validator, token);
                 if (pendingFees > 0) {
+                    vm.prank(validator);
                     try amm.distributeFees(validator, token) { }
                     catch (bytes memory reason) {
                         _assertKnownFeeManagerError(reason);
@@ -2573,6 +2578,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
             // Also distribute pathUSD fees
             uint256 pendingPathUSD = amm.collectedFees(validator, address(pathUSD));
             if (pendingPathUSD > 0) {
+                vm.prank(validator);
                 try amm.distributeFees(validator, address(pathUSD)) { }
                 catch (bytes memory reason) {
                     _assertKnownFeeManagerError(reason);
@@ -2874,6 +2880,7 @@ contract FeeAMMInvariantTest is InvariantBaseTest {
             || selector == IFeeAMM.InvalidToken.selector
             || selector == IFeeAMM.InsufficientLiquidity.selector
             || selector == ITIP20.InvalidCurrency.selector || _isKnownTIP20Error(selector)
+            || selector == bytes4(keccak256("Unauthorized()"))
             // FeeManager specific (string reverts)
             || keccak256(reason)
                 == keccak256(abi.encodeWithSignature("Error(string)", "ONLY_DIRECT_CALL"))


### PR DESCRIPTION
﻿## Summary
- Restrict `distributeFees` so only the validator (`msg.sender == validator`) can claim their accumulated fees, matching the caller-is-subject pattern of `setValidatorToken` / `setUserToken`.
- Add `Unauthorized` to the FeeManager ABI and reject unrelated EOA callers before any state mutation.
- Move `set_tip1060_storage_credit_minting(false)` after the zero-balance early return so no-op calls do not flip global storage-credit state.
- Update unit, integration, and FeeAMM invariant tests accordingly.

## Test plan
- [ ] `cargo test -p tempo-precompiles tip_fee_manager`
- [ ] `cargo test -p tempo-node --test it tip_fee_manager storage_credits` (CI)
- [ ] Confirm unauthorized caller reverts with `Unauthorized` and leaves `collectedFees` uncleared
- [ ] Confirm validator caller still distributes and zeros the ledger
