### PR TITLE
test(ci): terminate hung node integration tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -59,6 +59,7 @@ slow-timeout = { period = "5m", terminate-after = 1 }
 [[profile.ci.overrides]]
 filter = "package(tempo-node) & binary(it)"
 threads-required = 4
+slow-timeout = { period = "3m", terminate-after = 1 }
 
 [[profile.default.overrides]]
 filter = "test(can_restart_after_joining_from_snapshot)"
@@ -84,3 +85,4 @@ slow-timeout = { period = "4m", terminate-after = 1 }
 [[profile.default.overrides]]
 filter = "package(tempo-node) & binary(it)"
 threads-required = 4
+slow-timeout = { period = "4m", terminate-after = 1 }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,6 @@
+[profile.default]
+slow-timeout = { period = "3m", terminate-after = 1 }
+
 [profile.ci]
 fail-fast = false
 retries = 2
@@ -34,7 +37,6 @@ priority = -100
 filter = "package(tempo-e2e)"
 failure-output = "never"
 threads-required = 4
-slow-timeout = { period = "3m", terminate-after = 1 }
 
 # Separate profile for flaky snapshot-restart tests so they fail-fast independently.
 [profile.ci-flaky]
@@ -42,7 +44,6 @@ inherits = "ci"
 fail-fast = true
 retries = 0
 failure-output = "final"
-slow-timeout = { period = "3m", terminate-after = 1 }
 default-filter = "package(tempo-e2e) & test(can_restart_after_joining_from_snapshot)"
 
 # Dedicated profile for live RPC matrix tests (testnet/devnet).
@@ -59,7 +60,6 @@ slow-timeout = { period = "5m", terminate-after = 1 }
 [[profile.ci.overrides]]
 filter = "package(tempo-node) & binary(it)"
 threads-required = 4
-slow-timeout = { period = "3m", terminate-after = 1 }
 
 [[profile.default.overrides]]
 filter = "test(can_restart_after_joining_from_snapshot)"
@@ -80,9 +80,7 @@ priority = -100
 [[profile.default.overrides]]
 filter = "package(tempo-e2e)"
 threads-required = 4
-slow-timeout = { period = "4m", terminate-after = 1 }
 
 [[profile.default.overrides]]
 filter = "package(tempo-node) & binary(it)"
 threads-required = 4
-slow-timeout = { period = "4m", terminate-after = 1 }


### PR DESCRIPTION
Terminate `tempo-node` integration tests after three minutes in CI and four minutes locally instead of allowing hung node/RPC waits to block a shard indefinitely.

Prompted by: @pepyakin
