### PR TITLE
fix(precompiles): guard set_code overwrites and detect TIP20 by address prefix

### DIFF
--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -119,6 +119,13 @@ pub enum TempoPrecompileError {
     #[error("Gas limit exceeded")]
     OutOfGas,
 
+    /// `set_code` was called on an address that already has code. This is a "should be
+    /// impossible" invariant violation (callers must not overwrite live bytecode), so it
+    /// halts as a system/fatal error rather than reverting.
+    #[error("Code already exists at {0}")]
+    #[from(skip)]
+    CodeAlreadyExists(alloy::primitives::Address),
+
     /// The calldata's 4-byte selector does not match any known precompile function.
     #[error("Unknown function selector: {0:?}")]
     UnknownFunctionSelector([u8; 4]),
@@ -182,7 +189,7 @@ impl TempoPrecompileError {
             Self::ZoneFactoryError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
             Self::Panic(_) | Self::StorageDeltaUnderflow(_) => Panic::SELECTOR,
-            Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
+            Self::OutOfGas | Self::Fatal(_) | Self::CodeAlreadyExists(_) => [0, 0, 0, 0],
         }
         .into()
     }
@@ -191,9 +198,11 @@ impl TempoPrecompileError {
     /// rather than swallowed, because state may be inconsistent.
     pub fn is_system_error(&self) -> bool {
         match self {
-            Self::OutOfGas | Self::Fatal(_) | Self::Panic(_) | Self::StorageDeltaUnderflow(_) => {
-                true
-            }
+            Self::OutOfGas
+            | Self::Fatal(_)
+            | Self::Panic(_)
+            | Self::StorageDeltaUnderflow(_)
+            | Self::CodeAlreadyExists(_) => true,
             Self::StablecoinDEX(_)
             | Self::TIP20(_)
             | Self::TIP20ChannelReserveError(_)
@@ -285,6 +294,9 @@ impl TempoPrecompileError {
             .into(),
             Self::Fatal(msg) => {
                 return Err(PrecompileError::Fatal(msg));
+            }
+            err @ Self::CodeAlreadyExists(_) => {
+                return Err(PrecompileError::Fatal(err.to_string()));
             }
         };
         Ok(PrecompileOutput::revert(gas, bytes, reservoir))

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -14,7 +14,7 @@ use revm::{
 };
 use std::{cell::RefCell, rc::Rc};
 use tempo_chainspec::hardfork::TempoHardfork;
-use tempo_primitives::TempoBlockEnv;
+use tempo_primitives::{TempoAddressExt, TempoBlockEnv};
 
 /// Production [`PrecompileStorageProvider`] backed by the live EVM journal.
 ///
@@ -353,20 +353,33 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
     #[inline]
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {
         let code_len = code.len();
+
+        // Reject overwriting live bytecode before any gas/state mutation, so the Fatal halt
+        // leaves nothing partially written. Callers must never re-deploy over existing code.
+        if !self
+            .internals
+            .load_account_mut(address)?
+            .data
+            .account()
+            .info
+            .is_empty_code_hash()
+        {
+            return Err(TempoPrecompileError::CodeAlreadyExists(address));
+        }
+
         self.deduct_gas(self.gas_params.code_deposit_cost(code_len))?;
 
         // Track state gas for code deposit
         self.deduct_state_gas(self.gas_params.code_deposit_state_gas(code_len))?;
 
-        let was_empty = {
-            let mut account = self.internals.load_account_mut(address)?;
-            let was_empty = account.data.account().info.is_empty();
-            account.set_code_and_hash_slow(code);
-            was_empty
-        };
+        self.internals
+            .load_account_mut(address)?
+            .set_code_and_hash_slow(code);
 
-        // TIP-1016: charge TIP20 deployments as CREATE.
-        if self.amsterdam_eip8037_enabled && was_empty {
+        // TIP-1016: charge TIP20 deployments as CREATE. Keyed on the address prefix, not on
+        // whether the account was previously empty — a non-TIP20 deploy to a fresh address
+        // must not incur the CREATE charge.
+        if self.amsterdam_eip8037_enabled && address.is_tip20() {
             self.deduct_gas(self.gas_params.create_cost())?;
             self.deduct_state_gas(self.gas_params.create_state_gas())?;
             self.deduct_gas(self.gas_params.keccak256_cost(code_len.div_ceil(32)))?;
@@ -832,6 +845,24 @@ mod tests {
         }
     }
 
+    /// A random address carrying the TIP20 token prefix, so `is_tip20()` returns true.
+    fn tip20_address() -> Address {
+        let mut bytes = Address::random().into_array();
+        bytes[..12].copy_from_slice(&<Address as TempoAddressExt>::TIP20_PREFIX);
+        Address::from(bytes)
+    }
+
+    /// A random address guaranteed NOT to carry the TIP20 prefix, so `is_tip20()` is false.
+    /// State-gas tests use this so a prefix collision can't flip TIP-1016 CREATE detection.
+    fn non_tip20_address() -> Address {
+        loop {
+            let addr = Address::random();
+            if !addr.is_tip20() {
+                return addr;
+            }
+        }
+    }
+
     #[test]
     fn test_sstore_sload_actions_recording() -> eyre::Result<()> {
         let mut evm = TestEvm::default();
@@ -913,6 +944,36 @@ mod tests {
         };
 
         assert_eq!(data, *code.original_bytes());
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_code_rejects_overwrite() -> eyre::Result<()> {
+        let mut evm = TestEvm::default();
+        let mut provider = evm.provider_max_gas();
+
+        let addr = Address::random();
+        let original = Bytecode::new_raw(vec![0xff].into());
+        let overwrite = Bytecode::new_raw(vec![0xaa].into());
+
+        provider.set_code(addr, original.clone())?;
+
+        // Second set_code on the same address must be rejected, not silently applied.
+        let err = provider
+            .set_code(addr, overwrite)
+            .expect_err("set_code on an already-coded address must error");
+        assert_eq!(err, TempoPrecompileError::CodeAlreadyExists(addr));
+
+        std::mem::drop(provider);
+
+        let Some(StateLoad { data, is_cold: _ }) = evm.load_account_code(addr) else {
+            panic!("Failed to load account code")
+        };
+        assert_eq!(
+            data,
+            *original.original_bytes(),
+            "original bytecode must be unchanged after a rejected overwrite"
+        );
         Ok(())
     }
 
@@ -1175,7 +1236,7 @@ mod tests {
         let gas_params = evm.ctx().cfg.gas_params.clone();
         let mut provider = evm.provider_with_reservoir(0);
 
-        let (address, code_address, slot) = (Address::random(), Address::random(), U256::ONE);
+        let (address, code_address, slot) = (Address::random(), tip20_address(), U256::ONE);
 
         // SLOADs should not add state gas
         provider.sload(address, slot)?;
@@ -1346,7 +1407,7 @@ mod tests {
             + gas_params.keccak256_cost(code.len().div_ceil(32));
         let mut provider = evm.provider_with_reservoir(expected_state_gas);
 
-        provider.set_code(Address::random(), code)?;
+        provider.set_code(tip20_address(), code)?;
         assert_eq!(
             provider.gas_used(),
             expected_regular_gas,
@@ -1355,7 +1416,39 @@ mod tests {
         assert_eq!(
             provider.state_gas_used(),
             expected_state_gas,
-            "set_code on a new account should charge CREATE state gas plus code deposit state gas"
+            "set_code on a new TIP20 account should charge CREATE state gas plus code deposit state gas"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_set_code_tip1016_create_charge_keys_on_tip20_prefix() -> eyre::Result<()> {
+        let mut evm = TestEvm::new_with_tip1016(TempoHardfork::T4);
+        let gas_params = evm.ctx().cfg.gas_params.clone();
+        let code = Bytecode::new_raw(vec![0xef].into());
+
+        let deposit_only_gas = gas_params.code_deposit_cost(code.len());
+        let create_charge =
+            gas_params.create_cost() + gas_params.keccak256_cost(code.len().div_ceil(32));
+
+        // Non-TIP20 fresh address: code deposit only, NO CREATE charge.
+        let mut provider = evm.provider_with_reservoir(u64::MAX);
+        provider.set_code(non_tip20_address(), code.clone())?;
+        assert_eq!(
+            provider.gas_used(),
+            deposit_only_gas,
+            "non-TIP20 deploy must not incur the TIP-1016 CREATE charge"
+        );
+        std::mem::drop(provider);
+
+        // TIP20-prefixed fresh address: code deposit PLUS CREATE charge.
+        let mut provider = evm.provider_with_reservoir(u64::MAX);
+        provider.set_code(tip20_address(), code)?;
+        assert_eq!(
+            provider.gas_used(),
+            deposit_only_gas + create_charge,
+            "TIP20 deploy must incur the TIP-1016 CREATE charge"
         );
 
         Ok(())

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -117,6 +117,10 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
 
     fn set_code(&mut self, address: Address, code: Bytecode) -> Result<(), TempoPrecompileError> {
         let account = self.accounts.entry(address).or_default();
+        // Match the EVM provider: never silently overwrite existing code.
+        if !account.is_empty_code_hash() {
+            return Err(TempoPrecompileError::CodeAlreadyExists(address));
+        }
         account.code_hash = code.hash_slow();
         account.code = Some(code);
         Ok(())


### PR DESCRIPTION
﻿## Summary
- Add an overwrite guard in `EvmPrecompileStorageProvider::set_code` (and the `HashMapStorageProvider` mock) that returns `CodeAlreadyExists` before any gas/state mutation when the account already has code.
- Treat `CodeAlreadyExists` as a system/fatal error so a halt leaves no partial writes.
- Key the TIP-1016 CREATE gas charge on `address.is_tip20()` instead of the `was_empty` heuristic, so only real TIP20 deployments pay CREATE costs.
- Add unit tests for overwrite rejection and prefix-based CREATE charging; pin existing TIP-1016 success-path tests to TIP20-prefixed addresses.

Credits direction from #5723 / #6569 (stale-bot closed).

## Test plan
- [ ] `cargo test -p tempo-precompiles storage::evm`
- [ ] `cargo test -p tempo-precompiles test_set_code_rejects_overwrite`
- [ ] `cargo test -p tempo-precompiles test_set_code_tip1016_create_charge_keys_on_tip20_prefix`
- [ ] Confirm non-TIP20 fresh deploys no longer pay CREATE gas under TIP-1016
