### PR TITLE
refactor(nonce): hand prewarmed reads to the payload builder

### DIFF
--- a/contrib/bench/test-hardforks.nu
+++ b/contrib/bench/test-hardforks.nu
@@ -1,0 +1,28 @@
+#!/usr/bin/env nu
+
+# Run from the repository root: nu contrib/bench/test-hardforks.nu
+def main [] {
+    source ../../tempo.nu
+    use std/assert
+
+    assert ((hardfork-index T1) < (hardfork-index T1A))
+    assert ((hardfork-index T1C) < (hardfork-index T2))
+    assert ((hardfork-index T9) < (hardfork-index T10))
+    assert ((hardfork-index T10) < (hardfork-index T11))
+    assert equal (highest-hardfork [T9 T10 T11]) T11
+
+    for fork in [T10 T11] {
+        let fields = (hardfork-genesis-config-fields $fork)
+        assert equal ($fields | where fork == T9 | get 0.value) 0
+        assert equal ($fields | where fork == $fork | get 0.value) 0
+        assert equal ($fields | where fork == T12 | get 0.value) $TEMPO_DISABLED_HARDFORK_TIME
+    }
+    assert equal (
+        hardfork-genesis-config-fields T10 | where fork == T11 | get 0.value
+    ) $TEMPO_DISABLED_HARDFORK_TIME
+    assert equal (
+        hardfork-genesis-config-fields (latest-tempo-hardfork)
+        | where value != 0 | length
+    ) 0
+    print "Hardfork ordering tests passed"
+}

--- a/crates/evm/src/action_replay.rs
+++ b/crates/evm/src/action_replay.rs
@@ -241,7 +241,10 @@ where
         let now = U256::from(block_timestamp);
         let ptr = self.replay_state.expiring_nonce.ring_ptr(db)?;
 
-        let seen_slot = nonce_manager.expiring_nonce_seen[expiring_nonce.hash].slot();
+        let seen_slot = nonce_manager
+            .expiring_nonce_seen
+            .at_uncached(&expiring_nonce.hash)
+            .slot();
         let seen_expiry = db
             .storage(NONCE_PRECOMPILE_ADDRESS, seen_slot)
             .map_err(BlockExecutionError::other)?;
@@ -252,12 +255,18 @@ where
         let ptr_u32 = ptr
             .try_into()
             .map_err(|_| StorageActionReplayError::ActionConflict)?;
-        let ring_slot = nonce_manager.expiring_nonce_ring[ptr_u32].slot();
+        let ring_slot = nonce_manager
+            .expiring_nonce_ring
+            .at_uncached(&ptr_u32)
+            .slot();
         let old_hash = db
             .storage(NONCE_PRECOMPILE_ADDRESS, ring_slot)
             .map_err(BlockExecutionError::other)?;
         if !old_hash.is_zero() {
-            let old_seen_slot = nonce_manager.expiring_nonce_seen[B256::from(old_hash)].slot();
+            let old_seen_slot = nonce_manager
+                .expiring_nonce_seen
+                .at_uncached(&B256::from(old_hash))
+                .slot();
             let old_expiry = db
                 .storage(NONCE_PRECOMPILE_ADDRESS, old_seen_slot)
                 .map_err(BlockExecutionError::other)?;

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -764,6 +764,8 @@ where
                 .then(|| format!("{:?}", tx.transaction))
                 .unwrap_or_default();
 
+            pool_tx.seed_nonce_storage(executor.evm_mut().db_mut());
+
             let result_closure = |result: &TempoTxResult| {
                 cumulative_gas_used += result.block_gas_used();
                 cumulative_state_gas_used += result.state_gas_used();

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1006,6 +1006,56 @@ mod tests {
     }
 
     #[test]
+    fn nonce_prewarm_preserves_nonzero_eviction_results() {
+        use tempo_precompiles::{nonce::NonceManager, storage::Handler};
+
+        let mut context = prewarming_context(TaskExecutor::test(), false);
+        context.evm_env.block_env.basefee = 0;
+        context.evm_env.cfg_env.spec = tempo_chainspec::hardfork::TempoHardfork::T11;
+        context.evm_env.cfg_env.disable_nonce_check = true;
+        context.evm_env.cfg_env.disable_balance_check = true;
+        let nonce = NonceManager::new();
+        let old_hash = B256::repeat_byte(0x42);
+        let ring_slot = nonce.expiring_nonce_ring.at_uncached(&0).slot();
+        let old_seen_slot = nonce.expiring_nonce_seen.at_uncached(&old_hash).slot();
+        let parent_values = vec![
+            (nonce.expiring_nonce_ring_ptr.slot(), U256::ZERO),
+            (ring_slot, U256::from_be_bytes(old_hash.0)),
+            (old_seen_slot, U256::ONE),
+        ];
+        let mut backing = CacheDB::new(EmptyDB::default());
+        backing.insert_account_info(
+            NONCE_PRECOMPILE_ADDRESS,
+            AccountInfo {
+                nonce: 1,
+                ..Default::default()
+            },
+        );
+        for &(slot, value) in &parent_values {
+            backing
+                .insert_account_storage(NONCE_PRECOMPILE_ADDRESS, slot, value)
+                .unwrap();
+        }
+        let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
+        let mut warmed = PrewarmedTransaction::without_replay(tx.clone());
+        warmed.nonce_storage = Some(Arc::new(OnceLock::from(parent_values)));
+        let baseline = State::builder().with_database(backing.clone()).build();
+        let mut seeded = State::builder().with_database(backing).build();
+        seeded.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();
+        warmed.seed_nonce_storage(&mut seeded);
+        let mut baseline = TempoEvm::new(baseline, context.evm_env.clone());
+        let mut seeded = TempoEvm::new(seeded, context.evm_env);
+        let tx_env = tx.transaction.clone_tx_env();
+        let expected = baseline.transact_raw(tx_env.clone()).unwrap();
+        let actual = seeded.transact_raw(tx_env).unwrap();
+        assert_eq!(actual.result, expected.result);
+        assert_eq!(actual.state, expected.state);
+        let evicted = &actual.state[&NONCE_PRECOMPILE_ADDRESS].storage[&old_seen_slot];
+        assert_eq!(evicted.original_value(), U256::ONE);
+        assert_eq!(evicted.present_value(), U256::ZERO);
+    }
+
+    #[test]
     fn nonce_prewarm_seeds_missing_slots_without_overwriting_execution() {
         let mut backing = CacheDB::new(EmptyDB::default());
         backing.insert_account_info(

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -957,6 +957,17 @@ mod tests {
         let pool = WorkerPool::new(1, "nonce-read-handoff-test");
         pool.install_fn(|| {
             let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
+            // Reuse the worker after a speculative execution of the same transaction.
+            // Its writes must not become the parent values forwarded below.
+            let first_reads = Arc::new(OnceLock::new());
+            BestTransactionsPrewarming::prewarm_transaction(
+                context.clone(),
+                tx.clone(),
+                Some(7),
+                Some(first_reads.clone()),
+            );
+            assert!(first_reads.get().is_some());
+
             let reads = Arc::new(OnceLock::new());
             let warmed = BestTransactionsPrewarming::prewarm_transaction(
                 context.clone(),

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -17,13 +17,54 @@ use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
 use tempo_evm::{ExpiringNonceReplay, StorageActionReplay, TempoEvmConfig, evm::TempoEvm};
-use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
+use tempo_precompiles::{NONCE_PRECOMPILE_ADDRESS, nonce::NonceManager};
 use tempo_transaction_pool::{StateAwarePoolTransaction, best::BestTransaction};
 use tracing::{instrument, trace};
 
 pub(crate) type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
 
 type PrewarmedNonceStorage = Arc<OnceLock<Vec<(U256, U256)>>>;
+
+/// Reads predicted nonce slots from the parent database, without executing or
+/// modifying the journal. A prediction may miss, but never changes validation.
+fn read_nonce_storage<DB: Database>(
+    db: &mut DB,
+    seen_slot: U256,
+    offset: usize,
+    capacity: u32,
+) -> Result<Option<Vec<(U256, U256)>>, DB::Error> {
+    let nonce = NonceManager::new();
+    let ptr_slot = nonce.expiring_nonce_ring_ptr.slot();
+    let ptr_value = db.storage(NONCE_PRECOMPILE_ADDRESS, ptr_slot)?;
+    let Ok(ptr) = u32::try_from(ptr_value) else {
+        return Ok(None);
+    };
+    if capacity == 0 || ptr >= capacity {
+        return Ok(None);
+    }
+    let index =
+        ((u64::from(ptr) + (offset % capacity as usize) as u64) % u64::from(capacity)) as u32;
+    let ring_slot = nonce.expiring_nonce_ring.at_uncached(&index).slot();
+    let seen_value = db.storage(NONCE_PRECOMPILE_ADDRESS, seen_slot)?;
+    let ring_value = db.storage(NONCE_PRECOMPILE_ADDRESS, ring_slot)?;
+    let mut values = Vec::with_capacity(4);
+    values.extend([
+        (ptr_slot, ptr_value),
+        (seen_slot, seen_value),
+        (ring_slot, ring_value),
+    ]);
+    if !ring_value.is_zero() {
+        let old_hash = B256::from(ring_value.to_be_bytes::<32>());
+        let old_seen_slot = nonce.expiring_nonce_seen.at_uncached(&old_hash).slot();
+        if old_seen_slot != seen_slot {
+            values.push((
+                old_seen_slot,
+                db.storage(NONCE_PRECOMPILE_ADDRESS, old_seen_slot)?,
+            ));
+        }
+    }
+    Ok(Some(values))
+}
 
 struct WorkerPrewarmEvm {
     build: Arc<AtomicBool>,
@@ -207,6 +248,32 @@ impl BestTransactionsPrewarming {
         let replay = prewarm.with_worker_evm(|state| {
             let evm = state.as_mut()?;
 
+            if let (Some(storage), Some(offset)) = (&nonce_storage, expiring_nonce_offset) {
+                let spec = prewarm.evm_env.cfg_env.spec;
+                let seen_slot = if spec.is_t1b() {
+                    tx.transaction.expiring_nonce_slot()
+                } else {
+                    Some(
+                        NonceManager::new()
+                            .expiring_nonce_seen
+                            .at_uncached(tx.hash())
+                            .slot(),
+                    )
+                };
+                if let Some(seen_slot) = seen_slot
+                    && let Ok(Some(values)) = read_nonce_storage(
+                        evm.db_mut(),
+                        seen_slot,
+                        offset,
+                        spec.expiring_nonce_set_capacity(),
+                    )
+                {
+                    // Publish before speculative execution: all values came directly
+                    // from this build's parent, even if execution later fails.
+                    let _ = storage.set(values);
+                }
+            }
+
             let mut tx_env = tx.transaction.clone_tx_env();
             if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
                 tempo_tx_env.expiring_nonce_idx = expiring_nonce_offset;
@@ -230,18 +297,6 @@ impl BestTransactionsPrewarming {
             trace!(target: "payload_builder", "Prewarmed transaction");
 
             if !prewarm.parallel {
-                if let Some(storage) = &nonce_storage
-                    && let Some(account) = result.state.get(&NONCE_PRECOMPILE_ADDRESS)
-                {
-                    // Only forward the parent-state values, never speculative writes.
-                    let _ = storage.set(
-                        account
-                            .storage
-                            .iter()
-                            .map(|(&slot, value)| (slot, value.original_value()))
-                            .collect(),
-                    );
-                }
                 return None;
             }
 
@@ -1021,7 +1076,7 @@ mod tests {
         use tempo_precompiles::nonce::NonceManager;
 
         let capacity = tempo_chainspec::hardfork::TempoHardfork::T11.expiring_nonce_set_capacity();
-        for ptr in [0, capacity - 1] {
+        for (ptr, offset) in [(0, 0), (0, 1), (capacity - 1, 0), (capacity - 1, 1)] {
             let mut context = prewarming_context(TaskExecutor::test(), false);
             context.evm_env.block_env.basefee = 0;
             context.evm_env.cfg_env.spec = tempo_chainspec::hardfork::TempoHardfork::T11;
@@ -1051,7 +1106,22 @@ mod tests {
             }
             let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
             let mut warmed = PrewarmedTransaction::without_replay(tx.clone());
-            warmed.nonce_storage = Some(Arc::new(OnceLock::from(parent_values)));
+            let reads = read_nonce_storage(
+                &mut backing,
+                tx.transaction.expiring_nonce_slot().unwrap(),
+                offset,
+                capacity,
+            )
+            .unwrap()
+            .unwrap();
+            let predicted_index = (ptr + offset as u32) % capacity;
+            let predicted_slot = nonce
+                .expiring_nonce_ring
+                .at_uncached(&predicted_index)
+                .slot();
+            assert!(reads.iter().any(|(slot, _)| *slot == predicted_slot));
+            assert!(reads.contains(&(nonce.expiring_nonce_ring_ptr.slot(), U256::from(ptr))));
+            warmed.nonce_storage = Some(Arc::new(OnceLock::from(reads)));
             let baseline = State::builder().with_database(backing.clone()).build();
             let mut seeded = State::builder().with_database(backing).build();
             seeded.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,10 +1,7 @@
-use std::{
-    cell::RefCell,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-        mpsc::{self, Receiver, Sender},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc::{self, Receiver, Sender},
 };
 
 use alloy_primitives::B256;
@@ -12,7 +9,7 @@ use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Evm, EvmEnvFor};
 use reth_revm::database::StateProviderDatabase;
 use reth_storage_api::{StateProviderBox, StateProviderFactory};
-use reth_tasks::TaskExecutor;
+use reth_tasks::{TaskExecutor, WorkerPool};
 use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
@@ -21,21 +18,6 @@ use tempo_transaction_pool::{StateAwarePoolTransaction, best::BestTransaction};
 use tracing::{instrument, trace};
 
 pub(crate) type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
-
-// Leave enough queued work to overlap cold nonce storage reads with execution.
-// Two transactions per worker can let the builder catch up before those reads finish.
-const PREWARM_LOOKAHEAD_PER_WORKER: usize = 32;
-
-struct WorkerPrewarmEvm {
-    build: Arc<AtomicBool>,
-    evm: PrewarmEvmState,
-}
-
-thread_local! {
-    // The pool's generic worker-state slot belongs to engine prewarming. Keep the
-    // builder's EVM separate and identify its build before reusing cached state.
-    static BUILDER_PREWARM_EVM: RefCell<Option<WorkerPrewarmEvm>> = const { RefCell::new(None) };
-}
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
@@ -61,7 +43,7 @@ impl BestTransactionsPrewarming {
         let (commands_tx, commands_rx) = mpsc::channel();
         let this = Self {
             transactions_rx,
-            commands_tx,
+            commands_tx: commands_tx.clone(),
             stop: prewarm.stop.clone(),
         };
 
@@ -75,6 +57,7 @@ impl BestTransactionsPrewarming {
                         best_txs,
                         transactions_tx,
                         commands_rx,
+                        commands_tx,
                         prewarm,
                         next_expiring_nonce_offset: 0,
                     },
@@ -97,6 +80,11 @@ impl BestTransactionsPrewarming {
         let pool = executor.prewarming_pool();
 
         pool.in_place_scope(|scope| {
+            let prewarm = ctx.prewarm.clone();
+            scope.spawn(move |_| {
+                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
+            });
+
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
@@ -112,6 +100,7 @@ impl BestTransactionsPrewarming {
 
                 let parallel = ctx.prewarm.parallel;
                 let prewarm = ctx.prewarm.clone();
+                let commands_tx = ctx.commands_tx.clone();
                 let transactions_tx = ctx.transactions_tx.clone();
 
                 if !parallel {
@@ -125,14 +114,14 @@ impl BestTransactionsPrewarming {
                     if parallel {
                         let _ = transactions_tx.send(Some(tx));
                     }
+                    let _ = commands_tx.send(BestTransactionsCommand::Advance);
                 });
             };
 
             // Fill the initial batch of transactions to execute and prewarm.
             //
-            // Keep lookahead bounded by consumption, not worker completion. Running too far
-            // ahead can evict prewarmed nonce slots before the builder reads them.
-            for _ in 0..pool.current_num_threads() * PREWARM_LOOKAHEAD_PER_WORKER {
+            // We schedule 2x the number of threads to make sure that workers are never idle.
+            for _ in 0..pool.current_num_threads() * 2 {
                 advance(&mut ctx);
             }
 
@@ -149,20 +138,12 @@ impl BestTransactionsPrewarming {
                         ctx.best_txs.mark_invalid(&invalid.tx, invalid.kind);
                         ctx.transactions_tx = new_tx;
 
-                        let mut discarded = 0;
                         for tx in old_rx {
                             if let Some(tx) = tx
                                 && !is_invalidated_buffered_transaction(&invalid.tx, &tx.tx)
                             {
                                 let _ = ctx.transactions_tx.send(Some(tx));
-                            } else {
-                                discarded += 1;
                             }
-                        }
-                        // Discarded entries will never be consumed, so return their
-                        // lookahead credits here, including exhausted-source markers.
-                        for _ in 0..discarded {
-                            advance(&mut ctx);
                         }
                     }
                     BestTransactionsCommand::NoUpdates => {
@@ -180,9 +161,7 @@ impl BestTransactionsPrewarming {
             }
         });
 
-        pool.broadcast(pool.current_num_threads(), |_| {
-            ctx.prewarm.clear_worker_evm()
-        });
+        pool.clear();
     }
 
     /// Prewarms a transaction by executing it on top of the latest state.
@@ -198,12 +177,16 @@ impl BestTransactionsPrewarming {
     where
         Provider: StateProviderFactory + Clone + 'static,
     {
-        if prewarm.is_stopped() || (prewarm.parallel && !is_parallel_candidate(&tx)) {
-            return PrewarmedTransaction::without_replay(tx);
-        }
+        let replay = WorkerPool::with_worker_mut(|worker| {
+            if prewarm.parallel && !is_parallel_candidate(&tx) {
+                return None;
+            }
 
-        let replay = prewarm.with_worker_evm(|state| {
-            let evm = state.as_mut()?;
+            let evm = worker.get_or_init(|| prewarm.evm_for_ctx()).as_mut()?;
+
+            if prewarm.is_stopped() {
+                return None;
+            }
 
             let mut tx_env = tx.transaction.clone_tx_env();
             if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
@@ -279,9 +262,13 @@ impl Iterator for BestTransactionsPrewarming {
     type Item = PrewarmedTransaction;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let tx = self.transactions_rx.recv().ok()?;
-        let _ = self.commands_tx.send(BestTransactionsCommand::Advance);
-        tx
+        if let Ok(Some(tx)) = self.transactions_rx.try_recv() {
+            return Some(tx);
+        }
+        self.commands_tx
+            .send(BestTransactionsCommand::Advance)
+            .ok()?;
+        self.transactions_rx.recv().ok().flatten()
     }
 }
 
@@ -314,6 +301,7 @@ impl BestTransactions for BestTransactionsPrewarming {
 struct BestTransactionsPrewarmingContext<Txs, Provider> {
     best_txs: Txs,
     transactions_tx: Sender<Option<PrewarmedTransaction>>,
+    commands_tx: Sender<BestTransactionsCommand>,
     commands_rx: Receiver<BestTransactionsCommand>,
     prewarm: PrewarmingExecutionContext<Provider>,
     next_expiring_nonce_offset: usize,
@@ -413,32 +401,6 @@ where
         Some(evm)
     }
 
-    fn with_worker_evm<R>(&self, f: impl FnOnce(&mut PrewarmEvmState) -> R) -> R {
-        BUILDER_PREWARM_EVM.with_borrow_mut(|state| {
-            if state
-                .as_ref()
-                .is_none_or(|cached| !Arc::ptr_eq(&cached.build, &self.stop))
-            {
-                *state = Some(WorkerPrewarmEvm {
-                    build: self.stop.clone(),
-                    evm: self.evm_for_ctx(),
-                });
-            }
-            f(&mut state.as_mut().expect("worker EVM initialized").evm)
-        })
-    }
-
-    fn clear_worker_evm(&self) {
-        BUILDER_PREWARM_EVM.with_borrow_mut(|state| {
-            if state
-                .as_ref()
-                .is_some_and(|cached| Arc::ptr_eq(&cached.build, &self.stop))
-            {
-                *state = None;
-            }
-        });
-    }
-
     pub(crate) fn executor(&self) -> TaskExecutor {
         self.executor.clone()
     }
@@ -522,7 +484,6 @@ mod tests {
         Recovered, SealedHeader, transaction::error::InvalidTransactionError,
     };
     use reth_storage_api::noop::NoopProvider;
-    use reth_tasks::WorkerPool;
     use reth_transaction_pool::{
         TransactionOrigin, ValidPoolTransaction, identifier::TransactionId,
     };
@@ -783,40 +744,28 @@ mod tests {
     }
 
     #[test]
-    fn prewarming_lookahead_is_bounded_by_consumption() {
+    fn prewarming_eagerly_drains_source_iterator() {
         let sender = Address::random();
         let executor = TaskExecutor::test();
-        let lookahead =
-            executor.prewarming_pool().current_num_threads() * PREWARM_LOOKAHEAD_PER_WORKER;
-        let txs = (0..lookahead + 4)
+        let txs = (0..executor.prewarming_pool().current_num_threads() * 2 + 4)
             .map(|nonce| test_tx(sender, nonce as u64))
             .collect::<Vec<_>>();
         let expected = txs.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
         let log = Arc::new(Mutex::new(TestLog::default()));
 
-        let mut prewarming = prewarming_with_executor(executor.clone(), txs, log.clone());
-        wait_until(|| log.lock().unwrap().yielded >= lookahead);
-        let pool = executor.prewarming_pool();
-        pool.broadcast(pool.current_num_threads(), |_| {});
-        prewarming.no_updates();
-        wait_until(|| log.lock().unwrap().no_updates == 1);
-        assert_eq!(log.lock().unwrap().yielded, lookahead);
+        let mut prewarming = prewarming_with_executor(executor, txs, log.clone());
+        wait_until(|| log.lock().unwrap().yielded == expected.len());
 
-        let first = prewarming.next().expect("first transaction");
-        assert_eq!(*first.tx.hash(), expected[0]);
-        wait_until(|| log.lock().unwrap().yielded == lookahead + 1);
-
-        let actual = (1..expected.len())
+        let actual = (0..expected.len())
             .map(|_| *prewarming.next().expect("transaction").tx.hash())
             .collect::<Vec<_>>();
-        assert_eq!(actual, expected[1..]);
+        assert_eq!(actual, expected);
     }
 
     #[test]
     fn empty_source_is_polled_for_eager_advances_and_each_consumer_advance() {
         let executor = TaskExecutor::test();
-        let eager_advances =
-            executor.prewarming_pool().current_num_threads() * PREWARM_LOOKAHEAD_PER_WORKER;
+        let eager_advances = executor.prewarming_pool().current_num_threads() * 2;
         let log = Arc::new(Mutex::new(TestLog::default()));
         let mut prewarming = prewarming_with_executor(executor, Vec::new(), log.clone());
 
@@ -874,24 +823,6 @@ mod tests {
     }
 
     #[test]
-    fn invalidating_every_buffered_transaction_replenishes_lookahead() {
-        let sender = Address::random();
-        let txs = vec![test_tx(sender, 0), test_tx(sender, 1), test_tx(sender, 2)];
-        let log = Arc::new(Mutex::new(TestLog::default()));
-        let mut prewarming = prewarming(txs, log.clone());
-        let first = prewarming.next().expect("first transaction");
-        wait_until(|| log.lock().unwrap().yielded == 3);
-
-        prewarming.mark_invalid(
-            &first,
-            InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported),
-        );
-        assert!(prewarming.next().is_none());
-        assert!(prewarming.next().is_none());
-        assert_eq!(log.lock().unwrap().invalid, 1);
-    }
-
-    #[test]
     fn prewarming_does_not_use_shared_worker_state_slot() {
         let executor = TaskExecutor::test();
         let pool = executor.prewarming_pool();
@@ -904,7 +835,6 @@ mod tests {
 
         assert!(prewarming.next().is_some());
 
-        drop(prewarming);
         pool.broadcast(pool.current_num_threads(), |worker| {
             assert_eq!(*worker.get::<usize>(), 1);
         });
@@ -917,6 +847,7 @@ mod tests {
         context.evm_env.block_env.basefee = 0;
 
         let pool = WorkerPool::new(1, "prewarm-actions-test");
+        pool.init::<PrewarmEvmState>(|_| context.evm_for_ctx());
 
         pool.install_fn(|| {
             let failed_action = StorageAction::Sstore(
@@ -925,8 +856,11 @@ mod tests {
                 U256::from(2),
                 U256::from(3),
             );
-            context.with_worker_evm(|state| {
-                let evm = state.as_mut().expect("prewarm EVM");
+            WorkerPool::with_worker_mut(|worker| {
+                let evm = worker
+                    .get_mut::<PrewarmEvmState>()
+                    .as_mut()
+                    .expect("prewarm EVM");
                 // Model an action recorded before the failed execution returned an error.
                 assert_eq!(evm.replace_actions(vec![failed_action]), Some(Vec::new()));
             });
@@ -938,51 +872,24 @@ mod tests {
                 None,
             );
             assert!(failed.replay.is_none());
-            context.with_worker_evm(|state| {
-                let evm = state.as_mut().expect("prewarm EVM");
+            WorkerPool::with_worker_mut(|worker| {
+                let evm = worker
+                    .get_mut::<PrewarmEvmState>()
+                    .as_mut()
+                    .expect("prewarm EVM");
                 assert_eq!(evm.take_actions(), Some(Vec::new()));
             });
 
             let successful = BestTransactionsPrewarming::prewarm_transaction(
-                context.clone(),
+                context,
                 test_payment_tx(sender, 500_000),
                 None,
             );
             let replay = successful.replay.expect("successful prewarm replay");
             assert!(!replay.actions.is_empty());
             assert!(!replay.actions.contains(&failed_action));
-            context.clear_worker_evm();
         });
-    }
 
-    #[test]
-    fn worker_evm_is_scoped_to_its_build() {
-        let executor = TaskExecutor::test();
-        let first = prewarming_context(executor.clone(), true);
-        let second = prewarming_context(executor, true);
-        let pool = WorkerPool::new(1, "prewarm-build-test");
-        let action =
-            StorageAction::Sstore(Address::random(), U256::from(1), U256::ZERO, U256::from(2));
-
-        pool.install_fn(|| {
-            first.with_worker_evm(|state| {
-                state.as_mut().unwrap().replace_actions(vec![action]);
-            });
-            second.with_worker_evm(|state| {
-                let evm = state.as_mut().unwrap();
-                assert_eq!(evm.take_actions(), Some(Vec::new()));
-                evm.replace_actions(vec![action]);
-            });
-            // A previous build finishing must not clear the next build's EVM.
-            first.clear_worker_evm();
-            second.with_worker_evm(|state| {
-                assert_eq!(state.as_mut().unwrap().take_actions(), Some(vec![action]));
-            });
-            // Returning to an older context also starts from fresh state.
-            first.with_worker_evm(|state| {
-                assert_eq!(state.as_mut().unwrap().take_actions(), Some(Vec::new()));
-            });
-            first.clear_worker_evm();
-        });
+        pool.clear();
     }
 }

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -22,6 +22,10 @@ use tracing::{instrument, trace};
 
 pub(crate) type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
 
+// Leave enough queued work to overlap cold nonce storage reads with execution.
+// Two transactions per worker can let the builder catch up before those reads finish.
+const PREWARM_LOOKAHEAD_PER_WORKER: usize = 32;
+
 struct WorkerPrewarmEvm {
     build: Arc<AtomicBool>,
     evm: PrewarmEvmState,
@@ -128,7 +132,7 @@ impl BestTransactionsPrewarming {
             //
             // Keep lookahead bounded by consumption, not worker completion. Running too far
             // ahead can evict prewarmed nonce slots before the builder reads them.
-            for _ in 0..pool.current_num_threads() * 2 {
+            for _ in 0..pool.current_num_threads() * PREWARM_LOOKAHEAD_PER_WORKER {
                 advance(&mut ctx);
             }
 
@@ -782,7 +786,8 @@ mod tests {
     fn prewarming_lookahead_is_bounded_by_consumption() {
         let sender = Address::random();
         let executor = TaskExecutor::test();
-        let lookahead = executor.prewarming_pool().current_num_threads() * 2;
+        let lookahead =
+            executor.prewarming_pool().current_num_threads() * PREWARM_LOOKAHEAD_PER_WORKER;
         let txs = (0..lookahead + 4)
             .map(|nonce| test_tx(sender, nonce as u64))
             .collect::<Vec<_>>();
@@ -810,7 +815,8 @@ mod tests {
     #[test]
     fn empty_source_is_polled_for_eager_advances_and_each_consumer_advance() {
         let executor = TaskExecutor::test();
-        let eager_advances = executor.prewarming_pool().current_num_threads() * 2;
+        let eager_advances =
+            executor.prewarming_pool().current_num_threads() * PREWARM_LOOKAHEAD_PER_WORKER;
         let log = Arc::new(Mutex::new(TestLog::default()));
         let mut prewarming = prewarming_with_executor(executor, Vec::new(), log.clone());
 

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -17,54 +17,13 @@ use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
 use tempo_evm::{ExpiringNonceReplay, StorageActionReplay, TempoEvmConfig, evm::TempoEvm};
-use tempo_precompiles::{NONCE_PRECOMPILE_ADDRESS, nonce::NonceManager};
+use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 use tempo_transaction_pool::{StateAwarePoolTransaction, best::BestTransaction};
 use tracing::{instrument, trace};
 
 pub(crate) type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
 
 type PrewarmedNonceStorage = Arc<OnceLock<Vec<(U256, U256)>>>;
-
-/// Reads predicted nonce slots from the parent database, without executing or
-/// modifying the journal. A prediction may miss, but never changes validation.
-fn read_nonce_storage<DB: Database>(
-    db: &mut DB,
-    seen_slot: U256,
-    offset: usize,
-    capacity: u32,
-) -> Result<Option<Vec<(U256, U256)>>, DB::Error> {
-    let nonce = NonceManager::new();
-    let ptr_slot = nonce.expiring_nonce_ring_ptr.slot();
-    let ptr_value = db.storage(NONCE_PRECOMPILE_ADDRESS, ptr_slot)?;
-    let Ok(ptr) = u32::try_from(ptr_value) else {
-        return Ok(None);
-    };
-    if capacity == 0 || ptr >= capacity {
-        return Ok(None);
-    }
-    let index =
-        ((u64::from(ptr) + (offset % capacity as usize) as u64) % u64::from(capacity)) as u32;
-    let ring_slot = nonce.expiring_nonce_ring.at_uncached(&index).slot();
-    let seen_value = db.storage(NONCE_PRECOMPILE_ADDRESS, seen_slot)?;
-    let ring_value = db.storage(NONCE_PRECOMPILE_ADDRESS, ring_slot)?;
-    let mut values = Vec::with_capacity(4);
-    values.extend([
-        (ptr_slot, ptr_value),
-        (seen_slot, seen_value),
-        (ring_slot, ring_value),
-    ]);
-    if !ring_value.is_zero() {
-        let old_hash = B256::from(ring_value.to_be_bytes::<32>());
-        let old_seen_slot = nonce.expiring_nonce_seen.at_uncached(&old_hash).slot();
-        if old_seen_slot != seen_slot {
-            values.push((
-                old_seen_slot,
-                db.storage(NONCE_PRECOMPILE_ADDRESS, old_seen_slot)?,
-            ));
-        }
-    }
-    Ok(Some(values))
-}
 
 struct WorkerPrewarmEvm {
     build: Arc<AtomicBool>,
@@ -248,32 +207,6 @@ impl BestTransactionsPrewarming {
         let replay = prewarm.with_worker_evm(|state| {
             let evm = state.as_mut()?;
 
-            if let (Some(storage), Some(offset)) = (&nonce_storage, expiring_nonce_offset) {
-                let spec = prewarm.evm_env.cfg_env.spec;
-                let seen_slot = if spec.is_t1b() {
-                    tx.transaction.expiring_nonce_slot()
-                } else {
-                    Some(
-                        NonceManager::new()
-                            .expiring_nonce_seen
-                            .at_uncached(tx.hash())
-                            .slot(),
-                    )
-                };
-                if let Some(seen_slot) = seen_slot
-                    && let Ok(Some(values)) = read_nonce_storage(
-                        evm.db_mut(),
-                        seen_slot,
-                        offset,
-                        spec.expiring_nonce_set_capacity(),
-                    )
-                {
-                    // Publish before speculative execution: all values came directly
-                    // from this build's parent, even if execution later fails.
-                    let _ = storage.set(values);
-                }
-            }
-
             let mut tx_env = tx.transaction.clone_tx_env();
             if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
                 tempo_tx_env.expiring_nonce_idx = expiring_nonce_offset;
@@ -297,6 +230,18 @@ impl BestTransactionsPrewarming {
             trace!(target: "payload_builder", "Prewarmed transaction");
 
             if !prewarm.parallel {
+                if let Some(storage) = &nonce_storage
+                    && let Some(account) = result.state.get(&NONCE_PRECOMPILE_ADDRESS)
+                {
+                    // Only forward the parent-state values, never speculative writes.
+                    let _ = storage.set(
+                        account
+                            .storage
+                            .iter()
+                            .map(|(&slot, value)| (slot, value.original_value()))
+                            .collect(),
+                    );
+                }
                 return None;
             }
 
@@ -1076,7 +1021,7 @@ mod tests {
         use tempo_precompiles::nonce::NonceManager;
 
         let capacity = tempo_chainspec::hardfork::TempoHardfork::T11.expiring_nonce_set_capacity();
-        for (ptr, offset) in [(0, 0), (0, 1), (capacity - 1, 0), (capacity - 1, 1)] {
+        for ptr in [0, capacity - 1] {
             let mut context = prewarming_context(TaskExecutor::test(), false);
             context.evm_env.block_env.basefee = 0;
             context.evm_env.cfg_env.spec = tempo_chainspec::hardfork::TempoHardfork::T11;
@@ -1106,22 +1051,7 @@ mod tests {
             }
             let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
             let mut warmed = PrewarmedTransaction::without_replay(tx.clone());
-            let reads = read_nonce_storage(
-                &mut backing,
-                tx.transaction.expiring_nonce_slot().unwrap(),
-                offset,
-                capacity,
-            )
-            .unwrap()
-            .unwrap();
-            let predicted_index = (ptr + offset as u32) % capacity;
-            let predicted_slot = nonce
-                .expiring_nonce_ring
-                .at_uncached(&predicted_index)
-                .slot();
-            assert!(reads.iter().any(|(slot, _)| *slot == predicted_slot));
-            assert!(reads.contains(&(nonce.expiring_nonce_ring_ptr.slot(), U256::from(ptr))));
-            warmed.nonce_storage = Some(Arc::new(OnceLock::from(reads)));
+            warmed.nonce_storage = Some(Arc::new(OnceLock::from(parent_values)));
             let baseline = State::builder().with_database(backing.clone()).build();
             let mut seeded = State::builder().with_database(backing).build();
             seeded.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,23 +1,40 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
-use alloy_primitives::B256;
+use alloy_primitives::{B256, U256};
 use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
-use reth_evm::{Evm, EvmEnvFor};
-use reth_revm::database::StateProviderDatabase;
+use reth_evm::{Database, Evm, EvmEnvFor};
+use reth_revm::{State, database::StateProviderDatabase};
 use reth_storage_api::{StateProviderBox, StateProviderFactory};
-use reth_tasks::{TaskExecutor, WorkerPool};
+use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
 use tempo_evm::{ExpiringNonceReplay, StorageActionReplay, TempoEvmConfig, evm::TempoEvm};
+use tempo_precompiles::NONCE_PRECOMPILE_ADDRESS;
 use tempo_transaction_pool::{StateAwarePoolTransaction, best::BestTransaction};
 use tracing::{instrument, trace};
 
 pub(crate) type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
+
+type PrewarmedNonceStorage = Arc<OnceLock<Vec<(U256, U256)>>>;
+
+struct WorkerPrewarmEvm {
+    build: Arc<AtomicBool>,
+    evm: PrewarmEvmState,
+}
+
+thread_local! {
+    // Engine prewarming owns the pool's generic worker-state slot. Forwarded
+    // nonce reads must come from this build's parent, never a previous build.
+    static BUILDER_PREWARM_EVM: RefCell<Option<WorkerPrewarmEvm>> = const { RefCell::new(None) };
+}
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
@@ -80,11 +97,6 @@ impl BestTransactionsPrewarming {
         let pool = executor.prewarming_pool();
 
         pool.in_place_scope(|scope| {
-            let prewarm = ctx.prewarm.clone();
-            scope.spawn(move |_| {
-                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
-            });
-
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
@@ -102,15 +114,24 @@ impl BestTransactionsPrewarming {
                 let prewarm = ctx.prewarm.clone();
                 let commands_tx = ctx.commands_tx.clone();
                 let transactions_tx = ctx.transactions_tx.clone();
+                let nonce_storage = (!parallel && expiring_nonce_offset.is_some())
+                    .then(|| Arc::new(OnceLock::new()));
 
                 if !parallel {
-                    let _ = ctx
-                        .transactions_tx
-                        .send(Some(PrewarmedTransaction::without_replay(tx.clone())));
+                    let _ = ctx.transactions_tx.send(Some(PrewarmedTransaction {
+                        tx: tx.clone(),
+                        replay: None,
+                        nonce_storage: nonce_storage.clone(),
+                    }));
                 }
 
                 scope.spawn(move |_| {
-                    let tx = Self::prewarm_transaction(prewarm, tx, expiring_nonce_offset);
+                    let tx = Self::prewarm_transaction(
+                        prewarm,
+                        tx,
+                        expiring_nonce_offset,
+                        nonce_storage,
+                    );
                     if parallel {
                         let _ = transactions_tx.send(Some(tx));
                     }
@@ -161,7 +182,9 @@ impl BestTransactionsPrewarming {
             }
         });
 
-        pool.clear();
+        pool.broadcast(pool.current_num_threads(), |_| {
+            ctx.prewarm.clear_worker_evm()
+        });
     }
 
     /// Prewarms a transaction by executing it on top of the latest state.
@@ -173,20 +196,16 @@ impl BestTransactionsPrewarming {
         prewarm: PrewarmingExecutionContext<Provider>,
         tx: BestTransaction,
         expiring_nonce_offset: Option<usize>,
+        nonce_storage: Option<PrewarmedNonceStorage>,
     ) -> PrewarmedTransaction
     where
         Provider: StateProviderFactory + Clone + 'static,
     {
-        let replay = WorkerPool::with_worker_mut(|worker| {
-            if prewarm.parallel && !is_parallel_candidate(&tx) {
-                return None;
-            }
-
-            let evm = worker.get_or_init(|| prewarm.evm_for_ctx()).as_mut()?;
-
-            if prewarm.is_stopped() {
-                return None;
-            }
+        if prewarm.is_stopped() || (prewarm.parallel && !is_parallel_candidate(&tx)) {
+            return PrewarmedTransaction::without_replay(tx);
+        }
+        let replay = prewarm.with_worker_evm(|state| {
+            let evm = state.as_mut()?;
 
             let mut tx_env = tx.transaction.clone_tx_env();
             if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
@@ -194,7 +213,7 @@ impl BestTransactionsPrewarming {
             }
 
             let result = match evm.transact_raw(tx_env) {
-                Ok(result) => result.result,
+                Ok(result) => result,
                 Err(err) => {
                     // Discard actions recorded by the failed transaction before reusing this worker.
                     evm.clear_actions();
@@ -211,6 +230,18 @@ impl BestTransactionsPrewarming {
             trace!(target: "payload_builder", "Prewarmed transaction");
 
             if !prewarm.parallel {
+                if let Some(storage) = &nonce_storage
+                    && let Some(account) = result.state.get(&NONCE_PRECOMPILE_ADDRESS)
+                {
+                    // Only forward the parent-state values, never speculative writes.
+                    let _ = storage.set(
+                        account
+                            .storage
+                            .iter()
+                            .map(|(&slot, value)| (slot, value.original_value()))
+                            .collect(),
+                    );
+                }
                 return None;
             }
 
@@ -235,14 +266,18 @@ impl BestTransactionsPrewarming {
             );
 
             Some(Box::new(StorageActionReplay {
-                result,
+                result: result.result,
                 actions,
                 validator_fee: evm.validator_fee(),
                 expiring_nonce,
             }))
         });
 
-        PrewarmedTransaction { tx, replay }
+        PrewarmedTransaction {
+            tx,
+            replay,
+            nonce_storage,
+        }
     }
 }
 
@@ -312,11 +347,41 @@ struct BestTransactionsPrewarmingContext<Txs, Provider> {
 pub(crate) struct PrewarmedTransaction {
     pub(crate) tx: BestTransaction,
     pub(crate) replay: Option<Box<StorageActionReplay>>,
+    nonce_storage: Option<PrewarmedNonceStorage>,
 }
 
 impl PrewarmedTransaction {
     pub(crate) fn without_replay(tx: BestTransaction) -> Self {
-        Self { tx, replay: None }
+        Self {
+            tx,
+            replay: None,
+            nonce_storage: None,
+        }
+    }
+
+    /// Copies ready parent-state nonce reads into the block's database cache.
+    /// Does not wait for prewarming, overwrite executed state, or warm EVM gas slots.
+    pub(crate) fn seed_nonce_storage<DB: Database>(&self, db: &mut State<DB>) {
+        let Some(storage) = self
+            .nonce_storage
+            .as_ref()
+            .and_then(|storage| storage.get())
+        else {
+            return;
+        };
+        let Some(cached) = db.cache.accounts.get_mut(&NONCE_PRECOMPILE_ADDRESS) else {
+            return;
+        };
+        // Created/destroyed accounts have fully known storage. Parent-state values
+        // must not resurrect slots cleared by execution in this block.
+        if cached.status.is_storage_known() {
+            return;
+        }
+        if let Some(account) = &mut cached.account {
+            for &(slot, value) in storage {
+                account.storage.entry(slot).or_insert(value);
+            }
+        }
     }
 }
 
@@ -404,6 +469,32 @@ where
     pub(crate) fn executor(&self) -> TaskExecutor {
         self.executor.clone()
     }
+
+    fn with_worker_evm<R>(&self, f: impl FnOnce(&mut PrewarmEvmState) -> R) -> R {
+        BUILDER_PREWARM_EVM.with_borrow_mut(|state| {
+            if state
+                .as_ref()
+                .is_none_or(|cached| !Arc::ptr_eq(&cached.build, &self.stop))
+            {
+                *state = Some(WorkerPrewarmEvm {
+                    build: self.stop.clone(),
+                    evm: self.evm_for_ctx(),
+                });
+            }
+            f(&mut state.as_mut().expect("worker EVM initialized").evm)
+        })
+    }
+
+    fn clear_worker_evm(&self) {
+        BUILDER_PREWARM_EVM.with_borrow_mut(|state| {
+            if state
+                .as_ref()
+                .is_some_and(|cached| Arc::ptr_eq(&cached.build, &self.stop))
+            {
+                *state = None;
+            }
+        });
+    }
 }
 
 impl<Provider> PrewarmingExecutionContext<Provider> {
@@ -483,7 +574,13 @@ mod tests {
     use reth_primitives_traits::{
         Recovered, SealedHeader, transaction::error::InvalidTransactionError,
     };
+    use reth_revm::{
+        Database as _,
+        db::{CacheDB, EmptyDB, states::account_status::AccountStatus},
+        state::AccountInfo,
+    };
     use reth_storage_api::noop::NoopProvider;
+    use reth_tasks::WorkerPool;
     use reth_transaction_pool::{
         TransactionOrigin, ValidPoolTransaction, identifier::TransactionId,
     };
@@ -588,6 +685,14 @@ mod tests {
     }
 
     fn test_payment_tx(sender: Address, gas_limit: u64) -> BestTransaction {
+        test_payment_tx_with_nonce_key(sender, gas_limit, U256::ONE)
+    }
+
+    fn test_payment_tx_with_nonce_key(
+        sender: Address,
+        gas_limit: u64,
+        nonce_key: U256,
+    ) -> BestTransaction {
         let mut token = [0u8; 20];
         token[..2].copy_from_slice(&[0x20, 0xc0]);
         let token = Address::from(token);
@@ -604,7 +709,8 @@ mod tests {
                 value: U256::ZERO,
                 input: input.into(),
             }],
-            nonce_key: U256::ONE,
+            nonce_key,
+            valid_before: (nonce_key == U256::MAX).then(|| std::num::NonZeroU64::new(300).unwrap()),
             ..Default::default()
         };
         let envelope = TempoTxEnvelope::AA(tx.into_signed(Signature::test_signature().into()));
@@ -835,9 +941,170 @@ mod tests {
 
         assert!(prewarming.next().is_some());
 
+        drop(prewarming);
+
         pool.broadcast(pool.current_num_threads(), |worker| {
             assert_eq!(*worker.get::<usize>(), 1);
         });
+    }
+
+    #[test]
+    fn expiring_nonce_prewarm_forwards_original_values_and_preserves_execution() {
+        let executor = TaskExecutor::test();
+        let mut context = prewarming_context(executor, false);
+        context.evm_env.block_env.basefee = 0;
+        context.evm_env.cfg_env.spec = tempo_chainspec::hardfork::TempoHardfork::T11;
+        let pool = WorkerPool::new(1, "nonce-read-handoff-test");
+        pool.install_fn(|| {
+            let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
+            let reads = Arc::new(OnceLock::new());
+            let warmed = BestTransactionsPrewarming::prewarm_transaction(
+                context.clone(),
+                tx.clone(),
+                Some(7),
+                Some(reads.clone()),
+            );
+            let storage = reads
+                .get()
+                .expect("successful prewarm publishes nonce reads");
+            assert!(storage.len() >= 3);
+            assert!(storage.iter().all(|(_, value)| value.is_zero()));
+            assert!(storage.contains(&(U256::from(3), U256::ZERO)));
+
+            let mut backing = CacheDB::new(EmptyDB::default());
+            backing.insert_account_info(
+                NONCE_PRECOMPILE_ADDRESS,
+                AccountInfo {
+                    nonce: 1,
+                    ..Default::default()
+                },
+            );
+            let baseline = State::builder().with_database(backing.clone()).build();
+            let mut seeded = State::builder().with_database(backing).build();
+            seeded.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();
+            warmed.seed_nonce_storage(&mut seeded);
+            assert!(
+                !seeded.cache.accounts[&NONCE_PRECOMPILE_ADDRESS]
+                    .account
+                    .as_ref()
+                    .unwrap()
+                    .storage
+                    .is_empty()
+            );
+
+            let mut env = context.evm_env.clone();
+            env.cfg_env.disable_nonce_check = true;
+            env.cfg_env.disable_balance_check = true;
+            let mut baseline = TempoEvm::new(baseline, env.clone());
+            let mut seeded = TempoEvm::new(seeded, env);
+            let tx_env = tx.transaction.clone_tx_env();
+            let expected = baseline.transact_raw(tx_env.clone()).unwrap();
+            let actual = seeded.transact_raw(tx_env).unwrap();
+            assert_eq!(actual.result, expected.result);
+            assert_eq!(actual.state, expected.state);
+        });
+    }
+
+    #[test]
+    fn nonce_prewarm_seeds_missing_slots_without_overwriting_execution() {
+        let mut backing = CacheDB::new(EmptyDB::default());
+        backing.insert_account_info(
+            NONCE_PRECOMPILE_ADDRESS,
+            AccountInfo {
+                nonce: 1,
+                ..Default::default()
+            },
+        );
+        let mut db = State::builder().with_database(backing).build();
+        db.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();
+        let existing = U256::from(1);
+        let cleared = U256::from(2);
+        let missing = U256::from(3);
+        let account = db
+            .cache
+            .accounts
+            .get_mut(&NONCE_PRECOMPILE_ADDRESS)
+            .unwrap();
+        let storage = &mut account.account.as_mut().unwrap().storage;
+        storage.insert(existing, U256::from(99));
+        storage.insert(cleared, U256::ZERO);
+        let status = account.status;
+
+        let mut tx = PrewarmedTransaction::without_replay(test_tx(Address::random(), 0));
+        tx.nonce_storage = Some(Arc::new(OnceLock::from(vec![
+            (existing, U256::from(11)),
+            (cleared, U256::from(22)),
+            (missing, U256::from(33)),
+        ])));
+        tx.seed_nonce_storage(&mut db);
+        assert_eq!(
+            db.storage(NONCE_PRECOMPILE_ADDRESS, existing).unwrap(),
+            U256::from(99)
+        );
+        assert_eq!(
+            db.storage(NONCE_PRECOMPILE_ADDRESS, cleared).unwrap(),
+            U256::ZERO
+        );
+        assert_eq!(
+            db.storage(NONCE_PRECOMPILE_ADDRESS, missing).unwrap(),
+            U256::from(33)
+        );
+        assert_eq!(db.cache.accounts[&NONCE_PRECOMPILE_ADDRESS].status, status);
+    }
+
+    #[test]
+    fn nonce_prewarm_does_not_resurrect_known_storage() {
+        let mut tx = PrewarmedTransaction::without_replay(test_tx(Address::random(), 0));
+        let slot = U256::from(42);
+        tx.nonce_storage = Some(Arc::new(OnceLock::from(vec![(slot, U256::from(7))])));
+        for status in [
+            AccountStatus::LoadedNotExisting,
+            AccountStatus::InMemoryChange,
+            AccountStatus::Destroyed,
+            AccountStatus::DestroyedChanged,
+            AccountStatus::DestroyedAgain,
+        ] {
+            let mut db = State::builder().with_database(EmptyDB::default()).build();
+            db.insert_account_with_storage(
+                NONCE_PRECOMPILE_ADDRESS,
+                AccountInfo {
+                    nonce: 1,
+                    ..Default::default()
+                },
+                Default::default(),
+            );
+            db.cache
+                .accounts
+                .get_mut(&NONCE_PRECOMPILE_ADDRESS)
+                .unwrap()
+                .status = status;
+            tx.seed_nonce_storage(&mut db);
+            assert_eq!(
+                db.storage(NONCE_PRECOMPILE_ADDRESS, slot).unwrap(),
+                U256::ZERO
+            );
+            assert_eq!(db.cache.accounts[&NONCE_PRECOMPILE_ADDRESS].status, status);
+        }
+    }
+
+    #[test]
+    fn nonce_prewarm_is_nonblocking_and_does_not_load_accounts() {
+        let mut tx = PrewarmedTransaction::without_replay(test_tx(Address::random(), 0));
+        let ready = Arc::new(OnceLock::new());
+        tx.nonce_storage = Some(ready.clone());
+        let mut db = State::builder().with_database(EmptyDB::default()).build();
+        tx.seed_nonce_storage(&mut db);
+        assert!(db.cache.accounts.is_empty());
+        ready.set(vec![(U256::ONE, U256::ONE)]).unwrap();
+        tx.seed_nonce_storage(&mut db);
+        assert!(db.cache.accounts.is_empty());
+        db.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();
+        tx.seed_nonce_storage(&mut db);
+        assert!(
+            db.cache.accounts[&NONCE_PRECOMPILE_ADDRESS]
+                .account
+                .is_none()
+        );
     }
 
     #[test]
@@ -847,7 +1114,6 @@ mod tests {
         context.evm_env.block_env.basefee = 0;
 
         let pool = WorkerPool::new(1, "prewarm-actions-test");
-        pool.init::<PrewarmEvmState>(|_| context.evm_for_ctx());
 
         pool.install_fn(|| {
             let failed_action = StorageAction::Sstore(
@@ -856,11 +1122,8 @@ mod tests {
                 U256::from(2),
                 U256::from(3),
             );
-            WorkerPool::with_worker_mut(|worker| {
-                let evm = worker
-                    .get_mut::<PrewarmEvmState>()
-                    .as_mut()
-                    .expect("prewarm EVM");
+            context.with_worker_evm(|state| {
+                let evm = state.as_mut().expect("prewarm EVM");
                 // Model an action recorded before the failed execution returned an error.
                 assert_eq!(evm.replace_actions(vec![failed_action]), Some(Vec::new()));
             });
@@ -870,13 +1133,11 @@ mod tests {
                 context.clone(),
                 test_payment_tx(sender, 0),
                 None,
+                None,
             );
             assert!(failed.replay.is_none());
-            WorkerPool::with_worker_mut(|worker| {
-                let evm = worker
-                    .get_mut::<PrewarmEvmState>()
-                    .as_mut()
-                    .expect("prewarm EVM");
+            context.with_worker_evm(|state| {
+                let evm = state.as_mut().expect("prewarm EVM");
                 assert_eq!(evm.take_actions(), Some(Vec::new()));
             });
 
@@ -884,12 +1145,33 @@ mod tests {
                 context,
                 test_payment_tx(sender, 500_000),
                 None,
+                None,
             );
             let replay = successful.replay.expect("successful prewarm replay");
             assert!(!replay.actions.is_empty());
             assert!(!replay.actions.contains(&failed_action));
         });
+    }
 
-        pool.clear();
+    #[test]
+    fn nonce_read_worker_is_scoped_to_its_build() {
+        let executor = TaskExecutor::test();
+        let first = prewarming_context(executor.clone(), true);
+        let second = prewarming_context(executor, true);
+        let pool = WorkerPool::new(1, "nonce-read-build-test");
+        pool.install_fn(|| {
+            first.with_worker_evm(|state| {
+                assert!(state.is_some());
+                *state = None;
+            });
+            first.with_worker_evm(|state| assert!(state.is_none()));
+            second.with_worker_evm(|state| assert!(state.is_some()));
+            first.clear_worker_evm();
+            BUILDER_PREWARM_EVM.with_borrow(|state| {
+                assert!(Arc::ptr_eq(&state.as_ref().unwrap().build, &second.stop));
+            });
+            second.clear_worker_evm();
+            BUILDER_PREWARM_EVM.with_borrow(|state| assert!(state.is_none()));
+        });
     }
 }

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1007,52 +1007,61 @@ mod tests {
 
     #[test]
     fn nonce_prewarm_preserves_nonzero_eviction_results() {
-        use tempo_precompiles::{nonce::NonceManager, storage::Handler};
+        use tempo_precompiles::nonce::NonceManager;
 
-        let mut context = prewarming_context(TaskExecutor::test(), false);
-        context.evm_env.block_env.basefee = 0;
-        context.evm_env.cfg_env.spec = tempo_chainspec::hardfork::TempoHardfork::T11;
-        context.evm_env.cfg_env.disable_nonce_check = true;
-        context.evm_env.cfg_env.disable_balance_check = true;
-        let nonce = NonceManager::new();
-        let old_hash = B256::repeat_byte(0x42);
-        let ring_slot = nonce.expiring_nonce_ring.at_uncached(&0).slot();
-        let old_seen_slot = nonce.expiring_nonce_seen.at_uncached(&old_hash).slot();
-        let parent_values = vec![
-            (nonce.expiring_nonce_ring_ptr.slot(), U256::ZERO),
-            (ring_slot, U256::from_be_bytes(old_hash.0)),
-            (old_seen_slot, U256::ONE),
-        ];
-        let mut backing = CacheDB::new(EmptyDB::default());
-        backing.insert_account_info(
-            NONCE_PRECOMPILE_ADDRESS,
-            AccountInfo {
-                nonce: 1,
-                ..Default::default()
-            },
-        );
-        for &(slot, value) in &parent_values {
-            backing
-                .insert_account_storage(NONCE_PRECOMPILE_ADDRESS, slot, value)
-                .unwrap();
+        let capacity = tempo_chainspec::hardfork::TempoHardfork::T11.expiring_nonce_set_capacity();
+        for ptr in [0, capacity - 1] {
+            let mut context = prewarming_context(TaskExecutor::test(), false);
+            context.evm_env.block_env.basefee = 0;
+            context.evm_env.cfg_env.spec = tempo_chainspec::hardfork::TempoHardfork::T11;
+            context.evm_env.cfg_env.disable_nonce_check = true;
+            context.evm_env.cfg_env.disable_balance_check = true;
+            let nonce = NonceManager::new();
+            let old_hash = B256::repeat_byte(0x42);
+            let ring_slot = nonce.expiring_nonce_ring.at_uncached(&ptr).slot();
+            let old_seen_slot = nonce.expiring_nonce_seen.at_uncached(&old_hash).slot();
+            let parent_values = vec![
+                (nonce.expiring_nonce_ring_ptr.slot(), U256::from(ptr)),
+                (ring_slot, U256::from_be_bytes(old_hash.0)),
+                (old_seen_slot, U256::ONE),
+            ];
+            let mut backing = CacheDB::new(EmptyDB::default());
+            backing.insert_account_info(
+                NONCE_PRECOMPILE_ADDRESS,
+                AccountInfo {
+                    nonce: 1,
+                    ..Default::default()
+                },
+            );
+            for &(slot, value) in &parent_values {
+                backing
+                    .insert_account_storage(NONCE_PRECOMPILE_ADDRESS, slot, value)
+                    .unwrap();
+            }
+            let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
+            let mut warmed = PrewarmedTransaction::without_replay(tx.clone());
+            warmed.nonce_storage = Some(Arc::new(OnceLock::from(parent_values)));
+            let baseline = State::builder().with_database(backing.clone()).build();
+            let mut seeded = State::builder().with_database(backing).build();
+            seeded.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();
+            warmed.seed_nonce_storage(&mut seeded);
+            let mut baseline = TempoEvm::new(baseline, context.evm_env.clone());
+            let mut seeded = TempoEvm::new(seeded, context.evm_env);
+            let tx_env = tx.transaction.clone_tx_env();
+            let expected = baseline.transact_raw(tx_env.clone()).unwrap();
+            let actual = seeded.transact_raw(tx_env).unwrap();
+            assert_eq!(actual.result, expected.result);
+            assert_eq!(actual.state, expected.state);
+            let evicted = &actual.state[&NONCE_PRECOMPILE_ADDRESS].storage[&old_seen_slot];
+            assert_eq!(evicted.original_value(), U256::ONE);
+            assert_eq!(evicted.present_value(), U256::ZERO);
+            assert_eq!(
+                actual.state[&NONCE_PRECOMPILE_ADDRESS].storage
+                    [&nonce.expiring_nonce_ring_ptr.slot()]
+                    .present_value(),
+                U256::from((ptr + 1) % capacity),
+            );
         }
-        let tx = test_payment_tx_with_nonce_key(Address::random(), 500_000, U256::MAX);
-        let mut warmed = PrewarmedTransaction::without_replay(tx.clone());
-        warmed.nonce_storage = Some(Arc::new(OnceLock::from(parent_values)));
-        let baseline = State::builder().with_database(backing.clone()).build();
-        let mut seeded = State::builder().with_database(backing).build();
-        seeded.basic(NONCE_PRECOMPILE_ADDRESS).unwrap();
-        warmed.seed_nonce_storage(&mut seeded);
-        let mut baseline = TempoEvm::new(baseline, context.evm_env.clone());
-        let mut seeded = TempoEvm::new(seeded, context.evm_env);
-        let tx_env = tx.transaction.clone_tx_env();
-        let expected = baseline.transact_raw(tx_env.clone()).unwrap();
-        let actual = seeded.transact_raw(tx_env).unwrap();
-        assert_eq!(actual.result, expected.result);
-        assert_eq!(actual.state, expected.state);
-        let evicted = &actual.state[&NONCE_PRECOMPILE_ADDRESS].storage[&old_seen_slot];
-        assert_eq!(evicted.original_value(), U256::ONE);
-        assert_eq!(evicted.present_value(), U256::ZERO);
     }
 
     #[test]

--- a/crates/payload/builder/src/prewarming.rs
+++ b/crates/payload/builder/src/prewarming.rs
@@ -1,7 +1,10 @@
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-    mpsc::{self, Receiver, Sender},
+use std::{
+    cell::RefCell,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, Receiver, Sender},
+    },
 };
 
 use alloy_primitives::B256;
@@ -9,7 +12,7 @@ use reth_engine_tree::tree::{CachedStateProvider, SavedCache};
 use reth_evm::{Evm, EvmEnvFor};
 use reth_revm::database::StateProviderDatabase;
 use reth_storage_api::{StateProviderBox, StateProviderFactory};
-use reth_tasks::{TaskExecutor, WorkerPool};
+use reth_tasks::TaskExecutor;
 use reth_transaction_pool::{
     BestTransactions, PoolTransaction, error::InvalidPoolTransactionError,
 };
@@ -18,6 +21,17 @@ use tempo_transaction_pool::{StateAwarePoolTransaction, best::BestTransaction};
 use tracing::{instrument, trace};
 
 pub(crate) type PrewarmEvmState = Option<TempoEvm<StateProviderDatabase<StateProviderBox>>>;
+
+struct WorkerPrewarmEvm {
+    build: Arc<AtomicBool>,
+    evm: PrewarmEvmState,
+}
+
+thread_local! {
+    // The pool's generic worker-state slot belongs to engine prewarming. Keep the
+    // builder's EVM separate and identify its build before reusing cached state.
+    static BUILDER_PREWARM_EVM: RefCell<Option<WorkerPrewarmEvm>> = const { RefCell::new(None) };
+}
 
 /// Prewarming orchestrator that consumes source [`BestTransactions`] with bounded
 /// lookahead, prewarms buffered transactions in parallel, and produces a new
@@ -43,7 +57,7 @@ impl BestTransactionsPrewarming {
         let (commands_tx, commands_rx) = mpsc::channel();
         let this = Self {
             transactions_rx,
-            commands_tx: commands_tx.clone(),
+            commands_tx,
             stop: prewarm.stop.clone(),
         };
 
@@ -57,7 +71,6 @@ impl BestTransactionsPrewarming {
                         best_txs,
                         transactions_tx,
                         commands_rx,
-                        commands_tx,
                         prewarm,
                         next_expiring_nonce_offset: 0,
                     },
@@ -80,11 +93,6 @@ impl BestTransactionsPrewarming {
         let pool = executor.prewarming_pool();
 
         pool.in_place_scope(|scope| {
-            let prewarm = ctx.prewarm.clone();
-            scope.spawn(move |_| {
-                pool.init::<PrewarmEvmState>(|_| prewarm.evm_for_ctx());
-            });
-
             let advance = |ctx: &mut BestTransactionsPrewarmingContext<Txs, Provider>| {
                 let Some(tx) = ctx.best_txs.next() else {
                     let _ = ctx.transactions_tx.send(None);
@@ -100,7 +108,6 @@ impl BestTransactionsPrewarming {
 
                 let parallel = ctx.prewarm.parallel;
                 let prewarm = ctx.prewarm.clone();
-                let commands_tx = ctx.commands_tx.clone();
                 let transactions_tx = ctx.transactions_tx.clone();
 
                 if !parallel {
@@ -114,13 +121,13 @@ impl BestTransactionsPrewarming {
                     if parallel {
                         let _ = transactions_tx.send(Some(tx));
                     }
-                    let _ = commands_tx.send(BestTransactionsCommand::Advance);
                 });
             };
 
             // Fill the initial batch of transactions to execute and prewarm.
             //
-            // We schedule 2x the number of threads to make sure that workers are never idle.
+            // Keep lookahead bounded by consumption, not worker completion. Running too far
+            // ahead can evict prewarmed nonce slots before the builder reads them.
             for _ in 0..pool.current_num_threads() * 2 {
                 advance(&mut ctx);
             }
@@ -138,12 +145,20 @@ impl BestTransactionsPrewarming {
                         ctx.best_txs.mark_invalid(&invalid.tx, invalid.kind);
                         ctx.transactions_tx = new_tx;
 
+                        let mut discarded = 0;
                         for tx in old_rx {
                             if let Some(tx) = tx
                                 && !is_invalidated_buffered_transaction(&invalid.tx, &tx.tx)
                             {
                                 let _ = ctx.transactions_tx.send(Some(tx));
+                            } else {
+                                discarded += 1;
                             }
+                        }
+                        // Discarded entries will never be consumed, so return their
+                        // lookahead credits here, including exhausted-source markers.
+                        for _ in 0..discarded {
+                            advance(&mut ctx);
                         }
                     }
                     BestTransactionsCommand::NoUpdates => {
@@ -161,7 +176,9 @@ impl BestTransactionsPrewarming {
             }
         });
 
-        pool.clear();
+        pool.broadcast(pool.current_num_threads(), |_| {
+            ctx.prewarm.clear_worker_evm()
+        });
     }
 
     /// Prewarms a transaction by executing it on top of the latest state.
@@ -177,16 +194,12 @@ impl BestTransactionsPrewarming {
     where
         Provider: StateProviderFactory + Clone + 'static,
     {
-        let replay = WorkerPool::with_worker_mut(|worker| {
-            if prewarm.parallel && !is_parallel_candidate(&tx) {
-                return None;
-            }
+        if prewarm.is_stopped() || (prewarm.parallel && !is_parallel_candidate(&tx)) {
+            return PrewarmedTransaction::without_replay(tx);
+        }
 
-            let evm = worker.get_or_init(|| prewarm.evm_for_ctx()).as_mut()?;
-
-            if prewarm.is_stopped() {
-                return None;
-            }
+        let replay = prewarm.with_worker_evm(|state| {
+            let evm = state.as_mut()?;
 
             let mut tx_env = tx.transaction.clone_tx_env();
             if let Some(tempo_tx_env) = tx_env.tempo_tx_env.as_mut() {
@@ -262,13 +275,9 @@ impl Iterator for BestTransactionsPrewarming {
     type Item = PrewarmedTransaction;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Ok(Some(tx)) = self.transactions_rx.try_recv() {
-            return Some(tx);
-        }
-        self.commands_tx
-            .send(BestTransactionsCommand::Advance)
-            .ok()?;
-        self.transactions_rx.recv().ok().flatten()
+        let tx = self.transactions_rx.recv().ok()?;
+        let _ = self.commands_tx.send(BestTransactionsCommand::Advance);
+        tx
     }
 }
 
@@ -301,7 +310,6 @@ impl BestTransactions for BestTransactionsPrewarming {
 struct BestTransactionsPrewarmingContext<Txs, Provider> {
     best_txs: Txs,
     transactions_tx: Sender<Option<PrewarmedTransaction>>,
-    commands_tx: Sender<BestTransactionsCommand>,
     commands_rx: Receiver<BestTransactionsCommand>,
     prewarm: PrewarmingExecutionContext<Provider>,
     next_expiring_nonce_offset: usize,
@@ -401,6 +409,32 @@ where
         Some(evm)
     }
 
+    fn with_worker_evm<R>(&self, f: impl FnOnce(&mut PrewarmEvmState) -> R) -> R {
+        BUILDER_PREWARM_EVM.with_borrow_mut(|state| {
+            if state
+                .as_ref()
+                .is_none_or(|cached| !Arc::ptr_eq(&cached.build, &self.stop))
+            {
+                *state = Some(WorkerPrewarmEvm {
+                    build: self.stop.clone(),
+                    evm: self.evm_for_ctx(),
+                });
+            }
+            f(&mut state.as_mut().expect("worker EVM initialized").evm)
+        })
+    }
+
+    fn clear_worker_evm(&self) {
+        BUILDER_PREWARM_EVM.with_borrow_mut(|state| {
+            if state
+                .as_ref()
+                .is_some_and(|cached| Arc::ptr_eq(&cached.build, &self.stop))
+            {
+                *state = None;
+            }
+        });
+    }
+
     pub(crate) fn executor(&self) -> TaskExecutor {
         self.executor.clone()
     }
@@ -484,6 +518,7 @@ mod tests {
         Recovered, SealedHeader, transaction::error::InvalidTransactionError,
     };
     use reth_storage_api::noop::NoopProvider;
+    use reth_tasks::WorkerPool;
     use reth_transaction_pool::{
         TransactionOrigin, ValidPoolTransaction, identifier::TransactionId,
     };
@@ -744,22 +779,32 @@ mod tests {
     }
 
     #[test]
-    fn prewarming_eagerly_drains_source_iterator() {
+    fn prewarming_lookahead_is_bounded_by_consumption() {
         let sender = Address::random();
         let executor = TaskExecutor::test();
-        let txs = (0..executor.prewarming_pool().current_num_threads() * 2 + 4)
+        let lookahead = executor.prewarming_pool().current_num_threads() * 2;
+        let txs = (0..lookahead + 4)
             .map(|nonce| test_tx(sender, nonce as u64))
             .collect::<Vec<_>>();
         let expected = txs.iter().map(|tx| *tx.hash()).collect::<Vec<_>>();
         let log = Arc::new(Mutex::new(TestLog::default()));
 
-        let mut prewarming = prewarming_with_executor(executor, txs, log.clone());
-        wait_until(|| log.lock().unwrap().yielded == expected.len());
+        let mut prewarming = prewarming_with_executor(executor.clone(), txs, log.clone());
+        wait_until(|| log.lock().unwrap().yielded >= lookahead);
+        let pool = executor.prewarming_pool();
+        pool.broadcast(pool.current_num_threads(), |_| {});
+        prewarming.no_updates();
+        wait_until(|| log.lock().unwrap().no_updates == 1);
+        assert_eq!(log.lock().unwrap().yielded, lookahead);
 
-        let actual = (0..expected.len())
+        let first = prewarming.next().expect("first transaction");
+        assert_eq!(*first.tx.hash(), expected[0]);
+        wait_until(|| log.lock().unwrap().yielded == lookahead + 1);
+
+        let actual = (1..expected.len())
             .map(|_| *prewarming.next().expect("transaction").tx.hash())
             .collect::<Vec<_>>();
-        assert_eq!(actual, expected);
+        assert_eq!(actual, expected[1..]);
     }
 
     #[test]
@@ -823,6 +868,24 @@ mod tests {
     }
 
     #[test]
+    fn invalidating_every_buffered_transaction_replenishes_lookahead() {
+        let sender = Address::random();
+        let txs = vec![test_tx(sender, 0), test_tx(sender, 1), test_tx(sender, 2)];
+        let log = Arc::new(Mutex::new(TestLog::default()));
+        let mut prewarming = prewarming(txs, log.clone());
+        let first = prewarming.next().expect("first transaction");
+        wait_until(|| log.lock().unwrap().yielded == 3);
+
+        prewarming.mark_invalid(
+            &first,
+            InvalidPoolTransactionError::Consensus(InvalidTransactionError::TxTypeNotSupported),
+        );
+        assert!(prewarming.next().is_none());
+        assert!(prewarming.next().is_none());
+        assert_eq!(log.lock().unwrap().invalid, 1);
+    }
+
+    #[test]
     fn prewarming_does_not_use_shared_worker_state_slot() {
         let executor = TaskExecutor::test();
         let pool = executor.prewarming_pool();
@@ -835,6 +898,7 @@ mod tests {
 
         assert!(prewarming.next().is_some());
 
+        drop(prewarming);
         pool.broadcast(pool.current_num_threads(), |worker| {
             assert_eq!(*worker.get::<usize>(), 1);
         });
@@ -847,7 +911,6 @@ mod tests {
         context.evm_env.block_env.basefee = 0;
 
         let pool = WorkerPool::new(1, "prewarm-actions-test");
-        pool.init::<PrewarmEvmState>(|_| context.evm_for_ctx());
 
         pool.install_fn(|| {
             let failed_action = StorageAction::Sstore(
@@ -856,11 +919,8 @@ mod tests {
                 U256::from(2),
                 U256::from(3),
             );
-            WorkerPool::with_worker_mut(|worker| {
-                let evm = worker
-                    .get_mut::<PrewarmEvmState>()
-                    .as_mut()
-                    .expect("prewarm EVM");
+            context.with_worker_evm(|state| {
+                let evm = state.as_mut().expect("prewarm EVM");
                 // Model an action recorded before the failed execution returned an error.
                 assert_eq!(evm.replace_actions(vec![failed_action]), Some(Vec::new()));
             });
@@ -872,24 +932,51 @@ mod tests {
                 None,
             );
             assert!(failed.replay.is_none());
-            WorkerPool::with_worker_mut(|worker| {
-                let evm = worker
-                    .get_mut::<PrewarmEvmState>()
-                    .as_mut()
-                    .expect("prewarm EVM");
+            context.with_worker_evm(|state| {
+                let evm = state.as_mut().expect("prewarm EVM");
                 assert_eq!(evm.take_actions(), Some(Vec::new()));
             });
 
             let successful = BestTransactionsPrewarming::prewarm_transaction(
-                context,
+                context.clone(),
                 test_payment_tx(sender, 500_000),
                 None,
             );
             let replay = successful.replay.expect("successful prewarm replay");
             assert!(!replay.actions.is_empty());
             assert!(!replay.actions.contains(&failed_action));
+            context.clear_worker_evm();
         });
+    }
 
-        pool.clear();
+    #[test]
+    fn worker_evm_is_scoped_to_its_build() {
+        let executor = TaskExecutor::test();
+        let first = prewarming_context(executor.clone(), true);
+        let second = prewarming_context(executor, true);
+        let pool = WorkerPool::new(1, "prewarm-build-test");
+        let action =
+            StorageAction::Sstore(Address::random(), U256::from(1), U256::ZERO, U256::from(2));
+
+        pool.install_fn(|| {
+            first.with_worker_evm(|state| {
+                state.as_mut().unwrap().replace_actions(vec![action]);
+            });
+            second.with_worker_evm(|state| {
+                let evm = state.as_mut().unwrap();
+                assert_eq!(evm.take_actions(), Some(Vec::new()));
+                evm.replace_actions(vec![action]);
+            });
+            // A previous build finishing must not clear the next build's EVM.
+            first.clear_worker_evm();
+            second.with_worker_evm(|state| {
+                assert_eq!(state.as_mut().unwrap().take_actions(), Some(vec![action]));
+            });
+            // Returning to an older context also starts from fresh state.
+            first.with_worker_evm(|state| {
+                assert_eq!(state.as_mut().unwrap().take_actions(), Some(Vec::new()));
+            });
+            first.clear_worker_evm();
+        });
     }
 }

--- a/crates/precompiles/src/nonce/mod.rs
+++ b/crates/precompiles/src/nonce/mod.rs
@@ -96,7 +96,7 @@ impl NonceManager {
     /// Checks if a hash has been seen and is still valid (not expired).
     /// NOTE: internally used by the transaction pool.
     pub fn is_expiring_nonce_seen(&self, hash: B256, now: u64) -> Result<bool> {
-        let expiry = self.expiring_nonce_seen[hash].read()?;
+        let expiry = self.expiring_nonce_seen.at_uncached(&hash).read()?;
         Ok(expiry != 0 && expiry > now)
     }
 
@@ -136,32 +136,34 @@ impl NonceManager {
         }
 
         // 2. Replay check: reject if hash is already seen and not expired
-        let seen_expiry = self.expiring_nonce_seen[expiring_nonce_hash].read()?;
+        let mut seen = self.expiring_nonce_seen.at_uncached(&expiring_nonce_hash);
+        let seen_expiry = seen.read()?;
         if seen_expiry != 0 && seen_expiry > now {
             return Err(NonceError::expiring_nonce_replay().into());
         }
 
         // 3. Get current pointer (bounded in [0, CAPACITY)) and use directly as index
         let ptr = self.expiring_nonce_ring_ptr.read()?;
-        let idx = ptr;
-        let old_hash = self.expiring_nonce_ring[idx].read()?;
+        let mut ring_entry = self.expiring_nonce_ring.at_uncached(&ptr);
+        let old_hash = ring_entry.read()?;
 
         // 4. If there's an existing entry, check if it's expired (can be evicted)
         // Safety check: buffer is sized so entries should always be expired, but verify
         // in case TPS exceeds expectations.
         if old_hash != B256::ZERO {
-            let old_expiry = self.expiring_nonce_seen[old_hash].read()?;
+            let mut old_seen = self.expiring_nonce_seen.at_uncached(&old_hash);
+            let old_expiry = old_seen.read()?;
             if old_expiry != 0 && old_expiry > now {
                 // Entry is still valid, cannot evict - buffer is full
                 return Err(NonceError::expiring_nonce_set_full().into());
             }
             // Clear the old entry from seen set
-            self.expiring_nonce_seen[old_hash].write(0)?;
+            old_seen.write(0)?;
         }
 
         // 5. Insert new entry
-        self.expiring_nonce_ring[idx].write(expiring_nonce_hash)?;
-        self.expiring_nonce_seen[expiring_nonce_hash].write(valid_before)?;
+        ring_entry.write(expiring_nonce_hash)?;
+        seen.write(valid_before)?;
 
         // 6. Advance pointer (wraps at CAPACITY, not u32::MAX)
         let next = if ptr + 1 >= capacity { 0 } else { ptr + 1 };
@@ -457,6 +459,55 @@ mod tests {
     #[test]
     fn test_ring_buffer_pointer_wraps_at_t11_capacity() -> eyre::Result<()> {
         assert_ring_buffer_pointer_wraps_at_capacity(TempoHardfork::T11)
+    }
+
+    #[test]
+    fn test_expiring_nonce_eviction_at_expiry() -> eyre::Result<()> {
+        for spec in [TempoHardfork::T10, TempoHardfork::T11] {
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            let now = 1000;
+            let expiry = now + spec.expiring_nonce_max_expiry_secs();
+            let last = spec.expiring_nonce_set_capacity() - 1;
+            let old_hash = B256::repeat_byte(0xaa);
+            let new_hash = B256::repeat_byte(0xbb);
+            storage.set_timestamp(U256::from(now));
+
+            StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+                let mut mgr = NonceManager::new();
+                mgr.expiring_nonce_ring_ptr.write(last)?;
+                mgr.expiring_nonce_ring[last].write(old_hash)?;
+                mgr.expiring_nonce_seen[old_hash].write(expiry)?;
+
+                assert_eq!(
+                    mgr.check_and_mark_expiring_nonce(new_hash, expiry)
+                        .unwrap_err(),
+                    TempoPrecompileError::NonceError(NonceError::expiring_nonce_set_full())
+                );
+                assert_eq!(mgr.expiring_nonce_ring_ptr.read()?, last);
+                assert_eq!(mgr.expiring_nonce_ring[last].read()?, old_hash);
+                assert_eq!(mgr.expiring_nonce_seen[old_hash].read()?, expiry);
+                assert_eq!(mgr.expiring_nonce_seen[new_hash].read()?, 0);
+                Ok(())
+            })?;
+
+            storage.set_timestamp(U256::from(expiry));
+            StorageCtx::enter(&mut storage, || -> eyre::Result<()> {
+                let mut mgr = NonceManager::new();
+                let new_expiry = expiry + spec.expiring_nonce_max_expiry_secs();
+                mgr.check_and_mark_expiring_nonce(new_hash, new_expiry)?;
+                assert_eq!(mgr.expiring_nonce_ring_ptr.read()?, 0);
+                assert_eq!(mgr.expiring_nonce_ring[last].read()?, new_hash);
+                assert_eq!(mgr.expiring_nonce_seen[old_hash].read()?, 0);
+                assert_eq!(mgr.expiring_nonce_seen[new_hash].read()?, new_expiry);
+                assert_eq!(
+                    mgr.check_and_mark_expiring_nonce(new_hash, new_expiry)
+                        .unwrap_err(),
+                    TempoPrecompileError::NonceError(NonceError::expiring_nonce_replay())
+                );
+                Ok(())
+            })?;
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -66,6 +66,22 @@ impl<K, V: StorableType> Mapping<K, V> {
         self.base_slot
     }
 
+    /// Returns an owned handler without allocating an entry in the handler cache.
+    ///
+    /// Use this when the caller keeps the handler for its entire use, so subsequent
+    /// accesses do not need to look it up through this mapping again.
+    #[inline]
+    pub fn at_uncached(&self, key: &K) -> V::Handler
+    where
+        K: StorageKey,
+    {
+        V::handle(
+            key.mapping_slot(self.base_slot),
+            LayoutCtx::FULL,
+            self.address,
+        )
+    }
+
     /// Returns a `Handler` for the given key.
     ///
     /// This enables the composable pattern: `mapping.at(&key).read()`

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -260,6 +260,33 @@ mod tests {
     }
 
     #[test]
+    fn test_uncached_handler_shares_storage_with_cached_handler() -> eyre::Result<()> {
+        use crate::storage::{Handler, StorageCtx, hashmap::HashMapStorageProvider};
+
+        let mut storage = HashMapStorageProvider::new(1);
+        StorageCtx::enter(&mut storage, || {
+            let address = Address::random();
+            let base_slot = U256::random();
+            let mut mapping = Mapping::<B256, u64>::new(base_slot, address);
+            let key = B256::random();
+            let mut uncached = mapping.at_uncached(&key);
+
+            assert_eq!(uncached.slot(), mapping.at(&key).slot());
+            assert_eq!(uncached.address(), address);
+            assert_eq!(uncached.read()?, 0);
+            uncached.write(300)?;
+            assert_eq!(mapping.at(&key).read()?, 300);
+            mapping.at_mut(&key).write(600)?;
+            assert_eq!(uncached.read()?, 600);
+            assert_eq!(mapping.at_uncached(&B256::random()).read()?, 0);
+
+            let other = Mapping::<B256, u64>::new(base_slot, Address::random());
+            assert_eq!(other.at_uncached(&key).read()?, 0);
+            Ok(())
+        })
+    }
+
+    #[test]
     fn test_nested_mapping_basic_properties() {
         let address = Address::random();
         let base_slot = U256::random();

--- a/tempo.nu
+++ b/tempo.nu
@@ -339,6 +339,8 @@ def tempo-hardforks [] {
         | columns
         | where { |key| $key =~ '^t[0-9]+[a-z]?Time$' }
         | each { |key| $key | str replace "Time" "" | str upcase }
+        # JSON key order is not activation order (T10 can precede T1 and T2).
+        | sort --natural
     )
     if ($forks | is-empty) {
         print "Error: failed to read Tempo hardforks from crates/node/tests/assets/test-genesis.json"


### PR DESCRIPTION
## Summary
Forward parent-state nonce reads after prewarming execution, then seed only missing builder-cache entries without waiting or warming EVM gas slots. Preserve the 300-second expiry limit, three-million-entry ring, storage layout, and validation; also avoid temporary nonce mapping-handler allocations.

The benchmark helper sorts hardforks numerically so explicit T10/T11 controls activate the intended forks.

## Profile
The retained post-execution handoff reduced late builder nonce-check samples from 16.19% to 9.89%, with another 2.00% spent seeding the cache, but did not improve TPS. An early-read variant had similar net nonce CPU cost and lower observed TPS; that added experiment has been removed. No TPS improvement is proven.

## Verification
- [Removed early-read experiment](https://github.com/tempoxyz/tempo/actions/runs/34061214559): `1758d07a46` versus `f50fe613bb`, 600 seconds, 100 GiB state, 50k target TPS, four tokens, **one pair**; 8,763 → 8,041 TPS (-8.24%), zero transaction errors. Informational due to insufficient runs, not a statistically established regression.
- [Retained sustained handoff](https://github.com/tempoxyz/tempo/actions/runs/34058557270): **No Difference**, 9,444 → 9,384 TPS (-0.64%), zero transaction errors. Single-pair metrics are informational: the evaluator cannot calculate run-level confidence.
- [Sustained main-vs-main control](https://github.com/tempoxyz/tempo/actions/runs/34047548074): 8,220 → 7,949 TPS (-3.30%, neutral; CI ±3.15%), illustrating run-to-run noise.
- [Sustained T10/T11 control](https://github.com/tempoxyz/tempo/actions/runs/34061118350): identical `f50fe613bb` code, 600 seconds and one pair; 9,914 → 8,886 TPS (-10.37%, informational). Diagnostic only: T11 includes changes beyond the nonce window.
- Passed: `cargo test -p tempo-payload-builder --lib` (29 tests), nightly formatting and targeted Clippy, and the 300-second acceptance/301-second rejection test. Equivalence coverage includes worker reuse, ring wraparound, nonzero eviction, existing/cleared slots, and build isolation.

Prompted by: @shekhirin
