### PR TITLE
fix(ci): route reth updates to eng-reth-alerts

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -662,7 +662,7 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENG_TEMPO_WORKFLOWS_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENG_RETH_ALERTS_WEBHOOK_URL }}
           OLD_REV_IN: ${{ steps.update.outputs.old_rev }}
           NEW_REV_IN: ${{ steps.update.outputs.new_rev }}
           BUMPED_IN: ${{ steps.update.outputs.bumped }}


### PR DESCRIPTION
Routes Reth update notifications to the dedicated `#eng-reth-alerts` webhook.

Before merging, configure the `SLACK_ENG_RETH_ALERTS_WEBHOOK_URL` Actions secret with an incoming webhook for that channel. It is absent from the repository secret listing; organization secrets could not be verified with the current GitHub permissions. Without it, the workflow skips notifications.

Validation: YAML parsing and `git diff --check`. Live delivery remains unverified until the secret is configured and the change is merged.

Prompted by: @jenpaff
