### PR TITLE
chore(bench): tune multi-region nightly persistence settings

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -170,6 +170,8 @@ jobs:
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '5000' }}
       run-pairs: ${{ inputs['run-pairs'] || '3' }}
       clickhouse-run: feature-1
+      baseline-args: --engine.persistence-threshold 50 --engine.num-state-masking-blocks 40
+      feature-args: --engine.persistence-threshold 50 --engine.num-state-masking-blocks 40
       otlp: true
       valscope: true
     secrets:

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -23,6 +23,16 @@ on:
         type: string
         required: false
         default: ""
+      baseline-args:
+        description: Extra args passed only to the baseline node.
+        type: string
+        required: false
+        default: ""
+      feature-args:
+        description: Extra args passed only to the feature node.
+        type: string
+        required: false
+        default: ""
       duration:
         type: string
         required: false


### PR DESCRIPTION
Apply the nightly persistence settings from https://github.com/tempoxyz/tempo/pull/7455 to both sides of scheduled multi-region benchmarks: persistence threshold 50 and state-masking blocks 40. Expose the existing per-side node arguments to reusable workflow callers and pass the equivalent CLI flags; manual benchmark defaults remain unchanged.

Validation: actionlint 1.7.12, YAML parsing and input/default assertions, and `git diff --check` pass. The [benchmark-repo branch smoke run](https://github.com/tempoxyz/tempo-multi-region-benchmark/actions/runs/33898008268) passed, including teardown, with 1 GiB bloat, 10 validators in us-east-1, and one run pair. Both phases exited successfully; all 20 per-validator argument artifacts confirm threshold 50 and masking blocks 40. The manual smoke explicitly supplied the same arguments as the scheduled caller; the scheduled input wiring was checked statically.

Prompted by: @shekhirin
