### PR TITLE
fix(consensus): avoid blocking marshal on finalized block sync

### DIFF
--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -97,7 +97,7 @@
 
 use alloy_primitives::B256;
 use commonware_consensus::{Heightable as _, marshal::store::Blocks, types::Height};
-use commonware_runtime::{BufferPooler, Clock, Metrics, Storage};
+use commonware_runtime::{BufferPooler, Clock, Handle, Metrics, Storage};
 use commonware_storage::{
     archive::{self, Identifier, prunable},
     translator::TwoCap,
@@ -371,6 +371,13 @@ where
     async fn sync(&mut self) -> Result<(), Self::Error> {
         archive::Archive::sync(&mut self.prunable).await?;
         Ok(())
+    }
+
+    async fn start_sync(&mut self) -> Result<Handle<()>, Self::Error> {
+        // Marshal drives this handle outside its mailbox loop and gates finalized
+        // delivery on completion. The Blocks default calls sync().await instead,
+        // stalling unrelated proposal and verification requests on this fsync.
+        Ok(archive::Archive::start_sync(&mut self.prunable).await?)
     }
 
     /// Attempts to read `id` from the prunable archive, falling back to EL on miss.

--- a/crates/consensus/src/storage/hybrid/test/mod.rs
+++ b/crates/consensus/src/storage/hybrid/test/mod.rs
@@ -12,8 +12,12 @@
 pub(in crate::storage) mod utils;
 
 use commonware_macros::test_traced;
-use commonware_runtime::{Runner as _, Spawner, deterministic};
+use commonware_runtime::{
+    Runner as _, Spawner, deterministic,
+    mocks::{DelayedSyncContext, PendingSyncs, fail_pending_syncs, release_pending_syncs},
+};
 use commonware_utils::NZU64;
+use futures::FutureExt as _;
 
 use super::*;
 use crate::storage::PRUNABLE_ITEMS_PER_SECTION;
@@ -61,6 +65,61 @@ impl SetupHybrid {
         });
         (hybrid, provider)
     }
+}
+
+#[test_traced]
+fn start_sync_returns_before_durability_and_preserves_recovery() {
+    let block = make_block(1, B256::ZERO);
+    let expected = block.clone();
+    let (_, checkpoint) =
+        deterministic::Runner::default().start_and_recover(|context| async move {
+            let pending = PendingSyncs::default();
+            let context = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let (mut hybrid, _) = SetupHybrid::default().build(&context).await;
+            hybrid.put(block.clone()).await.expect("put");
+
+            // Calling the Blocks trait must forward the archive's deferred sync,
+            // rather than falling back to a blocking sync inside the marshal actor.
+            let mut handle = Blocks::start_sync(&mut hybrid).await.expect("start sync");
+            assert!(!pending.lock().is_empty(), "sync must remain in flight");
+            assert!((&mut handle).now_or_never().is_none());
+            assert_eq!(hybrid.get(Identifier::Index(1)).await.unwrap(), Some(block));
+
+            release_pending_syncs(&pending);
+            handle.await.expect("durability barrier");
+        });
+
+    deterministic::Runner::from(checkpoint).start(|context| async move {
+        let (hybrid, _) = SetupHybrid::default().build(&context).await;
+        assert_eq!(
+            hybrid.get(Identifier::Index(1)).await.unwrap(),
+            Some(expected)
+        );
+    });
+}
+
+#[test_traced]
+fn start_sync_propagates_durability_failure() {
+    deterministic::Runner::default().start(|context| async move {
+        let pending = PendingSyncs::default();
+        let context = DelayedSyncContext {
+            inner: context,
+            pending: pending.clone(),
+        };
+        let (mut hybrid, _) = SetupHybrid::default().build(&context).await;
+        hybrid.put(make_block(1, B256::ZERO)).await.expect("put");
+
+        let handle = Blocks::start_sync(&mut hybrid).await.expect("start sync");
+        assert!(!pending.lock().is_empty(), "sync must remain in flight");
+        fail_pending_syncs(&pending);
+        assert!(
+            handle.await.is_err(),
+            "failed sync must not acknowledge durability"
+        );
+    });
 }
 
 #[test_traced]


### PR DESCRIPTION
## Summary

Forward the hybrid finalized-block store's `start_sync` to its prunable archive so marshal can keep handling proposal and verification requests while the disk sync runs. Commonware's existing completion gate still holds finalized delivery until both archives are durable.

**No demonstrated throughput win; retain as draft.** The local main-versus-patch `summary.json` verdict is `Regression`: 8,474 to 8,462 TPS (-0.1%, neutral for TPS), builder p90 latency +5.3%, and median block time 495 to 513 ms (+3.6%). This is not a demonstrated fix for the local-to-regional throughput gap.

## Profile

Code inspection and delayed-sync regression tests establish the mailbox stall, not its importance to end-to-end throughput. The local result does not support it as a throughput bottleneck in this workload. Samply profiles were collected, but their timestamp origins could not be reliably aligned with the measured load windows, so no load-window hotspot attribution is claimed.

## Verification

- `cargo +stable test --locked -p tempo-consensus storage::hybrid::test --lib -j 4`: all 20 tests pass, including delayed completion, recovery, and sync failure. Both new `start_sync` tests fail with the original adapter implementation restored.
- `cargo +nightly fmt --check`: passes. CI test and lint jobs pass.
- Local [main-versus-main control](https://github.com/tempoxyz/tempo/actions/runs/34112860463) and [main-versus-patch comparison](https://github.com/tempoxyz/tempo/actions/runs/34113413038): three pairs, 300 seconds per phase, bloat=100, `tip20_existing_recipients`, 50,000 target TPS, 1,000 accounts, 5,000 concurrent requests, four tokens, 5,000,000,000 gas limits, samply and OTLP enabled. Baseline is `d093829e40704cf2472a3ef18d4a85695e6ec71f`; patch is `7835e4536d49eee611bcf7b56beb7b7e8d0e46ff`.
- The identical-code local control also reports `Regression`: 8,594 to 8,548 TPS (-0.5%, neutral for TPS), median block time +3.7%, and p99 block time 3,795 to 4,886 ms. The control cautions against assigning small changes to this patch; it does not turn the patch's regression verdict into a win.
- Ten validators across five regions: [main control](https://github.com/tempoxyz/tempo/actions/runs/34112860612) failed during its second phase when the benchmark client timed out reading block 205 through its RPC tunnel. Its `summary.json` has `exit_code: 1` and no feature result; infrastructure teardown succeeded. The [main-versus-patch run](https://github.com/tempoxyz/tempo/actions/runs/34113413603) remains in progress. Regional improvement and near-local throughput remain unverified.

Prompted by: @gakonst
