### PR TITLE
feat(bench): benchmark native MPP opens and settlements

### DIFF
--- a/contrib/bench/txgen/presets/mpp.yml
+++ b/contrib/bench/txgen/presets/mpp.yml
@@ -1,9 +1,8 @@
-# Native TIP-20 Channel Reserve opens: one channel per measured transaction.
+# Native TIP-20 Channel Reserve open -> signed settlement: two transactions per channel.
 # Fund the users with pathUSD for fees and token 1 for channel deposits.
 # The native reserve pulls deposits directly; no ERC-20 approval is needed.
-# Channels stay open, consuming one token base unit and creating state per tx.
-# Settlement and close workloads need the opening transaction's channel descriptor;
-# settlement additionally needs voucher signing, which txgen does not yet provide.
+# Settlement pays the full deposit to the payee; the settled channel state remains.
+# Requires txgen sequence `save` and Tempo `mpp_settle` support.
 
 chain_id: 1337
 
@@ -24,9 +23,7 @@ artifacts:
 templates:
   mpp_open:
     type: tempo
-    from:
-      pool: users
-      select: random
+    from: { var: payer.ref }
     gas_limit: 1000000
     fee_token: "0x20c0000000000000000000000000000000000000"
     expiring_nonce: true
@@ -36,15 +33,43 @@ templates:
       abi: TIP20ChannelReserve
       function: open
       args:
-        - pool:
-            pool: users
-            select: random
+        - { var: payee.address }
         - "0x0000000000000000000000000000000000000000"
         - "0x20c0000000000000000000000000000000000001"
         - 1
         - random_bytes: 32
         - "0x0000000000000000000000000000000000000000"
 
+  mpp_settle:
+    type: tempo
+    from: { var: payee.ref }
+    gas_limit: 1000000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 25
+    mpp_settle:
+      open_transaction: { var: opened.raw }
+      voucher_signer: { var: payer.ref }
+      cumulative_amount: 1
+
+sequences:
+  mpp_open_settle:
+    bindings:
+      payer:
+        account:
+          pool: users
+          select: random
+      payee:
+        account:
+          pool: users
+          select: random
+    steps:
+      - name: open
+        template: mpp_open
+        save: opened
+      - name: settle
+        template: mpp_settle
+
 mix:
-  - template: mpp_open
+  - sequence: mpp_open_settle
     weight: 100

--- a/contrib/bench/txgen/presets/mpp.yml
+++ b/contrib/bench/txgen/presets/mpp.yml
@@ -1,3 +1,10 @@
+# Native TIP-20 Channel Reserve opens: one channel per measured transaction.
+# Fund the users with pathUSD for fees and token 1 for channel deposits.
+# The native reserve pulls deposits directly; no ERC-20 approval is needed.
+# Channels stay open, consuming one token base unit and creating state per tx.
+# Settlement and close workloads need the opening transaction's channel descriptor;
+# settlement additionally needs voucher signing, which txgen does not yet provide.
+
 chain_id: 1337
 
 gas:
@@ -12,125 +19,32 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 artifacts:
-  ERC20: ../erc20.abi.json
-  MPPChannel:
-    abi: ../mpp-channel.json
-    bytecode: ../mpp-channel.json
-
-setup:
-  steps:
-    - id: channel
-      deploy:
-        type: eip1559
-        from:
-          pool: users
-          select: { index: 0 }
-        artifact: MPPChannel
-        gas_limit: 20000000
-        constructor_args: []
+  TIP20ChannelReserve: ../tip20-channel-reserve.abi.json
 
 templates:
-  mpp_approve:
-    type: tempo
-    gas_limit: 2000000
-    max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
-    fee_token: "0x20c0000000000000000000000000000000000000"
-    call:
-      to: "0x20c0000000000000000000000000000000000001"
-      abi: ERC20
-      function: approve
-      args: []
-
   mpp_open:
     type: tempo
-    gas_limit: 2000000
-    max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    from:
+      pool: users
+      select: random
+    gas_limit: 1000000
     fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 25
     call:
-      abi: MPPChannel
+      to: "0x4d50500000000000000000000000000000000000"
+      abi: TIP20ChannelReserve
       function: open
-      args: []
-
-  mpp_close:
-    type: tempo
-    gas_limit: 2000000
-    max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
-    fee_token: "0x20c0000000000000000000000000000000000000"
-    call:
-      abi: MPPChannel
-      function: close
-      args: []
-
-sequences:
-  mpp_approve_open_close:
-    bindings:
-      payer:
-        account:
-          pool: users
-          select: random
-      token:
-        address:
-          const: "0x20c0000000000000000000000000000000000001"
-      authorized_signer:
-        address:
-          const: "0x0000000000000000000000000000000000000000"
-      salt:
-        bytes32:
-          random_bytes: 32
-      channel_id:
-        abi_hash:
-          types: [address, address, address, bytes32, address, address, uint256]
-          values:
-            - { var: payer.address }
-            - { var: payer.address }
-            - { var: token }
-            - { var: salt }
-            - { var: authorized_signer }
-            - { var: setup.channel.address }
-            - { var: chain_id }
-      channel_key:
-        abi_encode_packed:
-          types: [bytes32, address, address, bytes32]
-          values:
-            - { var: channel_id }
-            - { var: token }
-            - { var: authorized_signer }
-            - { var: salt }
-    steps:
-      - name: approve
-        template: mpp_approve
-        with:
-          from: { var: payer.ref }
-          call:
-            args:
-              - { var: setup.channel.address }
-              - 1
-      - name: open
-        template: mpp_open
-        with:
-          from: { var: payer.ref }
-          call:
-            to: { var: setup.channel.address }
-            args:
-              - { var: payer.address }
-              - { var: token }
-              - 1
-              - { var: salt }
-              - { var: authorized_signer }
-      - name: close
-        template: mpp_close
-        with:
-          from: { var: payer.ref }
-          call:
-            to: { var: setup.channel.address }
-            args:
-              - { var: channel_key }
-              - 0
-              - "0x"
+      args:
+        - pool:
+            pool: users
+            select: random
+        - "0x0000000000000000000000000000000000000000"
+        - "0x20c0000000000000000000000000000000000001"
+        - 1
+        - random_bytes: 32
+        - "0x0000000000000000000000000000000000000000"
 
 mix:
-  - sequence: mpp_approve_open_close
+  - template: mpp_open
     weight: 100

--- a/contrib/bench/txgen/tip20-channel-reserve.abi.json
+++ b/contrib/bench/txgen/tip20-channel-reserve.abi.json
@@ -1,0 +1,39 @@
+[
+  {
+    "type": "function",
+    "name": "open",
+    "inputs": [
+      {
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "name": "deposit",
+        "type": "uint96"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "name": "authorizedSigner",
+        "type": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  }
+]


### PR DESCRIPTION
Replace the deployed-contract approve/open/close workload in `mpp.yml` with a native TIP-20 Channel Reserve **open -> signed settlement** sequence.

- Bind a payer and payee per channel, save the signed open, and use its actual descriptor and transaction context for the settlement voucher.
- Pay the full deposit to the payee in the second transaction. No deployment or token approval is needed; the settled channel state remains present.
- Preserve inclusion ordering between the two steps. The preset is 50% opens and 50% settlements by transaction count; `mix.yml` is unchanged.

## Dependency

Requires [txgen #200](https://github.com/tempoxyz/txgen/pull/200), which adds sequence-step `save` and native `mpp_settle` support. Merge and publish that change before using this preset with the default txgen image. For a pre-merge bench run, use `txgen-ref=57a891b99bc8a07b44bc0a67b2d98000c256e00c`.

## Validation

Resolved the preset through the benchmark helper, then generated and executed 100 transactions across three accounts on a fresh local Tempo v1.14.0 dev node:

- 50 distinct native channel opens and 50 successful settlements; zero reverted receipts.
- Every open included in an earlier block than its settlement.
- Every channel ended with `settled = deposit = 1` and no close request.
- Verified the settlement events and token transfers to each payee, zero reserve allowances, and zero final reserve token balance.

This is a local correctness smoke test, not a throughput comparison.

Prompted by: @shekhirin
