### PR TITLE
docs(tip): sync TIP-1098 with native verifier specification

### DIFF
--- a/tips/tip-1098.md
+++ b/tips/tip-1098.md
@@ -1,10 +1,10 @@
 ---
 id: TIP-1098
 title: Nitro-Backed Zone Batch Verification
-description: Defines the T11 verifier policy for Nitro-attested Zone batch proofs.
+description: Defines the native T11 verifier for Nitro-attested Zone batch proofs.
 authors: Roman Krasiuk
 status: Draft
-related: TIP-1090, TIP-1091, [Tempo Zones spec](https://github.com/tempoxyz/zones/blob/main/specs/spec.md), [AWS Nitro Attestation Process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
+related: TIP-1091, [Tempo Zones spec](https://github.com/tempoxyz/zones/blob/main/specs/spec.md), [AWS Nitro Attestation Process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
 protocolVersion: T11
 ---
 
@@ -12,61 +12,50 @@ protocolVersion: T11
 
 ## Abstract
 
-The Zone portal activates at T10 with a permissive verifier placeholder. This TIP activates the
-production verifier at T11, accepting only batches executed by the approved Zone stateless proof
-function inside AWS Nitro Enclaves. The verifier uses TIP-1090 to authenticate the Nitro document,
-pins the measured enclave image, and requires the document's signed `user_data` to commit to every
-public input used by `IVerifier`.
+The Zone portal activates at T10 with a permissive verifier placeholder. This TIP activates a
+native verifier at T11, accepting only batches executed by the approved Zone stateless proof
+function inside AWS Nitro Enclaves. The verifier authenticates the Nitro document directly, pins
+the measured enclave image, and requires the signed `user_data` to commit to every public input
+used by `IVerifier`. No separate, application-facing Nitro attestation precompile is introduced.
 
 ## Motivation
 
-Zone portals release withdrawals and advance their canonical Zone state only after calling a shared
-verifier. The T10 portal uses an intentionally permissive placeholder while proof production and
-Nitro document verification are brought online. Leaving that behavior in place would let an
+Zone portals release withdrawals and advance their canonical state only after calling the shared
+verifier at `0x5a56000000000000000000000000000000000000`. The T10 verifier is intentionally
+permissive while proof production is brought online. Leaving that behavior in place would let an
 authorized sequencer settle an arbitrary state transition.
 
-TIP-1090 authenticates an AWS Nitro document but deliberately does not decide which enclave image
-or application payload is trusted. This TIP supplies that Zone-specific policy and defines the
-exact commitment that connects a valid Nitro document to one portal batch.
+Validating Nitro attestations requires bounded CBOR and COSE decoding, an X.509 chain anchored to
+AWS, SHA-384 hashing, and P-384 signatures. The T11 native verifier performs those operations and
+the Zone-specific PCR, freshness, and batch-binding policy atomically.
 
 ## Assumptions
 
-- TIP-1090 is active at T11 and authenticates Nitro documents to the pinned AWS root, including
-  certificate validity at the current Tempo block timestamp.
-- TIP-1091's verifier remains at `0x5a56000000000000000000000000000000000000` and its runtime can
-  be replaced only by a hardfork.
-- The approved PCR tuple is produced by the canonical reproducible EIF build. A different image,
-  including a debug-mode image whose measurements are zeroed, is not trusted.
-- Portal transition checks prevent an otherwise valid document from being reused after the portal
-  has advanced. If this assumption fails, an old proof for the same public inputs may be replayed.
+- The AWS Nitro platform and commercial-partition Attestation PKI are trusted. The canonical root
+  is embedded in the verifier; rotating it requires a hardfork.
+- Revocation checking is not performed. Certificates are instead required to be valid at the
+  current Tempo block timestamp.
+- The measured enclave application is trusted exactly as identified by PCR0, PCR1, and PCR2. It
+  must not expose an endpoint that attests a caller-selected digest.
 
 ## Threat Model
 
-- **AWS Nitro platform and attestation PKI** are trusted to isolate the enclave, measure its image,
-  and sign authentic documents. Their compromise is out of scope.
-- **Enclave operator and transaction submitter** are untrusted. They may select requests, withhold
-  proofs, replay documents, or submit malformed data, but must not obtain an accepted attestation
-  for a caller-selected digest or a transition rejected by the measured SPF.
-- **Measured enclave application** is trusted exactly as identified by PCR0, PCR1, and PCR2. Its
-  complete request surface is security-critical; adding any arbitrary attestation endpoint requires
-  a new verifier policy.
-- **Zone sequencers** remain responsible for availability. A missing or unavailable attester may
-  halt settlement but must not cause proof verification to fail open.
+- Enclave operators, sequencers, and transaction submitters are untrusted. They may replay or
+  corrupt documents but cannot produce an accepted signature for a different measured image or
+  batch commitment.
+- Portal transition and batch-index checks prevent reuse after the portal advances.
 
 ---
 
 # Specification
 
-## Activation
+## Activation and Interface
 
-At the T11 boundary, Tempo MUST replace the permissive verifier runtime used by the T10 portal at
-`0x5a56000000000000000000000000000000000000` with the verifier defined by this TIP. The
-replacement applies to every existing and future Zone portal. Before T11, the T10 permissive
-placeholder remains unchanged.
+At T11, native dispatch MUST take precedence at the protocol-managed verifier address. The T10
+runtime remains observable account code and continues to execute before T11. No additional
+precompile address or runtime installation is defined.
 
-## Interface and Encoding
-
-The verifier retains the proof-agnostic interface installed by TIP-1091:
+The verifier retains the proof-agnostic interface extended by TIP-1096:
 
 ```solidity
 function verify(
@@ -77,24 +66,49 @@ function verify(
     uint64 expectedWithdrawalBatchIndex,
     BlockTransition calldata blockTransition,
     DepositQueueTransition calldata depositQueueTransition,
+    TokenEnablementTransition calldata tokenEnablementTransition,
     bytes32 withdrawalQueueHash,
     bytes calldata verifierConfig,
     bytes calldata proof
 ) external view returns (bool);
 ```
 
-For this policy, `verifierConfig` MUST be the single byte `0x01`. `proof` MUST be the raw
-COSE/CBOR AWS Nitro attestation document accepted by TIP-1090. Configuration `0x01` identifies the
-exact validation rules and PCR tuple in this TIP; measurement changes require a new configuration
-version and a hardfork-defined verifier runtime.
+`verifierConfig` MUST be the single byte `0x01`. `proof` MUST be the raw COSE/CBOR Nitro
+attestation document. Unsupported configuration, empty or invalid proof, policy failure, and
+commitment mismatch return `false`. Malformed function calldata follows the normal precompile ABI
+revert behavior; out-of-gas remains an exceptional halt.
 
-## Attestation Policy
+## Nitro Document Validation
 
-The verifier MUST call the TIP-1090 `verifyAttestation(bytes)` precompile. Given sufficient gas for
-the call, any precompile revert, malformed return, unsupported configuration, or empty proof MUST
-produce `false` rather than an accepted batch.
+All validation is internal to `verify` and MUST complete before Zone policy is applied.
 
-The returned document MUST contain the following 48-byte SHA-384 measurements:
+1. The document is limited to 24,576 bytes and decodes, with no trailing bytes, as an optionally
+   tag-18 `COSE_Sign1` array `[protected, unprotected, payload, signature]`.
+2. The protected header MUST be exactly the map `{1: -35}` after decoding. The payload is a
+   1–16,384-byte string and the ES384 signature is exactly 96-byte `r || s`. The unprotected map is
+   ignored.
+3. The payload is a CBOR map containing non-null, non-duplicate `module_id`, `digest`, `timestamp`,
+   `pcrs`, `certificate`, and `cabundle`. `digest` is `SHA384`; timestamp is a nonzero `uint64` in
+   milliseconds. Optional `public_key`, `user_data`, and `nonce` retain their AWS meanings; they
+   MAY be absent or CBOR null, which is represented internally as empty bytes.
+4. PCR indices are unique integers from 0 through 31, with 1–32 total entries and values of 32,
+   48, or 64 bytes. The CA bundle contains 1–32 DER certificates of at most 1,024 bytes each.
+   A non-null `public_key` is 1–1,024 bytes; `user_data` and `nonce` are at most 512 bytes. Unknown
+   payload keys and values are accepted. Definite and indefinite CBOR are accepted with nesting
+   limited to 16.
+5. `cabundle` is ordered `[ROOT, INTERM_1, …, INTERM_N]`; the document certificate is the leaf.
+   The first entry MUST byte-match the embedded AWS root. Every certificate MUST be strict DER,
+   X.509 v3, ECDSA-with-SHA384, and use an uncompressed P-384 key.
+6. Every validity interval contains the current block timestamp. Issuer and subject names link at
+   each step. Root and intermediates are CAs with `keyCertSign`; path-length limits count only
+   non-self-issued intermediate CAs as required by RFC 5280. The leaf is not a CA and has
+   `digitalSignature`. Unknown critical extensions are rejected.
+7. Every non-root certificate signature verifies under its parent. The COSE signature verifies
+   under the leaf over RFC 9052's exact `Sig_structure`. High- and low-s signatures are accepted.
+
+## Zone Policy
+
+The attestation MUST contain the following 48-byte SHA-384 measurements:
 
 | Register | Required value |
 |---|---|
@@ -102,88 +116,78 @@ The returned document MUST contain the following 48-byte SHA-384 measurements:
 | PCR1 | `<T11_PCR1_SHA384>` |
 | PCR2 | `<T11_PCR2_SHA384>` |
 
-PCR0, PCR1, and PCR2 MUST each be present and equal their required value. Other locked PCRs do not
-change this policy and MAY be present.
+Until these release measurements are finalized, the production verifier has no approved tuple and
+MUST return `false` after attestation validation. The tuple is a hardfork constant and is not
+runtime-configurable. Other locked PCRs MAY be present.
 
-The document timestamp, expressed in milliseconds, MUST NOT be greater than
-`block.timestamp * 1000 + 300_000`. There is no additional maximum age: TIP-1090 enforces current
-certificate validity, and the portal's state-transition and batch-index checks provide replay
-protection. The document's `user_data` MUST be exactly 32 bytes.
-
-## Batch Commitment
-
-The approved enclave MUST place this digest in `user_data`, and the verifier MUST reconstruct it:
+The document timestamp MUST NOT exceed `block.timestamp * 1000 + 300_000`; no additional maximum
+age is imposed. `user_data` MUST be exactly 32 bytes and equal:
 
 ```text
 keccak256(abi.encode(
-    keccak256("NitroBatchAttestation(uint256 parentChainId,address verifier,address portal,uint32 zoneId,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,uint64 expectedWithdrawalBatchIndex,bytes32 prevBlockHash,bytes32 nextBlockHash,bytes32 prevProcessedHash,bytes32 nextProcessedHash,uint64 prevDepositNumber,uint64 nextDepositNumber,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"),
-    parentChainId,
-    verifier,
-    portal,
+    keccak256("NitroBatchAttestation(uint256 parentChainId,address verifier,address portal,uint32 zoneId,uint64 tempoBlockNumber,uint64 anchorBlockNumber,bytes32 anchorBlockHash,uint64 expectedWithdrawalBatchIndex,bytes32 prevBlockHash,bytes32 nextBlockHash,bytes32 prevProcessedHash,bytes32 nextProcessedHash,uint64 prevDepositNumber,uint64 nextDepositNumber,uint64 prevProcessedTokenCount,uint64 nextProcessedTokenCount,bytes32 withdrawalQueueHash,bytes32 verifierConfigHash)"),
+    block.chainid,
+    address(this),
+    msg.sender,
     zoneId,
     tempoBlockNumber,
     anchorBlockNumber,
     anchorBlockHash,
     expectedWithdrawalBatchIndex,
-    prevBlockHash,
-    nextBlockHash,
-    prevProcessedHash,
-    nextProcessedHash,
-    prevDepositNumber,
-    nextDepositNumber,
+    blockTransition.prevBlockHash,
+    blockTransition.nextBlockHash,
+    depositQueueTransition.prevProcessedHash,
+    depositQueueTransition.nextProcessedHash,
+    depositQueueTransition.prevDepositNumber,
+    depositQueueTransition.nextDepositNumber,
+    tokenEnablementTransition.prevProcessedTokenCount,
+    tokenEnablementTransition.nextProcessedTokenCount,
     withdrawalQueueHash,
     keccak256(verifierConfig)
 ))
 ```
 
-The verifier MUST use `block.chainid` for `parentChainId`, `address(this)` for `verifier`, and
-`msg.sender` for `portal`. All integer values use the exact Solidity types shown in the type string.
-The verifier returns `true` if and only if TIP-1090 succeeds, all policy checks pass, and
-`user_data` equals this digest. It otherwise returns `false`; ordinary EVM exceptional halts such as
-out-of-gas retain their normal behavior.
+## Gas
 
-## Attesting Enclave Behavior
-
-The measured application MUST select a trusted Tempo chain specification by request chain ID and
-MUST reject a witness whose `parent_chain_id` differs from that request. It MUST execute the Zone
-SPF to completion, derive the batch digest from the SPF public inputs and output, and only then ask
-the Nitro Secure Module to place that digest in `user_data`. The NSM request MUST omit `nonce` and
-`public_key`.
-
-The application MUST NOT accept a caller-provided digest, verifier configuration, SPF output, or
-arbitrary NSM attestation payload. SPF rejection or NSM failure MUST return an error without a proof
-bundle.
+The verifier charges 6 gas per 32-byte calldata word before ABI decoding. Unsupported
+configuration, empty proof, and proof length above 24,576 bytes return `false` without Nitro base
+gas. Otherwise it charges 40,000 gas immediately before document parsing. After parsing determines
+the chain length, it charges 35,000 gas for each non-root certificate signature plus the COSE
+signature before performing any P-384 verification.
 
 # Tooling
 
-- The prover protocol distinguishes output-only `verify` requests from production `attest`
-  requests. A successful `attest` response contains configuration `0x01` and the raw Nitro document.
-- Production T11 sequencers MUST use an attesting Nitro prover. In-process SPF execution is useful
-  for diagnostics but cannot produce a settlement proof.
-- The reproducible EIF workflow MUST publish its EIF hash and raw PCR0/PCR1/PCR2 values. Release
-  tooling MUST verify that those values match this TIP and the deployed verifier constants.
-- If configured proof generation fails, a sequencer MUST NOT knowingly submit an empty proof as a
-  fallback.
+Consensus-critical CBOR/COSE and X.509 validation lives in the internal, `no_std`
+`tempo-nitro-attestation` crate. It uses a pinned `minicbor` pull decoder with explicit size,
+collection, and nesting bounds; the Zone verifier supplies AWS-LC SHA-384 and P-384 operations.
+The crate exposes categorized errors for tests and tooling, while the onchain verifier maps every
+non-gas validation failure to `false`.
+
+The repository vendors a fixed-time production AWS attestation, tests high-s acceptance and
+deterministic certificate mutations, and provides a differential fuzz target against
+`x509-parser` and `rustls-webpki`. The precompile benchmark compares the five-signature Nitro path
+with the existing P-256 verifier for gas calibration.
+
+The measured application selects a trusted Tempo chain specification by request chain ID, executes
+the Zone SPF to completion, derives the digest above from the public inputs and output, and only
+then asks the Nitro Security Module to place it in `user_data`. It MUST reject caller-provided
+digests, configuration, SPF outputs, arbitrary attestation payloads, chain mismatches, SPF failure,
+or NSM failure. Production sequencers MUST NOT submit an empty proof as fallback.
 
 # Observability
 
-No new onchain event is required. Successful settlements continue to emit the portal's
-`BatchSubmitted` event. Operators SHOULD expose attestation latency and failure counts, SPF failure
-counts, and settlement failures with stable error categories so a proof outage can be distinguished
-from an invalid transition or L1 submission failure.
+N/A. The verifier is a deterministic view function and emits no events. Existing transaction
+traces expose the verifier address, calldata, gas use, return value, and exceptional halt needed to
+distinguish policy rejection from out-of-gas.
 
 # Invariants
 
 | ID | Invariant | Description |
 |---|---|---|
-| **ZV1** | Measured execution | Every accepted proof contains the exact approved PCR0/PCR1/PCR2 tuple and chains to the TIP-1090 root. |
-| **ZV2** | Complete binding | Changing any verifier input, chain, verifier, or portal changes the required `user_data`. |
-| **ZV3** | No arbitrary signing | The measured enclave obtains `user_data` only from a successful SPF execution over a trusted chain specification. |
-| **ZV4** | Replay containment | A proof cannot be used by another chain, verifier, portal, Zone, batch index, anchor, or transition. |
-| **ZV5** | Fail closed | Unsupported configurations, proof errors, wrong measurements, invalid timestamps, and digest mismatches never return `true`. |
-| **ZV6** | Release consistency | The TIP, verifier runtime, and canonical EIF artifact identify the same PCR tuple. |
-
-Tests MUST cover the valid path; every configuration and proof failure; missing, malformed, and
-incorrect measurements; additional unrelated PCRs; the future-skew boundary; certificate-valid old
-documents; every digest-bound field; cross-language digest vectors; SPF rejection; chain mismatch;
-NSM failure; and configured-prover failure without transaction submission.
+| ZV1 | Chain of trust | Every accepted proof chains to the embedded AWS root. |
+| ZV2 | Measured execution | Every accepted proof contains the approved PCR0/1/2 tuple. |
+| ZV3 | Complete binding | Changing any verifier input, chain, verifier, or portal changes `user_data`. |
+| ZV4 | Fail closed | Unsupported configuration and all proof or policy errors return false. |
+| ZV5 | Bounded resources | Input, collections, fields, and CBOR nesting obey the stated limits. |
+| ZV6 | Gas before work | Parsing and signature gas are charged before their respective work. |
+| ZV7 | Release consistency | The TIP, verifier constants, and canonical EIF identify the same PCR tuple. |

--- a/tips/tip-1098.md
+++ b/tips/tip-1098.md
@@ -74,9 +74,13 @@ function verify(
 ```
 
 `verifierConfig` MUST be the single byte `0x01`. `proof` MUST be the raw COSE/CBOR Nitro
-attestation document. Unsupported configuration, empty or invalid proof, policy failure, and
-commitment mismatch return `false`. Malformed function calldata follows the normal precompile ABI
-revert behavior; out-of-gas remains an exceptional halt.
+attestation document.
+
+After charging input gas, calls with the `verify` selector and total calldata length exceeding
+25,188 bytes MUST return `false` before ABI decoding, without Nitro base or signature charges.
+All other calls follow normal precompile ABI dispatch: missing or unknown selectors and malformed
+arguments revert. Successfully decoded calls return `false` for unsupported configuration, empty
+or invalid proof, policy failure, or commitment mismatch. Out-of-gas remains an exceptional halt.
 
 ## Nitro Document Validation
 
@@ -149,11 +153,15 @@ keccak256(abi.encode(
 
 ## Gas
 
-The verifier charges 6 gas per 32-byte calldata word before ABI decoding. Unsupported
-configuration, empty proof, and proof length above 24,576 bytes return `false` without Nitro base
-gas. Otherwise it charges 40,000 gas immediately before document parsing. After parsing determines
-the chain length, it charges 35,000 gas for each non-root certificate signature plus the COSE
-signature before performing any P-384 verification.
+The verifier charges `30 * ceil(calldata.length / 32)` gas before ABI decoding. This covers the
+entire calldata, including the function selector and ABI padding. Unsupported configuration, empty
+proof, and proof length above 24,576 bytes return `false` without Nitro base or signature gas.
+
+Calls that reach document parsing pay 40,000 gas immediately before parsing. After successful
+parsing determines the chain length, the verifier charges `35,000 * (cabundle.length + 1)` gas
+before certificate validation or any P-384 verification. This counts every non-root certificate
+signature, including the leaf, plus the COSE signature; the pinned root is not self-verified.
+Validation failures retain charges already incurred. Insufficient gas remains an exceptional halt.
 
 # Tooling
 

--- a/tips/tip-1098.md
+++ b/tips/tip-1098.md
@@ -1,11 +1,11 @@
 ---
 id: TIP-1098
 title: Nitro-Backed Zone Batch Verification
-description: Defines the native T11 verifier for Nitro-attested Zone batch proofs.
+description: Defines the native T13 verifier for Nitro-attested Zone batch proofs.
 authors: Roman Krasiuk, Zygis
 status: Draft
 related: TIP-1091, [Tempo Zones spec](https://github.com/tempoxyz/zones/blob/main/specs/spec.md), [AWS Nitro Attestation Process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
-protocolVersion: T11
+protocolVersion: T13
 ---
 
 # TIP-1098: Nitro-Backed Zone Batch Verification
@@ -13,7 +13,7 @@ protocolVersion: T11
 ## Abstract
 
 The Zone portal activates at T10 with a permissive verifier placeholder. This TIP activates a
-native verifier at T11, accepting only batches executed by the approved Zone stateless proof
+native verifier at T13, accepting only batches executed by the approved Zone stateless proof
 function inside AWS Nitro Enclaves. The verifier authenticates the Nitro document directly, pins
 the measured enclave image, and requires the signed `user_data` to commit to every public input
 used by `IVerifier`. No separate, application-facing Nitro attestation precompile is introduced.
@@ -26,7 +26,7 @@ permissive while proof production is brought online. Leaving that behavior in pl
 authorized sequencer settle an arbitrary state transition.
 
 Validating Nitro attestations requires bounded CBOR and COSE decoding, an X.509 chain anchored to
-AWS, SHA-384 hashing, and P-384 signatures. The T11 native verifier performs those operations and
+AWS, SHA-384 hashing, and P-384 signatures. The T13 native verifier performs those operations and
 the Zone-specific PCR, freshness, and batch-binding policy atomically.
 
 ## Assumptions
@@ -51,8 +51,8 @@ the Zone-specific PCR, freshness, and batch-binding policy atomically.
 
 ## Activation and Interface
 
-At T11, native dispatch MUST take precedence at the protocol-managed verifier address. The T10
-runtime remains observable account code and continues to execute before T11. No additional
+At T13, native dispatch MUST take precedence at the protocol-managed verifier address. The T10
+runtime remains observable account code and continues to execute before T13. No additional
 precompile address or runtime installation is defined.
 
 The verifier retains the proof-agnostic interface extended by TIP-1096:
@@ -112,9 +112,9 @@ The attestation MUST contain the following 48-byte SHA-384 measurements:
 
 | Register | Required value |
 |---|---|
-| PCR0 | `<T11_PCR0_SHA384>` |
-| PCR1 | `<T11_PCR1_SHA384>` |
-| PCR2 | `<T11_PCR2_SHA384>` |
+| PCR0 | `<T13_PCR0_SHA384>` |
+| PCR1 | `<T13_PCR1_SHA384>` |
+| PCR2 | `<T13_PCR2_SHA384>` |
 
 Until these release measurements are finalized, the production verifier has no approved tuple and
 MUST return `false` after attestation validation. The tuple is a hardfork constant and is not

--- a/tips/tip-1098.md
+++ b/tips/tip-1098.md
@@ -2,7 +2,7 @@
 id: TIP-1098
 title: Nitro-Backed Zone Batch Verification
 description: Defines the native T11 verifier for Nitro-attested Zone batch proofs.
-authors: Roman Krasiuk
+authors: Roman Krasiuk, Zygis
 status: Draft
 related: TIP-1091, [Tempo Zones spec](https://github.com/tempoxyz/zones/blob/main/specs/spec.md), [AWS Nitro Attestation Process](https://github.com/aws/aws-nitro-enclaves-nsm-api/blob/main/docs/attestation_process.md)
 protocolVersion: T11


### PR DESCRIPTION
Sync the TIP-1098 specification changes from [#7287](https://github.com/tempoxyz/tempo/pull/7287) into [#7215](https://github.com/tempoxyz/tempo/pull/7215), covering native Nitro verification, validation bounds, and token-enablement commitment fields. Target T13 throughout, including PCR placeholders, as specified by [#7347](https://github.com/tempoxyz/tempo/pull/7347), and add Zygis as a co-author. Align gas charges and ABI error handling with the implementation, including the 30-gas calldata word cost and size rejection before ABI decoding.

Validation: compared gas accounting and ABI dispatch with the implementation at [d64d229](https://github.com/tempoxyz/tempo/commit/d64d229f2841ceeb78b7fce4c840943063708bc7); `git diff --check` passes. Only the TIP document changes, with authorship, T13 targeting, gas wording, and ABI error handling adjusted from the source PR.

Prompted by: @rkrasiuk
