### PR TITLE
feat(bench): expose configurable multi-region instance types

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -49,6 +49,16 @@ on:
         type: string
         required: false
         default: ""
+      instance-type:
+        description: Instance type for validators and snapshot builder. Empty uses the cloud default.
+        type: string
+        required: false
+        default: ""
+      local-ssd-count:
+        description: GCP Local SSD count. Empty uses the machine requirement or bloat-tier default.
+        type: string
+        required: false
+        default: ""
       tps:
         description: Target transactions per second.
         type: string
@@ -165,6 +175,8 @@ jobs:
       bloat: ${{ inputs.bloat || '100' }}
       validator-count: ${{ inputs['validator-count'] || '10' }}
       regions: ${{ inputs.regions || '' }}
+      instance-type: ${{ inputs['instance-type'] || '' }}
+      local-ssd-count: ${{ inputs['local-ssd-count'] || '' }}
       tps: ${{ inputs.tps || '50000' }}
       accounts: ${{ inputs.accounts || '1000' }}
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '5000' }}

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -39,6 +39,16 @@ on:
         type: string
         required: false
         default: ""
+      instance-type:
+        description: Instance type for validators and snapshot builder. Empty uses the cloud default.
+        type: string
+        required: false
+        default: ""
+      local-ssd-count:
+        description: GCP Local SSD count. Empty uses the machine requirement or bloat-tier default.
+        type: string
+        required: false
+        default: ""
       tps:
         type: string
         required: false
@@ -280,8 +290,8 @@ jobs:
       BENCH_INPUT_BLOAT: ${{ inputs.bloat || '100' }}
       BENCH_INPUT_VALIDATOR_COUNT: ${{ inputs['validator-count'] || (github.event_name == 'pull_request' && '1') || '10' }}
       BENCH_INPUT_REGIONS: ${{ inputs.regions || '' }}
-      BENCH_INPUT_INSTANCE_TYPE: ${{ (inputs.cloud || 'aws') == 'gcp' && 'n2-standard-8' || 'c6id.8xlarge' }}
-      BENCH_INPUT_LOCAL_SSD_COUNT: ${{ (inputs.cloud || 'aws') == 'gcp' && ((inputs.bloat || '100') == '100' && '4' || '1') || '4' }}
+      BENCH_INPUT_INSTANCE_TYPE: ${{ inputs['instance-type'] || '' }}
+      BENCH_INPUT_LOCAL_SSD_COUNT: ${{ inputs['local-ssd-count'] || '' }}
       BENCH_INPUT_TPS: ${{ inputs.tps || (github.event_name == 'pull_request' && '100') || '50000' }}
       BENCH_INPUT_ACCOUNTS: ${{ inputs.accounts || '1000' }}
       BENCH_INPUT_MAX_CONCURRENT_REQUESTS: ${{ inputs['max-concurrent-requests'] || (github.event_name == 'pull_request' && '10') || '5000' }}


### PR DESCRIPTION
Expose instance-type and local-ssd-count in the reusable multi-region workflow and scheduled manual-dispatch form, preserving the existing advanced manual form and scheduled defaults. Depends on https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/387 being merged first for hardware defaults, C4D-compatible disks/networking, and zone retries.

Validation: actionlint and whitespace checks passed; implementation smoke https://github.com/tempoxyz/tempo-multi-region-benchmark/actions/runs/34212053486 allocated four C4D instances in Virginia/Singapore, then failed on unavailable machine types in Oregon/Frankfurt and STOCKOUT in Tokyo, and destroyed all four instances (end-to-end benchmark validation remains blocked).

Prompted by: @Zygimantass