### PR TITLE
docs(tip-1096): specify hash-based token authentication

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -279,34 +279,16 @@ enabledTokenCount - lastProcessedEnabledTokenCount
 
 The existing append-only `_enabledTokens` array defines canonical enablement
 order. A full `advanceTempo` MUST process the complete unprocessed suffix visible
-at its final root. The supplied token addresses, order, and initialization
-metadata are authenticated using the existing token-enablement hash chain.
-Starting from `ZoneInbox.processedTokenEnablementHash`, the Inbox applies this
-transition for each supplied `EnabledToken` in order:
-
-```solidity
-nextHash = keccak256(abi.encode(nextHash, token, name, symbol, currency));
-```
-
-The resulting hash MUST equal `ZonePortal.tokenEnablementHash`, authenticated
-against the final imported Tempo state root, before the enablements are applied.
-After processing, the Inbox stores the resulting hash as
-`processedTokenEnablementHash`. Omitting, reordering, replaying, or changing an
-enablement's address or metadata invalidates the hash check.
-
-The portal appends each token to `_enabledTokens` and updates
-`tokenEnablementHash` atomically, using the same order and exact metadata bytes.
-Consequently, authenticating the hash chain is sufficient; the proof does not
-need to open each `_enabledTokens` array entry or separately read the committed
-metadata from token storage. Policy state used for Zone token initialization
-MUST still be authenticated against the final imported Tempo root.
+at its final root. The proof authenticates the supplied token addresses, order,
+and metadata by extending `ZoneInbox.processedTokenEnablementHash` with each
+enablement and requiring the resulting hash to equal
+`ZonePortal.tokenEnablementHash` at the final root. Policy state used for Zone
+token initialization is verified against the same root.
 
 The Zone stores `processedEnabledTokenCount`. A full block starts at that Zone
-count, not at the portal's last-settled count, and increments it by the number of
-enablements in the authenticated suffix. The resulting count equals
-`enabledTokenCount` at the final root. This prevents replay when several full
-blocks execute before their containing batch is submitted. Activation initializes
-the existing processed prefix as specified below.
+count, not at the portal's last-settled count, and processes every array entry up
+to `enabledTokenCount` at the final root. This prevents replay when several full
+blocks execute before their containing batch is submitted.
 
 The batch proof exposes the processed-count transition explicitly:
 
@@ -318,9 +300,8 @@ struct TokenEnablementTransition {
 ```
 
 Counts are sufficient because `_enabledTokens` is append-only, so each count
-uniquely identifies a prefix. The token hash chain authenticates enablements
-inside execution and proving; it does not need to be exposed as an additional
-processed-prefix hash in the settlement transition.
+uniquely identifies a prefix. Unlike the deposit queue, the token sequence does
+not require additional processed-prefix hashes in the settlement transition.
 
 Except during activation initialization, `submitBatch` requires:
 
@@ -331,11 +312,10 @@ transition.nextProcessedTokenCount <= enabledTokenCount
 ```
 
 The proof requires the Zone pre-state `processedEnabledTokenCount` to equal
-`prevProcessedTokenCount`, verifies the hash-chain checks and count updates for
-each full block, and requires the Zone post-state count to equal
-`nextProcessedTokenCount`. For each full block, the resulting Zone count MUST
-equal `enabledTokenCount` at that block's final imported Tempo root. A header-only
-block advances neither count
+`prevProcessedTokenCount`, verifies each newly processed suffix via the hash chain,
+and requires the Zone post-state count to equal `nextProcessedTokenCount`. For
+each full block, the resulting Zone count MUST equal `enabledTokenCount` at that
+block's final imported Tempo root. A header-only block advances neither count
 and contributes an identity step to its containing batch transition.
 
 After accepting the proof, `submitBatch` sets

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -279,14 +279,34 @@ enabledTokenCount - lastProcessedEnabledTokenCount
 
 The existing append-only `_enabledTokens` array defines canonical enablement
 order. A full `advanceTempo` MUST process the complete unprocessed suffix visible
-at its final root. The proof verifies the supplied token addresses against that
-array in order and verifies the metadata and policy state used for Zone token
-initialization against the same root.
+at its final root. The supplied token addresses, order, and initialization
+metadata are authenticated using the existing token-enablement hash chain.
+Starting from `ZoneInbox.processedTokenEnablementHash`, the Inbox applies this
+transition for each supplied `EnabledToken` in order:
+
+```solidity
+nextHash = keccak256(abi.encode(nextHash, token, name, symbol, currency));
+```
+
+The resulting hash MUST equal `ZonePortal.tokenEnablementHash`, authenticated
+against the final imported Tempo state root, before the enablements are applied.
+After processing, the Inbox stores the resulting hash as
+`processedTokenEnablementHash`. Omitting, reordering, replaying, or changing an
+enablement's address or metadata invalidates the hash check.
+
+The portal appends each token to `_enabledTokens` and updates
+`tokenEnablementHash` atomically, using the same order and exact metadata bytes.
+Consequently, authenticating the hash chain is sufficient; the proof does not
+need to open each `_enabledTokens` array entry or separately read the committed
+metadata from token storage. Policy state used for Zone token initialization
+MUST still be authenticated against the final imported Tempo root.
 
 The Zone stores `processedEnabledTokenCount`. A full block starts at that Zone
-count, not at the portal's last-settled count, and processes every array entry up
-to `enabledTokenCount` at the final root. This prevents replay when several full
-blocks execute before their containing batch is submitted.
+count, not at the portal's last-settled count, and increments it by the number of
+enablements in the authenticated suffix. The resulting count equals
+`enabledTokenCount` at the final root. This prevents replay when several full
+blocks execute before their containing batch is submitted. Activation initializes
+the existing processed prefix as specified below.
 
 The batch proof exposes the processed-count transition explicitly:
 
@@ -298,8 +318,9 @@ struct TokenEnablementTransition {
 ```
 
 Counts are sufficient because `_enabledTokens` is append-only, so each count
-uniquely identifies a prefix. Unlike the deposit queue, the token sequence does
-not require processed-prefix hashes.
+uniquely identifies a prefix. The token hash chain authenticates enablements
+inside execution and proving; it does not need to be exposed as an additional
+processed-prefix hash in the settlement transition.
 
 Except during activation initialization, `submitBatch` requires:
 
@@ -310,10 +331,11 @@ transition.nextProcessedTokenCount <= enabledTokenCount
 ```
 
 The proof requires the Zone pre-state `processedEnabledTokenCount` to equal
-`prevProcessedTokenCount`, verifies every newly processed array entry in order,
-and requires the Zone post-state count to equal `nextProcessedTokenCount`. For
-each full block, the resulting Zone count MUST equal `enabledTokenCount` at that
-block's final imported Tempo root. A header-only block advances neither count
+`prevProcessedTokenCount`, verifies the hash-chain checks and count updates for
+each full block, and requires the Zone post-state count to equal
+`nextProcessedTokenCount`. For each full block, the resulting Zone count MUST
+equal `enabledTokenCount` at that block's final imported Tempo root. A header-only
+block advances neither count
 and contributes an identity step to its containing batch transition.
 
 After accepting the proof, `submitBatch` sets

--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -301,7 +301,7 @@ struct TokenEnablementTransition {
 
 Counts are sufficient because `_enabledTokens` is append-only, so each count
 uniquely identifies a prefix. Unlike the deposit queue, the token sequence does
-not require additional processed-prefix hashes in the settlement transition.
+not require processed-prefix hashes.
 
 Except during activation initialization, `submitBatch` requires:
 
@@ -312,7 +312,7 @@ transition.nextProcessedTokenCount <= enabledTokenCount
 ```
 
 The proof requires the Zone pre-state `processedEnabledTokenCount` to equal
-`prevProcessedTokenCount`, verifies each newly processed suffix via the hash chain,
+`prevProcessedTokenCount`, verifies every newly processed array entry in order,
 and requires the Zone post-state count to equal `nextProcessedTokenCount`. For
 each full block, the resulting Zone count MUST equal `enabledTokenCount` at that
 block's final imported Tempo root. A header-only block advances neither count


### PR DESCRIPTION
Ref: https://tempoxyz.slack.com/archives/C09K7873V4N/p1787829901013709

Authenticate token enablements through the existing hash chain instead of per-entry array proofs, matching the agreed Zones implementation.
