### PR TITLE
fix(ci): suppress successful reth update notifications

### DIFF
--- a/.github/workflows/update-reth.yml
+++ b/.github/workflows/update-reth.yml
@@ -659,7 +659,7 @@ jobs:
 
       # ── Slack notification ─────────────────────────────────────
       - name: Notify Slack
-        if: always()
+        if: always() && job.status != 'success'
         env:
           GH_TOKEN: ${{ secrets.DEREK_UPDATE_RETH_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ENG_TEMPO_WORKFLOWS_WEBHOOK_URL }}


### PR DESCRIPTION
Skip Slack notifications for successful Reth updates, including runs already on the latest revision, to reduce informational noise. Failed and cancelled runs continue notifying the existing channel.

Supersedes the channel-routing proposal in https://github.com/tempoxyz/tempo/pull/7505; no new webhook secret is required.

Validation: workflow YAML parsing and `git diff --check`. Live notification behavior will take effect after merge.

Prompted by: @jenpaff
