### PR TITLE
fix(bench): preserve unknown receipt outcomes

### DIFF
--- a/contrib/bench/receipt-outcomes.nu
+++ b/contrib/bench/receipt-outcomes.nu
@@ -1,0 +1,40 @@
+# Receipt counts are optional in txgen reports. Submission success and builder
+# revert observations do not establish canonical block receipt outcomes.
+def receipt-outcomes [blocks: list<any>] {
+    let counts = ($blocks | each { |block|
+        let tx = $block.tx_count
+        let ok = ($block | get -o ok_count)
+        let err = ($block | get -o err_count)
+        let valid = if $ok == null and $err == null and $tx == 0 {
+            true
+        } else if ($ok | describe) != "int" or ($err | describe) != "int" {
+            false
+        } else {
+            $ok >= 0 and $err >= 0 and ($ok + $err) == $tx
+        }
+        {
+            tx: $tx
+            valid: $valid
+            known: (if $valid { $tx } else { 0 })
+            unknown: (if $valid { 0 } else { $tx })
+            ok: (if $valid { $ok | default 0 } else { 0 })
+            err: (if $valid { $err | default 0 } else { 0 })
+        }
+    })
+    let total = ($counts | get tx | prepend 0 | math sum)
+    let known = ($counts | get known | prepend 0 | math sum)
+    let unknown = ($counts | get unknown | prepend 0 | math sum)
+    let ok = ($counts | get ok | prepend 0 | math sum)
+    let err = ($counts | get err | prepend 0 | math sum)
+    let complete = ($counts | all { |count| $count.valid })
+    {
+        receipt_outcomes_complete: $complete
+        receipt_known_tx: $known
+        receipt_unknown_tx: $unknown
+        ok: (if $complete { $ok } else { null })
+        err: (if $complete { $err } else { null })
+        success_rate: (if $complete and $total > 0 {
+            100.0 * $ok / $total | math round --precision 1
+        } else { null })
+    }
+}

--- a/contrib/bench/tests/receipt-outcomes.nu
+++ b/contrib/bench/tests/receipt-outcomes.nu
@@ -1,0 +1,48 @@
+source ../receipt-outcomes.nu
+use std/assert
+
+let absent = (receipt-outcomes [{tx_count: 10}])
+assert equal $absent.ok null
+assert equal $absent.err null
+assert equal $absent.success_rate null
+assert equal $absent.receipt_unknown_tx 10
+
+let known = (receipt-outcomes [{tx_count: 10 ok_count: 8 err_count: 2}])
+assert equal $known.ok 8
+assert equal $known.err 2
+assert equal $known.success_rate 80.0
+assert $known.receipt_outcomes_complete
+
+let partial = (receipt-outcomes [
+    {tx_count: 10 ok_count: 8 err_count: 2}
+    {tx_count: 5}
+])
+assert equal $partial.receipt_known_tx 10
+assert equal $partial.receipt_unknown_tx 5
+assert equal $partial.success_rate null
+
+for bad in [
+    {tx_count: 10 ok_count: 10}
+    {tx_count: 10 ok_count: 8 err_count: 1}
+    {tx_count: 10 ok_count: -1 err_count: 11}
+    {tx_count: 10 ok_count: "8" err_count: 2}
+    {tx_count: 10 ok_count: 8.0 err_count: 2}
+] {
+    let outcome = (receipt-outcomes [$bad])
+    assert equal $outcome.success_rate null
+    assert equal $outcome.receipt_unknown_tx 10
+}
+
+for empty in [[] [{tx_count: 0}]] {
+    let outcome = (receipt-outcomes $empty)
+    assert equal $outcome.ok 0
+    assert equal $outcome.success_rate null
+    assert $outcome.receipt_outcomes_complete
+}
+let inconsistent_empty = (receipt-outcomes [
+    {tx_count: 0 ok_count: 1 err_count: 0}
+    {tx_count: 10 ok_count: 10 err_count: 0}
+])
+assert not $inconsistent_empty.receipt_outcomes_complete
+assert equal $inconsistent_empty.success_rate null
+print "Receipt outcome checks passed"

--- a/contrib/bench/tests/receipt-summary.nu
+++ b/contrib/bench/tests/receipt-summary.nu
@@ -1,0 +1,35 @@
+source ../../../tempo.nu
+use std/assert
+
+let scratch = (mktemp -d)
+let blocks = (1..8 | each { |number|
+    {
+        number: $number
+        timestamp_ms: ($number * 1000)
+        tx_count: 10
+        gas_used: 210000
+        block_time_ms: 1000
+    }
+})
+for label in ["baseline-1" "feature-1"] {
+    {blocks: $blocks samples: []} | to json | save ($scratch | path join $"report-($label).json")
+}
+generate-summary $scratch "same" "same" 0 "fixture" 10 8 --summary-warmup-blocks 2 | ignore
+let unknown = (open ($scratch | path join summary.json))
+assert equal $unknown.per_run.0.total_tx 60
+assert equal $unknown.per_run.0.success_rate null
+assert equal $unknown.per_run.0.receipt_unknown_tx 60
+assert ((open --raw ($scratch | path join summary.md)) | str contains "Receipt outcomes are unknown")
+
+let known_blocks = ($blocks | each { |block| $block | merge {ok_count: 8 err_count: 2} })
+for label in ["baseline-1" "feature-1"] {
+    {blocks: $known_blocks samples: []} | to json | save -f ($scratch | path join $"report-($label).json")
+}
+generate-summary $scratch "same" "same" 0 "fixture" 10 8 --summary-warmup-blocks 2 | ignore
+let known = (open ($scratch | path join summary.json))
+assert equal $known.per_run.0.ok 48
+assert equal $known.per_run.0.err 12
+assert equal $known.per_run.0.success_rate 80.0
+assert equal $known.per_run.0.receipt_unknown_tx 0
+assert not ((open --raw ($scratch | path join summary.md)) | str contains "Receipt outcomes are unknown")
+print $"Generated summary checks passed; fixtures: ($scratch)"

--- a/contrib/bench/tests/test_receipt_upload.py
+++ b/contrib/bench/tests/test_receipt_upload.py
@@ -1,0 +1,52 @@
+"""Check SQL generation without credentials or external writes."""
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+class ReceiptUploadTests(unittest.TestCase):
+    def generate(self, blocks):
+        script = Path(__file__).parents[1] / "upload-clickhouse-txgen.sh"
+        generator = script.read_text().split("<< 'PYEOF'\n", 1)[1].split("\nPYEOF", 1)[0]
+        with tempfile.TemporaryDirectory() as directory:
+            report = Path(directory) / "report.json"
+            report.write_text(json.dumps({"blocks": blocks}))
+            return subprocess.run(
+                [sys.executable, "-c", generator],
+                env={**os.environ, "REPORT_PATH": str(report), "BENCH_RUN_LABEL": "baseline-1"},
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+
+    def test_known_outcomes_are_preserved(self):
+        result = self.generate([{"tx_count": 10, "ok_count": 8, "err_count": 2}])
+        self.assertEqual(result.stdout.count("INSERT INTO"), 2)
+        self.assertIn(", 10, 8, 2, ", result.stdout)
+
+    def test_no_partial_insert_for_unknown_outcomes(self):
+        for block in [
+            {"tx_count": 10},
+            {"tx_count": 10, "ok_count": 10},
+            {"tx_count": 10, "ok_count": 8, "err_count": 1},
+            {"tx_count": 10, "ok_count": -1, "err_count": 11},
+            {"tx_count": 10, "ok_count": True, "err_count": 9},
+        ]:
+            with self.subTest(block=block):
+                result = self.generate([
+                    {"tx_count": 10, "ok_count": 10, "err_count": 0}, block
+                ])
+                self.assertEqual(result.stdout, "")
+                self.assertIn("Skipping report", result.stderr)
+
+    def test_empty_block(self):
+        self.assertEqual(self.generate([{"tx_count": 0}]).stdout.count("INSERT INTO"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contrib/bench/upload-clickhouse-txgen.sh
+++ b/contrib/bench/upload-clickhouse-txgen.sh
@@ -44,8 +44,8 @@ for label in baseline-1 feature-1 feature-2 baseline-2; do
   echo "  Processing: $label"
 
   # Generate SQL statements via python (one statement per line, no internal newlines)
-  QUERIES=$(REPORT_PATH="$REPORT" BENCH_RUN_LABEL="$label" python3 << 'PYEOF'
-import json, uuid, os
+  QUERIES=$(REPORT_PATH="$REPORT" BENCH_RUN_LABEL="$label" uv run python << 'PYEOF'
+import json, uuid, os, sys
 
 report = json.load(open(os.environ["REPORT_PATH"]))
 meta = report.get("metadata") or {}
@@ -65,12 +65,23 @@ def normalized_blocks(report):
     normalized = []
     for b in report.get("blocks") or []:
         tx_count = as_int(b.get("tx_count"))
+        ok_count = b.get("ok_count")
+        err_count = b.get("err_count")
+        if tx_count == 0 and ok_count is None and err_count is None:
+            ok_count = err_count = 0
+        if (type(ok_count) is not int or type(err_count) is not int
+                or ok_count < 0 or err_count < 0
+                or ok_count + err_count != tx_count):
+            # Legacy ClickHouse columns cannot represent unknown outcomes.
+            # Skip the whole report before producing any INSERT statements.
+            print("  Skipping report: receipt outcomes are unknown or inconsistent", file=sys.stderr)
+            raise SystemExit(0)
         normalized.append({
             "number": as_int(b.get("number")),
             "timestamp": as_int(b.get("timestamp", b.get("timestamp_ms"))),
             "tx_count": tx_count,
-            "ok_count": tx_count,
-            "err_count": 0,
+            "ok_count": ok_count,
+            "err_count": err_count,
             "gas_used": as_int(b.get("gas_used")),
             "latency_ms": b.get("block_time_ms"),
         })
@@ -156,6 +167,10 @@ if blocks:
     )
 PYEOF
   )
+
+  if [ -z "$QUERIES" ]; then
+    continue
+  fi
 
   echo "$QUERIES" | while IFS= read -r query; do
     [ -z "$query" ] && continue

--- a/tempo.nu
+++ b/tempo.nu
@@ -3,6 +3,7 @@
 # Tempo local utilities
 
 source contrib/bench/txgen/helpers.nu
+source contrib/bench/receipt-outcomes.nu
 
 const BENCH_DIR = "contrib/bench"
 const LOCALNET_DIR = "localnet"
@@ -1219,8 +1220,8 @@ def generate-summary [
                 number: ($b | get number)
                 timestamp: $timestamp
                 tx_count: $tx_count
-                ok_count: ($b | get -o ok_count | default $tx_count)
-                err_count: ($b | get -o err_count | default 0)
+                ok_count: ($b | get -o ok_count)
+                err_count: ($b | get -o err_count)
                 gas_used: ($b | get gas_used)
                 block_time_ms: ($b | get -o block_time_ms | default null)
             }
@@ -1345,8 +1346,7 @@ def generate-summary [
         }
 
         let total_tx = ($blocks | get tx_count | math sum)
-        let total_ok = ($blocks | get ok_count | math sum)
-        let total_err = ($blocks | get err_count | math sum)
+        let outcomes = (receipt-outcomes $blocks)
         let total_gas = ($blocks | get gas_used | math sum)
         let block_time_mean = if ($block_intervals | length) > 0 { $block_intervals | math avg | math round --precision 1 } else { 0.0 }
         let num_blocks = ($blocks | length)
@@ -1369,17 +1369,16 @@ def generate-summary [
         let gas_per_sec = ($total_gas / $time_span_s)
         let mgas_per_sec = ($gas_per_sec / 1_000_000) | math round --precision 1
 
-        let success_rate = if $total_tx > 0 {
-            (($total_ok / $total_tx) * 100) | math round --precision 1
-        } else { 0 }
-
         $run_data = ($run_data | append [{
             label: $label
             summary_warmup_blocks: $warmup_blocks
             blocks: $num_blocks
             total_tx: $total_tx
-            ok: $total_ok
-            err: $total_err
+            ok: $outcomes.ok
+            err: $outcomes.err
+            receipt_outcomes_complete: $outcomes.receipt_outcomes_complete
+            receipt_known_tx: $outcomes.receipt_known_tx
+            receipt_unknown_tx: $outcomes.receipt_unknown_tx
             total_gas: $total_gas
             block_time_mean: $block_time_mean
             builder_latency_p50: $run_builder.p50
@@ -1402,7 +1401,7 @@ def generate-summary [
             validation_latency_p90: $run_validation.p90
             validation_latency_p99: $run_validation.p99
             validation_gas_s: $run_validation_gas
-            success_rate: $success_rate
+            success_rate: $outcomes.success_rate
         }])
     }
 
@@ -1582,6 +1581,13 @@ def generate-summary [
     }
     if $feature_hardfork != "" {
         $config_lines = ($config_lines | append $"- Feature hardfork: ($feature_hardfork)")
+    }
+    let unknown_receipt_runs = ($run_data | where receipt_outcomes_complete == false | get label)
+    if ($unknown_receipt_runs | length) > 0 {
+        $config_lines = ($config_lines | append [
+            ""
+            $"Receipt outcomes are unknown or incomplete for: ($unknown_receipt_runs | str join ', '). Success rates are unavailable; throughput includes transactions with unverified outcomes."
+        ])
     }
 
     let summary_lines = ($config_lines | append [


### PR DESCRIPTION
Benchmark summaries currently treat missing receipt counts as successful transactions, and the legacy ClickHouse exporter writes every transaction as successful. Preserve unknown outcomes as null in summary JSON, warn in Markdown, and skip legacy exports whose receipt counts are missing or inconsistent.

Validated missing, partial, inconsistent, empty, and known receipt counts; generated JSON/Markdown with warmup exclusion; checked SQL generation without external writes. This fixes reporting only: collecting complete per-block receipt outcomes for new benchmark runs is still required.

Prompted by: @shekhirin
