### PR TITLE
fix(consensus): preserve transaction generator ownership

### DIFF
--- a/scripts/consensus/test-full-network-failure-and-recovery.sh
+++ b/scripts/consensus/test-full-network-failure-and-recovery.sh
@@ -63,12 +63,13 @@ main() {
   echo ""
 
   # Start transaction generator and assert block production
-  tx_gen_pid=$(start_tx_generator 10 "$SCRIPT_DIR")
+  start_tx_generator tx_gen_pid 10 "$SCRIPT_DIR"
   echo ""
 
   echo "Checking initial block production with tx generator..."
   if ! monitor_blocks "$rpc_url" 5 "  Monitoring for 5 seconds:"; then
     echo "Test FAILED: Initial block production not working"
+    stop_tx_generator "$tx_gen_pid" || true
     exit 1
   fi
   echo ""
@@ -102,12 +103,13 @@ main() {
   echo ""
 
   # Start transaction generator and ensure block production comes back up
-  tx_gen_pid=$(start_tx_generator 10 "$SCRIPT_DIR")
+  start_tx_generator tx_gen_pid 10 "$SCRIPT_DIR"
   echo ""
 
   echo "Checking block production after full restart..."
   if ! monitor_blocks "$rpc_url" 5 "  Monitoring for 5 seconds:"; then
     echo "Test FAILED: Network should resume block production after full restart"
+    stop_tx_generator "$tx_gen_pid" || true
     exit 1
   fi
   echo ""

--- a/scripts/consensus/test-network-halt-and-recovery.sh
+++ b/scripts/consensus/test-network-halt-and-recovery.sh
@@ -27,7 +27,7 @@ main() {
   echo ""
 
   # Start transaction generator and assert block production
-  tx_gen_pid=$(start_tx_generator 10 "$SCRIPT_DIR")
+  start_tx_generator tx_gen_pid 10 "$SCRIPT_DIR"
   echo ""
 
   echo "Checking initial block production with tx generator..."
@@ -74,7 +74,7 @@ main() {
   echo ""
 
   # Start transaction generator and assert block production
-  tx_gen_pid=$(start_tx_generator 10 "$SCRIPT_DIR")
+  start_tx_generator tx_gen_pid 10 "$SCRIPT_DIR"
   echo ""
 
   echo "Checking block production after recovery..."

--- a/scripts/consensus/test-partial-network-failure.sh
+++ b/scripts/consensus/test-partial-network-failure.sh
@@ -8,12 +8,22 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source test utilities
 source "$SCRIPT_DIR/test-utils.sh"
 
+tx_gen_pid=""
+cleanup_tx_generator() {
+  if [[ "$tx_gen_pid" =~ ^[0-9]+$ ]]; then
+    stop_tx_generator "$tx_gen_pid" || true
+    tx_gen_pid=""
+  fi
+}
+trap cleanup_tx_generator EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 echo "=== Partial Network Failure Test ==="
 
 # Main test
 main() {
   local rpc_url="http://localhost:8545"
-  local tx_gen_pid=""
 
   # Start the network and wait for it to be ready
   start_network "$SCRIPT_DIR"
@@ -27,7 +37,7 @@ main() {
   echo ""
 
   # Start transaction generator (perpetually)
-  tx_gen_pid=$(start_tx_generator 999999 "$SCRIPT_DIR")
+  start_tx_generator tx_gen_pid 999999 "$SCRIPT_DIR"
   echo ""
 
   # Stop one validator (validator-2)
@@ -39,16 +49,18 @@ main() {
   echo "Checking block production with one validator down..."
   if ! monitor_blocks "$rpc_url" 5 "  Monitoring for 5 seconds:"; then
     echo "Test FAILED: Network should continue producing blocks with one validator down"
-    stop_tx_generator "$tx_gen_pid" || true
+    cleanup_tx_generator
     exit 1
   fi
   echo ""
 
   # Stop transaction generator and check for failures
   if ! stop_tx_generator "$tx_gen_pid"; then
+    tx_gen_pid=""
     echo "Test FAILED: Transaction generator encountered failures"
     exit 1
   fi
+  tx_gen_pid=""
   echo ""
 
   echo "Test PASSED: Validator recovery working correctly"

--- a/scripts/consensus/test-test-utils.sh
+++ b/scripts/consensus/test-test-utils.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/test-utils.sh"
+
+tmp_dir=$(mktemp -d)
+tx_gen_pid=""
+export TX_GEN_READY_FILE="$tmp_dir/ready"
+cleanup() {
+  if [[ "$tx_gen_pid" =~ ^[0-9]+$ ]] && kill -0 "$tx_gen_pid" 2>/dev/null; then
+    kill "$tx_gen_pid" 2>/dev/null || true
+    wait "$tx_gen_pid" 2>/dev/null || true
+  fi
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
+
+cat >"$tmp_dir/tx-generator.sh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${2:-}" == "fail" ]]; then
+  exit 7
+fi
+trap 'exit 0' TERM
+: >"$TX_GEN_READY_FILE"
+while :; do
+  read -r -t 1 || true
+done
+EOF
+chmod +x "$tmp_dir/tx-generator.sh"
+
+start_tx_generator tx_gen_pid 999999 "$tmp_dir"
+[[ "$tx_gen_pid" =~ ^[0-9]+$ ]]
+kill -0 "$tx_gen_pid"
+for _ in {1..100}; do
+  [[ -e "$TX_GEN_READY_FILE" ]] && break
+  kill -0 "$tx_gen_pid"
+  sleep 0.01
+done
+[[ -e "$TX_GEN_READY_FILE" ]]
+stop_tx_generator "$tx_gen_pid"
+! kill -0 "$tx_gen_pid" 2>/dev/null
+
+if stop_tx_generator "not-a-pid"; then
+  echo "stop_tx_generator accepted an invalid PID" >&2
+  exit 1
+fi
+
+start_tx_generator tx_gen_pid fail "$tmp_dir"
+sleep 0.1
+if stop_tx_generator "$tx_gen_pid"; then
+  echo "stop_tx_generator ignored a failed generator" >&2
+  exit 1
+fi

--- a/scripts/consensus/test-utils.sh
+++ b/scripts/consensus/test-utils.sh
@@ -54,30 +54,44 @@ start_validator() {
 
 # Function to start background transaction generation
 start_tx_generator() {
-  local duration="${1:-999999}"
-  local script_dir="${2:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+  local output_var="$1"
+  local duration="${2:-999999}"
+  local script_dir="${3:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
   echo "Starting transaction generator..."
   "$script_dir/tx-generator.sh" --duration "$duration" >/dev/null 2>&1 &
-  local tx_gen_pid=$!
-  echo "  Transaction generator started (PID: $tx_gen_pid)"
-  echo "$tx_gen_pid"
+  printf -v "$output_var" '%s' "$!"
+  echo "  Transaction generator started (PID: ${!output_var})"
 }
 
 # Function to stop transaction generator
 stop_tx_generator() {
   local tx_gen_pid="$1"
-  if [ -n "$tx_gen_pid" ] && kill -0 "$tx_gen_pid" 2>/dev/null; then
+
+  if [[ ! "$tx_gen_pid" =~ ^[0-9]+$ ]]; then
+    echo "  ERROR: Invalid transaction generator PID: $tx_gen_pid"
+    return 1
+  fi
+
+  local was_running=false
+  if kill -0 "$tx_gen_pid" 2>/dev/null; then
+    was_running=true
     echo "Stopping transaction generator..."
     kill "$tx_gen_pid" 2>/dev/null || true
-    wait "$tx_gen_pid" 2>/dev/null
-    local exit_code=$?
-    echo "  Transaction generator stopped"
-    if [ $exit_code -ne 0 ] && [ $exit_code -ne 143 ]; then # 143 is SIGTERM
-      echo "  ERROR: Transaction generator failed with exit code $exit_code"
-      return 1
-    fi
   fi
+
+  local exit_code=0
+  wait "$tx_gen_pid" 2>/dev/null || exit_code=$?
+
+  if $was_running; then
+    echo "  Transaction generator stopped"
+  fi
+
+  if [ $exit_code -ne 0 ] && [ $exit_code -ne 143 ]; then # 143 is SIGTERM
+    echo "  ERROR: Transaction generator failed with exit code $exit_code"
+    return 1
+  fi
+
   return 0
 }
 


### PR DESCRIPTION
Fixes #7543

Starts consensus transaction generators in the parent test shell and returns their PID through a named variable, so callers can reliably stop and wait for them. Adds failure/signal cleanup for the perpetual generator and a focused regression covering PID assignment, termination, invalid input, and non-zero exit propagation.
