### PR TITLE
feat(consensus): add adaptive proposal pacing

### DIFF
--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -154,6 +154,11 @@ pub struct Args {
     #[arg(long = "consensus.network-budget", default_value = "50ms")]
     pub network_budget: PositiveDuration,
 
+    /// Adapt the local proposal budget to healthy notarization intervals.
+    /// Starts with `network-budget` and learns separately on each proposer.
+    #[arg(long = "consensus.adaptive-pacing", default_value_t = false)]
+    pub adaptive_pacing: bool,
+
     /// Deprecated compatibility flag. Ignored by the elastic proposal budget.
     #[arg(
         long = "consensus.time-to-prepare-proposal-transactions",

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -69,6 +69,7 @@ pub(in crate::consensus) struct Actor<TContext, TState = Uninit> {
 
 struct BuildProposalArgs {
     propose_start: Instant,
+    proposal_return_budget: Duration,
     parent_view: View,
     parent_digest: Digest,
     round: Round,
@@ -106,7 +107,11 @@ where
 {
     pub(super) async fn init(config: super::Config<TContext>) -> eyre::Result<Self> {
         let (tx, rx) = mailbox::new(config.context.child("mailbox"), config.mailbox_size);
-        let my_mailbox = Mailbox::from_sender(tx);
+        let my_mailbox = Mailbox::from_sender(
+            tx,
+            config.adaptive_pacing_target,
+            config.proposal_return_budget,
+        );
 
         let metrics = Metrics::init(&config.context);
 
@@ -274,6 +279,11 @@ impl Inner<Init> {
             started_at: propose_start,
         } = request;
 
+        // Snapshot once: builder and return pacing must share the same window.
+        let proposal_return_budget =
+            self.my_mailbox
+                .proposal_budget(round, parent_view, self.proposal_return_budget);
+
         // Report the parent we are asked to build on as the pending head,
         // so that the executor can get started on bringing the execution
         // layer to the right state. On the happy path there should always
@@ -318,6 +328,7 @@ impl Inner<Init> {
                     &context,
                     BuildProposalArgs {
                         propose_start,
+                        proposal_return_budget,
                         parent_view,
                         parent_digest,
                         round,
@@ -361,6 +372,8 @@ impl Inner<Init> {
 
                     // Keep waiting for the remaining return time, if there's anything left after building the block.
                     context.sleep_until(proposal_return.return_at).await;
+                    self.my_mailbox
+                        .proposal_returned(round, propose_start.elapsed());
                 }
 
                 eyre::Ok(block)
@@ -455,6 +468,7 @@ impl Inner<Init> {
     ) -> eyre::Result<(Block, Option<ProposalReturn>)> {
         let BuildProposalArgs {
             propose_start,
+            proposal_return_budget,
             parent_view,
             parent_digest,
             round,
@@ -581,9 +595,7 @@ impl Inner<Init> {
         // Give the builder only the proposal window that remains when payload
         // construction is requested. This accounts for a late `handle_propose`
         // start instead of resetting the budget at builder entry.
-        let build_budget = self
-            .proposal_return_budget
-            .saturating_sub(propose_start.elapsed());
+        let build_budget = proposal_return_budget.saturating_sub(propose_start.elapsed());
         let validation_latency_estimate = self
             .validation_latency_estimator
             .lock()
@@ -642,8 +654,7 @@ impl Inner<Init> {
         // Pace proposal return from the original propose start. Validators still
         // need to repeat replayable build work and marshal persistence, so leave
         // room for those costs before returning the proposal.
-        let return_delay = self
-            .proposal_return_budget
+        let return_delay = proposal_return_budget
             .saturating_sub(proposal_elapsed)
             .saturating_sub(validation_latency_elapsed)
             .saturating_sub(validator_marshal_persist);

--- a/crates/consensus/src/consensus/application/ingress.rs
+++ b/crates/consensus/src/consensus/application/ingress.rs
@@ -3,25 +3,80 @@ use commonware_actor::{
     mailbox::{self, Policy},
 };
 use commonware_consensus::{
-    Automaton, CertifiableAutomaton, Relay,
-    simplex::{Plan, types::Context},
+    Automaton, CertifiableAutomaton, Relay, Reporter,
+    simplex::{
+        Plan,
+        scheme::bls12381_threshold::vrf::Scheme,
+        types::{Activity, Context},
+    },
     types::{Round, View},
 };
 
-use commonware_cryptography::ed25519::PublicKey;
+use commonware_cryptography::{bls12381::primitives::variant::MinSig, ed25519::PublicKey};
 use commonware_utils::channel::oneshot;
-use std::{collections::VecDeque, time::Instant};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use super::pacing::Pacing;
 
 use crate::consensus::Digest;
 
 #[derive(Clone)]
 pub(crate) struct Mailbox {
     inner: mailbox::Sender<Message>,
+    pacing: Option<Arc<Mutex<Pacing>>>,
 }
 
 impl Mailbox {
-    pub(super) fn from_sender(inner: mailbox::Sender<Message>) -> Self {
-        Self { inner }
+    pub(super) fn from_sender(
+        inner: mailbox::Sender<Message>,
+        target: Option<Duration>,
+        budget: Duration,
+    ) -> Self {
+        Self {
+            inner,
+            pacing: target.map(|target| Arc::new(Mutex::new(Pacing::new(target, budget)))),
+        }
+    }
+
+    pub(super) fn proposal_budget(
+        &self,
+        round: Round,
+        parent: View,
+        default: Duration,
+    ) -> Duration {
+        self.pacing
+            .as_ref()
+            .and_then(|pacing| pacing.lock().ok())
+            .map_or(default, |mut pacing| pacing.begin(round, parent))
+    }
+
+    pub(super) fn proposal_returned(&self, round: Round, elapsed: Duration) {
+        if let Some(pacing) = &self.pacing
+            && let Ok(mut pacing) = pacing.lock()
+        {
+            pacing.returned(round, elapsed);
+        }
+    }
+}
+
+impl Reporter for Mailbox {
+    type Activity = Activity<Scheme<PublicKey, MinSig>, Digest>;
+
+    fn report(&mut self, activity: Self::Activity) -> Feedback {
+        if let Some(pacing) = &self.pacing
+            && let Ok(mut pacing) = pacing.lock()
+        {
+            match activity {
+                Activity::Notarization(n) => pacing.notarized(n.proposal.round, Instant::now()),
+                Activity::Nullification(n) => pacing.nullified(n.round),
+                _ => {}
+            }
+        }
+        Feedback::Ok
     }
 }
 
@@ -172,7 +227,7 @@ mod tests {
     fn broadcast_overflow_is_dropped() {
         deterministic::Runner::default().start(|context| async move {
             let (sender, mut receiver) = mailbox::new(context.child("mailbox"), NZUsize!(1));
-            let mut mailbox = Mailbox::from_sender(sender);
+            let mut mailbox = Mailbox::from_sender(sender, None, std::time::Duration::ZERO);
             let round = Round::new(Epoch::zero(), View::zero());
             let first = Digest(B256::with_last_byte(1));
             let second = Digest(B256::with_last_byte(2));

--- a/crates/consensus/src/consensus/application/mod.rs
+++ b/crates/consensus/src/consensus/application/mod.rs
@@ -15,6 +15,7 @@ use tempo_node::TempoFullNode;
 
 mod actor;
 mod ingress;
+mod pacing;
 
 pub(super) use actor::Actor;
 pub(crate) use ingress::Mailbox;
@@ -63,6 +64,7 @@ pub(super) struct Config<TContext> {
     /// subtracts time already spent in the view before handing the remaining
     /// budget to the payload builder.
     pub(super) proposal_return_budget: Duration,
+    pub(super) adaptive_pacing_target: Option<Duration>,
 
     /// The epoch strategy used by tempo, to map block heights to epochs.
     pub(super) epoch_strategy: FixedEpocher,

--- a/crates/consensus/src/consensus/application/pacing.rs
+++ b/crates/consensus/src/consensus/application/pacing.rs
@@ -1,0 +1,235 @@
+//! Local feedback for proposal pacing. Only our own healthy rounds train the
+//! controller, so each proposer learns its own network/validation overhead.
+//! All measurements use the local monotonic clock, never block timestamps.
+
+use std::time::{Duration, Instant};
+
+use commonware_consensus::types::{Round, View};
+
+const MIN_BUDGET: Duration = Duration::from_millis(50);
+const MAX_STEP: Duration = Duration::from_millis(10);
+const OVERRUN_TOLERANCE: Duration = Duration::from_millis(10);
+
+pub(super) struct Pacing {
+    target: Duration,
+    budget: Duration,
+    last: Option<(Round, Instant)>,
+    last_nullified: Option<Round>,
+    pending: Option<Sample>,
+}
+
+struct Sample {
+    round: Round,
+    parent: Round,
+    budget: Duration,
+    returned: bool,
+}
+
+impl Pacing {
+    pub(super) fn new(target: Duration, budget: Duration) -> Self {
+        Self {
+            target,
+            budget: budget.clamp(MIN_BUDGET.min(target), target),
+            last: None,
+            last_nullified: None,
+            pending: None,
+        }
+    }
+
+    pub(super) fn begin(&mut self, round: Round, parent: View) -> Duration {
+        // A nullified view or an epoch transition is not a healthy interval.
+        self.pending = self.last.and_then(|(last, _)| {
+            (last.epoch() == round.epoch()
+                && last.view() == parent
+                && parent.next() == round.view()
+                && self
+                    .last_nullified
+                    .is_none_or(|nullified| nullified < round))
+            .then_some(Sample {
+                round,
+                parent: last,
+                budget: self.budget,
+                returned: false,
+            })
+        });
+        self.budget
+    }
+
+    pub(super) fn returned(&mut self, round: Round, elapsed: Duration) {
+        if let Some(sample) = &mut self.pending
+            && sample.round == round
+        {
+            // Do not compensate for local builder or persistence overruns.
+            sample.returned = elapsed <= sample.budget.saturating_add(OVERRUN_TOLERANCE);
+        }
+    }
+
+    pub(super) fn nullified(&mut self, round: Round) {
+        self.last_nullified = Some(self.last_nullified.map_or(round, |last| last.max(round)));
+        if self.last.is_none_or(|(last, _)| round > last) {
+            self.pending = None;
+        }
+    }
+
+    pub(super) fn notarized(&mut self, round: Round, now: Instant) {
+        if self.last.is_some_and(|(last, _)| round <= last) {
+            return;
+        }
+        if let Some(sample) = self.pending.take()
+            && sample.round == round
+            && sample.returned
+            && let Some((parent, start)) = self.last
+            && parent == sample.parent
+            && let Some(interval) = now.checked_duration_since(start)
+            // Long stalls and catch-up bursts must not train normal pacing.
+            && interval >= self.target / 2
+            && interval <= self.target.saturating_mul(2)
+        {
+            // A slow integral controller: at most 10ms per local proposal,
+            // and only one eighth of the observed error. Bounds prevent windup
+            // when the target is infeasible and preserve some local work time.
+            if interval > self.target {
+                let step = ((interval - self.target) / 8).min(MAX_STEP);
+                self.budget = self.budget.saturating_sub(step);
+            } else {
+                let step = ((self.target - interval) / 8).min(MAX_STEP);
+                self.budget = self.budget.saturating_add(step);
+            }
+            self.budget = self.budget.clamp(MIN_BUDGET.min(self.target), self.target);
+            tracing::info!(
+                %round,
+                interval_ms = interval.as_secs_f64() * 1000.0,
+                proposal_budget_ms = self.budget.as_secs_f64() * 1000.0,
+                target_ms = self.target.as_secs_f64() * 1000.0,
+                "adjusted adaptive proposal pacing"
+            );
+        }
+        self.last = Some((round, now));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_consensus::types::Epoch;
+
+    fn round(view: u64) -> Round {
+        Round::new(Epoch::zero(), View::new(view))
+    }
+
+    fn sample(pacing: &mut Pacing, view: u64, now: &mut Instant, overhead: Duration) {
+        let budget = pacing.begin(round(view), View::new(view - 1));
+        pacing.returned(round(view), budget);
+        *now += budget + overhead;
+        pacing.notarized(round(view), *now);
+    }
+
+    #[test]
+    fn converges_and_recovers_when_network_latency_changes() {
+        let mut pacing = Pacing::new(Duration::from_millis(550), Duration::from_millis(500));
+        let mut now = Instant::now();
+        pacing.notarized(round(1), now);
+        for view in 2..82 {
+            sample(&mut pacing, view, &mut now, Duration::from_millis(210));
+        }
+        assert!(pacing.budget.abs_diff(Duration::from_millis(340)) < Duration::from_millis(1));
+        for view in 82..162 {
+            sample(&mut pacing, view, &mut now, Duration::from_millis(50));
+        }
+        assert!(pacing.budget.abs_diff(Duration::from_millis(500)) < Duration::from_millis(1));
+    }
+
+    #[test]
+    fn ignores_other_proposers_duplicates_skips_and_local_overruns() {
+        let initial = Duration::from_millis(500);
+        let mut pacing = Pacing::new(Duration::from_millis(550), initial);
+        let mut now = Instant::now();
+        pacing.notarized(round(1), now);
+        // Another proposer must not change our budget.
+        now += Duration::from_millis(700);
+        pacing.notarized(round(2), now);
+        pacing.notarized(round(2), now);
+        pacing.notarized(round(1), now);
+        assert_eq!(pacing.budget, initial);
+        // Local persistence took too long.
+        pacing.begin(round(3), View::new(2));
+        pacing.returned(round(3), Duration::from_millis(600));
+        now += Duration::from_millis(800);
+        pacing.notarized(round(3), now);
+        assert_eq!(pacing.budget, initial);
+        // A skipped view and a cancellation must not train the controller.
+        pacing.nullified(round(4));
+        pacing.begin(round(5), View::new(3));
+        pacing.returned(round(5), initial);
+        now += Duration::from_millis(700);
+        pacing.notarized(round(5), now);
+        pacing.begin(round(6), View::new(5));
+        now += Duration::from_millis(700);
+        pacing.notarized(round(6), now);
+        assert_eq!(pacing.budget, initial);
+    }
+
+    #[test]
+    fn limits_steps_and_preserves_budget_at_infeasible_targets() {
+        let mut pacing = Pacing::new(Duration::from_millis(550), Duration::from_millis(500));
+        let mut now = Instant::now();
+        pacing.notarized(round(1), now);
+        sample(&mut pacing, 2, &mut now, Duration::from_millis(300));
+        assert_eq!(pacing.budget, Duration::from_millis(490));
+        for view in 3..103 {
+            sample(&mut pacing, view, &mut now, Duration::from_millis(600));
+        }
+        assert_eq!(pacing.budget, MIN_BUDGET);
+        let tiny = Pacing::new(Duration::from_millis(1), Duration::ZERO);
+        assert_eq!(tiny.budget, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn ignores_stalls_and_epoch_transitions() {
+        let initial = Duration::from_millis(500);
+        let mut pacing = Pacing::new(Duration::from_millis(550), initial);
+        let mut now = Instant::now();
+        pacing.notarized(round(1), now);
+        sample(&mut pacing, 2, &mut now, Duration::from_secs(5));
+        assert_eq!(pacing.budget, initial);
+        let next_epoch = Round::new(Epoch::new(1), View::new(3));
+        pacing.begin(next_epoch, View::new(2));
+        pacing.returned(next_epoch, initial);
+        pacing.notarized(next_epoch, now + Duration::from_millis(700));
+        assert_eq!(pacing.budget, initial);
+    }
+
+    #[test]
+    fn rotating_proposers_learn_their_own_overhead() {
+        let target = Duration::from_millis(550);
+        let overheads = [100, 150, 210, 250, 300].map(Duration::from_millis);
+        let mut proposers = overheads.map(|_| Pacing::new(target, Duration::from_millis(500)));
+        let mut now = Instant::now();
+        for pacing in &mut proposers {
+            pacing.notarized(round(1), now);
+        }
+        for view in 2..502 {
+            let leader = (view as usize) % proposers.len();
+            let budget = proposers[leader].begin(round(view), View::new(view - 1));
+            proposers[leader].returned(round(view), budget);
+            now += budget + overheads[leader];
+            for pacing in &mut proposers {
+                pacing.notarized(round(view), now);
+            }
+        }
+        for (pacing, overhead) in proposers.iter().zip(overheads) {
+            assert!(pacing.budget.abs_diff(target - overhead) < Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn late_proposal_after_nullification_does_not_train() {
+        let initial = Duration::from_millis(500);
+        let mut pacing = Pacing::new(Duration::from_millis(550), initial);
+        let mut now = Instant::now();
+        pacing.notarized(round(1), now);
+        pacing.nullified(round(2));
+        sample(&mut pacing, 2, &mut now, Duration::from_millis(210));
+        assert_eq!(pacing.budget, initial);
+    }
+}

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -77,6 +77,8 @@ pub struct Builder<TBlocker, TPeerManager> {
     /// The leader uses this window for payload building, local marshal
     /// persistence, and any final wait before returning the proposal.
     pub proposal_return_budget: Duration,
+    /// Opt-in target for feedback from this node's healthy notarized proposals.
+    pub adaptive_pacing_target: Option<Duration>,
     pub time_to_build_subblock: Duration,
     pub subblock_broadcast_interval: Duration,
     pub fcu_heartbeat_interval: Duration,
@@ -269,6 +271,7 @@ where
             execution_node: execution_node.clone(),
             executor: executor_mailbox.clone(),
             proposal_return_budget: self.proposal_return_budget,
+            adaptive_pacing_target: self.adaptive_pacing_target,
             subblocks: subblocks.as_ref().map(|s| s.mailbox()),
             scheme_provider: scheme_provider.clone(),
             epoch_strategy: epoch_strategy.clone(),

--- a/crates/consensus/src/epoch/manager/actor.rs
+++ b/crates/consensus/src/epoch/manager/actor.rs
@@ -350,9 +350,12 @@ where
                 elector: elector::Random,
                 strategy: Sequential,
 
-                reporter: Reporters::<_, crate::subblocks::Mailbox, _>::from((
-                    self.config.subblocks.clone(),
-                    self.config.marshal.clone(),
+                reporter: Reporters::from((
+                    self.config.application.clone(),
+                    Reporters::<_, crate::subblocks::Mailbox, _>::from((
+                        self.config.subblocks.clone(),
+                        self.config.marshal.clone(),
+                    )),
                 )),
                 partition: format!(
                     "{partition_prefix}_consensus_epoch_{epoch}",

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -135,6 +135,7 @@ pub async fn run_consensus_stack(
         views_to_track: config.views_to_track,
         views_until_leader_skip: config.inactive_views_until_leader_skip,
         proposal_return_budget,
+        adaptive_pacing_target: config.adaptive_pacing.then_some(target_block_time),
         time_to_build_subblock: config.time_to_build_subblock.into_duration(),
         subblock_broadcast_interval: config.subblock_broadcast_interval.into_duration(),
         fcu_heartbeat_interval: config.fcu_heartbeat_interval.into_duration(),

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -331,6 +331,7 @@ where
             views_to_track: 10,
             views_until_leader_skip: 5,
             proposal_return_budget: self.proposal_return_budget,
+            adaptive_pacing_target: None,
             time_to_build_subblock: Duration::from_millis(100),
             subblock_broadcast_interval: Duration::from_millis(50),
             fcu_heartbeat_interval: Duration::from_secs(3),


### PR DESCRIPTION
Adds opt-in `--consensus.adaptive-pacing` to adjust the elastic proposal window toward the configured block interval. Each proposer learns from its own consecutive notarized rounds using a bounded correction; skipped views, epoch transitions, local work overruns, and long stalls do not train it. The builder and proposal return share one budget snapshot, with a 50 ms minimum (or the target if smaller).

Validation is in progress: targeted controller tests cover convergence, recovery, rotating proposers, bounds, and rejected samples; formatting and diff checks pass. The [main-versus-main noise benchmark](https://github.com/tempoxyz/tempo/actions/runs/33904934266) uses three 300-second pairs, 10 validators across five AWS regions, 100 GiB state, identical persistence settings, and Samply. Main-versus-branch results will be added before review; no performance improvement is claimed yet.

Prompted by: @shekhirin
