### PR TITLE
perf(precompiles): compare uncached typed slots with direct derivation

### DIFF
--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -221,46 +221,6 @@ mod tests {
     }
 
     #[test]
-    fn test_slot_uncached_matches_indexing() {
-        for base_slot in [U256::ZERO, U256::ONE, U256::MAX] {
-            let mapping = Mapping::<Address, U256>::new(base_slot, Address::ZERO);
-            for key in [
-                Address::ZERO,
-                Address::repeat_byte(0x13),
-                Address::repeat_byte(0xff),
-            ] {
-                let slot = mapping.slot_uncached(key);
-                assert_eq!(slot, key.mapping_slot(base_slot));
-                assert_eq!(slot, mapping[key].slot());
-                assert_eq!(slot, mapping.slot_uncached(key));
-            }
-        }
-    }
-
-    #[test]
-    fn test_slot_uncached_does_not_construct_handler() {
-        struct NoHandler;
-
-        impl StorableType for NoHandler {
-            const LAYOUT: Layout = Layout::Slots(1);
-            type Handler = ();
-
-            fn handle(_: U256, _: LayoutCtx, _: Address) -> Self::Handler {
-                panic!("slot_uncached must not construct a value handler");
-            }
-        }
-
-        let mapping = Mapping::<Address, NoHandler>::new(U256::ONE, Address::ZERO);
-        for key in [
-            Address::ZERO,
-            Address::repeat_byte(0x13),
-            Address::repeat_byte(0xff),
-        ] {
-            assert_eq!(mapping.slot_uncached(key), key.mapping_slot(U256::ONE));
-        }
-    }
-
-    #[test]
     fn test_mapping_basic_properties() {
         let address = Address::random();
         let base_slot = U256::random();
@@ -292,6 +252,7 @@ mod tests {
         let derived_slot = &mapping[test_key];
         let expected_slot = test_key.mapping_slot(base_slot);
         assert_eq!(derived_slot.slot(), expected_slot);
+        assert_eq!(mapping.slot_uncached(test_key), derived_slot.slot());
     }
 
     #[test]
@@ -307,7 +268,6 @@ mod tests {
         // Property 1: Chaining - first .at() returns intermediate Mapping with correct slot
         let intermediate = &nested[key1];
         let expected_intermediate_slot = key1.mapping_slot(base_slot);
-        assert_eq!(nested.slot_uncached(key1), expected_intermediate_slot);
         assert_eq!(
             intermediate.slot(),
             expected_intermediate_slot,
@@ -317,7 +277,6 @@ mod tests {
         // Property 2: Double-hash - second .at() returns final Slot with correct double-derived slot
         let final_slot = &intermediate[key2];
         let expected_final_slot = key2.mapping_slot(expected_intermediate_slot);
-        assert_eq!(intermediate.slot_uncached(key2), expected_final_slot);
         assert_eq!(
             final_slot.slot(),
             expected_final_slot,

--- a/crates/precompiles/src/storage/types/mapping.rs
+++ b/crates/precompiles/src/storage/types/mapping.rs
@@ -66,6 +66,17 @@ impl<K, V: StorableType> Mapping<K, V> {
         self.base_slot
     }
 
+    /// Computes the entry's storage slot without constructing or caching a value handler.
+    ///
+    /// Uses the normal mapping-slot hashing path, including any global keccak caching.
+    #[inline]
+    pub fn slot_uncached(&self, key: K) -> U256
+    where
+        K: StorageKey,
+    {
+        key.mapping_slot(self.base_slot)
+    }
+
     /// Returns a `Handler` for the given key.
     ///
     /// This enables the composable pattern: `mapping.at(&key).read()`
@@ -210,6 +221,46 @@ mod tests {
     }
 
     #[test]
+    fn test_slot_uncached_matches_indexing() {
+        for base_slot in [U256::ZERO, U256::ONE, U256::MAX] {
+            let mapping = Mapping::<Address, U256>::new(base_slot, Address::ZERO);
+            for key in [
+                Address::ZERO,
+                Address::repeat_byte(0x13),
+                Address::repeat_byte(0xff),
+            ] {
+                let slot = mapping.slot_uncached(key);
+                assert_eq!(slot, key.mapping_slot(base_slot));
+                assert_eq!(slot, mapping[key].slot());
+                assert_eq!(slot, mapping.slot_uncached(key));
+            }
+        }
+    }
+
+    #[test]
+    fn test_slot_uncached_does_not_construct_handler() {
+        struct NoHandler;
+
+        impl StorableType for NoHandler {
+            const LAYOUT: Layout = Layout::Slots(1);
+            type Handler = ();
+
+            fn handle(_: U256, _: LayoutCtx, _: Address) -> Self::Handler {
+                panic!("slot_uncached must not construct a value handler");
+            }
+        }
+
+        let mapping = Mapping::<Address, NoHandler>::new(U256::ONE, Address::ZERO);
+        for key in [
+            Address::ZERO,
+            Address::repeat_byte(0x13),
+            Address::repeat_byte(0xff),
+        ] {
+            assert_eq!(mapping.slot_uncached(key), key.mapping_slot(U256::ONE));
+        }
+    }
+
+    #[test]
     fn test_mapping_basic_properties() {
         let address = Address::random();
         let base_slot = U256::random();
@@ -256,6 +307,7 @@ mod tests {
         // Property 1: Chaining - first .at() returns intermediate Mapping with correct slot
         let intermediate = &nested[key1];
         let expected_intermediate_slot = key1.mapping_slot(base_slot);
+        assert_eq!(nested.slot_uncached(key1), expected_intermediate_slot);
         assert_eq!(
             intermediate.slot(),
             expected_intermediate_slot,
@@ -265,6 +317,7 @@ mod tests {
         // Property 2: Double-hash - second .at() returns final Slot with correct double-derived slot
         let final_slot = &intermediate[key2];
         let expected_final_slot = key2.mapping_slot(expected_intermediate_slot);
+        assert_eq!(intermediate.slot_uncached(key2), expected_final_slot);
         assert_eq!(
             final_slot.slot(),
             expected_final_slot,

--- a/crates/precompiles/src/storage_credits/mod.rs
+++ b/crates/precompiles/src/storage_credits/mod.rs
@@ -376,7 +376,10 @@ impl StorageCreditDeltas {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
+    use crate::{
+        storage::{StorageCtx, hashmap::HashMapStorageProvider},
+        tip20::TIP20Token,
+    };
 
     #[test]
     fn test_set_mode_budget_semantics() -> eyre::Result<()> {

--- a/crates/precompiles/src/storage_credits/mod.rs
+++ b/crates/precompiles/src/storage_credits/mod.rs
@@ -13,8 +13,8 @@ use crate::{
     ACCOUNT_KEYCHAIN_ADDRESS, STORAGE_CREDITS_ADDRESS,
     account_keychain::AccountKeychain,
     error::{Result, TempoPrecompileError},
-    storage::{Handler, LayoutCtx, StorableType, StorageCtx, StorageKey},
-    tip20::tip20_slots,
+    storage::{Handler, LayoutCtx, StorableType, StorageCtx},
+    tip20::TIP20Token,
 };
 use alloy::primitives::{Address, U256};
 use std::{cell::OnceCell, collections::BTreeMap};
@@ -321,9 +321,11 @@ impl NonCreditableSlots {
 
     #[inline]
     fn fee_balance_slot(&self) -> U256 {
-        *self
-            .fee_balance_slot
-            .get_or_init(|| self.fee_payer.mapping_slot(tip20_slots::BALANCES))
+        *self.fee_balance_slot.get_or_init(|| {
+            TIP20Token::from_address_unchecked(self.fee_token)
+                .balances
+                .slot_uncached(self.fee_payer)
+        })
     }
 
     #[inline]
@@ -374,10 +376,7 @@ impl StorageCreditDeltas {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        storage::{StorageCtx, hashmap::HashMapStorageProvider},
-        tip20::TIP20Token,
-    };
+    use crate::storage::{StorageCtx, hashmap::HashMapStorageProvider};
 
     #[test]
     fn test_set_mode_budget_semantics() -> eyre::Result<()> {

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -46,10 +46,10 @@ use tempo_precompiles::{
     error::TempoPrecompileError,
     nonce::{INonce::getNonceCall, NonceManager},
     storage::{
-        Handler as _, PrecompileStorageProvider, StorageActions, StorageCtx, StorageKey,
+        Handler as _, PrecompileStorageProvider, StorageActions, StorageCtx,
         evm::EvmPrecompileStorageProvider,
     },
-    tip20::{ITIP20::InsufficientBalance, TIP20Error, tip20_slots},
+    tip20::{ITIP20::InsufficientBalance, TIP20Error, TIP20Token},
     tip20_channel_reserve::TIP20ChannelReserve,
 };
 use tempo_primitives::{
@@ -2458,10 +2458,11 @@ pub fn get_token_balance<JOURNAL>(
 where
     JOURNAL: JournalTr,
 {
-    // Address has already been validated as having TIP20 prefix. Derive the balance slot directly
-    // instead of constructing a full token handle for a single mapping lookup.
+    // Address has already been validated as having TIP20 prefix.
     journal.load_account(token)?;
-    let balance_slot = sender.mapping_slot(tip20_slots::BALANCES);
+    let balance_slot = TIP20Token::from_address_unchecked(token)
+        .balances
+        .slot_uncached(sender);
     let balance = journal.sload(token, balance_slot)?.data;
 
     Ok(balance)

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -21,7 +21,7 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIPFeeAMM};
 use tempo_precompiles::{
     PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, storage::ContractStorage, test_util::TIP20Setup,
-    tip_fee_manager::TipFeeManager,
+    tip_fee_manager::TipFeeManager, tip20::TIP20Token,
 };
 use tempo_primitives::transaction::{
     Call, PrimitiveSignature, RecoveredTempoAuthorization, TempoSignature,

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -21,7 +21,7 @@ use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIPFeeAMM};
 use tempo_precompiles::{
     PATH_USD_ADDRESS, TIP_FEE_MANAGER_ADDRESS, storage::ContractStorage, test_util::TIP20Setup,
-    tip_fee_manager::TipFeeManager, tip20::TIP20Token,
+    tip_fee_manager::TipFeeManager,
 };
 use tempo_primitives::transaction::{
     Call, PrimitiveSignature, RecoveredTempoAuthorization, TempoSignature,

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -27,7 +27,10 @@ use std::{
 };
 use tempo_contracts::precompiles::ITIP20;
 use tempo_precompiles::{
-    DEFAULT_FEE_TOKEN, nonce::NonceManager, storage::StorageKey, tip20::tip20_slots,
+    DEFAULT_FEE_TOKEN,
+    nonce::NonceManager,
+    storage::StorageKey,
+    tip20::{TIP20Token, tip20_slots},
     tip403_registry::tip403_registry_slots,
 };
 use tempo_primitives::{
@@ -427,7 +430,9 @@ impl TempoPooledTransaction {
                 .resolved_fee_token()
                 .unwrap_or_else(|| self.inner().fee_token().unwrap_or(DEFAULT_FEE_TOKEN));
             let fee_payer = self.fee_payer().ok()?;
-            let slot = fee_payer.mapping_slot(tip20_slots::BALANCES);
+            let slot = TIP20Token::from_address_unchecked(fee_token)
+                .balances
+                .slot_uncached(fee_payer);
             Some((fee_token, slot))
         })
     }


### PR DESCRIPTION
This PR adds `Mapping::slot_uncached()`, which computes a storage slot without creating or caching a handler for that entry. It uses this method for the three fee-balance lookups in #7425 to preserve its optimization with the typed API