### PR TITLE
feat(consensus): judge builds against the pending head

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -136,6 +136,12 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// last forkchoice update, see [`DELIVERIES_PER_FORKCHOICE_UPDATE`].
     deliveries_since_forkchoice: usize,
 
+    /// The round of the newest consensus context whose parent was recorded
+    /// as the pending head. Reports come from concurrently running proposal
+    /// and verification handlers and can arrive out of order; an older
+    /// round's report must not supersede a newer one.
+    pending_head_reported_in: Round,
+
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
     /// slot because a node either verifies or proposes in a round, never
@@ -332,6 +338,7 @@ where
             pending_finalizations: VecDeque::new(),
             pending_acknowledgements: VecDeque::new(),
             deliveries_since_forkchoice: 0,
+            pending_head_reported_in: finalized_tip.0,
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -1009,6 +1016,15 @@ where
         fields(digest = %context.parent.1),
     )]
     fn record_pending_head(&mut self, context: Context<Digest, PublicKey>) {
+        if context.round < self.pending_head_reported_in {
+            debug!(
+                round = %context.round,
+                newest = %self.pending_head_reported_in,
+                "ignoring pending head report from an older round",
+            );
+            return;
+        }
+        self.pending_head_reported_in = context.round;
         self.notarized_tree.set_pending_head(
             Round::new(context.round.epoch(), context.parent.0),
             context.parent.1,

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -1132,11 +1132,17 @@ where
                 self.pending_consensus_request = Some((round, ConsensusRequest::Verify(request)));
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
-                // Builds are registered via a forkchoice update naming the
-                // parent as the head, so the build runs once the execution
-                // layer's head is there, waits while convergence is about to
-                // get there, and is dropped otherwise.
-                if self.notarized_tree.is_local_head(build.digest) {
+                // Consensus builds on the pending head it reported. The build
+                // runs once the execution layer's head is there, waits while
+                // convergence is about to get there, and is dropped otherwise.
+                let pending_head = self.notarized_tree.pending_head();
+                if build.digest != pending_head {
+                    info!(
+                        %pending_head,
+                        build.parent = %build.digest,
+                        "build is not on the pending head, dropping it",
+                    );
+                } else if self.notarized_tree.is_local_head(pending_head) {
                     let target = self.notarized_tree.local_state();
                     let fut = execute_forkchoice(
                         self.execution_node.clone(),
@@ -1146,7 +1152,7 @@ where
                     );
                     self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
                     return Ok(());
-                } else if self.is_convergence_target(build.digest) {
+                } else if self.is_convergence_target(pending_head) {
                     // Reschedules the request; the actor will not spin on
                     // `start_next_execution_request` as long as it remains
                     // scheduled before the select! in the select-loop (some

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -444,6 +444,11 @@ impl NotarizedTree {
 /// What the execution layer has, and the two walks that follow from it:
 /// the next block to deliver and the next block to make the head.
 impl NotarizedTree {
+    /// The block consensus reported building on: the convergence target.
+    pub(super) fn pending_head(&self) -> Digest {
+        self.pending_head.digest
+    }
+
     /// The highest finalized block the execution layer accepted: the
     /// finalized target of the next forkchoice update.
     pub(super) fn delivered_finalized(&self) -> (Height, Digest) {

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -239,6 +239,37 @@ fn build_on_a_head_the_network_finalized_past_is_dropped() {
 }
 
 #[test_traced]
+fn late_pending_head_report_from_an_older_round_is_ignored() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // Two validated siblings; consensus moves on to build on b1.
+        let a1 = make_block(1, 1, GENESIS);
+        let b1 = make_block(2, 1, GENESIS);
+        let (da1, db1) = (a1.digest(), b1.digest());
+        for (view, block) in [(1, a1), (2, b1)] {
+            h.verify(round(view), block)
+                .await
+                .expect("verification should complete")
+                .expect("block should be valid");
+        }
+        h.report_pending_head(4, 2, db1);
+        h.wait_until(|| h.execution.head() == db1).await;
+
+        // A report from an older context arrives late (the handlers run
+        // concurrently). It must not move the pending head back onto a1
+        // and cost the node its proposal on b1.
+        h.report_pending_head(3, 1, da1);
+        let proposal = make_block(5, 2, db1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(5), db1)
+            .await
+            .expect("the build on the current pending head must complete");
+        assert_eq!(h.execution.head(), db1);
+    });
+}
+
+#[test_traced]
 fn queued_build_is_dropped_when_finality_advances_past_its_parent() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -176,6 +176,69 @@ fn build_on_an_unknown_parent_is_dropped() {
 }
 
 #[test_traced]
+fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // a1 is known to the execution layer through its validation, but
+        // consensus never reports it as the pending head: a build on top of
+        // it is not what consensus builds on.
+        let a1 = make_block(1, 1, GENESIS);
+        let da1 = a1.digest();
+        h.verify(round(1), a1)
+            .await
+            .expect("verification should complete")
+            .expect("block should be valid");
+
+        let rx = h.build(round(2), da1);
+        rx.await
+            .expect_err("a build whose parent the head will not reach must fail");
+        assert!(
+            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
+            "no build may be registered off the pending head's path",
+        );
+    });
+}
+
+#[test_traced]
+fn build_on_a_head_the_network_finalized_past_is_dropped() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut h = Harness::start_at_genesis(&context);
+
+        // The head sits on notarized a1.
+        let a1 = make_block(1, 1, GENESIS);
+        let da1 = a1.digest();
+        h.verify(round(1), a1)
+            .await
+            .expect("a1 should validate")
+            .expect("a1 should be valid");
+        h.report_pending_head(2, 1, da1);
+        h.wait_until(|| h.execution.head() == da1).await;
+
+        // The network finalizes b1 on another branch. The tip report alone
+        // re-anchors the pending head onto the tip, so a1 is no longer what
+        // consensus builds on: the build is dropped before the finalized
+        // block is even delivered, and no payload is registered on the
+        // abandoned head.
+        let b1 = make_block(3, 1, GENESIS);
+        let db1 = b1.digest();
+        h.deliver_tip(round(3), 1, db1);
+        h.build(round(4), da1)
+            .await
+            .expect_err("the build on the abandoned head must fail");
+        assert!(
+            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
+            "no payload may be registered on the abandoned head",
+        );
+
+        h.deliver_finalized(b1)
+            .await
+            .expect("b1 should be acknowledged");
+        assert_eq!(h.execution.head(), db1);
+    });
+}
+
+#[test_traced]
 fn queued_build_is_dropped_when_finality_advances_past_its_parent() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -391,50 +391,6 @@ fn finality_is_locked_in_before_notarized_convergence() {
 }
 
 #[test_traced]
-fn slow_marshal_fetch_does_not_block_building() {
-    deterministic::Runner::default().start(|context| async move {
-        let h = Harness::start_at_genesis(&context);
-
-        // Leave the missing pending head's marshal subscription unresolved.
-        let pending = make_block(1, 1, GENESIS);
-        let pending_digest = pending.digest();
-        h.report_pending_head(2, 1, pending_digest);
-        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(1))])
-            .await;
-
-        // A proposal build on the known local head must be registered and
-        // delivered independently of the pending body fetch.
-        let proposal = make_block(3, 1, GENESIS);
-        let proposal_digest = proposal.digest();
-        h.execution.script_built_payload(built_payload(&proposal));
-        let build = h.build(round(3), GENESIS);
-        futures::pin_mut!(build);
-        let deadline = h.run_for(Duration::from_millis(100));
-        futures::pin_mut!(deadline);
-        let payload = match futures::future::select(build, deadline).await {
-            Either::Left((payload, _deadline)) => {
-                payload.expect("build should complete while the fetch is pending")
-            }
-            Either::Right(((), _build)) => {
-                panic!("the pending marshal fetch blocked building")
-            }
-        };
-
-        let (block, _) = payload.into_execution_payload();
-        assert_eq!(block.hash(), proposal_digest.0);
-        assert!(
-            h.execution.fcus().contains(&(GENESIS, GENESIS, true)),
-            "the attribute-carrying build FCU must reach the execution layer",
-        );
-        assert_eq!(
-            h.marshal.open_subscriptions(),
-            vec![(pending_digest, round(1))],
-            "building must not cancel or consume the independent body fetch",
-        );
-    });
-}
-
-#[test_traced]
 fn heartbeats_are_disarmed_while_work_is_active_or_queued() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::builder()


### PR DESCRIPTION
Consensus builds on the pending head it reported; a build request naming any other parent is not what consensus will vote on. Drop such a request right away instead of registering a payload on it or holding it until the head happens to get there. A build on the pending head runs once the head is there, waits while convergence is about to get there, and is dropped otherwise, as before.

`slow_marshal_fetch_does_not_block_building` built on the head while a different pending head was reported; that is no longer a valid request. Its validation twin covers slot independence from the body fetch.