### PR TITLE
fix(docs): propagate cargo documentation build failures

### DIFF
--- a/scripts/build-cargo-docs.sh
+++ b/scripts/build-cargo-docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Script to build cargo docs with the same flags as used in CI
 


### PR DESCRIPTION
Fixes #7533

Stops `build-cargo-docs.sh` immediately when `cargo docs` fails, so callers receive the original non-zero status and the success message is not printed. The failure and success paths were validated with stub Cargo commands, and `bash -n scripts/build-cargo-docs.sh` passes.
