### PR TITLE
docs(tips): approve TIP-1093 and TIP-1100

### DIFF
--- a/tips/tip-1093.md
+++ b/tips/tip-1093.md
@@ -3,7 +3,7 @@ id: TIP-1093
 title: Extend Expiring Nonce Window to Five Minutes
 description: Extends the expiring nonce validity window from 30 seconds to five minutes and resizes replay-protection storage accordingly.
 authors: @shekhirin
-status: Draft
+status: Approved
 related: TIP-1009, TIP-0001
 protocolVersion: T11
 ---

--- a/tips/tip-1100.md
+++ b/tips/tip-1100.md
@@ -3,7 +3,7 @@ id: TIP-1100
 title: Increase Precompile Input Gas Cost
 description: Increases the calldata input charge for Tempo precompiles from 6 to 30 gas per 32-byte word.
 authors: Arsenii Kulikov (@klkvr)
-status: Draft
+status: Approved
 related: TIP-1020
 protocolVersion: T11
 ---


### PR DESCRIPTION
Marks TIP-1093 and TIP-1100 as approved for the T11 network upgrade.

Prompted by: @jenpaff