### PR TITLE
fix(node): poll receipts in storage credit and liquidity tests

### DIFF
--- a/crates/node/tests/it/liquidity.rs
+++ b/crates/node/tests/it/liquidity.rs
@@ -9,7 +9,7 @@ use tempo_contracts::precompiles::{IFeeManager::setUserTokenCall, ITIP20};
 use tempo_precompiles::DEFAULT_FEE_TOKEN;
 use tempo_primitives::{TempoTransaction, TempoTxEnvelope, transaction::tempo_transaction::Call};
 
-use crate::utils::{get_tempo_receipt, setup_test_token};
+use crate::utils::{PendingTransactionBuilderExt, setup_test_token};
 
 /// Test block building when FeeAMM pool has insufficient liquidity for payment transactions
 #[tokio::test(flavor = "multi_thread")]
@@ -141,12 +141,11 @@ async fn test_block_building_insufficient_fee_amm_liquidity() -> eyre::Result<()
     };
     let signature = wallet.sign_hash_sync(&tx.signature_hash()).unwrap();
     let envelope: TempoTxEnvelope = tx.into_signed(signature.into()).into();
-    get_tempo_receipt(
-        provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
 
     // Now try to send payment transactions that require fee swaps
     // With insufficient liquidity, these should be excluded from blocks

--- a/crates/node/tests/it/liquidity.rs
+++ b/crates/node/tests/it/liquidity.rs
@@ -144,7 +144,7 @@ async fn test_block_building_insufficient_fee_amm_liquidity() -> eyre::Result<()
     provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
+        .get_receipt()
         .await?;
 
     // Now try to send payment transactions that require fee swaps

--- a/crates/node/tests/it/liquidity.rs
+++ b/crates/node/tests/it/liquidity.rs
@@ -9,7 +9,7 @@ use tempo_contracts::precompiles::{IFeeManager::setUserTokenCall, ITIP20};
 use tempo_precompiles::DEFAULT_FEE_TOKEN;
 use tempo_primitives::{TempoTransaction, TempoTxEnvelope, transaction::tempo_transaction::Call};
 
-use crate::utils::setup_test_token;
+use crate::utils::{get_tempo_receipt, setup_test_token};
 
 /// Test block building when FeeAMM pool has insufficient liquidity for payment transactions
 #[tokio::test(flavor = "multi_thread")]
@@ -141,11 +141,12 @@ async fn test_block_building_insufficient_fee_amm_liquidity() -> eyre::Result<()
     };
     let signature = wallet.sign_hash_sync(&tx.signature_hash()).unwrap();
     let envelope: TempoTxEnvelope = tx.into_signed(signature.into()).into();
-    provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?;
+    get_tempo_receipt(
+        provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
 
     // Now try to send payment transactions that require fee swaps
     // With insufficient liquidity, these should be excluded from blocks

--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -1,4 +1,4 @@
-use crate::utils::{TEST_MNEMONIC, TestNodeBuilder, setup_test_token};
+use crate::utils::{TEST_MNEMONIC, TestNodeBuilder, get_tempo_receipt, setup_test_token};
 use alloy::{
     network::ReceiptResponse,
     primitives::{Address, B256, Bytes, U256, aliases::U96},
@@ -83,19 +83,12 @@ async fn send_tempo_tx<P: Provider>(
             sig,
         )))
         .into();
-    // Poll the receipt as well as the heartbeat, which can miss the mined block.
-    // This Ethereum provider omits Tempo fields, so fetch the full receipt below.
-    let tx_hash = provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-
-    provider
-        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
-        .await
-        .map_err(Into::into)
+    get_tempo_receipt(
+        provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await
 }
 
 /// Regression for the TIP-1060 fee-collection path reported in PR review.
@@ -140,23 +133,17 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
             allowedCalls: vec![],
         },
     };
-    let authorize_hash = provider
-        .send_transaction(
-            TransactionRequest::default()
-                .to(ACCOUNT_KEYCHAIN_ADDRESS)
-                .input(authorize.abi_encode().into())
-                .gas_limit(2_000_000),
-        )
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let authorize_receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (authorize_hash,),
-        )
-        .await?;
+    let authorize_receipt = get_tempo_receipt(
+        provider
+            .send_transaction(
+                TransactionRequest::default()
+                    .to(ACCOUNT_KEYCHAIN_ADDRESS)
+                    .input(authorize.abi_encode().into())
+                    .gas_limit(2_000_000),
+            )
+            .await?,
+    )
+    .await?;
     assert!(
         authorize_receipt.status(),
         "access-key authorization must succeed"
@@ -201,15 +188,12 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
         )))
         .into();
 
-    let tx_hash = provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
-        .await?;
+    let receipt = get_tempo_receipt(
+        provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(
         !receipt.status(),
         "the access-key AA transaction must commit the user-call failure path"
@@ -354,18 +338,12 @@ async fn test_tip1060_rebalance_swap_does_not_mint_stale_fee_manager_custody_cre
             sig,
         )))
         .into();
-    let fee_tx_hash = root_provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let fee_tx_receipt = root_provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (fee_tx_hash,),
-        )
-        .await?;
+    let fee_tx_receipt = get_tempo_receipt(
+        root_provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(fee_tx_receipt.status());
 
     let custody_balance = fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await?;
@@ -435,18 +413,12 @@ async fn test_tip1060_rebalance_swap_does_not_mint_stale_fee_manager_custody_cre
             sig,
         )))
         .into();
-    let recreate_hash = root_provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let recreate_receipt = root_provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (recreate_hash,),
-        )
-        .await?;
+    let recreate_receipt = get_tempo_receipt(
+        root_provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(recreate_receipt.status());
     assert!(
         fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await? > U256::ZERO,
@@ -616,18 +588,12 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
             collect_fees_signature,
         )))
         .into();
-    let collect_fees_hash = provider
-        .send_raw_transaction(&collect_fees_envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let collect_fees_receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (collect_fees_hash,),
-        )
-        .await?;
+    let collect_fees_receipt = get_tempo_receipt(
+        provider
+            .send_raw_transaction(&collect_fees_envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(collect_fees_receipt.status());
     assert!(
         !root_fee_manager
@@ -724,18 +690,12 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
             recreate_signature,
         )))
         .into();
-    let recreate_hash = provider
-        .send_raw_transaction(&recreate_envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let recreate_receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (recreate_hash,),
-        )
-        .await?;
+    let recreate_receipt = get_tempo_receipt(
+        provider
+            .send_raw_transaction(&recreate_envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(recreate_receipt.status());
     assert!(
         !root_fee_manager
@@ -892,18 +852,12 @@ async fn test_tip1060_distribute_fees_receive_policy_guard_creations_are_account
             collect_fees_signature,
         )))
         .into();
-    let collect_fees_hash = provider
-        .send_raw_transaction(&collect_fees_envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let collect_fees_receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (collect_fees_hash,),
-        )
-        .await?;
+    let collect_fees_receipt = get_tempo_receipt(
+        provider
+            .send_raw_transaction(&collect_fees_envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(collect_fees_receipt.status());
     let payout_amount = root_fee_manager
         .collectedFees(validator_addr, fee_token_addr)
@@ -1157,23 +1111,17 @@ async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limi
             allowedCalls: vec![],
         },
     };
-    let authorize_hash = provider
-        .send_transaction(
-            TransactionRequest::default()
-                .to(ACCOUNT_KEYCHAIN_ADDRESS)
-                .input(authorize.abi_encode().into())
-                .gas_limit(2_000_000),
-        )
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let authorize_receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>(
-            "eth_getTransactionReceipt".into(),
-            (authorize_hash,),
-        )
-        .await?;
+    let authorize_receipt = get_tempo_receipt(
+        provider
+            .send_transaction(
+                TransactionRequest::default()
+                    .to(ACCOUNT_KEYCHAIN_ADDRESS)
+                    .input(authorize.abi_encode().into())
+                    .gas_limit(2_000_000),
+            )
+            .await?,
+    )
+    .await?;
     assert!(authorize_receipt.status());
 
     let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
@@ -1216,15 +1164,12 @@ async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limi
         )))
         .into();
 
-    let tx_hash = provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
-        .await?;
+    let receipt = get_tempo_receipt(
+        provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(receipt.status());
 
     let remaining_after = keychain
@@ -1325,15 +1270,12 @@ async fn test_tip1060_successful_fee_token_spend_fee_refund_cancels_restored_bal
         )))
         .into();
 
-    let tx_hash = fee_payer_provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let receipt = root_provider
-        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
-        .await?;
+    let receipt = get_tempo_receipt(
+        fee_payer_provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(receipt.status());
     assert_eq!(receipt.fee_token, Some(DEFAULT_FEE_TOKEN));
 
@@ -1421,15 +1363,12 @@ async fn test_tip1060_tip20_clear_mints_and_later_creation_redeems_credit() -> e
             sig,
         )))
         .into();
-    let hash = provider
-        .send_raw_transaction(&envelope.encoded_2718())
-        .await?
-        .get_receipt()
-        .await?
-        .transaction_hash;
-    let receipt = provider
-        .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (hash,))
-        .await?;
+    let receipt = get_tempo_receipt(
+        provider
+            .send_raw_transaction(&envelope.encoded_2718())
+            .await?,
+    )
+    .await?;
     assert!(receipt.status());
 
     assert_eq!(token.balanceOf(root_addr).call().await?, U256::ZERO);

--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -1,4 +1,6 @@
-use crate::utils::{TEST_MNEMONIC, TestNodeBuilder, get_tempo_receipt, setup_test_token};
+use crate::utils::{
+    PendingTransactionBuilderExt, TEST_MNEMONIC, TestNodeBuilder, setup_test_token,
+};
 use alloy::{
     network::ReceiptResponse,
     primitives::{Address, B256, Bytes, U256, aliases::U96},
@@ -83,12 +85,11 @@ async fn send_tempo_tx<P: Provider>(
             sig,
         )))
         .into();
-    get_tempo_receipt(
-        provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await
+    provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await
 }
 
 /// Regression for the TIP-1060 fee-collection path reported in PR review.
@@ -133,17 +134,16 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
             allowedCalls: vec![],
         },
     };
-    let authorize_receipt = get_tempo_receipt(
-        provider
-            .send_transaction(
-                TransactionRequest::default()
-                    .to(ACCOUNT_KEYCHAIN_ADDRESS)
-                    .input(authorize.abi_encode().into())
-                    .gas_limit(2_000_000),
-            )
-            .await?,
-    )
-    .await?;
+    let authorize_receipt = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .to(ACCOUNT_KEYCHAIN_ADDRESS)
+                .input(authorize.abi_encode().into())
+                .gas_limit(2_000_000),
+        )
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(
         authorize_receipt.status(),
         "access-key authorization must succeed"
@@ -188,12 +188,11 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
         )))
         .into();
 
-    let receipt = get_tempo_receipt(
-        provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let receipt = provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(
         !receipt.status(),
         "the access-key AA transaction must commit the user-call failure path"
@@ -338,12 +337,11 @@ async fn test_tip1060_rebalance_swap_does_not_mint_stale_fee_manager_custody_cre
             sig,
         )))
         .into();
-    let fee_tx_receipt = get_tempo_receipt(
-        root_provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let fee_tx_receipt = root_provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(fee_tx_receipt.status());
 
     let custody_balance = fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await?;
@@ -413,12 +411,11 @@ async fn test_tip1060_rebalance_swap_does_not_mint_stale_fee_manager_custody_cre
             sig,
         )))
         .into();
-    let recreate_receipt = get_tempo_receipt(
-        root_provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let recreate_receipt = root_provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(recreate_receipt.status());
     assert!(
         fee_token.balanceOf(TIP_FEE_MANAGER_ADDRESS).call().await? > U256::ZERO,
@@ -588,12 +585,11 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
             collect_fees_signature,
         )))
         .into();
-    let collect_fees_receipt = get_tempo_receipt(
-        provider
-            .send_raw_transaction(&collect_fees_envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let collect_fees_receipt = provider
+        .send_raw_transaction(&collect_fees_envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(collect_fees_receipt.status());
     assert!(
         !root_fee_manager
@@ -690,12 +686,11 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
             recreate_signature,
         )))
         .into();
-    let recreate_receipt = get_tempo_receipt(
-        provider
-            .send_raw_transaction(&recreate_envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let recreate_receipt = provider
+        .send_raw_transaction(&recreate_envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(recreate_receipt.status());
     assert!(
         !root_fee_manager
@@ -852,12 +847,11 @@ async fn test_tip1060_distribute_fees_receive_policy_guard_creations_are_account
             collect_fees_signature,
         )))
         .into();
-    let collect_fees_receipt = get_tempo_receipt(
-        provider
-            .send_raw_transaction(&collect_fees_envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let collect_fees_receipt = provider
+        .send_raw_transaction(&collect_fees_envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(collect_fees_receipt.status());
     let payout_amount = root_fee_manager
         .collectedFees(validator_addr, fee_token_addr)
@@ -1111,17 +1105,16 @@ async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limi
             allowedCalls: vec![],
         },
     };
-    let authorize_receipt = get_tempo_receipt(
-        provider
-            .send_transaction(
-                TransactionRequest::default()
-                    .to(ACCOUNT_KEYCHAIN_ADDRESS)
-                    .input(authorize.abi_encode().into())
-                    .gas_limit(2_000_000),
-            )
-            .await?,
-    )
-    .await?;
+    let authorize_receipt = provider
+        .send_transaction(
+            TransactionRequest::default()
+                .to(ACCOUNT_KEYCHAIN_ADDRESS)
+                .input(authorize.abi_encode().into())
+                .gas_limit(2_000_000),
+        )
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(authorize_receipt.status());
 
     let keychain = IAccountKeychainInstance::new(ACCOUNT_KEYCHAIN_ADDRESS, &provider);
@@ -1164,12 +1157,11 @@ async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limi
         )))
         .into();
 
-    let receipt = get_tempo_receipt(
-        provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let receipt = provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(receipt.status());
 
     let remaining_after = keychain
@@ -1270,12 +1262,11 @@ async fn test_tip1060_successful_fee_token_spend_fee_refund_cancels_restored_bal
         )))
         .into();
 
-    let receipt = get_tempo_receipt(
-        fee_payer_provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let receipt = fee_payer_provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(receipt.status());
     assert_eq!(receipt.fee_token, Some(DEFAULT_FEE_TOKEN));
 
@@ -1363,12 +1354,11 @@ async fn test_tip1060_tip20_clear_mints_and_later_creation_redeems_credit() -> e
             sig,
         )))
         .into();
-    let receipt = get_tempo_receipt(
-        provider
-            .send_raw_transaction(&envelope.encoded_2718())
-            .await?,
-    )
-    .await?;
+    let receipt = provider
+        .send_raw_transaction(&envelope.encoded_2718())
+        .await?
+        .get_tempo_receipt()
+        .await?;
     assert!(receipt.status());
 
     assert_eq!(token.balanceOf(root_addr).call().await?, U256::ZERO);

--- a/crates/node/tests/it/storage_credits.rs
+++ b/crates/node/tests/it/storage_credits.rs
@@ -83,11 +83,14 @@ async fn send_tempo_tx<P: Provider>(
             sig,
         )))
         .into();
+    // Poll the receipt as well as the heartbeat, which can miss the mined block.
+    // This Ethereum provider omits Tempo fields, so fetch the full receipt below.
     let tx_hash = provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
 
     provider
         .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
@@ -145,8 +148,9 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
                 .gas_limit(2_000_000),
         )
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let authorize_receipt = provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -200,8 +204,9 @@ async fn test_tip1060_keychain_fee_refund_does_not_retain_storage_credit() -> ey
     let tx_hash = provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let receipt = provider
         .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
         .await?;
@@ -352,8 +357,9 @@ async fn test_tip1060_rebalance_swap_does_not_mint_stale_fee_manager_custody_cre
     let fee_tx_hash = root_provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let fee_tx_receipt = root_provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -432,8 +438,9 @@ async fn test_tip1060_rebalance_swap_does_not_mint_stale_fee_manager_custody_cre
     let recreate_hash = root_provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let recreate_receipt = root_provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -612,8 +619,9 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
     let collect_fees_hash = provider
         .send_raw_transaction(&collect_fees_envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let collect_fees_receipt = provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -719,8 +727,9 @@ async fn test_tip1060_fee_manager_credit_from_distribute_fees_is_not_redeemable(
     let recreate_hash = provider
         .send_raw_transaction(&recreate_envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let recreate_receipt = provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -886,8 +895,9 @@ async fn test_tip1060_distribute_fees_receive_policy_guard_creations_are_account
     let collect_fees_hash = provider
         .send_raw_transaction(&collect_fees_envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let collect_fees_receipt = provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -1155,8 +1165,9 @@ async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limi
                 .gas_limit(2_000_000),
         )
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let authorize_receipt = provider
         .raw_request::<_, TempoTransactionReceipt>(
             "eth_getTransactionReceipt".into(),
@@ -1208,8 +1219,9 @@ async fn test_tip1060_successful_keychain_spend_fee_refund_cancels_restored_limi
     let tx_hash = provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let receipt = provider
         .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
         .await?;
@@ -1316,8 +1328,9 @@ async fn test_tip1060_successful_fee_token_spend_fee_refund_cancels_restored_bal
     let tx_hash = fee_payer_provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let receipt = root_provider
         .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (tx_hash,))
         .await?;
@@ -1411,8 +1424,9 @@ async fn test_tip1060_tip20_clear_mints_and_later_creation_redeems_credit() -> e
     let hash = provider
         .send_raw_transaction(&envelope.encoded_2718())
         .await?
-        .watch()
-        .await?;
+        .get_receipt()
+        .await?
+        .transaction_hash;
     let receipt = provider
         .raw_request::<_, TempoTransactionReceipt>("eth_getTransactionReceipt".into(), (hash,))
         .await?;

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -273,7 +273,7 @@ pub(crate) const TEST_MNEMONIC: &str =
 use alloy::{
     network::Ethereum,
     primitives::Address,
-    providers::{PendingTransactionBuilder, Provider},
+    providers::{PendingTransactionBuilder, Provider, RootProvider},
     sol_types::SolEvent,
     transports::http::reqwest::Url,
 };
@@ -287,6 +287,7 @@ use reth_node_builder::{NodeBuilder, NodeConfig, NodeHandle, rpc::RethRpcAddOns}
 use reth_node_core::args::RpcServerArgs;
 use reth_rpc_builder::RpcModuleSelection;
 use std::{sync::Arc, time::Duration};
+use tempo_alloy::{TempoNetwork, rpc::TempoTransactionReceipt};
 use tempo_chainspec::{
     hardfork::{TempoHardfork, TempoHardforks},
     spec::TempoChainSpec,
@@ -383,6 +384,19 @@ pub(crate) async fn setup_test_node(
     };
 
     Ok((setup.http_url, setup.local_node))
+}
+
+/// Poll a pending transaction's receipt using Tempo's AA-compatible receipt type.
+pub(crate) async fn get_tempo_receipt(
+    pending: PendingTransactionBuilder<Ethereum>,
+) -> eyre::Result<TempoTransactionReceipt> {
+    let (provider, config) = pending.split();
+    let provider = RootProvider::<TempoNetwork>::new(provider.client().clone());
+    // get_receipt also polls independently of the heartbeat for one confirmation,
+    // so it can recover when the heartbeat misses the block containing the transaction.
+    Ok(PendingTransactionBuilder::from_config(provider, config)
+        .get_receipt()
+        .await?)
 }
 
 pub(crate) async fn await_receipts(

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -274,6 +274,7 @@ use alloy::{
     network::Ethereum,
     primitives::Address,
     providers::{PendingTransactionBuilder, Provider, RootProvider},
+    rpc::client::RpcClient,
     sol_types::SolEvent,
     transports::http::reqwest::Url,
 };
@@ -391,7 +392,12 @@ pub(crate) async fn get_tempo_receipt(
     pending: PendingTransactionBuilder<Ethereum>,
 ) -> eyre::Result<TempoTransactionReceipt> {
     let (provider, config) = pending.split();
-    let provider = RootProvider::<TempoNetwork>::new(provider.client().clone());
+    let client = RpcClient::new(
+        provider.client().transport().clone(),
+        provider.client().is_local(),
+    )
+    .with_poll_interval(provider.client().poll_interval());
+    let provider = RootProvider::<TempoNetwork>::new(client);
     // get_receipt also polls independently of the heartbeat for one confirmation,
     // so it can recover when the heartbeat misses the block containing the transaction.
     Ok(PendingTransactionBuilder::from_config(provider, config)

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -387,22 +387,26 @@ pub(crate) async fn setup_test_node(
     Ok((setup.http_url, setup.local_node))
 }
 
-/// Poll a pending transaction's receipt using Tempo's AA-compatible receipt type.
-pub(crate) async fn get_tempo_receipt(
-    pending: PendingTransactionBuilder<Ethereum>,
-) -> eyre::Result<TempoTransactionReceipt> {
-    let (provider, config) = pending.split();
-    let client = RpcClient::new(
-        provider.client().transport().clone(),
-        provider.client().is_local(),
-    )
-    .with_poll_interval(provider.client().poll_interval());
-    let provider = RootProvider::<TempoNetwork>::new(client);
-    // get_receipt also polls independently of the heartbeat for one confirmation,
-    // so it can recover when the heartbeat misses the block containing the transaction.
-    Ok(PendingTransactionBuilder::from_config(provider, config)
-        .get_receipt()
-        .await?)
+pub(crate) trait PendingTransactionBuilderExt {
+    /// Poll the receipt using Tempo's AA-compatible receipt type.
+    async fn get_tempo_receipt(self) -> eyre::Result<TempoTransactionReceipt>;
+}
+
+impl PendingTransactionBuilderExt for PendingTransactionBuilder<Ethereum> {
+    async fn get_tempo_receipt(self) -> eyre::Result<TempoTransactionReceipt> {
+        let (provider, config) = self.split();
+        let client = RpcClient::new(
+            provider.client().transport().clone(),
+            provider.client().is_local(),
+        )
+        .with_poll_interval(provider.client().poll_interval());
+        let provider = RootProvider::<TempoNetwork>::new(client);
+        // get_receipt also polls independently of the heartbeat for one confirmation,
+        // so it can recover when the heartbeat misses the block containing the transaction.
+        Ok(PendingTransactionBuilder::from_config(provider, config)
+            .get_receipt()
+            .await?)
+    }
 }
 
 pub(crate) async fn await_receipts(


### PR DESCRIPTION
Use `.get_tempo_receipt().await` through `PendingTransactionBuilderExt` in the storage-credit tests and liquidity setup to recover when Alloy's heartbeat misses the mined block ([alloy-rs/alloy#4181](https://github.com/alloy-rs/alloy/issues/4181)). The extension delegates to Alloy's `.get_receipt()` with `TempoNetwork`, preserving confirmation/timeout configuration and returning `TempoTransactionReceipt` directly: Ethereum's receipt decoder rejects Tempo AA transaction type `0x76`.

Alloy 2.4.1 [backfills ordinary polling gaps](https://github.com/alloy-rs/alloy/blob/v2.4.1/crates/provider/src/blocks.rs#L196), but [starts or resumes at `tip - 1`](https://github.com/alloy-rs/alloy/blob/v2.4.1/crates/provider/src/blocks.rs#L177), leaving a missed-block window after the initial receipt check; independent receipt polling covers that window for one confirmation.

Validation before the extension-trait refactor: all eight storage-credit tests and the liquidity test passed on their first attempts; [both test shards and all four e2e shards passed](https://github.com/tempoxyz/tempo/actions/runs/33932837563), as did [formatting and clippy](https://github.com/tempoxyz/tempo/actions/runs/33932837843). Nightly formatting and whitespace checks pass after the refactor; CI for the updated revision is pending.

Prompted by: @pepyakin
