### PR TITLE
feat(consensus): force a forkchoice update every eight deliveries

### DIFF
--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -87,6 +87,15 @@ use notarized_tree::{LocalState, NotarizedTree};
 /// How often to probe whether the execution layer is ready to process blocks.
 const EXECUTION_LAYER_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 
+/// How many new-payload requests the execution layer may have executed -
+/// validations whatever their answer, `VALID` notarized and finalized
+/// deliveries - are collected before a forkchoice update is forced. The
+/// execution layer persists and prunes relative to its canonical head, so
+/// blocks delivered ahead of the update that canonicalizes them stay in
+/// memory. A queued consensus request runs ahead of the forced update, so
+/// the bound is one more than this in practice.
+const DELIVERIES_PER_FORKCHOICE_UPDATE: usize = 8;
+
 pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     context: ContextCell<TContext>,
 
@@ -122,6 +131,10 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// forkchoice update that finalizes them before they are acknowledged
     /// to the marshal actor. In height order.
     pending_acknowledgements: VecDeque<FinalizedBlockRequest>,
+
+    /// New-payload requests the execution layer may have executed since the
+    /// last forkchoice update, see [`DELIVERIES_PER_FORKCHOICE_UPDATE`].
+    deliveries_since_forkchoice: usize,
 
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
@@ -318,6 +331,7 @@ where
 
             pending_finalizations: VecDeque::new(),
             pending_acknowledgements: VecDeque::new(),
+            deliveries_since_forkchoice: 0,
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -517,6 +531,11 @@ where
         request: Option<VerifyBlockRequest>,
         status: eyre::Result<(PayloadStatusEnum, Duration)>,
     ) -> eyre::Result<()> {
+        // Every probe counts towards the forced forkchoice update, whatever
+        // it answered: the execution layer may execute an abandoned probe
+        // after the subscriber left, and buffers a `SYNCING` one to execute
+        // it once the parent arrives, without a `VALID` answer for either.
+        self.deliveries_since_forkchoice += 1;
         let Some(request) = request else {
             return Ok(());
         };
@@ -646,6 +665,7 @@ where
         match status {
             Ok(PayloadStatusEnum::Valid) => {
                 self.notarized_tree.mark_delivered(&digest);
+                self.deliveries_since_forkchoice += 1;
                 Ok(())
             }
             Ok(status) => {
@@ -707,6 +727,7 @@ where
 
         self.notarized_tree
             .set_delivered_finalized(block.height(), block.digest());
+        self.deliveries_since_forkchoice += 1;
         if block.height() <= self.notarized_tree.local_state().finalized.0 {
             // NOTE: this block is already final on the execution layer. This
             // can happen if marshal is anchored below the EL and delivers
@@ -816,8 +837,9 @@ where
 
     /// Climbs from the tracked finalized state to the finalized floor
     /// before entering the loop, through the regular finalization tasks
-    /// and their outcome handling, awaited in place. One forkchoice update
-    /// at the floor finalizes the delivered blocks.
+    /// and their outcome handling, awaited in place. Every
+    /// [`DELIVERIES_PER_FORKCHOICE_UPDATE`] delivered blocks, and at the
+    /// floor, a forkchoice update finalizes them.
     #[instrument(skip_all, err)]
     async fn backfill_to_finalized_floor(&mut self) -> eyre::Result<()> {
         let start = self.notarized_tree.local_state().finalized.0.get() + 1;
@@ -857,7 +879,10 @@ where
                     )
                 })?;
 
-            if height == end && self.start_forkchoice_update()? {
+            if (self.deliveries_since_forkchoice >= DELIVERIES_PER_FORKCHOICE_UPDATE
+                || height == end)
+                && self.start_forkchoice_update()?
+            {
                 let finished = (&mut self.execution_task).await;
                 self.handle_execution_task_finished(finished)
                     .wrap_err_with(|| {
@@ -1063,9 +1088,10 @@ where
                 .converges_imminently(digest, self.context.current())
     }
 
-    /// Picks the next execution task: consensus request, finalized
-    /// deliveries, the forkchoice update finalizing them, notarized
-    /// deliveries, the forkchoice update moving the head. Finality goes
+    /// Picks the next execution task: consensus request, the forkchoice
+    /// update forced by a long run of deliveries, finalized deliveries, the
+    /// forkchoice update finalizing them, notarized deliveries, the
+    /// forkchoice update moving the head. Finality goes
     /// first so a long notarized run never holds up acknowledgements;
     /// deliveries go before the update so one update covers a whole run.
     #[instrument(
@@ -1140,6 +1166,14 @@ where
             None => {}
         }
 
+        // Too many blocks delivered since the last forkchoice update: lock
+        // them in before delivering more.
+        if self.deliveries_since_forkchoice >= DELIVERIES_PER_FORKCHOICE_UPDATE
+            && self.start_forkchoice_update()?
+        {
+            return Ok(());
+        }
+
         // Finalizations are delivered in order and acknowledged so that the
         // marshal actor can make progress. Every finalized block is
         // delivered, whether or not the execution layer is thought to know
@@ -1172,9 +1206,14 @@ where
     /// Starts the forkchoice update onto the next target, if any; returns
     /// whether it did.
     fn start_forkchoice_update(&mut self) -> eyre::Result<bool> {
+        // The counter is only cleared once an update is on its way: with no
+        // target, the delivered blocks stay uncanonicalized and the debt
+        // stands until the ancestry becomes walkable. Whatever the update
+        // then does not cover cannot be canonicalized by any update.
         let Some(target) = self.next_forkchoice_target()? else {
             return Ok(false);
         };
+        self.deliveries_since_forkchoice = 0;
         let fut = execute_forkchoice(self.execution_node.clone(), Span::current(), target, None);
         self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Forkchoice, fut));
         Ok(true)

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -83,6 +83,45 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
 }
 
 #[test_traced]
+fn long_delivery_runs_are_locked_in_every_few_blocks() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+
+        // Ten notarized blocks above genesis, all bodies fetched tip-down.
+        let mut blocks = Vec::new();
+        let mut parent = GENESIS;
+        for height in 1..=10 {
+            let block = make_block(height, height, parent);
+            parent = block.digest();
+            blocks.push(block);
+        }
+        let digests = blocks.iter().map(|b| b.digest()).collect::<Vec<_>>();
+        h.report_pending_head(11, 10, digests[9]);
+        for block in blocks.iter().rev() {
+            h.wait_until(|| {
+                h.marshal
+                    .fulfill_subscription(block.digest(), block.clone())
+            })
+            .await;
+        }
+
+        // The run is delivered bottom-up, with a forkchoice update forced
+        // after every eight deliveries so that the execution layer never
+        // holds more than that many uncanonicalized blocks.
+        h.wait_until(|| h.execution.head() == digests[9]).await;
+        assert_eq!(h.execution.new_payloads(), digests);
+        assert_eq!(
+            h.execution.fcus(),
+            vec![
+                STARTUP_FCU,
+                (digests[7], GENESIS, false),
+                (digests[9], GENESIS, false),
+            ],
+        );
+    });
+}
+
+#[test_traced]
 fn dropped_body_fetch_is_retried() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);


### PR DESCRIPTION
One forkchoice update per drained run keeps the engine calls minimal, but the execution layer persists and prunes relative to its canonical head: every block delivered ahead of the update that canonicalizes it stays in memory. A long run of notarized deliveries, or a long startup backfill, would let that grow without bound.

Count `VALID` new-payload answers - validations, notarized and finalized deliveries alike - and force an update once eight have accumulated since the last one, in the scheduler and in the backfill.