### PR TITLE
perf(net): benchmark bounded transaction fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9695,7 +9695,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9725,7 +9725,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9759,7 +9759,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9783,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9794,7 +9794,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9822,7 +9822,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9845,7 +9845,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9886,7 +9886,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "clap",
  "eyre",
@@ -9909,7 +9909,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9925,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9941,7 +9941,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9954,7 +9954,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9984,7 +9984,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9998,7 +9998,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10008,7 +10008,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10034,7 +10034,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10054,7 +10054,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10072,7 +10072,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10085,7 +10085,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10104,7 +10104,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10142,7 +10142,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10156,7 +10156,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "serde",
  "serde_json",
@@ -10166,7 +10166,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10192,7 +10192,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "bytes",
  "futures",
@@ -10212,7 +10212,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10229,7 +10229,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "bindgen",
  "cc",
@@ -10238,7 +10238,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "futures",
  "libc",
@@ -10252,7 +10252,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10261,7 +10261,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10275,7 +10275,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10334,7 +10334,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10359,7 +10359,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10383,7 +10383,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10398,7 +10398,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10412,7 +10412,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10649,7 +10649,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10673,7 +10673,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "bytes",
  "eyre",
@@ -10702,7 +10702,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10714,7 +10714,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10738,7 +10738,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10750,7 +10750,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10773,7 +10773,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10816,7 +10816,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10866,7 +10866,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10893,7 +10893,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10909,7 +10909,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10924,7 +10924,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11000,7 +11000,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11030,7 +11030,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11073,7 +11073,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11093,7 +11093,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11124,7 +11124,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11171,7 +11171,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11221,7 +11221,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11237,7 +11237,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11268,7 +11268,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11320,7 +11320,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11348,7 +11348,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11362,7 +11362,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11382,7 +11382,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11397,7 +11397,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11423,7 +11423,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11440,7 +11440,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11468,7 +11468,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11489,7 +11489,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11515,7 +11515,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "clap",
  "eyre",
@@ -11535,7 +11535,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11554,7 +11554,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11651,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11667,7 +11667,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11692,7 +11692,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.1"
-source = "git+https://github.com/paradigmxyz/reth?rev=5f02aa3#5f02aa39320492be78ea75a25eded41ddf5159b7"
+source = "git+https://github.com/paradigmxyz/reth?rev=5f3a72cfe9f28a552df45beb6bb4b3df75c94512#5f3a72cfe9f28a552df45beb6bb4b3df75c94512"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
 reth-codecs = { version = "0.6.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
 reth-primitives-traits = { version = "0.6.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5f02aa3", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "5f3a72cfe9f28a552df45beb6bb4b3df75c94512", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Pins Reth to a backport of paradigmxyz/reth#26924 on Tempo’s existing dependency revision, replacing repeated pending-hash scans with per-peer request queues. [Three regional pairs](https://github.com/tempoxyz/tempo/actions/runs/34212917907) show no repeatable throughput improvement: TPS +4.0%, −2.8%, +0.2% (mean 5658→5682), with mixed p99 and more submission failures; retain as an experiment while per-node metrics are analyzed.

# PR stack
Review the common base first; the follow-ups are independent:

1. fix(payload): account for queue time in build budgets #7535
2. perf(net): benchmark bounded transaction fetching #7539 — this PR
3. fix(payload): bound prewarming coordinator waits #7540
4. chore(consensus): report proposal return waits #7553
