### PR TITLE
chore(release): prepare v1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13291,7 +13291,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13455,7 +13455,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13526,7 +13526,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13556,7 +13556,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13570,7 +13570,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13622,7 +13622,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13674,7 +13674,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13693,7 +13693,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13701,7 +13701,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13726,7 +13726,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13804,7 +13804,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13842,7 +13842,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13862,7 +13862,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13898,7 +13898,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13947,7 +13947,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13980,7 +13980,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "clap",
@@ -14005,7 +14005,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -14014,7 +14014,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14057,7 +14057,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14069,7 +14069,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.13.2"
+version = "1.14.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Prepares Tempo v1.14.0 from aae17533e90ec31058a35402f0900bf14165d1a5 by updating the workspace version and lockfile.

Prompted by: @klkvr