### PR TITLE
fix(bench): repair precompile benchmark setup

### DIFF
--- a/.github/scripts/test-bench-hardforks.nu
+++ b/.github/scripts/test-bench-hardforks.nu
@@ -1,0 +1,20 @@
+#!/usr/bin/env nu
+# Run from the repository root: nu .github/scripts/test-bench-hardforks.nu
+use std/assert
+source ../../tempo.nu
+
+let expected = [T0 T1 T1A T1B T1C T2 T3 T4 T5 T6 T7 T8 T9 T10 T11 T12]
+assert equal (tempo-hardforks) $expected
+assert equal (latest-tempo-hardfork) T12
+assert equal (highest-hardfork [T9 T10 T1A]) T10
+
+# Every selected fork must retain all predecessors and disable all successors,
+# including when the fixture's JSON keys put T10 before T1.
+for cutoff in $expected {
+    let fields = (hardfork-genesis-config-fields $cutoff)
+    let index = ($expected | enumerate | where item == $cutoff | get 0.index)
+    assert equal ($fields | where value == 0 | get fork) ($expected | take ($index + 1))
+    assert equal ($fields | where value != 0 | get fork) ($expected | skip ($index + 1))
+}
+
+print "Benchmark hardfork order and activation cutoffs are valid"

--- a/.github/scripts/test-bench-hardforks.nu
+++ b/.github/scripts/test-bench-hardforks.nu
@@ -18,3 +18,5 @@ for cutoff in $expected {
 }
 
 print "Benchmark hardfork order and activation cutoffs are valid"
+# Do not invoke tempo.nu's interactive help entrypoint after the tests.
+exit 0

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -363,6 +363,40 @@ def e2e-snapshots-ready [a_db: string, b_db: string] {
     (e2e-snapshot-ready $a_db) and (e2e-snapshot-ready $b_db)
 }
 
+# Cached snapshots can assign validators to a,b in a different order. Keep each
+# signing key/share bundle intact and bind it to its advertised peer address.
+def e2e-snapshot-topology [a_db: string, b_db: string] {
+    let a_meta = $"($a_db)/($BENCH_META_SUBDIR)"
+    let b_meta = $"($b_db)/($BENCH_META_SUBDIR)"
+    if (open $"($a_meta)/genesis.json") != (open $"($b_meta)/genesis.json") {
+        error make { msg: "Local e2e snapshots have different genesis configurations" }
+    }
+    let a_peers = (open --raw $"($a_meta)/trusted-peers.txt" | str trim | split row "," | each { str trim } | sort)
+    let b_peers = (open --raw $"($b_meta)/trusted-peers.txt" | str trim | split row "," | each { str trim } | sort)
+    if $a_peers != $b_peers {
+        error make { msg: "Local e2e snapshots have different trusted peers" }
+    }
+    let peers = ($a_peers | parse --regex '^enode://(?<identity>[0-9a-f]{128})@(?<ip>[^:]+):(?<port>[0-9]+)$'
+        | each { |peer| $peer | update port { into int } })
+    let expected_addresses = ($E2E_VALIDATORS | split row "," | sort)
+    let actual_addresses = ($peers | each { |peer| $"($peer.ip):($peer.port - 1)" } | sort)
+    if ($a_peers | length) != 2 or ($peers | length) != 2 or $actual_addresses != $expected_addresses {
+        error make { msg: "Local e2e snapshot peers must match the two configured validator addresses" }
+    }
+    let a_identity = (open --raw $"($a_db)/enode.identity" | str trim)
+    let b_identity = (open --raw $"($b_db)/enode.identity" | str trim)
+    let a_peer = ($peers | where identity == $a_identity)
+    let b_peer = ($peers | where identity == $b_identity)
+    if $a_identity == $b_identity or ($a_peer | length) != 1 or ($b_peer | length) != 1 {
+        error make { msg: "Local e2e snapshot identities must each match a distinct trusted peer" }
+    }
+    {
+        trusted_peers: ($a_peers | str join ",")
+        a: { identity: $a_identity, ip: $a_peer.0.ip, consensus_port: ($a_peer.0.port - 1) }
+        b: { identity: $b_identity, ip: $b_peer.0.ip, consensus_port: ($b_peer.0.port - 1) }
+    }
+}
+
 def e2e-snapshot-state-hardfork [datadir: string] {
     let marker = (read-bench-marker $datadir)
     if $marker == null {
@@ -1008,6 +1042,9 @@ def run-local-e2e-phase [run: record, ctx: record] {
     cleanup-local-e2e-processes
     bench-restore-at $ctx.a.state_path $ctx.a.mount $ctx.a.datadir
     bench-restore-at $ctx.b.state_path $ctx.b.mount $ctx.b.datadir
+    if (e2e-snapshot-topology $ctx.a.datadir $ctx.b.datadir) != $ctx.snapshot_topology {
+        error make { msg: "Local e2e snapshot identities or peer configuration changed after recovery" }
+    }
 
     for path in [$genesis $ctx.a.node_dir $ctx.b.node_dir] {
         if not ($path | path exists) {
@@ -1474,16 +1511,11 @@ def "main e2e" [
     }
     let a_validator = ($validator_list | get 0)
     let b_validator = ($validator_list | get 1)
-    let a_ip = ($a_validator | split row ":" | get 0)
-    let a_consensus_port = ($a_validator | split row ":" | get 1 | into int)
-    let b_ip = ($b_validator | split row ":" | get 0)
-    let b_consensus_port = ($b_validator | split row ":" | get 1 | into int)
     let a_db = $"($E2E_A_MOUNT)/tempo_e2e_($bloat_mib)mb"
     let b_db = $"($E2E_B_MOUNT)/tempo_e2e_($bloat_mib)mb"
     let a_identity = $a_db
     let b_identity = $b_db
     let genesis_path = $"($a_db)/($BENCH_META_SUBDIR)/genesis.json"
-    let a_trusted_peers_path = $"($a_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
     let run_started_at = (date now)
     let timestamp = ($run_started_at | format date "%Y%m%d-%H%M%S-%3f")
     let benchmark_id = ($env | get --optional BENCHMARK_ID)
@@ -1594,17 +1626,9 @@ def "main e2e" [
         e2e-synthesize-genesis $genesis_path $baseline_genesis_path $baseline_hardfork_name $gas_limit $general_gas_limit
         e2e-synthesize-genesis $genesis_path $feature_genesis_path $feature_hardfork_name $gas_limit $general_gas_limit
     }
-    let trusted_peers = if ($a_trusted_peers_path | path exists) {
-        open $a_trusted_peers_path | str trim
-    } else {
-        let b_trusted_peers_path = $"($b_db)/($BENCH_META_SUBDIR)/trusted-peers.txt"
-        if ($b_trusted_peers_path | path exists) {
-            open $b_trusted_peers_path | str trim
-        } else {
-            print $"Error: trusted peers file not found in ($a_trusted_peers_path) or ($b_trusted_peers_path)"
-            exit 1
-        }
-    }
+    let snapshot_topology = (e2e-snapshot-topology $a_db $b_db)
+    let trusted_peers = $snapshot_topology.trusted_peers
+    print $"Local e2e snapshot bindings: a=($snapshot_topology.a.ip):($snapshot_topology.a.consensus_port), b=($snapshot_topology.b.ip):($snapshot_topology.b.consensus_port)"
 
     let results_dir = $"($BENCH_RESULTS_DIR)/($timestamp)"
     mkdir $results_dir
@@ -1682,13 +1706,14 @@ def "main e2e" [
     let ctx = {
         genesis: $genesis_path
         trusted_peers: $trusted_peers
+        snapshot_topology: $snapshot_topology
         a: {
             state_path: $E2E_A_STATE_PATH
             mount: $E2E_A_MOUNT
             datadir: $a_db
             node_dir: $a_identity
-            ip: $a_ip
-            consensus_port: $a_consensus_port
+            ip: $snapshot_topology.a.ip
+            consensus_port: $snapshot_topology.a.consensus_port
             cpus: $E2E_A_CPUS
             memory: $E2E_A_MEMORY
         }
@@ -1697,8 +1722,8 @@ def "main e2e" [
             mount: $E2E_B_MOUNT
             datadir: $b_db
             node_dir: $b_identity
-            ip: $b_ip
-            consensus_port: $b_consensus_port
+            ip: $snapshot_topology.b.ip
+            consensus_port: $snapshot_topology.b.consensus_port
             cpus: $E2E_B_CPUS
             memory: $E2E_B_MEMORY
         }

--- a/contrib/bench/tests/e2e-snapshot-topology.nu
+++ b/contrib/bench/tests/e2e-snapshot-topology.nu
@@ -1,0 +1,65 @@
+#!/usr/bin/env nu
+source ../../../bench-e2e.nu
+use std/assert
+
+# Run from the repository root: nu contrib/bench/tests/e2e-snapshot-topology.nu
+let root = (mktemp -d)
+let a = $"($root)/a"
+let b = $"($root)/b"
+let id_a = "51177dde89242d9121d787a681bd2a0bd6013428a6b83e684a253815db96d8b3bd42c409d2f0f0c805fb913f2066f597e0df65451bca3e81ca718afaa0763de3"
+let id_b = "5b0ef8c9bd756af433edc3129975888f6f18b8185b2afbaabc8bb3029a00cf815252cfe424044db42f1c8c4fa805bec74438bdc1ad482c648cdf8807290a86c9"
+let peer_a = $"enode://($id_a)@127.0.0.2:8001"
+let peer_b = $"enode://($id_b)@127.0.0.3:8101"
+let peers = $"($peer_a),($peer_b)"
+try {
+    for dir in [$a $b] {
+        mkdir $"($dir)/.bench-meta" $"($dir)/db"
+        { config: { chainId: 1337 } } | to json | save $"($dir)/.bench-meta/genesis.json"
+        $peers | save $"($dir)/.bench-meta/trusted-peers.txt"
+        for file in [signing.key signing.share enode.key db/sentinel] {
+            $"unchanged-($dir)-($file)" | save $"($dir)/($file)"
+        }
+    }
+    $id_a | save $"($a)/enode.identity"
+    $id_b | save $"($b)/enode.identity"
+    let normal = (e2e-snapshot-topology $a $b)
+    assert equal $normal.a.consensus_port 8000
+    assert equal $normal.b.consensus_port 8100
+
+    # Peer-list order is irrelevant, but identity-to-address association is not.
+    $"($peer_b),($peer_a)" | save -f $"($b)/.bench-meta/trusted-peers.txt"
+    assert equal (e2e-snapshot-topology $a $b) $normal
+    $id_b | save -f $"($a)/enode.identity"
+    $id_a | save -f $"($b)/enode.identity"
+    let swapped = (e2e-snapshot-topology $a $b)
+    assert equal $swapped.a.ip "127.0.0.3"
+    assert equal $swapped.a.consensus_port 8100
+    assert equal $swapped.b.ip "127.0.0.2"
+    assert equal $swapped.b.consensus_port 8000
+    for dir in [$a $b] {
+        for file in [signing.key signing.share enode.key db/sentinel] {
+            assert equal (open --raw $"($dir)/($file)") $"unchanged-($dir)-($file)"
+        }
+    }
+
+    $id_a | save -f $"($a)/enode.identity"
+    assert (try { e2e-snapshot-topology $a $b | ignore; false } catch { true }) "duplicate identities must fail"
+    "unknown" | save -f $"($a)/enode.identity"
+    assert (try { e2e-snapshot-topology $a $b | ignore; false } catch { true }) "unlisted identities must fail"
+    $id_b | save -f $"($a)/enode.identity"
+    $peer_a | save -f $"($a)/.bench-meta/trusted-peers.txt"
+    assert (try { e2e-snapshot-topology $a $b | ignore; false } catch { true }) "different peer configurations must fail"
+    for dir in [$a $b] {
+        ($peers | str replace "127.0.0.3" "127.0.0.4") | save -f $"($dir)/.bench-meta/trusted-peers.txt"
+    }
+    assert (try { e2e-snapshot-topology $a $b | ignore; false } catch { true }) "unexpected endpoints must fail"
+    for dir in [$a $b] { $peers | save -f $"($dir)/.bench-meta/trusted-peers.txt" }
+    { config: { chainId: 9999 } } | to json | save -f $"($b)/.bench-meta/genesis.json"
+    assert (try { e2e-snapshot-topology $a $b | ignore; false } catch { true }) "different genesis configurations must fail"
+} catch { |err|
+    rm -rf $root
+    error make $err
+}
+rm -rf $root
+print "Local e2e snapshot topology checks passed"
+exit 0

--- a/contrib/bench/txgen/erc20.abi.json
+++ b/contrib/bench/txgen/erc20.abi.json
@@ -1,6 +1,17 @@
 [
   {
     "type": "function",
+    "name": "transferWithMemo",
+    "inputs": [
+      { "name": "to", "type": "address" },
+      { "name": "amount", "type": "uint256" },
+      { "name": "memo", "type": "bytes32" }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "transfer",
     "inputs": [
       {

--- a/contrib/bench/txgen/presets/signature-recover.yml
+++ b/contrib/bench/txgen/presets/signature-recover.yml
@@ -1,0 +1,40 @@
+# One successful secp256k1 recovery per transaction; no contract loop or batching.
+# Fixture: private scalar 1 signs the raw 32-byte 0xaa digest (r || s || v).
+# Expected signer: 0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf.
+chain_id: 1337
+
+gas:
+  max_fee_per_gas: 100000000000
+  max_priority_fee_per_gas: 100000000000
+
+accounts:
+  users:
+    mnemonic: "test test test test test test test test test test test junk"
+    range:
+      - 0
+      - ${TXGEN_ACCOUNTS}
+
+artifacts:
+  SignatureVerifier: ../signature-verifier.abi.json
+
+templates:
+  signature_recover:
+    type: tempo
+    from:
+      pool: users
+      select: random
+    gas_limit: 300000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 10
+    call:
+      to: "0x5165300000000000000000000000000000000000"
+      abi: SignatureVerifier
+      function: recover
+      args:
+        - "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        - "0xcf8298b9d991a37626f9816dd75ff8427f5169a0f122a65b8554e9f6504c984f3490ec2e5a8ddaebd27bbb531fefad6336d2a794dbcf2e0f3cae0e7b34bd33e01c"
+
+mix:
+  - template: signature_recover
+    weight: 100

--- a/contrib/bench/txgen/presets/tip20-memo.yml
+++ b/contrib/bench/txgen/presets/tip20-memo.yml
@@ -1,0 +1,19 @@
+# Match the existing-recipient, direct-auth, pathUSD transfer control, adding a memo.
+include:
+  - tip20/base.yml
+  - tip20/recipient-existing.yml
+  - tip20/fee-token-pathusd.yml
+  - tip20/auth-direct.yml
+  - tip20/nonce-expiring.yml
+
+merge:
+  templates:
+    tip20_transfer:
+      call:
+        function: transferWithMemo
+        args:
+          - address_pool:
+              pool: existing_recipients
+              select: random
+          - 1
+          - "0x1111111111111111111111111111111111111111111111111111111111111111"

--- a/contrib/bench/txgen/signature-verifier.abi.json
+++ b/contrib/bench/txgen/signature-verifier.abi.json
@@ -1,0 +1,12 @@
+[
+  {
+    "type": "function",
+    "name": "recover",
+    "inputs": [
+      { "name": "hash", "type": "bytes32" },
+      { "name": "signature", "type": "bytes" }
+    ],
+    "outputs": [{ "name": "signer", "type": "address" }],
+    "stateMutability": "view"
+  }
+]

--- a/tempo.nu
+++ b/tempo.nu
@@ -339,6 +339,8 @@ def tempo-hardforks [] {
         | columns
         | where { |key| $key =~ '^t[0-9]+[a-z]?Time$' }
         | each { |key| $key | str replace "Time" "" | str upcase }
+        # JSON field order is not protocol order (T10 may appear before T1).
+        | sort --natural
     )
     if ($forks | is-empty) {
         print "Error: failed to read Tempo hardforks from crates/node/tests/assets/test-genesis.json"


### PR DESCRIPTION
## Summary

- Sort benchmark hardforks in protocol order instead of JSON field order: selecting T10 previously disabled T1–T9, causing local validators to reject block 1 before any workload ran.
- Add ordinary memo-transfer and valid secp256k1 recovery presets for the mainnet precompile-throughput study.
- Reuse the cached validator identity fix and regression tests described below. No node implementation or protocol gas prices change; this PR claims benchmark setup repairs, not a node performance improvement.

## Snapshot setup

Reuse Alexey's existing [cached validator identity fix](https://github.com/tempoxyz/tempo/commit/0a558a41a04e8ff81145eeecf1d207e532b848dd), with its topology regression tests. The corrected [new-recipient run](https://github.com/tempoxyz/tempo/actions/runs/33927632202) reached block 1 with the correct forks but exposed reversed cached identities on ghr-euw-05; [memo](https://github.com/tempoxyz/tempo/actions/runs/33927637046) hit the same readiness failure there. Neither produced workload measurements. The affected workloads were requeued with the identity fix.

## Profile and benchmark evidence

Both node sides are pinned to [bbb6761e75b926c7a0d77d3ac62290fc00cc5fa5](https://github.com/tempoxyz/tempo/commit/bbb6761e75b926c7a0d77d3ac62290fc00cc5fa5), with T10, three 90-second pairs, samply, 100,000 MiB bloat and identical sender settings. Cross-workload runner executions are separate. The eight-workload matrix completed; these are main/main noise controls, not main/branch speedup claims.

- [Existing-recipient control](https://github.com/tempoxyz/tempo/actions/runs/33927628729): median validation 1.901 Ggas/s.
- [Memo preset](https://github.com/tempoxyz/tempo/actions/runs/33928530604): 1.934 Ggas/s, zero builder revert observations. Its same-node summary flags a Regression on timing metrics, while wall gas throughput changes -0.6% and validation throughput +0.7%; do not interpret that as an implementation change.
- [Recovery preset](https://github.com/tempoxyz/tempo/actions/runs/33927638360): 0.924 Ggas/s, zero builder revert observations. Representative feature-1 validator profiles show roughly 35% secp256k1 sampled observations; a pricing candidate, not a calibrated marginal tariff.
- The control profile also shows OTLP exporter spinning. Completed checks with OTLP off and samply retained measure median validation throughput of [1.959 Ggas/s for transfer](https://github.com/tempoxyz/tempo/actions/runs/33929241457), [16.779 Ggas/s for DEX](https://github.com/tempoxyz/tempo/actions/runs/33929241323), and [0.906 Ggas/s for recovery](https://github.com/tempoxyz/tempo/actions/runs/33929241450). Each has six samples and zero builder revert observations; runtime forks, node SHAs, CPU model and absence of OTLP exporters were verified. These results are separate from the OTLP-on matrix. The DEX main/main verdict says Improvement despite identical node builds; that is run variability, not a speedup from this PR.

Known measurement limitation: `tempo.nu` defaults missing block receipt counts to success; these txgen reports omit those counts. Reported success percentages are not receipt-verified. The [new-recipient rerun](https://github.com/tempoxyz/tempo/actions/runs/33928209440) records substantial builder reverts and is excluded from successful-transfer pricing. This PR does not repair receipt-status reporting. Zero builder reverts in the other runs is supporting telemetry, not an independent canonical receipt census.

## Verification

- `nu .github/scripts/test-bench-hardforks.nu` — all activation cutoffs pass.
- `nu contrib/bench/tests/e2e-snapshot-topology.nu` — normal/swapped identities and mismatch rejection pass without changing key/share data.
- Generated 20 transactions from each new preset using the pinned txgen revision.
- Corrected runtime fork logs and report node SHAs match the intended configuration across all eight completed workloads.
- The original failed control is [33926771560](https://github.com/tempoxyz/tempo/actions/runs/33926771560); startup failures generated no valid workload evidence and are excluded.
- Full CI is not green: [test shard 1/2](https://github.com/tempoxyz/tempo/actions/runs/33928209342/job/101201372669) exceeded the 30-minute job limit while `storage_credits::test_tip1060_tip20_clear_mints_and_later_creation_redeems_credit` remained running. The cause of that test hang is not established here. Formatting, clippy, CLI smoke tests and all four e2e shards passed.

Prompted by: @shekhirin
