### PR TITLE
fix(bench): raise e2e transaction pool byte limits

### DIFF
--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -35,6 +35,10 @@ const E2E_LOCAL_RETH_ARGS = [
     "--txpool.pending-max-count" "200000"
     "--txpool.basefee-max-count" "200000"
     "--txpool.queued-max-count" "200000"
+    # Keep byte limits above the benchmark working set now that AA pools enforce them.
+    "--txpool.pending-max-size" "1024"
+    "--txpool.basefee-max-size" "1024"
+    "--txpool.queued-max-size" "1024"
     "--txpool.max-pending-txns" "200000"
     "--txpool.max-new-txns" "200000"
     "--txpool.max-batch-size" "200000"


### PR DESCRIPTION
Raise the bench-e2e pending, basefee, and queued pool byte limits from the inherited 100 MiB to 1 GiB alongside the existing 200,000-transaction limits. Before https://github.com/tempoxyz/tempo/pull/7144, AA pools did not enforce the byte limit; this gives benchmark workloads more headroom after that enforcement was added.

Validated Nushell parsing, `git diff --check`, and baseline argument overrides. [One-pair TIP-20 benchmark](https://github.com/tempoxyz/tempo/actions/runs/34109579888): 90 seconds per side, 50,000 target TPS, and 5,000 concurrent requests, with explicit 100 MiB baseline overrides versus the 1 GiB feature defaults.

Prompted by: @shekhirin
