### PR TITLE
chore: tag reth team in all update alerts

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -687,21 +687,19 @@ jobs:
 
           # Determine overall status
           JOB_STATUS="${JOB_STATUS_IN}"
+          MENTION="<!subteam^S09KMRP46D7|reth>"
           if [ "$JOB_STATUS" = "success" ]; then
             EMOJI="✅"
             STATUS="succeeded"
             COLOR="#2eb67d"
-            MENTION=""
           elif [ "$JOB_STATUS" = "cancelled" ]; then
             EMOJI="⚠️"
             STATUS="cancelled"
             COLOR="#e0a523"
-            MENTION="<!subteam^S09KMRP46D7|reth>"
           else
             EMOJI="❌"
             STATUS="failed"
             COLOR="#e01e5a"
-            MENTION="<!subteam^S09KMRP46D7|reth>"
           fi
 
           # Build detail lines


### PR DESCRIPTION
## Summary

- tag the Reth Slack user group on successful dependency-update alerts
- preserve the existing mention on cancelled and failed alerts

## Validation

- `git diff --check`
- rendered the success payload with `jq` and confirmed the user-group mention is present

Prompted by: @emmajam