### PR TITLE
fix(payload): account for queue time in build budgets

### DIFF
--- a/crates/consensus/src/executor/actor/tests/build.rs
+++ b/crates/consensus/src/executor/actor/tests/build.rs
@@ -414,6 +414,8 @@ fn payload_attributes_reach_the_execution_layer_unchanged() {
             Vec::new,
         )
         .with_payload_build_budget(build_budget);
+        let build_start = std::time::Instant::now();
+        let remaining_budget = attributes.payload_build_budget(build_start);
 
         let proposal = make_block(1, 1, GENESIS);
         h.execution.script_built_payload(built_payload(&proposal));
@@ -429,7 +431,7 @@ fn payload_attributes_reach_the_execution_layer_unchanged() {
         assert_eq!(received.timestamp_millis(), 123_456);
         assert_eq!(received.extra_data(), &extra_data);
         assert_eq!(received.consensus_context(), Some(consensus_context));
-        assert_eq!(received.payload_build_budget(), Some(build_budget));
+        assert_eq!(received.payload_build_budget(build_start), remaining_budget);
         assert!(received.validation_latency_estimate().is_none());
         assert!(received.subblocks().is_empty());
     });

--- a/crates/payload/builder/src/lib.rs
+++ b/crates/payload/builder/src/lib.rs
@@ -394,6 +394,7 @@ where
         check_cancel!();
 
         let start = Instant::now();
+        let payload_build_budget = attributes.payload_build_budget(start);
 
         let block_time_millis =
             (attributes.timestamp_millis() - parent_header.timestamp_millis()) as f64;
@@ -634,7 +635,6 @@ where
         // Consensus builds carry a remaining proposal budget. When present, the
         // builder stops pool tx execution before projected proposer and validator
         // work would consume that window.
-        let payload_build_budget = attributes.payload_build_budget();
         let build_time_multiplier = self.build_time_multiplier();
         let marshal_persist = marshal_persist_estimate();
         let validation_latency = attributes.validation_latency_estimate();
@@ -1264,6 +1264,7 @@ where
             subblock_transactions,
             total_transactions,
             ?elapsed,
+            ?payload_build_budget,
             ?validation_work_duration,
             ?validation_latency_duration,
             ?normal_transaction_fill_elapsed,

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -5,7 +5,10 @@ use alloy_rpc_types_eth::Withdrawal;
 use reth_ethereum_engine_primitives::EthPayloadAttributes;
 use reth_node_api::PayloadAttributes;
 use serde::{Deserialize, Serialize};
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tempo_primitives::{RecoveredSubBlock, TempoConsensusContext};
 
 /// Container type for all components required to build a payload.
@@ -23,11 +26,12 @@ pub struct TempoPayloadAttributes {
     inner: EthPayloadAttributes,
     /// Remaining local proposal budget available to this payload build.
     ///
-    /// Consensus sets this to the proposal return budget left when it dispatches
-    /// the build. `None` means the build was not requested by consensus, so the
+    /// Consensus records the budget and its monotonic start when it dispatches
+    /// the build, so queueing does not restart the proposal window.
+    /// `None` means the build was not requested by consensus, so the
     /// builder should not stop early for block pacing.
     #[serde(skip)]
-    payload_build_budget: Option<Duration>,
+    payload_build_budget: Option<(Instant, Duration)>,
     /// Validation latency estimate for a consensus payload build.
     ///
     /// Consensus snapshots this from recent locally validated blocks. `None`
@@ -109,17 +113,23 @@ impl TempoPayloadAttributes {
     /// requested. The builder treats it as a shared budget for leader
     /// build/persist work and validator replay/persist work.
     pub fn with_payload_build_budget(mut self, budget: Duration) -> Self {
-        self.payload_build_budget = Some(budget);
+        self.payload_build_budget = Some((Instant::now(), budget));
         self
     }
 
-    /// Returns the consensus-provided build budget, if this is a paced build.
+    /// Returns the proposal budget remaining at builder entry.
+    ///
+    /// Pass the same instant used to measure elapsed builder work. This charges
+    /// executor, forkchoice-update, and payload-worker queueing once, without
+    /// charging builder setup twice. Cloned attributes retain the original clock.
     ///
     /// `None` is intentional for non-consensus builds such as dev or external
     /// payload requests; those builds are not constrained by the consensus
     /// block-time budget.
-    pub fn payload_build_budget(&self) -> Option<Duration> {
-        self.payload_build_budget
+    pub fn payload_build_budget(&self, build_start: Instant) -> Option<Duration> {
+        self.payload_build_budget.map(|(requested_at, budget)| {
+            budget.saturating_sub(build_start.saturating_duration_since(requested_at))
+        })
     }
 
     /// Sets the validation latency estimate for a consensus payload build.
@@ -256,6 +266,55 @@ mod tests {
     use super::*;
     use alloy_rpc_types_eth::Withdrawal;
     use tempo_primitives::ed25519::PublicKey;
+
+    #[test]
+    fn payload_budget_includes_queue_time_and_survives_cloning() {
+        let attrs =
+            TempoPayloadAttributes::default().with_payload_build_budget(Duration::from_millis(500));
+        let (requested_at, _) = attrs.payload_build_budget.unwrap();
+        let queued = attrs.clone();
+
+        assert_eq!(
+            queued.payload_build_budget(requested_at + Duration::from_millis(300)),
+            Some(Duration::from_millis(200)),
+        );
+        // A later worker attempt must not restart the original window.
+        assert_eq!(
+            queued.payload_build_budget(requested_at + Duration::from_millis(450)),
+            Some(Duration::from_millis(50)),
+        );
+    }
+
+    #[test]
+    fn expired_payload_budget_stays_paced() {
+        let attrs =
+            TempoPayloadAttributes::default().with_payload_build_budget(Duration::from_millis(500));
+        let (requested_at, _) = attrs.payload_build_budget.unwrap();
+        for elapsed in [500, 501, 10_000] {
+            assert_eq!(
+                attrs.payload_build_budget(requested_at + Duration::from_millis(elapsed)),
+                Some(Duration::ZERO),
+            );
+        }
+        assert_eq!(
+            TempoPayloadAttributes::default().payload_build_budget(requested_at),
+            None,
+        );
+    }
+
+    #[test]
+    fn payload_budget_clock_is_local_only() {
+        let attrs =
+            TempoPayloadAttributes::default().with_payload_build_budget(Duration::from_millis(500));
+        let encoded = serde_json::to_value(&attrs).unwrap();
+        assert!(encoded.get("payloadBuildBudget").is_none());
+        let decoded: TempoPayloadAttributes = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.payload_build_budget(Instant::now()), None);
+        assert_eq!(
+            attrs.payload_id(&B256::ZERO),
+            decoded.payload_id(&B256::ZERO)
+        );
+    }
 
     trait TestExt: Sized {
         fn random() -> Self;

--- a/crates/payload/types/src/attrs.rs
+++ b/crates/payload/types/src/attrs.rs
@@ -273,6 +273,7 @@ mod tests {
             TempoPayloadAttributes::default().with_payload_build_budget(Duration::from_millis(500));
         let (requested_at, _) = attrs.payload_build_budget.unwrap();
         let queued = attrs.clone();
+        assert_eq!(queued.payload_build_budget, attrs.payload_build_budget);
 
         assert_eq!(
             queued.payload_build_budget(requested_at + Duration::from_millis(300)),


### PR DESCRIPTION
Subtract executor, forkchoice-update, and worker queue time from the proposal budget before packing transactions. Preserve the original monotonic clock across attribute clones and build attempts, so a delayed build cannot restart an expired window; include the remaining budget in the payload log.

In [three regional pairs](https://github.com/tempoxyz/tempo/actions/runs/34203107054), mean block interval falls 4.7% (778 → 741 ms), while sustained TPS falls 3.0% (5,749 → 5,579). This corrects deadline accounting; it does not remove persistence stalls or establish a throughput improvement.

# PR stack
Review the common base first; the follow-ups are independent:

1. fix(payload): account for queue time in build budgets #7535 — this PR
2. perf(net): benchmark bounded transaction fetching #7539
3. fix(payload): bound prewarming coordinator waits #7540
4. chore(consensus): report proposal return waits #7553
