### PR TITLE
fix(rpc): include input and value compatibility fields

### DIFF
--- a/crates/alloy/src/rpc/receipt.rs
+++ b/crates/alloy/src/rpc/receipt.rs
@@ -20,7 +20,7 @@ pub struct TempoTransactionReceipt {
     pub input: Bytes,
 
     /// Compatibility placeholder for EVM tooling that expects transaction value on receipts.
-    #[serde(default, with = "alloy_serde::quantity")]
+    #[serde(default)]
     pub value: U256,
 
     /// Token that was used to pay fees for the transaction.

--- a/crates/alloy/src/rpc/receipt.rs
+++ b/crates/alloy/src/rpc/receipt.rs
@@ -1,6 +1,6 @@
 use alloy_consensus::ReceiptWithBloom;
 use alloy_network::ReceiptResponse;
-use alloy_primitives::{Address, B256, BlockHash, TxHash};
+use alloy_primitives::{Address, B256, BlockHash, Bytes, TxHash, U256};
 use alloy_rpc_types_eth::{Log, TransactionReceipt};
 use serde::{Deserialize, Serialize};
 use tempo_primitives::TempoReceipt;
@@ -14,6 +14,14 @@ pub struct TempoTransactionReceipt {
     #[deref]
     #[deref_mut]
     pub inner: TransactionReceipt<ReceiptWithBloom<TempoReceipt<Log>>>,
+
+    /// Compatibility placeholder for EVM tooling that expects transaction input on receipts.
+    #[serde(default)]
+    pub input: Bytes,
+
+    /// Compatibility placeholder for EVM tooling that expects transaction value on receipts.
+    #[serde(default, with = "alloy_serde::quantity")]
+    pub value: U256,
 
     /// Token that was used to pay fees for the transaction.
     ///

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -592,6 +592,8 @@ where
             .map(|(inner, tx)| {
                 let mut receipt = TempoTransactionReceipt {
                     inner,
+                    input: Default::default(),
+                    value: U256::ZERO,
                     fee_token: None,
                     // should never fail, we only deal with valid transactions here
                     fee_payer: tx

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -848,6 +848,17 @@ pub(super) async fn run_fill_sign_send_matrix<E: TestEnv>(env: &mut E) -> eyre::
 // Unified matrix runners, generic over TestEnv
 // ===========================================================================
 
+fn assert_evm_compat_fields(value: &serde_json::Value) {
+    assert_eq!(
+        value["input"], "0x",
+        "input compatibility field should be present and empty"
+    );
+    assert_eq!(
+        value["value"], "0x0",
+        "value compatibility field should be present and zero"
+    );
+}
+
 /// Submit a signed envelope and assert the expected outcome.
 /// When `sync` is true, uses `submit_tx_sync` for the Success path.
 /// When `fee_payer_ctx` is Some on Success, asserts that the fee payer spent tokens.
@@ -872,6 +883,7 @@ async fn submit_expecting<E: TestEnv>(
                 .map(|s| s == "0x1")
                 .unwrap_or(false);
             assert!(status, "Transaction should succeed");
+            assert_evm_compat_fields(&receipt);
             if let Some(ctx) = fee_payer_ctx {
                 assert_fee_payer_spent(env.provider(), ctx, &receipt).await?;
             }
@@ -889,6 +901,7 @@ async fn submit_expecting<E: TestEnv>(
                 .map(|s| s == "0x1")
                 .unwrap_or(false);
             assert!(!status, "Transaction should revert (status 0x0)");
+            assert_evm_compat_fields(&receipt);
         }
     }
     Ok(tx_hash)
@@ -1894,6 +1907,7 @@ pub(super) async fn run_fill_sign_send<E: TestEnv>(
             .raw_request("eth_getTransactionByHash".into(), [tx_hash])
             .await?;
         let tx_data = raw_tx.expect("Mined transaction should be retrievable via RPC");
+        assert_evm_compat_fields(&tx_data);
         let nonce_key_str = tx_data["nonceKey"]
             .as_str()
             .expect("nonceKey field should be present in transaction response");

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -463,7 +463,7 @@ mod serde_impl {
         tx: Cow<'a, TempoTransaction>,
         #[serde(default)]
         input: Bytes,
-        #[serde(default, with = "alloy_serde::quantity")]
+        #[serde(default)]
         value: U256,
         signature: Cow<'a, TempoSignature>,
         hash: Cow<'a, B256>,

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -461,6 +461,10 @@ mod serde_impl {
     struct AASignedHelper<'a> {
         #[serde(flatten)]
         tx: Cow<'a, TempoTransaction>,
+        #[serde(default)]
+        input: Bytes,
+        #[serde(default, with = "alloy_serde::quantity")]
+        value: U256,
         signature: Cow<'a, TempoSignature>,
         hash: Cow<'a, B256>,
     }
@@ -476,6 +480,8 @@ mod serde_impl {
             }
             AASignedHelper {
                 tx: Cow::Borrowed(&self.tx),
+                input: Bytes::new(),
+                value: U256::ZERO,
                 signature: Cow::Borrowed(&self.signature),
                 hash: Cow::Borrowed(self.hash()),
             }
@@ -538,6 +544,9 @@ mod serde_impl {
                 !json.contains("signature_hash"),
                 "signature_hash cache must not be serialized"
             );
+            let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+            assert_eq!(value["input"], "0x");
+            assert_eq!(value["value"], "0x0");
 
             println!("\n=== AASigned JSON Output ===");
             println!("{json}");


### PR DESCRIPTION
## Summary
- add `input` and `value` compatibility fields to Tempo transaction receipts with empty/zero defaults
- emit the same top-level placeholders for Tempo AA transaction JSON while keeping `calls` authoritative
- assert both fields in transaction serialization and RPC integration coverage

## Tests
- `cargo +1.95.0 fmt --all -- --check`
- `cargo +1.95.0 test -p tempo-primitives test_serde_output`
- `cargo +1.95.0 check -p tempo-alloy --features reth`
- `CXX=g++ cargo +1.95.0 check -p tempo-node --tests`

Fixes #1184