### PR TITLE
fix(ci): use allowed action for release PRs

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -66,7 +66,7 @@ jobs:
               path.write_text("---\n" + "".join(kept) + "---\n" + body, encoding="utf-8")
           PY
 
-      - uses: tempoxyz/changelogs@29ac40b71b3966761305991d99f21c5195d7466b # master @ 2026-06-09 (post-v0.6.3)
+      - uses: tempoxyz/changelogs@32803466719b87cd6de2a87d2d8f1198c26e3022 # tempoxyz/changelogs#159: first-party PR action
         id: changelogs
         with:
           conventional-commit: true

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -66,7 +66,7 @@ jobs:
               path.write_text("---\n" + "".join(kept) + "---\n" + body, encoding="utf-8")
           PY
 
-      - uses: tempoxyz/changelogs@32803466719b87cd6de2a87d2d8f1198c26e3022 # tempoxyz/changelogs#159: first-party PR action
+      - uses: tempoxyz/changelogs@83e69646d7ef76c5f35364d3a06fce3a6fe62bf9 # tempoxyz/changelogs#159: vendored Peter Evans action
         id: changelogs
         with:
           conventional-commit: true


### PR DESCRIPTION
Pin `changelogs` to `83e69646d7ef76c5f35364d3a06fce3a6fe62bf9`, the latest commit on its default branch (`master`) containing merged [changelogs PR #159](https://github.com/tempoxyz/changelogs/pull/159). This uses the vendored Peter Evans action to resolve the [Release PR setup failure](https://github.com/tempoxyz/tempo/actions/runs/34121359247/job/101739893213) while preserving upstream behavior.