### PR TITLE
fix(ci): require release tag version boundary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,15 +66,14 @@ jobs:
           persist-credentials: false
       - uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
       - name: Verify crate version matches tag
-        # Check that the Cargo version starts with the tag,
-        # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
+        # Accept the exact Cargo version or a hyphen-delimited prerelease of it.
         env:
           TAG: ${{ needs.get-version.outputs.version }}
         run: |
           tag="$TAG"
           tag=${tag#v}
           cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tempo").version')
-          [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn't match the Cargo version $cargo_ver"; exit 1; }
+          [[ "$tag" == "$cargo_ver" || "$tag" == "$cargo_ver"-* ]] || { echo "Tag $tag doesn't match the Cargo version $cargo_ver"; exit 1; }
 
   build-release:
     name: Build Release Binaries


### PR DESCRIPTION
Fixes #7541

Requires release tags to match either the exact Cargo version or a hyphen-delimited prerelease, preventing version-prefix collisions such as `1.13.20` matching `1.13.2`.

Verified exact, RC, patch-collision, arbitrary-suffix, and mismatched-version cases against the workflow step.
