### PR TITLE
docs(tip-1096): initialize token cursor in first full block

### DIFF
--- a/tips/tip-1096.md
+++ b/tips/tip-1096.md
@@ -285,10 +285,11 @@ enablement and requiring the resulting hash to equal
 `ZonePortal.tokenEnablementHash` at the final root. Policy state used for Zone
 token initialization is verified against the same root.
 
-The Zone stores `processedEnabledTokenCount`. A full block starts at that Zone
-count, not at the portal's last-settled count, and processes every array entry up
-to `enabledTokenCount` at the final root. This prevents replay when several full
-blocks execute before their containing batch is submitted.
+The Zone stores `processedEnabledTokenCount`. After the activation initialization
+described below, a full block starts at that Zone count, not at the portal's
+last-settled count, and processes every array entry up to `enabledTokenCount` at
+the final root. This prevents replay when several full blocks execute before
+their containing batch is submitted.
 
 The batch proof exposes the processed-count transition explicitly:
 
@@ -331,24 +332,36 @@ recovery, but they are not settlement boundaries. They may only form a prefix of
 the first post-activation batch, which MUST end in a full block and use
 operational settlement.
 
-The first post-activation proof supplies a count `N` and authenticates the Tempo
-header stored in the parent Zone state. Against that header's state root, it MUST
-prove both:
+The first post-activation full block initializes the Zone's
+`processedEnabledTokenCount`. Any preceding header-only blocks MUST leave this
+count at its physical pre-state value `0`.
+
+The full block authenticates its complete unprocessed token suffix using the
+hash-chain check described above. Against the same imported Tempo root, the
+proof authenticates the portal's `enabledTokenCount`, denoted `C`. Let `k` be the
+number of supplied token enablements. The proof MUST require `k <= C` and derive
+the previously processed count `N` as:
 
 ```text
-ZoneInbox.processedTokenEnablementHash == ZonePortal.tokenEnablementHash
-ZonePortal.enabledTokenCount            == N
+N = C - k
 ```
 
-The activation state transition internally derives `N` and initializes the
-Zone's `processedEnabledTokenCount` to `N` before executing the first block. For
-this one batch, `TokenEnablementTransition.prevProcessedTokenCount` MUST remain
-the physical pre-state value `0`; the proof authenticates `N` internally before
-processing the outstanding suffix. The verifier treats an uninitialized portal
-cursor as the activation case instead of requiring ordinary count continuity.
+The stored `processedTokenEnablementHash` commits to the previously processed
+prefix. Extending it with the supplied suffix to the authenticated portal hash
+binds that prefix and suffix to `C`; no separate token-state proof at the parent
+Tempo checkpoint is required.
 
-The proof MUST additionally verify against the full block's final imported Tempo
-root that both outstanding-work bounds hold:
+After processing the suffix, the first full block MUST set
+`processedEnabledTokenCount` to `C`. Later full blocks advance the local count
+normally, including when they execute before this batch is submitted. For this
+activation batch, `TokenEnablementTransition.prevProcessedTokenCount` MUST remain
+the physical pre-state value `0`; `N` is an internal proof value and is not
+written into the preceding header-only blocks. The verifier treats an
+uninitialized portal cursor as the activation case instead of requiring
+ordinary count continuity.
+
+The proof MUST additionally verify against the batch's final full block's
+imported Tempo root that both outstanding-work bounds hold:
 
 ```text
 ZonePortal.depositCount
@@ -360,12 +373,13 @@ ZonePortal.enabledTokenCount
     <= MAX_UNPROCESSED_TOKEN_ENABLEMENTS
 ```
 
-For this activation batch, `N` is the effective previous processed-token count
-for the outstanding-work bound even though
+For this activation batch, `N` derived at the first full block remains the
+effective previous processed-token count for the outstanding-work bound. Later
+full blocks MUST NOT reset this baseline.
 `TokenEnablementTransition.prevProcessedTokenCount` remains the physical Zone
 pre-state value `0`. Subsequent batches use the transition's ordinary previous
 count. The activation batch's next count includes `N` and the complete suffix
-processed by its final full block.
+processed across all of its full blocks.
 
 Only after accepting a proof that satisfies these checks does `submitBatch` set
 `lastProcessedEnabledTokenCount` to the transition's next count and set


### PR DESCRIPTION
Ref: #7522

Initialize the token cursor in the first post-activation full block using the authenticated token hash chain and final-root count, leaving preceding header-only blocks unchanged. Derive the legacy prefix count from that full block's suffix and retain the original activation batch limits without requiring a separate parent-checkpoint token proof.

Stacked on #7522.