### PR TITLE
refactor(consensus): drop the forkchoice update kind marker

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -824,13 +824,7 @@ where
         }
 
         let target = self.notarized_tree.local_state();
-        let fut = execute_forkchoice(
-            self.execution_node.clone(),
-            Span::current(),
-            target,
-            None,
-            ForkchoiceUpdateKind::Heartbeat,
-        );
+        let fut = execute_forkchoice(self.execution_node.clone(), Span::current(), target, None);
         self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Heartbeat, fut));
         Ok(())
     }
@@ -1039,9 +1033,6 @@ where
                         cause.clone(),
                         target,
                         Some((cause, build)),
-                        ForkchoiceUpdateKind::Canonicalize {
-                            head_or_finalized: HeadOrFinalized::Head,
-                        },
                     );
                     self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
                     return Ok(());
@@ -1074,16 +1065,10 @@ where
                 NextToForward::Block(block) => {
                     execute_notarization(self.execution_node.clone(), block, target).boxed()
                 }
-                NextToForward::Repoint(..) => execute_forkchoice(
-                    self.execution_node.clone(),
-                    Span::current(),
-                    target,
-                    None,
-                    ForkchoiceUpdateKind::Canonicalize {
-                        head_or_finalized: HeadOrFinalized::Head,
-                    },
-                )
-                .boxed(),
+                NextToForward::Repoint(..) => {
+                    execute_forkchoice(self.execution_node.clone(), Span::current(), target, None)
+                        .boxed()
+                }
             };
             self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Notarize, fut));
             return Ok(());
@@ -1238,12 +1223,6 @@ struct VerifyBlockRequest {
     /// a value when validation was not possible or the request was
     /// superseded.
     response: oneshot::Sender<Option<Duration>>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ForkchoiceUpdateKind {
-    Heartbeat,
-    Canonicalize { head_or_finalized: HeadOrFinalized },
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -1408,7 +1387,6 @@ async fn execute_forkchoice(
     cause: Span,
     target: LocalState,
     build: Option<(Span, Build)>,
-    kind: ForkchoiceUpdateKind,
 ) -> ExecutionTaskOutcome {
     let build = build.filter(|(_, build)| {
         if build.response.is_canceled() {
@@ -1433,7 +1411,7 @@ async fn execute_forkchoice(
         None => (None, None),
     };
 
-    let response = submit_forkchoice_update(&execution_node, cause, target, attributes, kind).await;
+    let response = submit_forkchoice_update(&execution_node, cause, target, attributes).await;
     ExecutionTaskOutcome::Forkchoice {
         target,
         build,
@@ -1461,16 +1439,7 @@ async fn execute_finalization(
     let status = deliver_block(&execution_node, request.block.clone(), None).await;
     let response = match &status {
         Ok(PayloadStatusEnum::Valid) => {
-            submit_forkchoice_update(
-                &execution_node,
-                request.cause.clone(),
-                target,
-                None,
-                ForkchoiceUpdateKind::Canonicalize {
-                    head_or_finalized: HeadOrFinalized::Finalized,
-                },
-            )
-            .await
+            submit_forkchoice_update(&execution_node, request.cause.clone(), target, None).await
         }
         _ => None,
     };
@@ -1501,16 +1470,7 @@ async fn execute_notarization(
     let status = deliver_block(&execution_node, block, None).await;
     let response = match &status {
         Ok(PayloadStatusEnum::Valid) => {
-            submit_forkchoice_update(
-                &execution_node,
-                Span::current(),
-                target,
-                None,
-                ForkchoiceUpdateKind::Canonicalize {
-                    head_or_finalized: HeadOrFinalized::Head,
-                },
-            )
-            .await
+            submit_forkchoice_update(&execution_node, Span::current(), target, None).await
         }
         _ => None,
     };
@@ -1677,7 +1637,6 @@ async fn run_payload_job(
         head_block_height = %canonicalized.head.0,
         finalized_block_hash = %canonicalized.finalized.1,
         finalized_block_height = %canonicalized.finalized.0,
-        ?kind,
     ),
 )]
 async fn submit_forkchoice_update(
@@ -1685,7 +1644,6 @@ async fn submit_forkchoice_update(
     cause: Span,
     canonicalized: LocalState,
     attrs: Option<TempoPayloadAttributes>,
-    kind: ForkchoiceUpdateKind,
 ) -> Option<eyre::Result<ForkchoiceUpdated>> {
     match is_stale_forkchoice(execution_node, canonicalized) {
         Ok(false) => {}
@@ -1837,21 +1795,4 @@ fn finalization_target(
             .update_finalized(block.height(), block.digest())
             .update_head(block.height(), block.digest())
     })
-}
-
-/// Marker to indicate whether the head hash or finalized hash should be updated.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HeadOrFinalized {
-    Head,
-    Finalized,
-}
-
-impl std::fmt::Display for HeadOrFinalized {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let msg = match self {
-            Self::Head => "head",
-            Self::Finalized => "finalized",
-        };
-        f.write_str(msg)
-    }
 }


### PR DESCRIPTION
`ForkchoiceUpdateKind` and `HeadOrFinalized` only fed a tracing field on `submit_forkchoice_update`. The task type on the enclosing span already says whether an update is a heartbeat, a build, a notarized or a finalized canonicalization.