### PR TITLE
ci(bench): pin tcp metrics runner for validation

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -405,7 +405,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: e1c94e1660d7a4598866c7e855f2ec231cba206c # TCP route/qdisc diagnostics validation
+          ref: bb575178180237726e6510712a75a46026b4d1be # TCP route/qdisc diagnostics validation
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -297,7 +297,7 @@ jobs:
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BENCH_ARGS: ${{ inputs['bench-args'] || '' }}
       BENCH_INPUT_RUN_PAIRS: ${{ inputs['run-pairs'] || (github.event_name == 'pull_request' && '1') || '3' }}
-      BENCH_INPUT_CLICKHOUSE_RUN: ${{ inputs['clickhouse-run'] || 'feature-1' }}
+      BENCH_INPUT_CLICKHOUSE_RUN: "" # Publish both validation phases
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
       CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
@@ -561,7 +561,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
+            --metrics-push-url "" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -615,7 +615,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
+            --metrics-push-url "" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -662,7 +662,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
+            --metrics-push-url "" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -709,7 +709,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
+            --metrics-push-url "" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -406,7 +406,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: 414751efc6d4f26f6a35259923f2ea812d3bcd54 # TCP route/qdisc diagnostics validation
+          ref: a27f8d96ab3067a50f334c01c960c2e6c1b911a3 # TCP route/qdisc diagnostics validation
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false
@@ -773,6 +773,9 @@ jobs:
           echo "path=$results_dir" >> "$GITHUB_OUTPUT"
           echo "Results directory: $results_dir"
 
+      - name: Publish and verify high-resolution validator TCP
+        run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" "$BENCH_RESULTS_DIR"
+
       - name: Verify TCP rows were automatically published
         run: |
           python3 - <<'PY'
@@ -797,7 +800,7 @@ jobs:
               run_id = str(uuid.UUID(report["benchmark_id"]))
               with gzip.open(root / phase / "txgen-report.samples.ndjson.gz", "rt") as samples:
                   expected = sum(1 for line in samples if json.loads(line)["name"].startswith("tempo_tcp_"))
-              rows = int(query(f"SELECT count() FROM txgen_metric_samples WHERE run_id='{run_id}' AND startsWith(metric_name, 'tempo_tcp_')"))
+              rows = int(query(f"SELECT count() FROM txgen_metric_samples WHERE run_id='{run_id}' AND source != 'tcp-highres' AND startsWith(metric_name, 'tempo_tcp_')"))
               marker = int(query(f"SELECT count() FROM txgen_runs WHERE run_id='{run_id}'"))
               result = {"phase": phase, "run_id": run_id, "tcp_archive_rows": expected, "tcp_clickhouse_rows": rows, "run_markers": marker}
               results.append(result)

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -265,7 +265,6 @@ jobs:
       TERRAFORM_DIR: ${{ (inputs.cloud || 'aws') == 'gcp' && 'tempo-multi-region-benchmark/terraform/gcp' || 'tempo-multi-region-benchmark/terraform' }}
       BENCHMARK_ID: bench-e2e-multi-region-${{ github.run_id }}-${{ github.run_attempt }}
       BENCH_RESULTS_DIR: tempo-bench-e2e-multi-region-results
-      BENCH_RPC_PATH_COMPARISON: "true"
       BENCH_INPUT_CLOUD: ${{ inputs.cloud || 'aws' }}
       BENCH_GCP_PROJECT_ID: chain-benchmarking-zygis
       BENCH_GCP_WIF_PROVIDER: projects/383683155128/locations/global/workloadIdentityPools/tempo-benchmark/providers/tempo-benchmark
@@ -298,7 +297,7 @@ jobs:
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BENCH_ARGS: ${{ inputs['bench-args'] || '' }}
       BENCH_INPUT_RUN_PAIRS: ${{ inputs['run-pairs'] || (github.event_name == 'pull_request' && '1') || '3' }}
-      BENCH_INPUT_CLICKHOUSE_RUN: "" # Publish the feature validation run
+      BENCH_INPUT_CLICKHOUSE_RUN: ${{ inputs['clickhouse-run'] || 'feature-1' }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
       CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
@@ -350,15 +349,6 @@ jobs:
             fi
           done
 
-      - name: Require automatic ClickHouse publishing
-        run: |
-          for name in CLICKHOUSE_URL CLICKHOUSE_USER CLICKHOUSE_PASSWORD; do
-            if [[ -z "${!name:-}" ]]; then
-              echo "::error::$name is required for this TCP validation run"
-              exit 1
-            fi
-          done
-
       - name: Fetch ClickHouse metric allowlist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -385,13 +375,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: 31e7d3811840ab5e8d906144601efc07b0fe8ac0 # Validator TCP diagnostics validation
+          ref: e1c94e1660d7a4598866c7e855f2ec231cba206c # TCP metrics PR #386
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false
-
-      - name: Verify ClickHouse access before provisioning
-        run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" --check-access
 
       - name: Validate Tempo commit ancestry
         run: |
@@ -529,7 +516,6 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
-            --run-side feature \
             --stage fetch-tempo-binaries \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -553,7 +539,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "--disable-tx-gossip" \
+            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -566,7 +552,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "" \
+            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -584,7 +570,6 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
-            --run-side feature \
             --stage generate-initial-validator-state \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -608,7 +593,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "--disable-tx-gossip" \
+            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -621,7 +606,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "" \
+            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -632,7 +617,6 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
-            --run-side feature \
             --stage initialize-validator-state \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -656,7 +640,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "--disable-tx-gossip" \
+            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -669,7 +653,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "" \
+            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -680,7 +664,6 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
-            --run-side feature \
             --stage run-benchmarks \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -704,7 +687,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "--disable-tx-gossip" \
+            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -717,7 +700,7 @@ jobs:
             --regions "${{ steps.regions.outputs.regions }}" \
             --instance-type "$BENCH_INPUT_INSTANCE_TYPE" \
             --local-ssd-count "$BENCH_INPUT_LOCAL_SSD_COUNT" \
-            --metrics-push-url "" \
+            --metrics-push-url "${{ secrets.BENCH_VICTORIAMETRICS_URL }}" \
             --logs-push-url "${{ secrets.TEMPO_TELEMETRY_URL || secrets.BENCH_LOGS_PUSH_URL }}" \
             --victoriametrics-url "${{ secrets.VICTORIAMETRICS_URL }}" \
             --victorialogs-url "${{ secrets.VICTORIALOGS_URL }}"
@@ -754,12 +737,6 @@ jobs:
           fi
           echo "path=$results_dir" >> "$GITHUB_OUTPUT"
           echo "Results directory: $results_dir"
-
-      - name: Publish and verify high-resolution validator TCP
-        run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" "$BENCH_RESULTS_DIR"
-
-      - name: Verify TCP rows were automatically published
-        run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" "$BENCH_RESULTS_DIR" --verify-publication
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -358,6 +358,27 @@ jobs:
             fi
           done
 
+      - name: Verify ClickHouse access before provisioning
+        run: |
+          python3 - <<'PY'
+          import os, urllib.request, uuid, json, gzip
+          from pathlib import Path
+
+          def query(sql):
+              request = urllib.request.Request(os.environ["CLICKHOUSE_URL"], data=sql.encode(), headers={
+                  "X-ClickHouse-User": os.environ["CLICKHOUSE_USER"],
+                  "X-ClickHouse-Key": os.environ["CLICKHOUSE_PASSWORD"],
+              })
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      return response.read().decode().strip()
+              except Exception as exc:
+                  raise SystemExit("ClickHouse verification failed: " + type(exc).__name__) from None
+
+          assert query("SELECT 1") == "1"
+          print("ClickHouse authenticated query succeeded")
+          PY
+
       - name: Fetch ClickHouse metric allowlist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -746,6 +767,39 @@ jobs:
           fi
           echo "path=$results_dir" >> "$GITHUB_OUTPUT"
           echo "Results directory: $results_dir"
+
+      - name: Verify TCP rows were automatically published
+        run: |
+          python3 - <<'PY'
+          import os, urllib.request, uuid, json, gzip
+          from pathlib import Path
+
+          def query(sql):
+              request = urllib.request.Request(os.environ["CLICKHOUSE_URL"], data=sql.encode(), headers={
+                  "X-ClickHouse-User": os.environ["CLICKHOUSE_USER"],
+                  "X-ClickHouse-Key": os.environ["CLICKHOUSE_PASSWORD"],
+              })
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      return response.read().decode().strip()
+              except Exception as exc:
+                  raise SystemExit("ClickHouse verification failed: " + type(exc).__name__) from None
+
+          root = Path(os.environ["BENCH_RESULTS_DIR"])
+          results = []
+          for phase in ("baseline-1", "feature-1"):
+              report = json.loads((root / phase / "txgen-report.json").read_text())
+              run_id = str(uuid.UUID(report["benchmark_id"]))
+              with gzip.open(root / phase / "txgen-report.samples.ndjson.gz", "rt") as samples:
+                  expected = sum(1 for line in samples if json.loads(line)["name"].startswith("tempo_tcp_"))
+              rows = int(query(f"SELECT count() FROM txgen_metric_samples WHERE run_id='{run_id}' AND startsWith(metric_name, 'tempo_tcp_')"))
+              marker = int(query(f"SELECT count() FROM txgen_runs WHERE run_id='{run_id}'"))
+              result = {"phase": phase, "run_id": run_id, "tcp_archive_rows": expected, "tcp_clickhouse_rows": rows, "run_markers": marker}
+              results.append(result)
+              print(json.dumps(result))
+          (root / "tcp-publication-verification.json").write_text(json.dumps(results, indent=2))
+          assert all(r["tcp_archive_rows"] > 0 and r["tcp_archive_rows"] == r["tcp_clickhouse_rows"] and r["run_markers"] == 1 for r in results), "TCP publication counts differ from archives"
+          PY
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -265,6 +265,7 @@ jobs:
       TERRAFORM_DIR: ${{ (inputs.cloud || 'aws') == 'gcp' && 'tempo-multi-region-benchmark/terraform/gcp' || 'tempo-multi-region-benchmark/terraform' }}
       BENCHMARK_ID: bench-e2e-multi-region-${{ github.run_id }}-${{ github.run_attempt }}
       BENCH_RESULTS_DIR: tempo-bench-e2e-multi-region-results
+      BENCH_RPC_PATH_COMPARISON: "true"
       BENCH_INPUT_CLOUD: ${{ inputs.cloud || 'aws' }}
       BENCH_GCP_PROJECT_ID: chain-benchmarking-zygis
       BENCH_GCP_WIF_PROVIDER: projects/383683155128/locations/global/workloadIdentityPools/tempo-benchmark/providers/tempo-benchmark
@@ -405,7 +406,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: bb575178180237726e6510712a75a46026b4d1be # TCP route/qdisc diagnostics validation
+          ref: 414751efc6d4f26f6a35259923f2ea812d3bcd54 # TCP route/qdisc diagnostics validation
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false
@@ -546,6 +547,7 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
+            --run-side feature \
             --stage fetch-tempo-binaries \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -569,7 +571,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-args "--disable-tx-gossip" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -600,6 +602,7 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
+            --run-side feature \
             --stage generate-initial-validator-state \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -623,7 +626,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-args "--disable-tx-gossip" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -647,6 +650,7 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
+            --run-side feature \
             --stage initialize-validator-state \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -670,7 +674,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-args "--disable-tx-gossip" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -694,6 +698,7 @@ jobs:
         continue-on-error: true
         run: |
           "$BENCH_REPO_DIR/scripts/run_comparison.sh" \
+            --run-side feature \
             --stage run-benchmarks \
             --cloud "$BENCH_INPUT_CLOUD" \
             --gcp-project-id "$BENCH_GCP_PROJECT_ID" \
@@ -717,7 +722,7 @@ jobs:
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
-            --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
+            --feature-args "--disable-tx-gossip" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
             --general-gas-limit "$BENCH_INPUT_GENERAL_GAS_LIMIT" \
             --no-cache "$BENCH_INPUT_NO_CACHE" \
@@ -787,7 +792,7 @@ jobs:
 
           root = Path(os.environ["BENCH_RESULTS_DIR"])
           results = []
-          for phase in ("baseline-1", "feature-1"):
+          for phase in ("feature-1",):
               report = json.loads((root / phase / "txgen-report.json").read_text())
               run_id = str(uuid.UUID(report["benchmark_id"]))
               with gzip.open(root / phase / "txgen-report.samples.ndjson.gz", "rt") as samples:

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -406,7 +406,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: a27f8d96ab3067a50f334c01c960c2e6c1b911a3 # TCP route/qdisc diagnostics validation
+          ref: 9f83bbb1856bb23431f9655d7085df523618d6fb # TCP route/qdisc diagnostics validation
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -298,7 +298,7 @@ jobs:
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BENCH_ARGS: ${{ inputs['bench-args'] || '' }}
       BENCH_INPUT_RUN_PAIRS: ${{ inputs['run-pairs'] || (github.event_name == 'pull_request' && '1') || '3' }}
-      BENCH_INPUT_CLICKHOUSE_RUN: "" # Publish both validation phases
+      BENCH_INPUT_CLICKHOUSE_RUN: "" # Publish the feature validation run
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}
       CLICKHOUSE_PASSWORD: ${{ secrets.CLICKHOUSE_PASSWORD }}
@@ -359,27 +359,6 @@ jobs:
             fi
           done
 
-      - name: Verify ClickHouse access before provisioning
-        run: |
-          python3 - <<'PY'
-          import os, urllib.request, uuid, json, gzip
-          from pathlib import Path
-
-          def query(sql):
-              request = urllib.request.Request(os.environ["CLICKHOUSE_URL"], data=sql.encode(), headers={
-                  "X-ClickHouse-User": os.environ["CLICKHOUSE_USER"],
-                  "X-ClickHouse-Key": os.environ["CLICKHOUSE_PASSWORD"],
-              })
-              try:
-                  with urllib.request.urlopen(request, timeout=60) as response:
-                      return response.read().decode().strip()
-              except Exception as exc:
-                  raise SystemExit("ClickHouse verification failed: " + type(exc).__name__) from None
-
-          assert query("SELECT 1") == "1"
-          print("ClickHouse authenticated query succeeded")
-          PY
-
       - name: Fetch ClickHouse metric allowlist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -406,10 +385,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: 9f83bbb1856bb23431f9655d7085df523618d6fb # TCP route/qdisc diagnostics validation
+          ref: 31e7d3811840ab5e8d906144601efc07b0fe8ac0 # Validator TCP diagnostics validation
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false
+
+      - name: Verify ClickHouse access before provisioning
+        run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" --check-access
 
       - name: Validate Tempo commit ancestry
         run: |
@@ -777,37 +759,7 @@ jobs:
         run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" "$BENCH_RESULTS_DIR"
 
       - name: Verify TCP rows were automatically published
-        run: |
-          python3 - <<'PY'
-          import os, urllib.request, uuid, json, gzip
-          from pathlib import Path
-
-          def query(sql):
-              request = urllib.request.Request(os.environ["CLICKHOUSE_URL"], data=sql.encode(), headers={
-                  "X-ClickHouse-User": os.environ["CLICKHOUSE_USER"],
-                  "X-ClickHouse-Key": os.environ["CLICKHOUSE_PASSWORD"],
-              })
-              try:
-                  with urllib.request.urlopen(request, timeout=60) as response:
-                      return response.read().decode().strip()
-              except Exception as exc:
-                  raise SystemExit("ClickHouse verification failed: " + type(exc).__name__) from None
-
-          root = Path(os.environ["BENCH_RESULTS_DIR"])
-          results = []
-          for phase in ("feature-1",):
-              report = json.loads((root / phase / "txgen-report.json").read_text())
-              run_id = str(uuid.UUID(report["benchmark_id"]))
-              with gzip.open(root / phase / "txgen-report.samples.ndjson.gz", "rt") as samples:
-                  expected = sum(1 for line in samples if json.loads(line)["name"].startswith("tempo_tcp_"))
-              rows = int(query(f"SELECT count() FROM txgen_metric_samples WHERE run_id='{run_id}' AND source != 'tcp-highres' AND startsWith(metric_name, 'tempo_tcp_')"))
-              marker = int(query(f"SELECT count() FROM txgen_runs WHERE run_id='{run_id}'"))
-              result = {"phase": phase, "run_id": run_id, "tcp_archive_rows": expected, "tcp_clickhouse_rows": rows, "run_markers": marker}
-              results.append(result)
-              print(json.dumps(result))
-          (root / "tcp-publication-verification.json").write_text(json.dumps(results, indent=2))
-          assert all(r["tcp_archive_rows"] > 0 and r["tcp_archive_rows"] == r["tcp_clickhouse_rows"] and r["run_markers"] == 1 for r in results), "TCP publication counts differ from archives"
-          PY
+        run: python3 "$BENCH_REPO_DIR/scripts/publish_tcp_highres.py" "$BENCH_RESULTS_DIR" --verify-publication
 
       - name: Upload artifacts
         if: always()

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -349,6 +349,15 @@ jobs:
             fi
           done
 
+      - name: Require automatic ClickHouse publishing
+        run: |
+          for name in CLICKHOUSE_URL CLICKHOUSE_USER CLICKHOUSE_PASSWORD; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::$name is required for this TCP validation run"
+              exit 1
+            fi
+          done
+
       - name: Fetch ClickHouse metric allowlist
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
@@ -375,7 +384,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: tempoxyz/tempo-multi-region-benchmark
-          ref: ${{ github.repository == 'tempoxyz/tempo-multi-region-benchmark' && github.sha || 'main' }}
+          ref: e1c94e1660d7a4598866c7e855f2ec231cba206c # TCP route/qdisc diagnostics validation
           path: ${{ env.BENCH_REPO_DIR }}
           token: ${{ steps.github-sts.outputs.token }}
           persist-credentials: false


### PR DESCRIPTION
Pins the benchmark runner to the TCP-only collector in [benchmark PR #386](https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/386). This temporary validation PR preserves the base workflow’s inputs, phase selection, gossip behavior, txgen placement, and reporting configuration.

The pinned collector was exercised in [run 34209190918](https://github.com/tempoxyz/tempo/actions/runs/34209190918); the cleaned workflow has not been rerun. The current diff is only the runner revision pin.
