### PR TITLE
refactor(consensus): remove explicit pending_head reporting

### DIFF
--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -274,23 +274,6 @@ impl Inner<Init> {
             started_at: propose_start,
         } = request;
 
-        // Report the parent we are asked to build on as the pending head,
-        // so that the executor can get started on bringing the execution
-        // layer to the right state. On the happy path there should always
-        // be enough headroom between this and the eventual request to build
-        // a block.
-        //
-        // If the EL is not (yet) in the correct state to build a block the
-        // build will fail fast.
-        debug!("reporting notarized tip");
-        if let Err(error) = self.executor.report_pending_head(Context {
-            round,
-            leader: leader.clone(),
-            parent: (parent_view, parent_digest),
-        }) {
-            warn!(%error, "failed reporting the proposal parent as the pending head");
-        }
-
         let proposal_block = {
             let mut proposal = Box::pin(async {
                 // Follow the commonware marshal::standard::inline application:
@@ -613,7 +596,14 @@ impl Inner<Init> {
         let payload = self
             .state
             .executor
-            .build_proposal(round, parent.digest(), attrs)?
+            .build_proposal(
+                Context {
+                    round,
+                    leader,
+                    parent: (parent_view, parent_digest),
+                },
+                attrs,
+            )?
             .await
             .wrap_err(
                 "executor dropped the payload channel: the build failed (the \
@@ -687,17 +677,6 @@ impl Inner<Init> {
         proposer: PublicKey,
         round: Round,
     ) -> eyre::Result<VerifyResult> {
-        // Report the parent we are asked to verify against as the pending
-        // head, so that the executor keeps driving the execution layer
-        // towards it even if this verification is aborted.
-        if let Err(error) = self.executor.report_pending_head(Context {
-            round,
-            leader: proposer.clone(),
-            parent: (parent_view, parent_digest),
-        }) {
-            warn!(%error, "failed reporting the verify parent as the pending head");
-        }
-
         let block = subscribe(&self.execution_node, round, payload, &self.marshal)
             .await
             .wrap_err("failed getting proposal block")?;
@@ -742,11 +721,14 @@ impl Inner<Init> {
         }
 
         let validation_duration = verify_block(
-            round,
+            Context {
+                round,
+                leader: proposer,
+                parent: (parent_view, parent_digest),
+            },
             &self.epoch_strategy,
             &self.state.executor,
             &block,
-            parent_digest,
             &self.scheme_provider,
         )
         .await
@@ -851,14 +833,13 @@ struct VerifyResult {
 /// not know the block's parent or the request was superseded by a
 /// newer-round request.
 async fn verify_block(
-    round: Round,
+    context: Context<Digest, PublicKey>,
     epoch_strategy: &FixedEpocher,
     executor: &crate::executor::Mailbox,
     block: &Block,
-    parent_digest: Digest,
     scheme_provider: &SchemeProvider,
 ) -> eyre::Result<Option<Duration>> {
-    let epoch = round.epoch();
+    let epoch = context.round.epoch();
     let epoch_info = epoch_strategy
         .containing(block.height())
         .expect("epoch strategy is for all heights");
@@ -866,7 +847,7 @@ async fn verify_block(
         info!("block does not belong to this epoch");
         return Ok(None);
     }
-    if block.parent_hash() != *parent_digest {
+    if block.parent_hash() != *context.parent.1 {
         info!(
             "parent digest stored in block must match the digest of the parent \
             argument but doesn't"
@@ -888,7 +869,7 @@ async fn verify_block(
     );
 
     executor
-        .verify_block(round, block.clone(), validator_set)
+        .verify_block(context, block.clone(), validator_set)
         .await
 }
 

--- a/crates/consensus/src/executor/actor.rs
+++ b/crates/consensus/src/executor/actor.rs
@@ -43,8 +43,7 @@ use alloy_rpc_types_engine::{ForkchoiceUpdated, PayloadId, PayloadStatusEnum};
 use commonware_consensus::{
     Heightable as _,
     marshal::Update,
-    simplex::types::Context,
-    types::{Height, Round},
+    types::{Height, Round, View},
 };
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_runtime::{
@@ -121,7 +120,8 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
 
     /// The timer for the next FCU heartbeat.
     ///
-    /// Armed only when no execution-layer work is active or queued.
+    /// Armed when no execution-layer work can start, including while a build
+    /// waits for its parent. This also wakes convergence retries after rejection.
     fcu_heartbeat_timer: OptionFuture<BoxFuture<'static, ()>>,
 
     /// Finalized blocks waiting to be delivered to the execution layer.
@@ -136,11 +136,11 @@ pub(crate) struct Actor<TContext, TExecutionLayer, TMarshal> {
     /// last forkchoice update, see [`DELIVERIES_PER_FORKCHOICE_UPDATE`].
     deliveries_since_forkchoice: usize,
 
-    /// The round of the newest consensus context whose parent was recorded
-    /// as the pending head. Reports come from concurrently running proposal
-    /// and verification handlers and can arrive out of order; an older
-    /// round's report must not supersede a newer one.
-    pending_head_reported_in: Round,
+    /// The newest round observed through build and verify contexts or
+    /// finalized-tip reports. Requests can arrive out of order; an older
+    /// round's parent must not supersede a newer one's. Retained independently
+    /// of request cancellation and completion.
+    latest_consensus_round: Round,
 
     /// The latest not-yet-started consensus request - validating a proposed
     /// block or building one - keyed by its round. The two kinds share one
@@ -338,7 +338,7 @@ where
             pending_finalizations: VecDeque::new(),
             pending_acknowledgements: VecDeque::new(),
             deliveries_since_forkchoice: 0,
-            pending_head_reported_in: finalized_tip.0,
+            latest_consensus_round: finalized_tip.0,
             pending_consensus_request: None,
 
             execution_task: OptionFuture::none(),
@@ -916,10 +916,7 @@ where
     }
 
     fn update_fcu_heartbeat_timer(&mut self) {
-        if self.execution_task.is_none()
-            && self.pending_finalizations.is_empty()
-            && self.pending_consensus_request.is_none()
-        {
+        if self.execution_task.is_none() && self.pending_finalizations.is_empty() {
             self.arm_fcu_heartbeat_timer();
         } else {
             self.disarm_fcu_heartbeat_timer();
@@ -930,8 +927,8 @@ where
     /// real work to do first.
     #[instrument(skip_all)]
     fn send_forkchoice_update_heartbeat(&mut self) -> eyre::Result<()> {
-        // The heartbeat timer is only armed while no other execution-layer
-        // work is active or queued.
+        // A waiting build must not suppress retries of its parent's delivery.
+        // Give convergence priority over re-affirming the tracked state.
         if !self.execution_task.is_none() {
             return Ok(());
         }
@@ -951,14 +948,20 @@ where
         let cause = message.cause;
         match message.command {
             Command::Build(build) => {
+                self.record_convergence_target(build.context.round, build.context.parent);
+                // Cancellation discards the build work, not its parent target.
+                if build.response.is_canceled() {
+                    return Ok(());
+                }
                 queue_consensus_request(
                     &mut self.pending_consensus_request,
-                    build.round,
+                    build.context.round,
                     ConsensusRequest::Build { cause, build },
                 );
             }
             Command::Finalize(finalized) => match *finalized {
                 Update::Tip(round, height, digest) => {
+                    self.record_convergence_target(round, (round.view(), digest));
                     // A now-stale in-flight body fetch is dropped by
                     // `update_notarized_block_fetch` on the next loop
                     // iteration.
@@ -973,23 +976,21 @@ where
                     });
                 }
             },
-            Command::PendingHeadReport(report) => {
-                self.record_pending_head(report.context);
-            }
             Command::VerifyBlock(request) => {
                 let VerifyBlock {
-                    round,
+                    context,
                     block,
                     validator_set,
                     response,
                 } = *request;
+                self.record_convergence_target(context.round, context.parent);
                 // Keep the block body around even if this request is aborted:
                 // once the block is notarized, the tree needs the body to
                 // forward it to the execution layer.
                 self.notarized_tree.record_block(block.clone());
                 queue_consensus_request(
                     &mut self.pending_consensus_request,
-                    round,
+                    context.round,
                     ConsensusRequest::Verify(VerifyBlockRequest {
                         cause,
                         block,
@@ -1002,8 +1003,10 @@ where
         Ok(())
     }
 
-    /// Records the context's parent as the pending head that consensus
-    /// reports building on.
+    /// Records the newest observed consensus round and its convergence target.
+    /// Build and verify requests select their parent; finalized-tip reports
+    /// select the finalized block itself. A later round can select an older
+    /// parent after nullifications, so the observed round orders targets.
     ///
     /// NOTE: the first proposed block of an epoch will always have a round
     /// `round = (<epoch>, <view>) = (<epoch>, 0)`. This is not a real round
@@ -1013,22 +1016,20 @@ where
     /// start a simplex engine for `<epoch>` if it does not have this block.
     #[instrument(
         skip_all,
-        fields(digest = %context.parent.1),
+        fields(
+            %round,
+            latest_consensus_round = %self.latest_consensus_round,
+            target.view = %target.0,
+            target.digest = %target.1,
+        ),
     )]
-    fn record_pending_head(&mut self, context: Context<Digest, PublicKey>) {
-        if context.round < self.pending_head_reported_in {
-            debug!(
-                round = %context.round,
-                newest = %self.pending_head_reported_in,
-                "ignoring pending head report from an older round",
-            );
-            return;
+    fn record_convergence_target(&mut self, round: Round, target: (View, Digest)) {
+        if round >= self.latest_consensus_round {
+            info!("updating convergence target");
+            self.latest_consensus_round = round;
+            self.notarized_tree
+                .set_pending_head(Round::new(round.epoch(), target.0), target.1);
         }
-        self.pending_head_reported_in = context.round;
-        self.notarized_tree.set_pending_head(
-            Round::new(context.round.epoch(), context.parent.0),
-            context.parent.1,
-        );
     }
 
     /// Keeps the fetch of missing notarized block bodies pointed at the
@@ -1128,9 +1129,8 @@ where
         // Latency critical requests come first: consensus is waiting on
         // them to vote on or propose a block.
         //
-        // Fail fast if validation or building cannot start immediately, unless
-        // the parent is expected to be made available to the execution layer
-        // imminently.
+        // Validation waits only for imminent parent convergence; builds wait
+        // for their selected parent even when its body still needs fetching.
         match self.pending_consensus_request.take() {
             Some((round, ConsensusRequest::Verify(request))) => {
                 let parent = request.block.parent_digest();
@@ -1148,14 +1148,14 @@ where
                 self.pending_consensus_request = Some((round, ConsensusRequest::Verify(request)));
             }
             Some((round, ConsensusRequest::Build { cause, build })) => {
-                // Consensus builds on the pending head it reported. The build
-                // runs once the execution layer's head is there, waits while
-                // convergence is about to get there, and is dropped otherwise.
+                // Admission selected this request's parent as the pending head
+                // unless a newer context had already arrived. Keep the build
+                // queued until convergence reaches it or the target changes.
                 let pending_head = self.notarized_tree.pending_head();
-                if build.digest != pending_head {
+                if build.context.parent.1 != pending_head {
                     info!(
                         %pending_head,
-                        build.parent = %build.digest,
+                        build.parent = %build.context.parent.1,
                         "build is not on the pending head, dropping it",
                     );
                 } else if self.notarized_tree.is_local_head(pending_head) {
@@ -1168,21 +1168,11 @@ where
                     );
                     self.set_execution_task(ExecutionTask::new(ExecutionTaskType::Build, fut));
                     return Ok(());
-                } else if self.is_convergence_target(pending_head) {
-                    // Reschedules the request; the actor will not spin on
-                    // `start_next_execution_request` as long as it remains
-                    // scheduled before the select! in the select-loop (some
-                    // other event needs to take place first; ideally the
-                    // result of the convergence target we are falling through
-                    // to).
+                } else {
+                    // Fall through to convergence. The next body fetch,
+                    // delivery, or retry heartbeat wakes the waiting build.
                     self.pending_consensus_request =
                         Some((round, ConsensusRequest::Build { cause, build }));
-                } else {
-                    info!(
-                        execution.head_hash = %self.notarized_tree.local_state().head.1,
-                        build.parent = %build.digest,
-                        "not ready to build new block, dropping it",
-                    );
                 }
             }
             None => {}
@@ -1355,7 +1345,7 @@ impl Future for PendingNotarizedBlock {
 /// asked to validate the round's proposal or to build it.
 enum ConsensusRequest {
     Verify(VerifyBlockRequest),
-    Build { cause: Span, build: Build },
+    Build { cause: Span, build: Box<Build> },
 }
 
 /// Queues `request` into `slot` unless the slot already holds a request from
@@ -1552,7 +1542,7 @@ async fn execute_forkchoice(
     execution_node: impl ExecutionLayer,
     cause: Span,
     target: LocalState,
-    build: Option<(Span, Build)>,
+    build: Option<(Span, Box<Build>)>,
 ) -> ExecutionTaskOutcome {
     let build = build.filter(|(_, build)| {
         if build.response.is_canceled() {
@@ -1565,15 +1555,14 @@ async fn execute_forkchoice(
         true
     });
     let (build, attributes) = match build {
-        Some((
-            cause,
-            Build {
-                round: _,
-                digest: _,
+        Some((cause, build)) => {
+            let Build {
                 attributes,
                 response,
-            },
-        )) => (Some((cause, response)), Some(*attributes)),
+                ..
+            } = *build;
+            (Some((cause, response)), Some(*attributes))
+        }
         None => (None, None),
     };
 

--- a/crates/consensus/src/executor/actor/notarized_tree/mod.rs
+++ b/crates/consensus/src/executor/actor/notarized_tree/mod.rs
@@ -101,19 +101,19 @@ impl LocalState {
 /// execution layer's head can be moved onto.
 ///
 /// The canonical target is `pending_head`: the parent of the most recent
-/// consensus context. This is expected to be reported by the simplex engine via
-/// the application actor, and constitutes the view (/block) that simplex
-/// expects to verify or build blocks on top of.
+/// consensus request context, carried by a build or verification request. It
+/// constitutes the view (/block) that simplex expects to verify or build
+/// blocks on top of.
 ///
 /// Contexts double as notarization proofs for their parents, but parents are
 /// not monotonic: after nullifications, a later view may build on an *older*
-/// notarized block than its predecessor. Reports arrive in consensus order,
-/// so the last report wins, and the canonical path is the pending head's
+/// notarized block than its predecessor. The actor guards updates by request
+/// round, so the newest context wins, and the canonical path is the pending head's
 /// ancestry rather than the highest known notarization's.
 ///
 /// Block bodies are captured from validation requests and the node's own
 /// builds (the proposer never verifies its own block) or fetched from the
-/// marshal actor; combined with the reports, they reconstruct the
+/// marshal actor; combined with the contexts, they reconstruct the
 /// canonical path on top of the finalized tip.
 ///
 /// The tree holds data strictly above the finalized *network* tip,
@@ -147,10 +147,10 @@ pub(super) struct NotarizedTree {
     /// finalized side of the last accepted forkchoice state. Trails
     /// `delivered_finalized` until the forkchoice update lands.
     local_finalized_tip: (Height, Digest),
-    /// The pending head reported by the most recent consensus context: the
+    /// The pending head selected by the newest consensus request context: the
     /// tip of the canonical path the execution layer's head is converged
     /// onto. Points to the known network finalized tip if no pending head was
-    /// reported yet or if it goes stale.
+    /// selected yet or if it goes stale.
     pending_head: PendingHead,
     /// The execution layer's current head: the head side of the last
     /// accepted forkchoice state.
@@ -287,7 +287,7 @@ impl NotarizedTree {
     }
 
     /// Records a consensus context's parent as the pending head of the
-    /// chain, superseding any previous report.
+    /// chain, superseding any previous target.
     pub(super) fn set_pending_head(&mut self, notarized_in: Round, digest: Digest) {
         self.pending_head = PendingHead {
             notarized_in,

--- a/crates/consensus/src/executor/actor/tests/backfill.rs
+++ b/crates/consensus/src/executor/actor/tests/backfill.rs
@@ -10,7 +10,7 @@ use commonware_runtime::{Runner as _, deterministic};
 
 use super::harness::{
     FakeExecution, FakeMarshal, ForkchoiceStateExt as _, GENESIS, Harness, HarnessOptions,
-    STARTUP_FCU, make_block, round,
+    STARTUP_FCU, built_payload, make_block, round,
 };
 
 #[test_traced]
@@ -87,15 +87,20 @@ fn backfill_then_converges_onto_a_notarized_extension() {
             .await;
         assert_eq!(h.execution.head(), d2);
 
-        // Report a pending head two blocks above the backfilled boundary.
+        // Request a build two blocks above the backfilled boundary.
         // Supplying only that block first makes the actor discover and fetch
         // the missing ancestor before forwarding both blocks bottom-up.
-        h.report_pending_head(5, 4, d4);
+        let proposal = make_block(5, 5, d4);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(5), d4);
         h.wait_until(|| h.marshal.fulfill_subscription(d4, b4.clone()))
             .await;
         h.wait_until(|| h.marshal.fulfill_subscription(d3, b3.clone()))
             .await;
-        h.wait_until(|| h.execution.head() == d4).await;
+        build
+            .await
+            .expect("build should complete above the backfilled boundary");
+        assert_eq!(h.execution.head(), d4);
 
         assert_eq!(h.marshal.get_block_log(), vec![1, 2]);
         assert_eq!(
@@ -105,7 +110,12 @@ fn backfill_then_converges_onto_a_notarized_extension() {
         assert_eq!(h.execution.new_payloads(), vec![d1, d2, d3, d4]);
         assert_eq!(
             h.execution.fcus(),
-            vec![STARTUP_FCU, (d2, d2, false), (d4, d2, false)],
+            vec![
+                STARTUP_FCU,
+                (d2, d2, false),
+                (d4, d2, false),
+                (d4, d2, true)
+            ],
             "the backfill finalizes the floor with one update, and notarized \
             convergence must preserve that boundary",
         );

--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -21,21 +21,24 @@ fn building_on_an_unfinalized_head_leaves_forkchoice_unchanged() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
-        // Converge onto an unfinalized b1 so the two sides of forkchoice are
-        // observably different before the build starts.
+        // Verifying b2 converges onto its unfinalized parent b1, making the
+        // two sides of forkchoice observably different before the build.
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
         h.verify(round(1), b1)
             .await
             .expect("b1 should validate")
             .expect("b1 should be valid");
-        h.report_pending_head(2, 1, d1);
+        h.verify(round(2), make_block(2, 2, d1))
+            .await
+            .unwrap()
+            .unwrap();
         h.wait_until(|| h.execution.head() == d1).await;
         assert_eq!(h.execution.finalized(), Some((0, GENESIS)));
 
-        let proposal = make_block(2, 2, d1);
+        let proposal = make_block(3, 2, d1);
         h.execution.script_built_payload(built_payload(&proposal));
-        h.build(round(2), d1)
+        h.build_on(round(3), 1, d1)
             .await
             .expect("payload should be delivered");
 
@@ -76,8 +79,14 @@ fn pending_payload_job_is_delivered() {
 
         // The delivered block is recorded in the notarized tree: once it is
         // notarized, convergence forwards it without a marshal fetch.
-        h.report_pending_head(2, 1, digest);
-        h.wait_until(|| h.execution.head() == digest).await;
+        let next_proposal = make_block(2, 2, digest);
+        h.execution
+            .script_built_payload(built_payload(&next_proposal));
+        let next_build = h.build(round(2), digest);
+        next_build
+            .await
+            .expect("next build should complete on the retained or fetched parent");
+        assert_eq!(h.execution.head(), digest);
         assert!(h.marshal.subscribe_log().is_empty());
     });
 }
@@ -113,14 +122,20 @@ fn subscriber_cancellation_immediately_before_delivery_discards_the_payload() {
         // Conversely, the actor only asks marshal for a pending-head body when
         // that body is absent from the cache. Observing the subscription below
         // therefore proves that this raced payload was not retained.
-        h.report_pending_head(2, 1, digest);
+        let next_proposal = make_block(2, 2, digest);
+        h.execution
+            .script_built_payload(built_payload(&next_proposal));
+        let next_build = h.build(round(2), digest);
         h.wait_until(|| h.marshal.open_subscriptions() == vec![(digest, round(1))])
             .await;
         assert!(
             h.marshal.fulfill_subscription(digest, proposal),
             "the discarded payload must be fetched before convergence",
         );
-        h.wait_until(|| h.execution.head() == digest).await;
+        next_build
+            .await
+            .expect("next build should complete on the retained or fetched parent");
+        assert_eq!(h.execution.head(), digest);
     });
 }
 
@@ -159,30 +174,38 @@ fn build_is_deferred_while_its_parent_converges_just_in_time() {
 }
 
 #[test_traced]
-fn build_on_an_unknown_parent_is_dropped() {
+fn build_waits_for_its_unknown_parent_to_be_fetched_and_canonicalized() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
-        let stranger = make_block(7, 7, GENESIS);
-        let rx = h.build(round(8), stranger.digest());
-        rx.await
-            .expect_err("a build that cannot start must signal failure");
-
+        let parent = make_block(7, 1, GENESIS);
+        let digest = parent.digest();
+        let proposal = make_block(8, 2, digest);
+        let mut rx = h.build(round(8), digest);
+        h.wait_until(|| h.marshal.open_subscriptions().contains(&(digest, round(7))))
+            .await;
+        assert!(rx.try_recv().expect("build must remain queued").is_none());
         assert!(
             !h.execution.fcus().iter().any(|(_, _, attrs)| *attrs),
             "no build may be registered for an unknown parent",
         );
+
+        h.execution.script_built_payload(built_payload(&proposal));
+        assert!(h.marshal.fulfill_subscription(digest, parent));
+        rx.await
+            .expect("build should complete once its parent converges");
+        assert_eq!(h.execution.head(), digest);
+        assert!(h.execution.fcus().contains(&(digest, GENESIS, true)));
     });
 }
 
 #[test_traced]
-fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
+fn build_selects_its_known_parent_as_the_head() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
-        // a1 is known to the execution layer through its validation, but
-        // consensus never reports it as the pending head: a build on top of
-        // it is not what consensus builds on.
+        // Validation alone does not make a1 the head. The subsequent build
+        // selects it as its parent and drives the execution layer onto it.
         let a1 = make_block(1, 1, GENESIS);
         let da1 = a1.digest();
         h.verify(round(1), a1)
@@ -190,13 +213,12 @@ fn build_on_a_known_block_off_the_pending_head_path_is_dropped() {
             .expect("verification should complete")
             .expect("block should be valid");
 
-        let rx = h.build(round(2), da1);
-        rx.await
-            .expect_err("a build whose parent the head will not reach must fail");
-        assert!(
-            !h.execution.fcus().iter().any(|(.., attrs)| *attrs),
-            "no build may be registered off the pending head's path",
-        );
+        assert_eq!(h.execution.head(), GENESIS);
+        let proposal = make_block(2, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), da1).await.expect("build should complete");
+        assert_eq!(h.execution.head(), da1);
+        assert!(h.execution.fcus().contains(&(da1, GENESIS, true)));
     });
 }
 
@@ -212,7 +234,10 @@ fn build_on_a_head_the_network_finalized_past_is_dropped() {
             .await
             .expect("a1 should validate")
             .expect("a1 should be valid");
-        h.report_pending_head(2, 1, da1);
+        h.verify(round(2), make_block(2, 2, da1))
+            .await
+            .expect("child should validate")
+            .expect("child should be valid");
         h.wait_until(|| h.execution.head() == da1).await;
 
         // The network finalizes b1 on another branch. The tip report alone
@@ -223,7 +248,7 @@ fn build_on_a_head_the_network_finalized_past_is_dropped() {
         let b1 = make_block(3, 1, GENESIS);
         let db1 = b1.digest();
         h.deliver_tip(round(3), 1, db1);
-        h.build(round(4), da1)
+        h.build_on(round(4), 1, da1)
             .await
             .expect_err("the build on the abandoned head must fail");
         assert!(
@@ -239,7 +264,7 @@ fn build_on_a_head_the_network_finalized_past_is_dropped() {
 }
 
 #[test_traced]
-fn late_pending_head_report_from_an_older_round_is_ignored() {
+fn canceled_build_keeps_its_parent_target_despite_an_older_request() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
@@ -253,13 +278,16 @@ fn late_pending_head_report_from_an_older_round_is_ignored() {
                 .expect("verification should complete")
                 .expect("block should be valid");
         }
-        h.report_pending_head(4, 2, db1);
+        let build = h.build_on(round(4), 2, db1);
+        drop(build);
         h.wait_until(|| h.execution.head() == db1).await;
 
-        // A report from an older context arrives late (the handlers run
-        // concurrently). It must not move the pending head back onto a1
-        // and cost the node its proposal on b1.
-        h.report_pending_head(3, 1, da1);
+        // An older build arrives after the newest build has been canceled.
+        // Its context must not restore the previous target.
+        h.build_on(round(3), 1, da1)
+            .await
+            .expect_err("an older build cannot select a different parent");
+        assert_eq!(h.execution.head(), db1);
         let proposal = make_block(5, 2, db1);
         h.execution.script_built_payload(built_payload(&proposal));
         h.build(round(5), db1)

--- a/crates/consensus/src/executor/actor/tests/convergence.rs
+++ b/crates/consensus/src/executor/actor/tests/convergence.rs
@@ -1,5 +1,5 @@
 //! Scenario tests for notarized-chain convergence: the executor drives the
-//! execution layer's head onto the pending head reported by consensus,
+//! execution layer's head onto the parent selected by consensus requests,
 //! fetching missing bodies from the marshal actor, and never runs ahead of
 //! the finalization pipeline.
 
@@ -10,29 +10,32 @@ use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 
 use super::harness::{
-    ForkchoiceStateExt as _, GENESIS, Harness, HarnessOptions, STARTUP_FCU, make_block, round,
+    ForkchoiceStateExt as _, GENESIS, Harness, HarnessOptions, STARTUP_FCU, built_payload,
+    make_block, round,
 };
 
 #[test_traced]
-fn pending_head_with_known_body_is_forwarded() {
+fn build_converges_onto_its_verified_parent() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
 
-        // The validation request records the body; the pending-head report
-        // marks it as the convergence target.
+        // The validation request records the body; the later build request
+        // selects it as the convergence target and builds on it.
         h.verify(round(1), b1)
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.report_pending_head(2, 1, d1);
+        let proposal = make_block(2, 2, d1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), d1).await.expect("build should complete");
 
-        h.wait_until(|| h.execution.head() == d1).await;
+        assert_eq!(h.execution.head(), d1);
         assert_eq!(
             h.execution.fcus().last(),
-            Some(&(d1, GENESIS, false)),
+            Some(&(d1, GENESIS, true)),
             "convergence must move the head without touching the finalized tip",
         );
         assert!(
@@ -54,7 +57,9 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
 
         // Only the pending head is known; every body on its ancestry is
         // missing and must be fetched, walking the path tip-down.
-        h.report_pending_head(4, 3, d3);
+        let proposal = make_block(4, 4, d3);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(4), d3);
 
         h.wait_until(|| h.marshal.fulfill_subscription(d3, b3.clone()))
             .await;
@@ -63,7 +68,10 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
 
-        h.wait_until(|| h.execution.head() == d3).await;
+        build
+            .await
+            .expect("build should complete after fetching its ancestry");
+        assert_eq!(h.execution.head(), d3);
         assert_eq!(
             h.marshal.subscribe_log(),
             vec![(d3, round(3)), (d2, round(2)), (d1, round(1))],
@@ -76,8 +84,8 @@ fn missing_ancestor_bodies_are_fetched_and_forwarded_bottom_up() {
         );
         assert_eq!(
             h.execution.fcus(),
-            vec![STARTUP_FCU, (d3, GENESIS, false)],
-            "one forkchoice update moves the head across the whole delivered run",
+            vec![STARTUP_FCU, (d3, GENESIS, false), (d3, GENESIS, true)],
+            "one update converges across the delivered run before the build submits attributes",
         );
     });
 }
@@ -96,7 +104,9 @@ fn long_delivery_runs_are_locked_in_every_few_blocks() {
             blocks.push(block);
         }
         let digests = blocks.iter().map(|b| b.digest()).collect::<Vec<_>>();
-        h.report_pending_head(11, 10, digests[9]);
+        let proposal = make_block(11, 11, digests[9]);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(11), digests[9]);
         for block in blocks.iter().rev() {
             h.wait_until(|| {
                 h.marshal
@@ -108,7 +118,10 @@ fn long_delivery_runs_are_locked_in_every_few_blocks() {
         // The run is delivered bottom-up, with a forkchoice update forced
         // after every eight deliveries so that the execution layer never
         // holds more than that many uncanonicalized blocks.
-        h.wait_until(|| h.execution.head() == digests[9]).await;
+        build
+            .await
+            .expect("build should complete after the long delivery run");
+        assert_eq!(h.execution.head(), digests[9]);
         assert_eq!(h.execution.new_payloads(), digests);
         assert_eq!(
             h.execution.fcus(),
@@ -116,6 +129,7 @@ fn long_delivery_runs_are_locked_in_every_few_blocks() {
                 STARTUP_FCU,
                 (digests[7], GENESIS, false),
                 (digests[9], GENESIS, false),
+                (digests[9], GENESIS, true),
             ],
         );
     });
@@ -128,7 +142,9 @@ fn dropped_body_fetch_is_retried() {
 
         let b1 = make_block(1, 1, GENESIS);
         let d1 = b1.digest();
-        h.report_pending_head(2, 1, d1);
+        let proposal = make_block(2, 2, d1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(2), d1);
 
         // Marshal gives up on the first subscription; the block is still on
         // the canonical notarized path, so the fetch must be re-issued.
@@ -137,7 +153,10 @@ fn dropped_body_fetch_is_retried() {
 
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
-        h.wait_until(|| h.execution.head() == d1).await;
+        build
+            .await
+            .expect("build should complete after retrying its parent");
+        assert_eq!(h.execution.head(), d1);
     });
 }
 
@@ -150,17 +169,22 @@ fn stale_body_fetch_is_dropped_when_the_pending_head_moves() {
         let a1 = make_block(5, 1, GENESIS);
         let (d1, da1) = (b1.digest(), a1.digest());
 
-        h.report_pending_head(2, 1, d1);
+        let first = h.build(round(2), d1);
         h.wait_until(|| !h.marshal.open_subscriptions().is_empty())
             .await;
 
         // A newer context re-anchors the pending head onto a different
         // block; the in-flight fetch is now pointless and must be dropped
         // (nobody is required to serve a forked-out block).
-        h.report_pending_head(6, 5, da1);
+        let proposal = make_block(6, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let second = h.build(round(6), da1);
         h.wait_until(|| h.marshal.open_subscriptions() == vec![(da1, round(5))])
             .await;
 
+        first
+            .await
+            .expect_err("the newer build must supersede the first");
         assert!(
             !h.marshal.fulfill_subscription(d1, b1),
             "the stale subscription must have been dropped",
@@ -168,12 +192,15 @@ fn stale_body_fetch_is_dropped_when_the_pending_head_moves() {
 
         h.wait_until(|| h.marshal.fulfill_subscription(da1, a1.clone()))
             .await;
-        h.wait_until(|| h.execution.head() == da1).await;
+        second
+            .await
+            .expect("build on the new branch should complete");
+        assert_eq!(h.execution.head(), da1);
     });
 }
 
 #[test_traced]
-fn rejected_notarized_block_is_withheld_then_retried() {
+fn waiting_build_allows_its_rejected_parent_to_be_retried() {
     deterministic::Runner::default().start(|context| async move {
         // Retries of rejected notarized blocks are driven by later events;
         // with nothing else going on, the FCU heartbeat is what re-runs the
@@ -196,7 +223,9 @@ fn rejected_notarized_block_is_withheld_then_retried() {
         h.execution
             .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
 
-        h.report_pending_head(2, 1, d1);
+        let proposal = make_block(2, 2, d1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let mut build = h.build(round(2), d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
 
@@ -210,11 +239,20 @@ fn rejected_notarized_block_is_withheld_then_retried() {
             "a rejected block must not be retried in a tight loop",
         );
         assert_eq!(h.execution.head(), GENESIS);
+        assert!(
+            build
+                .try_recv()
+                .expect("build must remain queued")
+                .is_none()
+        );
 
         // After the retry delay (10s) the block becomes forwardable again.
         h.run_for(Duration::from_secs(6)).await;
         h.wait_until(|| h.execution.head() == d1).await;
         assert_eq!(h.execution.new_payloads(), vec![d1, d1]);
+        build
+            .await
+            .expect("build must complete after its parent is accepted");
     });
 }
 
@@ -234,7 +272,9 @@ fn new_payload_transport_error_is_withheld_then_retried() {
         h.execution
             .script_new_payload(d1, Ok(PayloadStatusEnum::Valid));
 
-        h.report_pending_head(2, 1, d1);
+        let proposal = make_block(2, 2, d1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(2), d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
 
@@ -248,7 +288,10 @@ fn new_payload_transport_error_is_withheld_then_retried() {
         );
 
         h.run_for(Duration::from_secs(6)).await;
-        h.wait_until(|| h.execution.head() == d1).await;
+        build
+            .await
+            .expect("build should complete after retrying its parent");
+        assert_eq!(h.execution.head(), d1);
         assert_eq!(h.execution.new_payloads(), vec![d1, d1]);
     });
 }
@@ -270,10 +313,13 @@ fn rejected_notarized_fcu_is_fatal() {
             }),
         );
 
-        h.report_pending_head(2, 1, d1);
+        let build = h.build(round(2), d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
 
+        build
+            .await
+            .expect_err("failed parent convergence must fail the build");
         h.actor
             .await
             .expect("actor should shut down cleanly on a rejected forkchoice update");
@@ -302,10 +348,13 @@ fn notarized_fcu_transport_error_is_fatal() {
             Err("connection closed"),
         );
 
-        h.report_pending_head(2, 1, d1);
+        let build = h.build(round(2), d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
 
+        build
+            .await
+            .expect_err("failed parent convergence must fail the build");
         h.actor
             .await
             .expect("actor should shut down cleanly on a forkchoice transport error");
@@ -324,7 +373,7 @@ fn syncing_notarized_payload_is_rejected_without_updating_forkchoice() {
         h.execution
             .script_new_payload(d1, Ok(PayloadStatusEnum::Syncing));
 
-        h.report_pending_head(2, 1, d1);
+        let mut build = h.build(round(2), d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
@@ -333,6 +382,12 @@ fn syncing_notarized_payload_is_rejected_without_updating_forkchoice() {
 
         assert_eq!(h.execution.fcus(), vec![STARTUP_FCU]);
         assert_eq!(h.execution.head(), GENESIS);
+        assert!(
+            build
+                .try_recv()
+                .expect("build should still be waiting on its parent")
+                .is_none()
+        );
 
         let candidate = make_block(3, 1, GENESIS);
         assert!(
@@ -341,6 +396,9 @@ fn syncing_notarized_payload_is_rejected_without_updating_forkchoice() {
                 .expect("the actor should survive a SYNCING notarized payload")
                 .is_some(),
         );
+        build
+            .await
+            .expect_err("the newer verification must supersede the waiting build");
     });
 }
 
@@ -354,7 +412,7 @@ fn accepted_notarized_payload_is_rejected_without_updating_forkchoice() {
         h.execution
             .script_new_payload(d1, Ok(PayloadStatusEnum::Accepted));
 
-        h.report_pending_head(2, 1, d1);
+        let mut build = h.build(round(2), d1);
         h.wait_until(|| h.marshal.fulfill_subscription(d1, b1.clone()))
             .await;
         h.wait_until(|| h.execution.new_payloads() == vec![d1])
@@ -363,6 +421,12 @@ fn accepted_notarized_payload_is_rejected_without_updating_forkchoice() {
 
         assert_eq!(h.execution.fcus(), vec![STARTUP_FCU]);
         assert_eq!(h.execution.head(), GENESIS);
+        assert!(
+            build
+                .try_recv()
+                .expect("build should still be waiting on its parent")
+                .is_none()
+        );
 
         let candidate = make_block(3, 1, GENESIS);
         assert!(
@@ -371,6 +435,9 @@ fn accepted_notarized_payload_is_rejected_without_updating_forkchoice() {
                 .expect("the actor should survive an ACCEPTED notarized payload")
                 .is_some(),
         );
+        build
+            .await
+            .expect_err("the newer verification must supersede the waiting build");
     });
 }
 
@@ -389,19 +456,29 @@ fn stranded_head_is_repointed_onto_the_finalized_tip() {
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.report_pending_head(2, 1, da1);
-        h.wait_until(|| h.execution.head() == da1).await;
+        let proposal = make_block(2, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), da1).await.expect("build should complete");
+        assert_eq!(h.execution.head(), da1);
 
         let payloads_before = h.execution.new_payloads();
-        h.report_pending_head(5, 0, GENESIS);
-        h.wait_until(|| h.execution.head() == GENESIS).await;
+        let proposal = make_block(5, 1, GENESIS);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(5), GENESIS)
+            .await
+            .expect("build should complete");
+        assert_eq!(h.execution.head(), GENESIS);
 
         assert_eq!(
             h.execution.new_payloads(),
             payloads_before,
             "a repoint is a bare forkchoice update; no payload is forwarded",
         );
-        assert_eq!(h.execution.fcus().last(), Some(&(GENESIS, GENESIS, false)));
+        assert!(
+            h.execution
+                .fcus()
+                .ends_with(&[(GENESIS, GENESIS, false), (GENESIS, GENESIS, true),])
+        );
     });
 }
 
@@ -416,8 +493,10 @@ fn failed_repoint_is_fatal() {
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.report_pending_head(2, 1, da1);
-        h.wait_until(|| h.execution.head() == da1).await;
+        let proposal = make_block(2, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), da1).await.expect("build should complete");
+        assert_eq!(h.execution.head(), da1);
 
         // A repoint targets an ancestor the execution layer provably has;
         // failure means consensus and execution disagree fundamentally.
@@ -427,7 +506,9 @@ fn failed_repoint_is_fatal() {
                 validation_error: "corrupt".into(),
             }),
         );
-        h.report_pending_head(5, 0, GENESIS);
+        h.build(round(5), GENESIS)
+            .await
+            .expect_err("failed repoint must fail the build");
 
         h.actor
             .await
@@ -450,14 +531,18 @@ fn repoint_transport_error_is_fatal() {
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.report_pending_head(2, 1, da1);
-        h.wait_until(|| h.execution.head() == da1).await;
+        let proposal = make_block(2, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), da1).await.expect("build should complete");
+        assert_eq!(h.execution.head(), da1);
 
         h.execution.script_fcu(
             ForkchoiceState::from_finalized_head(GENESIS, GENESIS),
             Err("connection closed"),
         );
-        h.report_pending_head(5, 0, GENESIS);
+        h.build(round(5), GENESIS)
+            .await
+            .expect_err("failed repoint must fail the build");
 
         h.actor
             .await
@@ -476,8 +561,10 @@ fn repoint_canonical_lookup_error_is_fatal() {
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.report_pending_head(2, 1, da1);
-        h.wait_until(|| h.execution.head() == da1).await;
+        let proposal = make_block(2, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), da1).await.expect("build should complete");
+        assert_eq!(h.execution.head(), da1);
         let accepted_fcus = h.execution.fcus();
 
         // Repointing checks the locally tracked finalized hash through the
@@ -485,7 +572,9 @@ fn repoint_canonical_lookup_error_is_fatal() {
         h.execution.set_finalized(0, GENESIS);
         h.execution
             .script_canonical_block_hash(0, Err("database unavailable"));
-        h.report_pending_head(5, 0, GENESIS);
+        h.build(round(5), GENESIS)
+            .await
+            .expect_err("failed repoint must fail the build");
 
         let execution = h.execution.clone();
         h.actor
@@ -509,22 +598,26 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
         let b2 = make_block(2, 2, b1.digest());
         let d2 = b2.digest();
         for (view, block) in [(1, b1), (2, b2)] {
-            let digest = block.digest();
             h.verify(round(view), block)
                 .await
                 .expect("verification should complete")
                 .expect("block should be valid");
-            h.report_pending_head(view + 1, view, digest);
-            h.wait_until(|| h.execution.head() == digest).await;
         }
+        let proposal = make_block(3, 3, d2);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(3), d2).await.expect("build should complete");
+        h.wait_until(|| h.execution.head() == d2).await;
 
         // Branch A: a1 at the same height as b1, body fetched from marshal.
         let a1 = make_block(3, 1, GENESIS);
         let da1 = a1.digest();
-        h.report_pending_head(4, 3, da1);
+        let proposal = make_block(4, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(4), da1);
         h.wait_until(|| h.marshal.fulfill_subscription(da1, a1.clone()))
             .await;
-        h.wait_until(|| h.execution.head() == da1).await;
+        build.await.expect("build on branch A should complete");
+        assert_eq!(h.execution.head(), da1);
         let fetches = h.marshal.subscribe_log().len();
 
         // Flip back to branch B: both bodies are still resident, so the
@@ -532,7 +625,11 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
         // already knows the branch, so the head is repointed onto it with a
         // bare forkchoice update.
         let payloads_before = h.execution.new_payloads();
-        h.report_pending_head(5, 2, d2);
+        let proposal = make_block(5, 3, d2);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build_on(round(5), 2, d2)
+            .await
+            .expect("build should complete");
         h.wait_until(|| h.execution.head() == d2).await;
         assert_eq!(
             h.marshal.subscribe_log().len(),
@@ -544,7 +641,11 @@ fn branch_flip_flop_reconverges_from_resident_bodies() {
             payloads_before,
             "a branch the execution layer knows is not delivered again",
         );
-        assert_eq!(h.execution.fcus().last(), Some(&(d2, GENESIS, false)));
+        assert!(
+            h.execution
+                .fcus()
+                .ends_with(&[(d2, GENESIS, false), (d2, GENESIS, true),])
+        );
     });
 }
 
@@ -575,8 +676,9 @@ fn advancing_finalized_tip_prunes_covered_state() {
         // A stale context naming the pruned block must not resurrect it:
         // its round is covered by the finalized tip, so the tree re-anchors
         // on the tip instead of fetching or forwarding a1.
-        h.report_pending_head(2, 1, da1);
-        h.run_for(Duration::from_millis(500)).await;
+        h.build_on(round(2), 1, da1)
+            .await
+            .expect_err("a build on a pruned parent must fail");
 
         assert!(
             h.marshal.subscribe_log().is_empty(),

--- a/crates/consensus/src/executor/actor/tests/finalization.rs
+++ b/crates/consensus/src/executor/actor/tests/finalization.rs
@@ -7,11 +7,13 @@
 use alloy_rpc_types_engine::{ForkchoiceState, PayloadStatusEnum};
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
+use futures::channel::oneshot;
+use tempo_payload_types::TempoBuiltPayload;
 use tempo_primitives::ed25519::PublicKey;
 
 use super::harness::{
     ElCall, ForkchoiceStateExt as _, GENESIS, Harness, HarnessOptions, STARTUP_FCU,
-    STARTUP_FCU_CALL, make_block, make_block_with_proposer, round,
+    STARTUP_FCU_CALL, built_payload, make_block, make_block_with_proposer, round,
 };
 use crate::consensus::Digest;
 
@@ -196,35 +198,40 @@ fn new_payload_transport_error_is_fatal() {
 }
 
 /// Converges the head onto `a1 -> a2` (branch A) through validations and
-/// pending-head reports, then reports an unknown block as the pending head
-/// so that the pending head's ancestry is not walkable: the forkchoice step
+/// a build, then requests another build on an unknown parent so that
+/// the pending head's ancestry is not walkable: the forkchoice step
 /// cannot derive the head from the tree and must consult the execution
 /// layer's canonical chain when finality advances.
-async fn converge_on_branch_a_with_unwalkable_pending_head(h: &Harness) -> (Digest, Digest) {
+async fn converge_on_branch_a_with_unwalkable_pending_head(
+    h: &Harness,
+) -> (Digest, Digest, oneshot::Receiver<TempoBuiltPayload>) {
     let a1 = make_block(1, 1, GENESIS);
     let a2 = make_block(2, 2, a1.digest());
     let (da1, da2) = (a1.digest(), a2.digest());
-    for (view, block, digest) in [(1, a1, da1), (2, a2, da2)] {
+    for (view, block) in [(1, a1), (2, a2)] {
         h.verify(round(view), block)
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.report_pending_head(view + 1, view, digest);
-        h.wait_until(|| h.execution.head() == digest).await;
     }
+    let proposal = make_block(3, 3, da2);
+    h.execution.script_built_payload(built_payload(&proposal));
+    h.build(round(3), da2)
+        .await
+        .expect("build on branch A should complete");
 
     let unknown = make_block(4, 3, da2).digest();
-    h.report_pending_head(5, 4, unknown);
+    let build = h.build_on(round(5), 4, unknown);
     h.wait_until(|| h.marshal.open_subscriptions() == vec![(unknown, round(4))])
         .await;
-    (da1, da2)
+    (da1, da2, build)
 }
 
 #[test_traced]
 fn canonical_block_lookup_error_is_fatal() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
-        let (_, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+        let (_, da2, _build) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
         let fcus_before = h.execution.fcus();
 
         // b1 finalizes below the head on another branch. Whether the head
@@ -255,7 +262,7 @@ fn canonical_block_lookup_error_is_fatal() {
 fn finalizing_below_a_head_on_another_branch_moves_the_head() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
-        let (_, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+        let (_, da2, _build) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
 
         // b1 finalizes at height 1 on branch B while the head is a2 at
         // height 2 on branch A. The head does not descend from the
@@ -278,7 +285,7 @@ fn finalizing_below_a_head_on_another_branch_moves_the_head() {
 fn finalizing_below_a_descending_head_keeps_the_head() {
     deterministic::Runner::default().start(|context| async move {
         let mut h = Harness::start_at_genesis(&context);
-        let (da1, da2) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
+        let (da1, da2, _build) = converge_on_branch_a_with_unwalkable_pending_head(&h).await;
 
         // a1 finalizes below the head a2 while the pending head's ancestry
         // is not walkable. The canonical chain shows that the head descends
@@ -466,14 +473,13 @@ fn finalizing_a_canonical_ancestor_leaves_the_head_untouched() {
             .await
             .expect("b1 should validate")
             .expect("b1 should be valid");
-        h.report_pending_head(2, 1, d1);
-        h.wait_until(|| h.execution.head() == d1).await;
-
         h.verify(round(2), b2.clone())
             .await
             .expect("b2 should validate")
             .expect("b2 should be valid");
-        h.report_pending_head(3, 2, d2);
+        let proposal = make_block(3, 3, d2);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(3), d2).await.expect("build should complete");
         h.wait_until(|| h.execution.head() == d2).await;
 
         h.deliver_tip(round(1), 1, d1);
@@ -507,7 +513,9 @@ fn finalizing_a_conflicting_branch_moves_the_head() {
             .await
             .expect("a1 should validate")
             .expect("a1 should be valid");
-        h.report_pending_head(2, 1, da1);
+        let proposal = make_block(2, 2, da1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), da1).await.expect("build should complete");
         h.wait_until(|| h.execution.head() == da1).await;
 
         h.deliver_tip(round(2), 1, db1);

--- a/crates/consensus/src/executor/actor/tests/harness.rs
+++ b/crates/consensus/src/executor/actor/tests/harness.rs
@@ -26,7 +26,7 @@ use alloy_rpc_types_engine::{
     ForkchoiceState, ForkchoiceUpdated, PayloadId, PayloadStatus, PayloadStatusEnum,
 };
 use commonware_consensus::{
-    Heightable as _, Reporter as _,
+    CertifiableBlock as _, Heightable as _, Reporter as _,
     marshal::Update,
     simplex::types::Context,
     types::{Epoch, Height, Round, View},
@@ -1106,18 +1106,6 @@ where
         waiter
     }
 
-    /// Reports `parent` (notarized in `parent_view`) as the pending head via
-    /// a consensus context at `context_view`.
-    pub(super) fn report_pending_head(&self, context_view: u64, parent_view: u64, parent: Digest) {
-        self.mailbox
-            .report_pending_head(Context {
-                round: round(context_view),
-                leader: tempo_primitives::ed25519::PublicKey::from_seed(42).to_inner(),
-                parent: (View::new(parent_view), parent),
-            })
-            .expect("actor should accept the pending-head report");
-    }
-
     /// Requests validation of `block`, resolving to the verdict.
     pub(super) fn verify(
         &self,
@@ -1134,7 +1122,9 @@ where
         validator_set: Option<Vec<B256>>,
     ) -> impl Future<Output = eyre::Result<Option<Duration>>> + use<TContext> {
         let mailbox = self.mailbox.clone();
-        async move { mailbox.verify_block(round, block, validator_set).await }
+        let mut context = block.context();
+        context.round = round;
+        async move { mailbox.verify_block(context, block, validator_set).await }
     }
 
     /// Requests a proposal build on top of `parent`, returning the payload
@@ -1153,8 +1143,38 @@ where
         parent: Digest,
         attributes: TempoPayloadAttributes,
     ) -> futures::channel::oneshot::Receiver<TempoBuiltPayload> {
+        let parent_view = if parent == GENESIS {
+            0
+        } else {
+            round.view().get().saturating_sub(1)
+        };
         self.mailbox
-            .build_proposal(round, parent, attributes)
+            .build_proposal(
+                Context {
+                    round,
+                    leader: tempo_primitives::ed25519::PublicKey::from_seed(42).to_inner(),
+                    parent: (View::new(parent_view), parent),
+                },
+                attributes,
+            )
+            .expect("actor should accept the build request")
+    }
+
+    pub(super) fn build_on(
+        &self,
+        round: Round,
+        parent_view: u64,
+        parent: Digest,
+    ) -> futures::channel::oneshot::Receiver<TempoBuiltPayload> {
+        self.mailbox
+            .build_proposal(
+                Context {
+                    round,
+                    leader: tempo_primitives::ed25519::PublicKey::from_seed(42).to_inner(),
+                    parent: (View::new(parent_view), parent),
+                },
+                attributes(),
+            )
             .expect("actor should accept the build request")
     }
 }

--- a/crates/consensus/src/executor/actor/tests/metrics.rs
+++ b/crates/consensus/src/executor/actor/tests/metrics.rs
@@ -5,7 +5,7 @@
 use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 
-use super::harness::{GENESIS, Harness, make_block, round};
+use super::harness::{GENESIS, Harness, built_payload, make_block, round};
 
 fn gauge(h: &Harness, name: &str) -> i64 {
     let name = format!("executor_{name}");
@@ -87,7 +87,7 @@ fn convergence_depth_tracks_known_and_unknown_pending_heads() {
 
         // Before its body arrives, the pending head's height is unknown. The
         // actor keeps the last published value rather than inventing a depth.
-        h.report_pending_head(3, 2, d2);
+        let mut first = h.build(round(3), d2);
         h.wait_until(|| h.marshal.open_subscriptions() == vec![(d2, round(2))])
             .await;
         assert_eq!(gauge(&h, "convergence_depth"), 0);
@@ -99,13 +99,29 @@ fn convergence_depth_tracks_known_and_unknown_pending_heads() {
             .await;
         h.wait_until(|| gauge(&h, "convergence_depth") == 2).await;
 
+        assert!(
+            first
+                .try_recv()
+                .expect("build must wait for its ancestry")
+                .is_none()
+        );
+
         // Move to another pending head whose body has not arrived. Unknown
         // depth must preserve the last known value, including a non-zero one.
         let unknown = make_block(3, 3, GENESIS).digest();
-        h.report_pending_head(4, 3, unknown);
+        let mut second = h.build(round(4), unknown);
         h.wait_until(|| h.marshal.open_subscriptions() == vec![(unknown, round(3))])
             .await;
         assert_eq!(gauge(&h, "convergence_depth"), 2);
+        first
+            .await
+            .expect_err("the newer build supersedes the old one");
+        assert!(
+            second
+                .try_recv()
+                .expect("new build must wait for its ancestry")
+                .is_none()
+        );
     });
 }
 
@@ -117,15 +133,19 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         let b1 = make_block(1, 1, GENESIS);
         let b2 = make_block(2, 2, b1.digest());
         let b3 = make_block(3, 3, b2.digest());
-        let (d1, d2, d3) = (b1.digest(), b2.digest(), b3.digest());
-        for (view, block, digest) in [(1, b1, d1), (2, b2, d2), (3, b3, d3)] {
+        let d3 = b3.digest();
+        for (view, block) in [(1, b1), (2, b2), (3, b3)] {
             h.verify(round(view), block)
                 .await
                 .expect("verification should complete")
                 .expect("block should be valid");
-            h.report_pending_head(view + 1, view, digest);
-            h.wait_until(|| h.execution.head() == digest).await;
         }
+        let proposal = make_block(4, 4, d3);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(4), d3)
+            .await
+            .expect("build on branch B should complete");
+        h.wait_until(|| h.execution.head() == d3).await;
         h.wait_until(|| gauge(&h, "convergence_depth") == 0).await;
 
         // Re-anchor onto a2 on a side branch at height 2 while its parent
@@ -134,11 +154,17 @@ fn convergence_depth_is_negative_while_reanchoring_below_the_local_head() {
         let a1 = make_block(4, 1, GENESIS);
         let a2 = make_block(5, 2, a1.digest());
         let da2 = a2.digest();
-        h.report_pending_head(6, 5, da2);
+        let mut build = h.build(round(6), da2);
         h.wait_until(|| h.marshal.fulfill_subscription(da2, a2.clone()))
             .await;
         h.wait_until(|| gauge(&h, "convergence_depth") == -1).await;
         assert_eq!(h.execution.head(), d3);
+        assert!(
+            build
+                .try_recv()
+                .expect("build must wait for the new branch's ancestry")
+                .is_none()
+        );
     });
 }
 
@@ -160,18 +186,24 @@ fn uncanonicalized_blocks_tracks_delivered_blocks_off_the_canonical_chain() {
             .await;
 
         // Moving the head onto it canonicalizes it.
-        h.report_pending_head(2, 1, d1);
+        let proposal = make_block(2, 2, d1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), d1)
+            .await
+            .expect("build should complete after canonicalizing its parent");
         h.wait_until(|| h.execution.head() == d1).await;
         h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 0)
             .await;
 
-        // A validated sibling stays on a side branch.
+        // A newer verification of a sibling selects genesis as the parent.
+        // Converging back onto it leaves both validated blocks off-chain.
         let a1 = make_block(3, 1, GENESIS);
         h.verify(round(3), a1)
             .await
             .expect("verification should complete")
             .expect("block should be valid");
-        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 1)
+        h.wait_until(|| h.execution.head() == GENESIS).await;
+        h.wait_until(|| gauge(&h, "uncanonicalized_blocks") == 2)
             .await;
     });
 }

--- a/crates/consensus/src/executor/actor/tests/scheduling.rs
+++ b/crates/consensus/src/executor/actor/tests/scheduling.rs
@@ -15,22 +15,22 @@ use super::harness::{
 };
 
 #[test_traced]
-fn slow_marshal_fetch_does_not_block_validation() {
+fn newer_verification_supersedes_a_build_waiting_on_marshal() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
         // Leave the missing pending head's marshal subscription unresolved.
-        let pending = make_block(1, 1, GENESIS);
+        let pending = make_block(3, 1, GENESIS);
         let pending_digest = pending.digest();
-        h.report_pending_head(2, 1, pending_digest);
-        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(1))])
+        let build = h.build(round(4), pending_digest);
+        h.wait_until(|| h.marshal.open_subscriptions() == vec![(pending_digest, round(3))])
             .await;
 
-        // The body fetch has its own slot in the actor loop. An unrelated
-        // validation against the known finalized parent must still run.
-        let candidate = make_block(3, 1, GENESIS);
+        // A newer verification selects the known finalized parent. It must
+        // supersede the waiting build without waiting for its marshal fetch.
+        let candidate = make_block(5, 1, GENESIS);
         let candidate_digest = candidate.digest();
-        let verify = h.verify(round(3), candidate);
+        let verify = h.verify(round(5), candidate);
         futures::pin_mut!(verify);
         let deadline = h.run_for(Duration::from_millis(100));
         futures::pin_mut!(deadline);
@@ -45,11 +45,12 @@ fn slow_marshal_fetch_does_not_block_validation() {
 
         assert!(verdict.is_some());
         assert_eq!(h.execution.new_payloads(), vec![candidate_digest]);
-        assert_eq!(
-            h.marshal.open_subscriptions(),
-            vec![(pending_digest, round(1))],
-            "validation must not cancel or consume the independent body fetch",
-        );
+        build
+            .await
+            .expect_err("the newer verification must supersede the waiting build");
+        h.wait_until(|| h.marshal.open_subscriptions().is_empty())
+            .await;
+        assert_eq!(h.execution.head(), GENESIS);
     });
 }
 
@@ -255,74 +256,29 @@ fn one_execution_task_at_a_time_and_consensus_requests_win_the_next_slot() {
 }
 
 #[test_traced]
-fn consensus_work_takes_priority_over_ready_convergence() {
+fn verification_precedes_ready_parent_convergence() {
     deterministic::Runner::default().start(|context| async move {
-        let mut h = Harness::start_at_genesis(&context);
+        let h = Harness::start_at_genesis(&context);
+        let parent = make_block(1, 1, GENESIS);
+        let parent_digest = parent.digest();
+        h.verify(round(1), parent).await.unwrap().unwrap();
+        assert_eq!(h.execution.head(), GENESIS);
 
-        let b1 = make_block(1, 1, GENESIS);
-        let d1 = b1.digest();
-        let release_finalization = h
-            .execution
-            .script_delayed_new_payload(d1, Ok(PayloadStatusEnum::Valid));
-        h.deliver_tip(round(1), 1, d1);
-        let finalized = h.deliver_finalized(b1);
-        h.wait_until(|| h.execution.new_payloads() == vec![d1])
-            .await;
-
-        // Make convergence onto b2 ready while finalization still owns the
-        // slot: its pending-head report and body are both already in hand.
-        let b2 = make_block(2, 2, d1);
-        let d2 = b2.digest();
-        h.report_pending_head(3, 2, d2);
-        h.wait_until(|| h.marshal.fulfill_subscription(d2, b2.clone()))
-            .await;
-        h.run_for(Duration::from_millis(10)).await;
-
-        // Queue a validation that also becomes runnable once b1 is finalized.
-        // It must stay queued until the occupied slot becomes available.
-        let candidate = make_block(3, 2, d1);
+        // This request makes both verification and parent convergence ready
+        // in the same admission. The candidate's probe must win the slot.
+        let candidate = make_block(2, 2, parent_digest);
         let candidate_digest = candidate.digest();
-        let verify = h.verify(round(3), candidate);
-        futures::pin_mut!(verify);
-        let deadline = h.run_for(Duration::from_millis(10));
-        futures::pin_mut!(deadline);
-        let verify = match futures::future::select(verify, deadline).await {
-            Either::Left(_) => panic!("verification resolved while the slot was held"),
-            Either::Right(((), verify)) => verify,
-        };
-
-        release_finalization
-            .send(())
-            .expect("finalization should still be gated");
-        finalized.await.expect("first block should be acknowledged");
-        assert!(
-            verify
-                .await
-                .expect("verification should complete")
-                .is_some(),
-            "candidate should be valid",
-        );
-        h.wait_until(|| h.execution.head() == d2).await;
-
+        h.verify(round(2), candidate).await.unwrap().unwrap();
+        h.wait_until(|| h.execution.head() == parent_digest).await;
         assert_eq!(
             h.execution.calls(),
             vec![
                 STARTUP_FCU_CALL,
-                ElCall::NewPayload(d1),
-                // Both operations were ready when the delivery of b1
-                // released the slot, but latency-critical consensus work
-                // ran first. Finality is locked in next, before notarized
-                // convergence delivers b2 and moves the head onto it.
+                ElCall::NewPayload(parent_digest),
                 ElCall::NewPayload(candidate_digest),
                 ElCall::Fcu {
-                    head: d1,
-                    finalized: d1,
-                    with_attrs: false,
-                },
-                ElCall::NewPayload(d2),
-                ElCall::Fcu {
-                    head: d2,
-                    finalized: d1,
+                    head: parent_digest,
+                    finalized: GENESIS,
                     with_attrs: false,
                 },
             ],
@@ -351,7 +307,7 @@ fn finality_is_locked_in_before_notarized_convergence() {
         // and queue the second finalized block behind it.
         let n3 = make_block(3, 3, d2);
         let d3 = n3.digest();
-        h.report_pending_head(4, 3, d3);
+        let build = h.build(round(4), d3);
         h.wait_until(|| h.marshal.fulfill_subscription(d3, n3.clone()))
             .await;
         h.run_for(Duration::from_millis(10)).await;
@@ -363,7 +319,11 @@ fn finality_is_locked_in_before_notarized_convergence() {
             .expect("finalization should still be gated");
         w1.await.expect("first block should be acknowledged");
         w2.await.expect("second block should be acknowledged");
-        h.wait_until(|| h.execution.head() == d3).await;
+        h.wait_until(|| !h.execution.pending_payload_jobs().is_empty())
+            .await;
+        let payload_id = h.execution.pending_payload_jobs()[0];
+        h.wait_until(|| h.execution.calls().contains(&ElCall::Resolve(payload_id)))
+            .await;
 
         assert_eq!(
             h.execution.calls(),
@@ -385,8 +345,20 @@ fn finality_is_locked_in_before_notarized_convergence() {
                     finalized: d2,
                     with_attrs: false,
                 },
+                ElCall::Fcu {
+                    head: d3,
+                    finalized: d2,
+                    with_attrs: true,
+                },
+                ElCall::Resolve(payload_id),
             ],
         );
+        let proposal = make_block(4, 4, d3);
+        h.execution
+            .deliver_payload(payload_id, built_payload(&proposal));
+        build
+            .await
+            .expect("build should complete after finality and parent convergence");
     });
 }
 
@@ -669,17 +641,27 @@ fn held_build_is_rescheduled_after_a_stale_repoint() {
             .await
             .expect("verification should complete")
             .expect("a2 should be valid");
-        h.report_pending_head(4, 3, da2);
+        h.verify(round(4), make_block(4, 3, da2))
+            .await
+            .unwrap()
+            .unwrap();
+        // The stale FCU only moves the actor's tracked head. The EL itself
+        // stays on b2, so observe convergence through the actor's gauge.
+        h.wait_until(|| {
+            h.metrics()
+                .lines()
+                .any(|line| line == "executor_convergence_depth 0")
+        })
+        .await;
 
-        // Hold the execution slot with a validation (held itself until the
-        // head is on a2) so that the re-anchor on the finalized tip and the
-        // build on it queue up behind it.
-        let a3 = make_block(4, 3, da2);
+        // Hold the execution slot with another validation so that the build
+        // re-anchoring onto the finalized tip queues up behind it.
+        let a3 = make_block(5, 3, da2);
         let da3 = a3.digest();
         let release = h
             .execution
             .script_delayed_new_payload(da3, Ok(PayloadStatusEnum::Valid));
-        let validation = h.verify(round(4), a3);
+        let validation = h.verify(round(5), a3);
         futures::pin_mut!(validation);
         let deadline = h.run_for(Duration::from_millis(1));
         futures::pin_mut!(deadline);
@@ -689,8 +671,7 @@ fn held_build_is_rescheduled_after_a_stale_repoint() {
         };
         h.wait_until(|| h.execution.new_payloads().last() == Some(&da3))
             .await;
-        h.report_pending_head(5, 1, d1);
-        let build = h.build(round(5), d1);
+        let build = h.build_on(round(6), 1, d1);
         futures::pin_mut!(build);
         release.send(()).expect("validation should still be gated");
         validation

--- a/crates/consensus/src/executor/actor/tests/verify.rs
+++ b/crates/consensus/src/executor/actor/tests/verify.rs
@@ -9,7 +9,7 @@ use commonware_macros::test_traced;
 use commonware_runtime::{Runner as _, deterministic};
 use futures::future::Either;
 
-use super::harness::{GENESIS, Harness, make_block, round};
+use super::harness::{GENESIS, Harness, built_payload, make_block, round};
 
 #[test_traced]
 fn valid_block_resolves_with_a_duration() {
@@ -26,6 +26,126 @@ fn valid_block_resolves_with_a_duration() {
             "a valid block resolves with its duration"
         );
         assert_eq!(h.execution.new_payloads(), vec![b1.digest()]);
+    });
+}
+
+#[test_traced]
+fn verification_selects_only_its_parent_even_when_the_candidate_is_invalid() {
+    for status in [
+        PayloadStatusEnum::Valid,
+        PayloadStatusEnum::Invalid {
+            validation_error: "bad state root".into(),
+        },
+    ] {
+        deterministic::Runner::default().start(|context| async move {
+            let h = Harness::start_at_genesis(&context);
+            let parent = make_block(1, 1, GENESIS);
+            let parent_digest = parent.digest();
+            h.verify(round(1), parent).await.unwrap().unwrap();
+            assert_eq!(h.execution.head(), GENESIS);
+
+            let candidate = make_block(2, 2, parent_digest);
+            let candidate_digest = candidate.digest();
+            let is_valid = matches!(status, PayloadStatusEnum::Valid);
+            h.execution.script_new_payload(candidate_digest, Ok(status));
+            let verdict = h.verify(round(2), candidate).await.unwrap();
+            assert_eq!(verdict.is_some(), is_valid);
+            h.wait_until(|| h.execution.head() == parent_digest).await;
+            assert!(
+                h.execution
+                    .fcus()
+                    .iter()
+                    .all(|(head, _, _)| *head != candidate_digest),
+                "the candidate must never become head through its own verification",
+            );
+
+            // The target survives verification completion. A delayed build
+            // from an older round cannot restore genesis as the pending head.
+            h.build(round(1), GENESIS)
+                .await
+                .expect_err("older build must be dropped");
+            assert_eq!(h.execution.head(), parent_digest);
+        });
+    }
+}
+
+#[test_traced]
+fn older_verification_completion_does_not_restore_its_parent_target() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+        let parent = make_block(1, 1, GENESIS);
+        let parent_digest = parent.digest();
+        h.verify(round(1), parent).await.unwrap().unwrap();
+        let candidate = make_block(2, 2, parent_digest);
+        let candidate_digest = candidate.digest();
+        let release = h
+            .execution
+            .script_delayed_new_payload(candidate_digest, Ok(PayloadStatusEnum::Valid));
+        let verify = Box::pin(h.verify(round(2), candidate));
+        let started =
+            Box::pin(h.wait_until(|| h.execution.new_payloads().contains(&candidate_digest)));
+        let verify = match futures::future::select(verify, started).await {
+            Either::Left(_) => panic!("verification must remain gated"),
+            Either::Right(((), verify)) => verify,
+        };
+
+        // A higher round after nullifications builds on the older ancestor.
+        // Record it while the older verification is still in flight.
+        let proposal = make_block(3, 1, GENESIS);
+        h.execution.script_built_payload(built_payload(&proposal));
+        let build = h.build(round(3), GENESIS);
+        h.run_for(Duration::from_millis(10)).await;
+        release
+            .send(())
+            .expect("verification should still be gated");
+        verify.await.unwrap().unwrap();
+        build.await.expect("newer build should complete on genesis");
+        assert_eq!(h.execution.head(), GENESIS);
+        assert!(
+            h.execution
+                .fcus()
+                .iter()
+                .all(|(head, _, _)| *head != candidate_digest)
+        );
+    });
+}
+
+#[test_traced]
+fn canceled_verification_keeps_its_parent_convergence_target() {
+    deterministic::Runner::default().start(|context| async move {
+        let h = Harness::start_at_genesis(&context);
+        let parent = make_block(1, 1, GENESIS);
+        let parent_digest = parent.digest();
+        let candidate = make_block(2, 2, parent_digest);
+        let candidate_digest = candidate.digest();
+        let _release = h
+            .execution
+            .script_delayed_new_payload(candidate_digest, Ok(PayloadStatusEnum::Valid));
+        let verify = Box::pin(h.verify(round(2), candidate));
+        let started =
+            Box::pin(h.wait_until(|| h.execution.new_payloads().contains(&candidate_digest)));
+        let verify = match futures::future::select(verify, started).await {
+            Either::Left(_) => panic!("verification must remain gated"),
+            Either::Right(((), verify)) => verify,
+        };
+        drop(verify);
+
+        h.wait_until(|| {
+            h.marshal
+                .fulfill_subscription(parent_digest, parent.clone())
+        })
+        .await;
+        h.wait_until(|| h.execution.head() == parent_digest).await;
+        assert_eq!(
+            h.execution.new_payloads(),
+            vec![candidate_digest, parent_digest]
+        );
+        assert!(
+            h.execution
+                .fcus()
+                .iter()
+                .all(|(head, _, _)| *head != candidate_digest)
+        );
     });
 }
 
@@ -78,10 +198,9 @@ fn unknown_parent_fails_fast_when_no_convergence_is_expected() {
     deterministic::Runner::default().start(|context| async move {
         let h = Harness::start_at_genesis(&context);
 
-        // b2's parent b1 was never seen: not the local tip, not being
-        // finalized, not the pending head. The request must not be held
-        // back; it runs, the execution layer reports SYNCING, and the
-        // subscriber learns of the failure through the dropped channel.
+        // b2's parent b1 was never seen. The request selects it as the pending
+        // head, but convergence needs a body fetch first. Verification still
+        // probes immediately, and SYNCING drops the response channel.
         let b1 = make_block(1, 1, GENESIS);
         let b2 = make_block(2, 2, b1.digest());
         let _ = h
@@ -261,8 +380,10 @@ fn cancellation_before_verification_delivery_still_leaves_the_body_for_convergen
         h.run_for(Duration::from_millis(50)).await;
 
         // The recorded body still serves convergence: no fetch is needed
-        // once the block is reported as the pending head.
-        h.report_pending_head(2, 1, d1);
+        // once a build names the block as its parent.
+        let proposal = make_block(2, 2, d1);
+        h.execution.script_built_payload(built_payload(&proposal));
+        h.build(round(2), d1).await.expect("build should complete");
         h.wait_until(|| h.execution.head() == d1).await;
         assert!(h.marshal.subscribe_log().is_empty());
     });

--- a/crates/consensus/src/executor/ingress.rs
+++ b/crates/consensus/src/executor/ingress.rs
@@ -1,6 +1,6 @@
 use alloy_primitives::B256;
 use commonware_actor::Feedback;
-use commonware_consensus::{Reporter, marshal::Update, simplex::types::Context, types::Round};
+use commonware_consensus::{Reporter, marshal::Update, simplex::types::Context};
 use commonware_cryptography::ed25519::PublicKey;
 use eyre::WrapErr as _;
 use futures::channel::{mpsc, oneshot};
@@ -16,28 +16,12 @@ pub(crate) struct Mailbox {
 }
 
 impl Mailbox {
-    /// Reports that, from simplex's point of view, `context`'s parent is
-    /// the pending head of the chain: the block the proposal of this
-    /// context builds on or is verified against. The agent converges the
-    /// execution layer's head onto it.
-    ///
-    /// The parent is necessarily notarized — simplex only hands out
-    /// propose/verify contexts with notarized parents — so the report
-    /// doubles as a notarization proof. Reported parents are not monotonic
-    /// (after nullifications, a later view may build on an older notarized
-    /// block), so the newest *context* wins, and the head may legitimately
-    /// move backwards.
-    pub(crate) fn report_pending_head(
-        &self,
-        context: Context<Digest, PublicKey>,
-    ) -> eyre::Result<()> {
-        self.inner
-            .unbounded_send(Message::in_current_span(PendingHeadReport { context }))
-            .wrap_err("failed sending pending-head report to agent, this means it exited")
-    }
-
-    /// Requests the agent to verify the block proposed in `round` against the
+    /// Requests the agent to verify the block proposed in `context` against the
     /// execution layer.
+    ///
+    /// The parent in the newest request context selects the pending head,
+    /// independently of whether the request completes or is canceled. Verifying
+    /// the candidate does not make the candidate itself the pending head.
     ///
     /// The block is validated via a single new-payload request, which requires
     /// the execution layer to already know the block's parent. If it does not,
@@ -48,14 +32,14 @@ impl Mailbox {
     /// request from a newer round replaces a queued one.
     pub(crate) async fn verify_block(
         &self,
-        round: Round,
+        context: Context<Digest, PublicKey>,
         block: Block,
         validator_set: Option<Vec<B256>>,
     ) -> eyre::Result<Option<Duration>> {
         let (response, rx) = oneshot::channel();
         self.inner
             .unbounded_send(Message::in_current_span(VerifyBlock {
-                round,
+                context,
                 block: Arc::new(block),
                 validator_set,
                 response,
@@ -67,8 +51,10 @@ impl Mailbox {
         )
     }
 
-    /// Requests the executor to build a proposal on top of `digest` in
-    /// `round`.
+    /// Requests the executor to build a proposal on top of `context`'s parent.
+    ///
+    /// The parent in the newest request context selects the pending head,
+    /// independently of whether the request completes or is canceled.
     ///
     /// The built payload is delivered on the returned channel once the
     /// execution layer finishes constructing it. The receiver may be dropped
@@ -78,22 +64,21 @@ impl Mailbox {
     /// Conversely, the executor dropping its sender means the build failed;
     /// the executor logs the cause.
     ///
-    /// If the executor's tracked execution layer state is outdated, the build
-    /// fails fast.
+    /// The build waits for the execution layer's head to converge on its parent.
+    /// It is dropped if that parent is superseded by a newer request's parent or
+    /// by finality before the build starts.
     ///
     /// The round arbitrates the slot shared with validation requests: only a
     /// request from a newer round replaces a queued one.
     pub(crate) fn build_proposal(
         &self,
-        round: Round,
-        digest: Digest,
+        context: Context<Digest, PublicKey>,
         attributes: TempoPayloadAttributes,
     ) -> eyre::Result<oneshot::Receiver<TempoBuiltPayload>> {
         let (response, rx) = oneshot::channel();
         self.inner
             .unbounded_send(Message::in_current_span(Build {
-                round,
-                digest,
+                context,
                 attributes: Box::new(attributes),
                 response,
             }))
@@ -122,38 +107,23 @@ impl Message {
 #[derive(Debug)]
 pub(super) enum Command {
     /// Requests the agent to canonicalize the head and build a new payload.
-    Build(Build),
+    Build(Box<Build>),
     /// Requests the agent to verify a block against the execution layer.
     VerifyBlock(Box<VerifyBlock>),
     /// Requests the agent to forward a finalization event to the execution layer.
     Finalize(Box<Update<Block>>),
-    /// Reports the contained context's parent as the pending head that
-    /// consensus builds on.
-    PendingHeadReport(PendingHeadReport),
-}
-
-#[derive(Debug)]
-pub(super) struct PendingHeadReport {
-    pub(super) context: Context<Digest, PublicKey>,
-}
-
-impl From<PendingHeadReport> for Command {
-    fn from(value: PendingHeadReport) -> Self {
-        Self::PendingHeadReport(value)
-    }
 }
 
 #[derive(Debug)]
 pub(super) struct Build {
-    pub(super) round: Round,
-    pub(super) digest: Digest,
+    pub(super) context: Context<Digest, PublicKey>,
     pub(super) attributes: Box<TempoPayloadAttributes>,
     pub(super) response: oneshot::Sender<TempoBuiltPayload>,
 }
 
 #[derive(Debug)]
 pub(super) struct VerifyBlock {
-    pub(super) round: Round,
+    pub(super) context: Context<Digest, PublicKey>,
     pub(super) block: Arc<Block>,
     pub(super) validator_set: Option<Vec<B256>>,
     pub(super) response: oneshot::Sender<Option<Duration>>,
@@ -161,7 +131,7 @@ pub(super) struct VerifyBlock {
 
 impl From<Build> for Command {
     fn from(value: Build) -> Self {
-        Self::Build(value)
+        Self::Build(Box::new(value))
     }
 }
 


### PR DESCRIPTION
Folds pending head reporting into the `verify` and `build` verbs the application uses to interact with the executor actor.

The reason is that when migrating to deferred verification, verify calls are not guaranteed to be in order and the `pending-head` marker loses its signal.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>