### PR TITLE
refactor(consensus): make DKG storage mutations consume ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,13 +34,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -50,9 +60,9 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "aes",
- "cipher",
+ "cipher 0.4.4",
  "ctr",
  "ghash",
  "subtle",
@@ -67,7 +77,7 @@ dependencies = [
  "age-core",
  "base64 0.21.7",
  "bech32",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "cookie-factory",
  "hmac 0.12.1",
  "i18n-embed",
@@ -91,7 +101,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
 dependencies = [
  "base64 0.21.7",
- "chacha20poly1305",
+ "chacha20poly1305 0.10.1",
  "cookie-factory",
  "hkdf",
  "io_tee",
@@ -145,6 +155,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -627,7 +646,7 @@ checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -957,7 +976,7 @@ dependencies = [
  "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -975,7 +994,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
- "syn 2.0.117",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
@@ -993,7 +1012,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
@@ -1126,7 +1145,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1220,7 +1239,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1394,7 +1413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1404,7 +1423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1442,7 +1461,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1455,7 +1474,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1561,7 +1580,7 @@ checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1657,7 +1676,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1668,7 +1687,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1706,7 +1725,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1754,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -1765,14 +1784,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1984,7 +2004,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2222,7 +2242,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.2",
  "shlex",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2292,11 +2312,10 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
@@ -2440,7 +2459,7 @@ dependencies = [
  "cow-utils",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -2498,7 +2517,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2522,7 +2541,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2594,7 +2613,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2605,9 +2624,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2709,7 +2728,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
 ]
 
@@ -2720,6 +2739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -2730,11 +2750,23 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
- "aead",
+ "aead 0.5.2",
  "chacha20 0.9.1",
- "cipher",
- "poly1305",
+ "cipher 0.4.4",
+ "poly1305 0.8.0",
  "zeroize",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
+dependencies = [
+ "aead 0.6.1",
+ "chacha20 0.10.0",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -2785,8 +2817,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -2831,7 +2874,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2848,12 +2891,6 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "cmov"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
 
 [[package]]
 name = "cmov"
@@ -3031,9 +3068,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-actor"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51f1d2adda7330ae87c9ac815d707a2a41bb91a11dc1a588e5a81fe2a5a2b1b"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3045,9 +3081,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-broadcast"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0e4a50ee1fa3ed2db220da0b0b85546556edc20cc5b71acc90af3d50a94821"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -3062,9 +3097,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785ff1148d798363638d83a1dfcca9db8ac6001a27292a23dc10a8595e1ee480"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3080,21 +3114,19 @@ dependencies = [
 
 [[package]]
 name = "commonware-codec-macros"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e308eca99c0be5ae7d8c19ecb5c2c85b7484b3b7e24f6e36eaed46a9a7cad0c"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "commonware-coding"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d561336cf1562aca4ac8df2c51035fdab8bd9d8a6f23764ba3c7ad9b87f574c9"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3111,9 +3143,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-conformance"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f699cf65cc26c9b918e05609d35a65acadad7308bdb9d18d7531ac44f2ad9601"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "commonware-conformance-macros",
  "commonware-formatting",
@@ -3121,25 +3152,23 @@ dependencies = [
  "futures",
  "serde",
  "sha2 0.11.0",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
 name = "commonware-conformance-macros"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e236944369aef0319add1863118783522ddc59601ab716b5413ef423e45a2f"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "commonware-consensus"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c854f77e510cf97cffcf02723737bca035ee77b1aa9fc7d6dd88694d3c8f0d"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3168,9 +3197,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-cryptography"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bb1a88685e18438cea8258ae5073c89175dcd7c1f8711f5b60ef0be17c80ff"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3180,22 +3208,22 @@ dependencies = [
  "blst",
  "bytes",
  "cfg-if",
- "chacha20poly1305",
+ "chacha20poly1305 0.11.0",
  "commonware-codec",
  "commonware-formatting",
  "commonware-macros",
  "commonware-math",
  "commonware-parallel",
  "commonware-utils",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "crc-fast",
- "ctutils 0.3.1",
+ "ctutils",
  "curve25519-dalek 5.0.0",
  "ecdsa 0.17.0",
  "fixedbitset",
  "getrandom 0.2.17",
  "getrandom 0.4.3",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-rational",
  "num-traits",
  "once_cell",
@@ -3211,9 +3239,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-formatting"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d388a79f0fad7ad9fad6b5f4a594c1e6675935221224aaa4d7e376b362c203"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -3221,9 +3248,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-invariants"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b658c809535115a70bfc39f37a16a0b5b5999d68b27098a2270ec406d76b7bc7"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "arbitrary",
  "commonware-formatting",
@@ -3235,9 +3261,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49853beaa75a447c448eaf6a48a38ba247a85792807956bc4487565a35fa35b"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3245,22 +3270,20 @@ dependencies = [
 
 [[package]]
 name = "commonware-macros-impl"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b099d6d10014a6ab1ae0b112c8329570adacc1fdbf6b27c9aebb38195f4eee"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "toml 0.9.12+spec-1.1.0",
+ "syn 2.0.119",
+ "toml 1.1.5+spec-1.1.0",
 ]
 
 [[package]]
 name = "commonware-math"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fd414779c4ebd26d9806cf012ad4f490555844aedafafa64cc26428e2f854f1"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3274,9 +3297,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-p2p"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3775a5d3bb4dcb20d654ff64b5504234822995dc16cb4417ea65b03225944ed7"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -3301,9 +3323,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-parallel"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a1b76ed5be614064839d20ec70f0177f92ba7da04dea0f5b0411c7e10a9ad6"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3314,9 +3335,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-resolver"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5958d4f162dc81cecf87cda2c00fdca00a750c994149f776d0b1ed39e0bb921c"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -3336,9 +3356,8 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082c8a0fc3962c3aceddf9f5532322b15564369a7b9bf846220ff750051ce9cb"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "ahash",
  "axum",
@@ -3367,7 +3386,7 @@ dependencies = [
  "rand_core 0.10.1",
  "rayon",
  "sha2 0.11.0",
- "sysinfo 0.37.2",
+ "sysinfo 0.39.6",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3377,21 +3396,19 @@ dependencies = [
 
 [[package]]
 name = "commonware-runtime-macros"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4982c0997b8a5d2039234a55fff383e443cc72f0c7b2a52b8ab93075c3edeae"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "commonware-storage"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "627b4a7d67ab75bf4d8115fd883d74b9839b36a1405f5b23a874827a62dfceb1"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3406,7 +3423,7 @@ dependencies = [
  "commonware-utils",
  "futures",
  "futures-util",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "thiserror 2.0.18",
  "tracing",
  "zstd",
@@ -3414,11 +3431,10 @@ dependencies = [
 
 [[package]]
 name = "commonware-stream"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce2d3acfc869e78d33577c1284d9cf2a0a67f98fcf09ab5d6e43efeed2d2bf4"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
- "chacha20poly1305",
+ "chacha20poly1305 0.11.0",
  "commonware-codec",
  "commonware-cryptography",
  "commonware-formatting",
@@ -3434,14 +3450,12 @@ dependencies = [
 
 [[package]]
 name = "commonware-utils"
-version = "2026.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54c7b4991ff7135416985adf3bf39f16f77cd2066fbbe2e3854e99379d90c6e5"
+version = "2026.9.0"
+source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
 dependencies = [
  "ahash",
  "arbitrary",
  "bytes",
- "cfg-if",
  "commonware-codec",
  "commonware-formatting",
  "commonware-macros",
@@ -3449,7 +3463,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.3.4",
  "getrandom 0.4.3",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-bigint",
  "num-integer",
  "num-rational",
@@ -3520,9 +3534,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3694,18 +3708,20 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.7.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1c047a62b0cc3e145fa84415a3191f628e980b194c2755aa12300a4e6cbd928"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
- "criterion-plot 0.6.0",
+ "criterion-plot 0.8.2",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
@@ -3727,9 +3743,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.6.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b1bcc0dc7dfae599d84ad0b1a55f80cde8af3725da8313b528da95ef783e338"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools 0.13.0",
@@ -3771,18 +3787,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossterm"
@@ -3836,7 +3852,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
- "ctutils 0.4.2",
+ "ctutils",
  "getrandom 0.4.3",
  "hybrid-array",
  "num-traits",
@@ -3879,16 +3895,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
-dependencies = [
- "cmov 0.4.6",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -3897,7 +3904,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
- "cmov 0.5.4",
+ "cmov",
  "subtle",
 ]
 
@@ -3941,7 +3948,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3965,7 +3972,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3976,7 +3983,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4018,7 +4025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4096,7 +4103,7 @@ checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4107,7 +4114,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4129,7 +4136,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -4169,7 +4176,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
- "ctutils 0.4.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -4225,6 +4232,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4232,7 +4249,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4285,7 +4302,7 @@ checksum = "1ec431cd708430d5029356535259c5d645d60edd3d39c54e5eea9782d46caa7d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4352,7 +4369,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4448,7 +4465,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4468,7 +4485,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4535,7 +4552,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4713,7 +4730,7 @@ checksum = "6dc7a9cb3326bafb80642c5ce99b39a2c0702d4bfa8ee8a3e773791a6cbe2407"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4916,7 +4933,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5680,7 +5697,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unic-langid",
 ]
 
@@ -5694,7 +5711,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5889,7 +5906,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5994,6 +6011,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6016,7 +6042,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6178,7 +6204,7 @@ checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6224,7 +6250,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6252,7 +6278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6381,7 +6407,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6851,7 +6877,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6875,7 +6901,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6944,7 +6970,7 @@ checksum = "161ab904c2c62e7bda0f7562bf22f96440ca35ff79e66c800cbac298f2f4f5ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7075,7 +7101,7 @@ checksum = "59b43b4fd69e3437618106f7754f34021b831a514f9e1a98ae863cabcd8d8dad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7290,9 +7316,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "arbitrary",
  "num-integer",
@@ -7385,7 +7411,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7413,12 +7439,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
 ]
 
 [[package]]
@@ -7429,6 +7482,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -7700,7 +7764,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7844,7 +7908,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7857,7 +7921,7 @@ dependencies = [
  "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7895,7 +7959,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8015,7 +8079,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8026,7 +8090,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -8038,7 +8112,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -8142,7 +8216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8231,7 +8305,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8243,7 +8317,7 @@ dependencies = [
  "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8281,9 +8355,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.24.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
+checksum = "1784dc11a05f5a8f57c4a62915686be140f24f70301290b997e317241fa9ffc2"
 dependencies = [
  "dtoa",
  "itoa",
@@ -8293,13 +8367,13 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
+checksum = "01e34894696ff94f64a20c2c373a6440903e9c2789a303d68ec6e6f953f890e4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -8339,7 +8413,7 @@ checksum = "fb6dc647500e84a25a85b100e76c85b8ace114c209432dc174f20aac11d4ed6c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8350,7 +8424,7 @@ checksum = "c57924a81864dddafba92e1bf92f9bf82f97096c44489548a60e888e1547549b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8396,7 +8470,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8842,7 +8916,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9217,7 +9291,7 @@ checksum = "e7e508fcbb8cb775639dbbb56b81b62756d4322f28e76c60a52aa32575f993fe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9567,7 +9641,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "byteorder",
- "cipher",
+ "cipher 0.4.4",
  "concat-kdf",
  "ctr",
  "digest 0.10.7",
@@ -12168,7 +12242,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.117",
+ "syn 2.0.119",
  "walkdir",
 ]
 
@@ -12392,7 +12466,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -12493,7 +12567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct 1.0.0",
- "ctutils 0.4.2",
+ "ctutils",
  "der 0.8.1",
  "hybrid-array",
  "subtle",
@@ -12677,7 +12751,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -12755,7 +12829,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13106,7 +13180,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13157,9 +13231,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13175,7 +13260,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13195,21 +13280,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "sysinfo"
-version = "0.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
-dependencies = [
- "libc",
- "memchr",
- "ntapi",
- "objc2-core-foundation",
- "objc2-io-kit",
- "windows 0.61.3",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13223,6 +13294,21 @@ dependencies = [
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
  "windows 0.62.2",
 ]
 
@@ -13905,7 +13991,7 @@ dependencies = [
  "alloy",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14135,7 +14221,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14146,7 +14232,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "test-case-core",
 ]
 
@@ -14182,7 +14268,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14193,7 +14279,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14352,7 +14438,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14434,6 +14520,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14465,18 +14566,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"
@@ -14627,7 +14728,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -14813,7 +14914,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15007,6 +15108,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsigned-varint"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15137,7 +15248,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15231,7 +15342,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -15479,7 +15590,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15490,7 +15601,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -15963,7 +16074,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -15984,7 +16095,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -16004,28 +16115,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -16060,7 +16171,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3069,7 +3069,8 @@ dependencies = [
 [[package]]
 name = "commonware-actor"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e96ef599ff4c2ec1608c9b5b3527ae76be6b48cfc71dc9c89910105febc3ec91"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3082,7 +3083,8 @@ dependencies = [
 [[package]]
 name = "commonware-broadcast"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f11e2cda843c7a2d3480ea7fa2fe6d9a7b4f897dfcef395c9b85e5bceb2db7f8"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -3098,7 +3100,8 @@ dependencies = [
 [[package]]
 name = "commonware-codec"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1e1bd11366f81e304c737c098eb0c075cef59e21daff44c3227952c2f75b49"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3115,7 +3118,8 @@ dependencies = [
 [[package]]
 name = "commonware-codec-macros"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ccca449c618a38da9b867c128ec1e7be55cfe0b69b8814c25daac229ac6cc9"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3126,7 +3130,8 @@ dependencies = [
 [[package]]
 name = "commonware-coding"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07145b2f348a8d3faa058dca684a5a37e0cede9f53ef123421c2227d40477afb"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -3144,7 +3149,8 @@ dependencies = [
 [[package]]
 name = "commonware-conformance"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1125e27828ae3d9074bb1f1559ac22de6ce0c848ebac8c0f222ab42d1ef64efc"
 dependencies = [
  "commonware-conformance-macros",
  "commonware-formatting",
@@ -3158,7 +3164,8 @@ dependencies = [
 [[package]]
 name = "commonware-conformance-macros"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5cab4092adfafbec0b752c1f02322c9cc76258218f2678a73ea54c0671e6bb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3168,7 +3175,8 @@ dependencies = [
 [[package]]
 name = "commonware-consensus"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2af83244a9e1982617148e577a6f692b22f4bf727976cddf978d4afcd73a4e7"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -3198,7 +3206,8 @@ dependencies = [
 [[package]]
 name = "commonware-cryptography"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6b593210847c596c6657f2fb033c57ac0ef2f7ce68559c0e79040a34b65b7e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3240,7 +3249,8 @@ dependencies = [
 [[package]]
 name = "commonware-formatting"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdfc3a5a45f024571d9abce2bdb5a52081f9f017e61b80e2bff89856361ceee"
 dependencies = [
  "commonware-macros",
  "const-hex",
@@ -3249,7 +3259,8 @@ dependencies = [
 [[package]]
 name = "commonware-invariants"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0fbc4a20cba4987e31206b6b34b1f8809816408f1cffb874dff4dffc4fa2b0"
 dependencies = [
  "arbitrary",
  "commonware-formatting",
@@ -3262,7 +3273,8 @@ dependencies = [
 [[package]]
 name = "commonware-macros"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3058bc70420515d6e92d99510ec2b2a2e1d029a6aced44d243c05ce8d60c6493"
 dependencies = [
  "commonware-macros-impl",
  "tokio",
@@ -3271,7 +3283,8 @@ dependencies = [
 [[package]]
 name = "commonware-macros-impl"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbcf77c39d7486af7394b1d1c4d268d08a5763036b813a2e6aba2ee825b5bd45"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3283,7 +3296,8 @@ dependencies = [
 [[package]]
 name = "commonware-math"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0227b6d4c3e264894c92c682e532128dd22c21bf835c86a6ec6ba9cb15e3f87"
 dependencies = [
  "arbitrary",
  "bytes",
@@ -3298,7 +3312,8 @@ dependencies = [
 [[package]]
 name = "commonware-p2p"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf74a0456b74a0f84e4ab23a8765227d9c52cdef63f4968670c96467b3c63a"
 dependencies = [
  "commonware-actor",
  "commonware-codec",
@@ -3324,7 +3339,8 @@ dependencies = [
 [[package]]
 name = "commonware-parallel"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10bae95b6d977699c212691a996805e241936d8f958c73a1ebff0190376d1260"
 dependencies = [
  "cfg-if",
  "commonware-macros",
@@ -3336,7 +3352,8 @@ dependencies = [
 [[package]]
 name = "commonware-resolver"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cde1899be3cb1ff031f144fce7236aab504e6f56378235f16bd0469e9545e3"
 dependencies = [
  "bytes",
  "commonware-actor",
@@ -3357,7 +3374,8 @@ dependencies = [
 [[package]]
 name = "commonware-runtime"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4d9bbc36e8d5df471666c5a3f2fa2599f1e860bc61c05c1879ec5643701d9"
 dependencies = [
  "ahash",
  "axum",
@@ -3397,7 +3415,8 @@ dependencies = [
 [[package]]
 name = "commonware-runtime-macros"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d478d4299c93e9f9a80064efdacd69ac0fe8324a9dc44264edbcd0d47c5d6eb3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -3408,7 +3427,8 @@ dependencies = [
 [[package]]
 name = "commonware-storage"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ec50ba1efad76170c65d8c53baefc49da20eed02df9eedb3aa0754f2ff1d53"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3432,7 +3452,8 @@ dependencies = [
 [[package]]
 name = "commonware-stream"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4448b7e1d6a0d7a3fc9521be6ddebba0e3bde321da63e414233b6c53bd39e77"
 dependencies = [
  "chacha20poly1305 0.11.0",
  "commonware-codec",
@@ -3451,7 +3472,8 @@ dependencies = [
 [[package]]
 name = "commonware-utils"
 version = "2026.9.0"
-source = "git+https://github.com/commonwarexyz/monorepo?rev=29ad3abd1241dcc9555a4c20c86b821ecd039048#29ad3abd1241dcc9555a4c20c86b821ecd039048"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a611d1e0f4285e396deab2e76cf0554f05fee53e9c3d69a53374ce069b88ab44"
 dependencies = [
  "ahash",
  "arbitrary",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,19 +245,19 @@ alloy-signer-local = "2.4.1"
 alloy-signer-trezor = "2.4.1"
 alloy-transport = "2.4.1"
 
-commonware-actor = "2026.7.1"
-commonware-broadcast = "2026.7.1"
-commonware-codec = "2026.7.1"
-commonware-consensus = "2026.7.1"
-commonware-cryptography = { version = "2026.7.1", default-features = false }
-commonware-macros = "2026.7.1"
-commonware-math = "2026.7.1"
-commonware-p2p = "2026.7.1"
-commonware-parallel = "2026.7.1"
-commonware-resolver = "2026.7.1"
-commonware-runtime = "2026.7.1"
-commonware-storage = "2026.7.1"
-commonware-utils = "2026.7.1"
+commonware-actor = "2026.9.0"
+commonware-broadcast = "2026.9.0"
+commonware-codec = "2026.9.0"
+commonware-consensus = "2026.9.0"
+commonware-cryptography = { version = "2026.9.0", default-features = false }
+commonware-macros = "2026.9.0"
+commonware-math = "2026.9.0"
+commonware-p2p = "2026.9.0"
+commonware-parallel = "2026.9.0"
+commonware-resolver = "2026.9.0"
+commonware-runtime = "2026.9.0"
+commonware-storage = "2026.9.0"
+commonware-utils = "2026.9.0"
 
 arbitrary = { version = "1.4", features = ["derive"] }
 async-lock = "3.4.2"
@@ -293,7 +293,7 @@ minisign-verify = "0.2"
 once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 p256 = { version = "0.13", default-features = false }
 parking_lot = "0.12.5"
-prometheus-client = "0.24.0"
+prometheus-client = "0.25.1"
 sysinfo = { version = "0.38.4", default-features = false, features = ["disk", "system"] }
 proptest = "1.9"
 proptest-arbitrary-interop = "0.1.0"
@@ -412,17 +412,17 @@ vergen-git2 = "10.0.1"
 
 [patch.crates-io]
 
-# Commonware v2026.7.0
-# commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
-# commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
+# Commonware v2026.9.0 release candidate
+commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
+commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -409,20 +409,3 @@ vergen-git2 = "10.0.1"
 # reth-trie-db = { path = "../reth/crates/trie/db" }
 # reth-trie-parallel = { path = "../reth/crates/trie/parallel" }
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
-
-[patch.crates-io]
-
-# Commonware v2026.9.0 release candidate
-commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-codec = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-consensus = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-cryptography = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-macros = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-math = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-p2p = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-parallel = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-resolver = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-runtime = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-storage = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }
-commonware-utils = { git = "https://github.com/commonwarexyz/monorepo", rev = "29ad3abd1241dcc9555a4c20c86b821ecd039048" }

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -356,10 +356,18 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
             )
         });
 
+        #[expect(
+            deprecated,
+            reason = "Maintain backward compatibility until all nodes have been updated; \
+                      V1 blob creation will be enabled in a followup."
+        )]
         let runtime_config = commonware_runtime::tokio::Config::default()
             .with_tcp_nodelay(Some(true))
             .with_worker_threads(args.consensus.worker_threads)
             .with_storage_directory(consensus_storage)
+            .with_storage_blob_layouts(
+                commonware_runtime::BlobLayout::V0..=commonware_runtime::BlobLayout::V0,
+            )
             .with_catch_panics(true);
 
         let runner = commonware_runtime::tokio::Runner::new(runtime_config);

--- a/bin/tempo/src/lib.rs
+++ b/bin/tempo/src/lib.rs
@@ -453,6 +453,14 @@ pub fn tempo_main_with(mut overrides: TempoOverrides) -> eyre::Result<()> {
         |spec: Arc<TempoChainSpec>| (TempoEvmConfig::new(spec.clone()), TempoConsensus::new(spec));
 
     cli.run_with_components::<TempoNode>(components, async move |builder, args| {
+        if let Some(value) = args.consensus.message_backlog {
+            warn!(
+                flag = "--consensus.message-backlog",
+                value,
+                "deprecated flag ignored; P2P queue capacities are derived from peer-set limits and channel quotas"
+            );
+        }
+
         // Register before launch because each RLPx session negotiates its
         // subprotocols during the handshake. The startup channel passes the
         // consensus half of the transport to the consensus thread.

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -228,8 +228,8 @@ fn prepare_snapshot_consensus_archive(
         #[expect(
             deprecated,
             reason = "Keep exported snapshots readable by nodes using Commonware before 2026.9.0 \
-                      until all nodes have been updated. Only the fresh output uses V0; \
-                      the source runtime must accept both layouts."
+                      until all nodes have been updated; V1 blob creation will be enabled \
+                      in a followup."
         )]
         let output_runtime_config = commonware_runtime::tokio::Config::default()
             .with_storage_directory(archive_storage_dir)
@@ -247,8 +247,17 @@ fn prepare_snapshot_consensus_archive(
         })
     });
 
-    let source_runtime_config =
-        commonware_runtime::tokio::Config::default().with_storage_directory(consensus_dir);
+    #[expect(
+        deprecated,
+        reason = "Opening snapshot source archives can create recovery metadata. Maintain \
+                  backward compatibility until all nodes have been updated; V1 blob creation \
+                  will be enabled in a followup."
+    )]
+    let source_runtime_config = commonware_runtime::tokio::Config::default()
+        .with_storage_directory(consensus_dir)
+        .with_storage_blob_layouts(
+            commonware_runtime::BlobLayout::V0..=commonware_runtime::BlobLayout::V0,
+        );
 
     let source_runner = commonware_runtime::tokio::Runner::new(source_runtime_config);
     let state = source_runner.start(|context| async move {

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -227,7 +227,10 @@ fn prepare_snapshot_consensus_archive(
     let writer_thread = thread::spawn(move || -> eyre::Result<()> {
         // Keep exported snapshots readable by nodes using Commonware before 2026.9.0.
         // Only the fresh output uses V0; the source runtime must accept both layouts.
-        #[allow(deprecated)]
+        #[expect(
+            deprecated,
+            reason = "maintain backward compatibility until all nodes have been updated"
+        )]
         let output_runtime_config = commonware_runtime::tokio::Config::default()
             .with_storage_directory(archive_storage_dir)
             .with_storage_blob_layouts(

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -225,8 +225,14 @@ fn prepare_snapshot_consensus_archive(
     let (archive_entries_tx, archive_entries_rx) = tokio::sync::mpsc::channel(64);
 
     let writer_thread = thread::spawn(move || -> eyre::Result<()> {
+        // Keep exported snapshots readable by nodes using Commonware before 2026.9.0.
+        // Only the fresh output uses V0; the source runtime must accept both layouts.
+        #[allow(deprecated)]
         let output_runtime_config = commonware_runtime::tokio::Config::default()
-            .with_storage_directory(archive_storage_dir);
+            .with_storage_directory(archive_storage_dir)
+            .with_storage_blob_layouts(
+                commonware_runtime::BlobLayout::V0..=commonware_runtime::BlobLayout::V0,
+            );
         let output_runner = commonware_runtime::tokio::Runner::new(output_runtime_config);
         output_runner.start(|context| async move {
             tempo_consensus::storage::snapshot::write_archive(

--- a/bin/tempo/src/snapshot_manifest.rs
+++ b/bin/tempo/src/snapshot_manifest.rs
@@ -225,11 +225,11 @@ fn prepare_snapshot_consensus_archive(
     let (archive_entries_tx, archive_entries_rx) = tokio::sync::mpsc::channel(64);
 
     let writer_thread = thread::spawn(move || -> eyre::Result<()> {
-        // Keep exported snapshots readable by nodes using Commonware before 2026.9.0.
-        // Only the fresh output uses V0; the source runtime must accept both layouts.
         #[expect(
             deprecated,
-            reason = "maintain backward compatibility until all nodes have been updated"
+            reason = "Keep exported snapshots readable by nodes using Commonware before 2026.9.0 \
+                      until all nodes have been updated. Only the fresh output uses V0; \
+                      the source runtime must accept both layouts."
         )]
         let output_runtime_config = commonware_runtime::tokio::Config::default()
             .with_storage_directory(archive_storage_dir)

--- a/crates/consensus-config/src/tests.rs
+++ b/crates/consensus-config/src/tests.rs
@@ -3,7 +3,10 @@ use std::io::Write as _;
 use commonware_codec::Encode as _;
 use commonware_cryptography::{
     Signer as _,
-    bls12381::{dkg::feldman_desmedt as dkg, primitives::variant::MinSig},
+    bls12381::{
+        dkg::feldman_desmedt as dkg,
+        primitives::{sharing::Mode, variant::MinSig},
+    },
     ed25519::PrivateKey,
 };
 use commonware_utils::{N3f1, NZU32};
@@ -214,7 +217,7 @@ fn signing_share_roundtrip() {
     let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let (_, mut shares) =
-        dkg::deal_anonymous::<MinSig, N3f1>(&mut rng, Default::default(), NZU32!(1));
+        dkg::deal_anonymous::<MinSig, N3f1>(&mut rng, Mode::NonZeroCounter, NZU32!(1));
     let share = shares.remove(0);
     let signing_share: SigningShare = share.into();
     assert_eq!(

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -183,7 +183,7 @@ pub(crate) mod marshal {
                 start,
                 partition_prefix: config.partition_prefix,
                 mailbox_size: config.mailbox_size,
-                view_retention_timeout: config.view_retention_timeout,
+                view_retention: config.view_retention_timeout,
                 prunable_items_per_section: storage::PRUNABLE_ITEMS_PER_SECTION,
                 page_cache,
                 replay_buffer: storage::REPLAY_BUFFER,
@@ -197,7 +197,7 @@ pub(crate) mod marshal {
         )
         .await;
 
-        if let Some(marshal_stored_height) = marshal_stored_height {
+        if let Some(marshal_stored_height) = marshal_stored_height.height() {
             ensure!(
                 finalized_tip.1 >= marshal_stored_height,
                 "finalizations archive is inconsistent with the node's consensus metadata: \
@@ -209,9 +209,11 @@ pub(crate) mod marshal {
         }
 
         let startup_floor_height = finalized_floor.0;
-        let last_finalized_height = marshal_stored_height.map_or(startup_floor_height, |height| {
-            height.max(startup_floor_height)
-        });
+        let last_finalized_height = marshal_stored_height
+            .height()
+            .map_or(startup_floor_height, |height| {
+                height.max(startup_floor_height)
+            });
 
         info!(
             marshal_stored = ?marshal_stored_height,

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -173,7 +173,7 @@ pub(crate) mod marshal {
             .await?;
         }
 
-        let (actor, mailbox, marshal_stored_height) = core::Actor::init(
+        let (actor, mailbox, marshal_floor) = core::Actor::init(
             context,
             finalizations_by_height,
             finalized_blocks,
@@ -197,7 +197,7 @@ pub(crate) mod marshal {
         )
         .await;
 
-        if let Some(marshal_stored_height) = marshal_stored_height.height() {
+        if let Some(marshal_stored_height) = marshal_floor.height() {
             ensure!(
                 finalized_tip.1 >= marshal_stored_height,
                 "finalizations archive is inconsistent with the node's consensus metadata: \
@@ -209,14 +209,14 @@ pub(crate) mod marshal {
         }
 
         let startup_floor_height = finalized_floor.0;
-        let last_finalized_height = marshal_stored_height
+        let last_finalized_height = marshal_floor
             .height()
             .map_or(startup_floor_height, |height| {
                 height.max(startup_floor_height)
             });
 
         info!(
-            marshal_stored = ?marshal_stored_height,
+            marshal_stored = ?marshal_floor,
             selected_floor = %startup_floor_height,
             "setting marshal sync floor"
         );

--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -92,11 +92,6 @@ pub struct Args {
     #[arg(long = "consensus.worker-threads", default_value_t = 3)]
     pub worker_threads: usize,
 
-    /// The maximum number of messages that can be queued on the various consensus
-    /// channels before blocking.
-    #[arg(long = "consensus.message-backlog", default_value_t = 16_384)]
-    pub message_backlog: usize,
-
     /// The overall number of items that can be received on the various consensus
     /// channels before blocking.
     #[arg(long = "consensus.mailbox-size", default_value = "16384")]
@@ -263,6 +258,14 @@ pub struct Args {
     /// Timeout for the handshake process.
     #[arg(long = "consensus.handshake-timeout", default_value = "5s")]
     pub handshake_timeout: PositiveDuration,
+
+    /// Timeout for resolving, connecting to, and handshaking with a peer.
+    #[arg(long = "consensus.dial-timeout", default_value = "15s")]
+    pub dial_timeout: PositiveDuration,
+
+    /// Maximum number of distinct peers retained for each validator set.
+    #[arg(long = "consensus.max-peers-per-set", default_value = "1024")]
+    pub max_peers_per_set: NonZeroUsize,
 
     /// Maximum number of concurrent handshake attempts allowed.
     #[arg(

--- a/crates/consensus/src/args.rs
+++ b/crates/consensus/src/args.rs
@@ -92,6 +92,15 @@ pub struct Args {
     #[arg(long = "consensus.worker-threads", default_value_t = 3)]
     pub worker_threads: usize,
 
+    /// Deprecated compatibility flag. P2P queue capacities are derived from
+    /// peer-set limits and channel quotas, so this value is ignored.
+    #[arg(
+        long = "consensus.message-backlog",
+        value_name = "COUNT",
+        help = "Deprecated: ignored; P2P queue capacities are derived from peer-set limits and channel quotas."
+    )]
+    pub message_backlog: Option<usize>,
+
     /// The overall number of items that can be received on the various consensus
     /// channels before blocking.
     #[arg(long = "consensus.mailbox-size", default_value = "16384")]
@@ -574,6 +583,25 @@ mod tests {
         ] {
             parse(&["--dev", flag, "1ms"]);
         }
+    }
+
+    #[test]
+    fn deprecated_message_backlog_is_only_set_when_supplied() {
+        assert_eq!(parse(&["--dev"]).consensus.message_backlog, None);
+        for value in ["0", "16384", "32768"] {
+            assert_eq!(
+                parse(&["--dev", "--consensus.message-backlog", value])
+                    .consensus
+                    .message_backlog,
+                Some(value.parse().unwrap()),
+            );
+        }
+        assert_eq!(
+            parse(&["--dev", "--consensus.message-backlog=16384"])
+                .consensus
+                .message_backlog,
+            Some(16384),
+        );
     }
 
     fn encrypt(plaintext: &[u8], passphrase: &str) -> Vec<u8> {

--- a/crates/consensus/src/config.rs
+++ b/crates/consensus/src/config.rs
@@ -24,8 +24,6 @@ pub const MARSHAL_CHANNEL_IDENT: commonware_p2p::Channel = 4;
 pub const DKG_CHANNEL_IDENT: commonware_p2p::Channel = 5;
 pub const SUBBLOCKS_CHANNEL_IDENT: commonware_p2p::Channel = 6;
 
-pub(crate) const NUMBER_CONCURRENT_FETCHES: NonZeroUsize = NZUsize!(4);
-
 pub(crate) const PEERSETS_TO_TRACK: NonZeroUsize = NZUsize!(3);
 
 pub(crate) const BLOCKS_FREEZER_TABLE_INITIAL_SIZE_BYTES: u32 = 2u32.pow(21); // 100MB

--- a/crates/consensus/src/consensus/engine.rs
+++ b/crates/consensus/src/consensus/engine.rs
@@ -212,7 +212,6 @@ where
             peer_provider: peer_manager_mailbox.clone(),
             mailbox_size: self.mailbox_size,
             blocker: self.blocker.clone(),
-            initial: Duration::from_secs(1),
             timeout: Duration::from_secs(2),
             fetch_retry_timeout: Duration::from_millis(100),
             priority_requests: false,

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -823,7 +823,7 @@ where
                         info!("local DKG ceremony was a success");
                         Some((new_output, ShareState::Plaintext(Some(new_share))))
                     }
-                    Err(reason @ dkg::Error::MissingPlayerDealing) => {
+                    Err(dkg::FinalizeError::Error(reason @ dkg::Error::MissingPlayerDealing)) => {
                         warn!(
                             reason = %Report::new(reason),
                             "missing critical DKG state to reconstruct a share in this epoch; has \
@@ -1146,7 +1146,9 @@ where
                             info!("local DKG ceremony was a success");
                             Some((new_output, ShareState::Plaintext(Some(new_share))))
                         }
-                        Err(reason @ dkg::Error::MissingPlayerDealing) => {
+                        Err(dkg::FinalizeError::Error(
+                            reason @ dkg::Error::MissingPlayerDealing,
+                        )) => {
                             warn!(
                                 reason = %Report::new(reason),
                                 "missing critical DKG state to reconstruct a share in this epoch; has \
@@ -1437,7 +1439,7 @@ where
         let (recovered_output, share) = match player.finalize(&mut self.context, logs, &Sequential)
         {
             Ok(recovered) => recovered,
-            Err(dkg::Error::MissingPlayerDealing) => return Ok(None),
+            Err(dkg::FinalizeError::Error(dkg::Error::MissingPlayerDealing)) => return Ok(None),
             Err(error) => {
                 return Err(eyre::Report::new(error))
                     .wrap_err("failed finalizing revealed share from dealer logs");

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -191,17 +191,13 @@ where
             return;
         };
 
-        let Ok(mut storage) = self.heal(opened).await else {
+        let Ok(storage) = self.heal(opened).await else {
             return;
         };
 
-        if self
-            .prepopulate_to_last_finalized_height(&mut storage)
-            .await
-            .is_err()
-        {
+        let Ok(mut storage) = self.prepopulate_to_last_finalized_height(storage).await else {
             return;
-        }
+        };
 
         let (mux, mut dkg_mux) = mux::Muxer::new(
             self.context.child("dkg_mux"),
@@ -213,9 +209,10 @@ where
         mux.start();
 
         let reason = loop {
-            if let Err(error) = self.run_dkg_loop(&mut storage, &mut dkg_mux).await {
-                break error;
-            }
+            storage = match self.run_dkg_loop(storage, &mut dkg_mux).await {
+                Ok(storage) => storage,
+                Err(error) => break error,
+            };
         };
 
         tracing::warn_span!("dkg_actor").in_scope(|| {
@@ -228,18 +225,14 @@ where
 
     async fn run_dkg_loop<TStorageContext, TSender, TReceiver>(
         &mut self,
-        storage: &mut state::Storage<TStorageContext>,
+        mut storage: state::Storage<TStorageContext>,
         mux: &mut MuxHandle<TSender, TReceiver>,
-    ) -> eyre::Result<()>
+    ) -> eyre::Result<state::Storage<TStorageContext>>
     where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
         TSender: Sender<PublicKey = PublicKey>,
         TReceiver: Receiver<PublicKey = PublicKey>,
     {
-        ensure!(
-            !storage.is_poisoned(),
-            "DKG storage must be reopened after a failed or cancelled mutation"
-        );
         let state = storage.current();
 
         self.metrics.reset();
@@ -254,7 +247,7 @@ where
 
         if let Some(previous) = state.epoch.previous() {
             // NOTE: State::prune emits an error event.
-            storage.prune(previous).await.wrap_err_with(|| {
+            storage = storage.prune(previous).await.wrap_err_with(|| {
                 format!("unable to prune storage before up until epoch `{previous}`",)
             })?;
         }
@@ -319,7 +312,7 @@ where
                 }
 
                 Some((cause, block, ack)) = self.pending_finalized_blocks.next() => {
-                    let should_break = match self
+                    let (updated_storage, new_state) = self
                         .handle_finalized_header(
                             cause,
                             &state,
@@ -331,8 +324,9 @@ where
                             block.header().clone(),
                         )
                         .await
-                        .wrap_err("failed handling finalized block")?
-                    {
+                        .wrap_err("failed handling finalized block")?;
+                    storage = updated_storage;
+                    let should_break = match new_state {
                         Some(new_state) => {
                             info_span!("run_dkg_loop", epoch = %state.epoch).in_scope(|| {
                                 info!(
@@ -341,13 +335,10 @@ where
                                 )
                             });
 
-                            if let Err(err) = storage
+                            storage = storage
                                 .set_state(new_state)
                                 .await
-                                .wrap_err("failed appending new state to journal")
-                            {
-                                break Err(err);
-                            }
+                                .wrap_err("failed appending new state to journal")?;
                             // Emits an error event.
                             let _ = self.exit_epoch(&state);
 
@@ -357,7 +348,7 @@ where
                     };
                     ack.acknowledge();
                     if should_break {
-                        break Ok(());
+                        break Ok(storage);
                     }
                 }
 
@@ -365,7 +356,7 @@ where
                     match network_msg {
                         Ok((sender, message)) => {
                             // Produces an error event.
-                            let result = self.handle_network_msg(
+                            storage = self.handle_network_msg(
                                 &round,
                                 &mut round_sender,
                                 storage,
@@ -373,15 +364,7 @@ where
                                 player_state.as_mut(),
                                 sender,
                                 message,
-                            ).await;
-                            // Malformed messages and send failures are recoverable,
-                            // but a failed storage mutation consumes its handle.
-                            // Exit with the original I/O error before another message
-                            // can access the poisoned storage.
-                            if storage.is_poisoned() {
-                                result.wrap_err("DKG storage invalidated while handling a network message")?;
-                                bail!("DKG storage invalidated without a reported error");
-                            }
+                            ).await.wrap_err("failed persisting DKG network message")?;
                         }
                         Err(err) => {
                             break Err(err).wrap_err("network p2p subchannel closed")
@@ -443,7 +426,7 @@ where
                             if let Ok(Some((hole, request))) = self
                                 .handle_get_dkg_outcome(
                                     &msg.cause,
-                                    storage,
+                                    &mut storage,
                                     &player_state,
                                     &round,
                                     &state,
@@ -483,7 +466,7 @@ where
                         .take_request()
                         .expect("if the stream is yielding blocks, there must be a receiver");
                     if let Ok(Some((hole, request))) = self
-                        .handle_get_dkg_outcome(&cause, storage, &player_state, &round, &state, request)
+                        .handle_get_dkg_outcome(&cause, &mut storage, &player_state, &round, &state, request)
                         .await
                     {
                         let stream = match self
@@ -561,8 +544,8 @@ where
     #[instrument(skip_all, err)]
     async fn prepopulate_to_last_finalized_height<TStorageContext>(
         &self,
-        storage: &mut state::Storage<TStorageContext>,
-    ) -> eyre::Result<()>
+        mut storage: state::Storage<TStorageContext>,
+    ) -> eyre::Result<state::Storage<TStorageContext>>
     where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
     {
@@ -578,7 +561,7 @@ where
         // The DKG actor may have persisted the new epoch before the finalized floor caught up
         // during shutdown. Do not replay prior-epoch headers against the newer DKG round.
         if round.epoch() > epoch_info.epoch() {
-            return Ok(());
+            return Ok(storage);
         }
 
         let mut height = storage
@@ -604,21 +587,22 @@ where
                 "neither consensus nor execution layer had a header for block at height `{height}`"
             ))?;
 
-            self.record_finalized_header(storage, &round, header, None)
+            storage = self
+                .record_finalized_header(storage, &round, header, None)
                 .await
                 .wrap_err("failed backfilling header to storage")?;
             height = height.next();
         }
-        Ok(())
+        Ok(storage)
     }
 
     async fn record_finalized_header<TStorageContext>(
         &self,
-        storage: &mut state::Storage<TStorageContext>,
+        mut storage: state::Storage<TStorageContext>,
         round: &Round,
         header: TempoHeader,
         dealer_state: Option<&mut Dealer>,
-    ) -> eyre::Result<()>
+    ) -> eyre::Result<state::Storage<TStorageContext>>
     where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
     {
@@ -636,7 +620,7 @@ where
                     }
                     Ok((dealer, log)) => (dealer, log),
                 };
-                storage
+                storage = storage
                     .append_dealer_log(round.epoch(), dealer.clone(), log)
                     .await
                     .wrap_err("failed to append dealer log from finalized header")?;
@@ -697,7 +681,7 @@ where
 
     /// Handles a finalized block.
     ///
-    /// Returns a new [`State`] after finalizing the boundary block of the epoch.
+    /// Returns storage and, at the epoch boundary, a new [`State`].
     ///
     /// Some block heights are special cased:
     ///
@@ -740,11 +724,11 @@ where
         state: &State,
         round: &Round,
         round_channel: &mut TSender,
-        storage: &mut state::Storage<TStorageContext>,
+        mut storage: state::Storage<TStorageContext>,
         dealer_state: &mut Option<Dealer>,
         player_state: &mut Option<Player>,
         header: TempoHeader,
-    ) -> eyre::Result<Option<State>>
+    ) -> eyre::Result<(state::Storage<TStorageContext>, Option<State>)>
     where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
         TSender: Sender<PublicKey = PublicKey>,
@@ -774,7 +758,7 @@ where
                     after a boundary block completed an epoch, but before \
                     it was fully processed by other actors"
                 );
-                return Ok(None);
+                return Ok((storage, None));
             }
             Ordering::Equal => {
                 // Normal, expected behavior.
@@ -784,15 +768,16 @@ where
         match epoch_info.phase() {
             EpochPhase::Early => {
                 if let Some(dealer_state) = dealer_state {
-                    self.distribute_shares(
-                        storage,
-                        round.epoch(),
-                        dealer_state,
-                        player_state,
-                        round_channel,
-                    )
-                    .await
-                    .wrap_err("failed distributing shares")?;
+                    storage = self
+                        .distribute_shares(
+                            storage,
+                            round.epoch(),
+                            dealer_state,
+                            player_state,
+                            round_channel,
+                        )
+                        .await
+                        .wrap_err("failed distributing shares")?;
                 }
             }
             EpochPhase::Midpoint | EpochPhase::Late => {
@@ -803,11 +788,12 @@ where
         }
 
         if height != epoch_info.last() {
-            self.record_finalized_header(storage, round, header, dealer_state.as_mut())
+            storage = self
+                .record_finalized_header(storage, round, header, dealer_state.as_mut())
                 .await
                 .wrap_err("failed to record finalized header")?;
 
-            return Ok(None);
+            return Ok((storage, None));
         }
 
         info!("reached last block of epoch; reading DKG outcome from header");
@@ -902,25 +888,28 @@ where
             self.metrics.successes.metric().inc();
         }
 
-        Ok(Some(State {
-            epoch: onchain_outcome.epoch,
-            seed: Summary::random(self.context.as_present_mut()),
-            output: onchain_outcome.output.clone(),
-            share,
-            players: onchain_outcome.next_players,
-            is_full_dkg: onchain_outcome.is_next_full_dkg,
-        }))
+        Ok((
+            storage,
+            Some(State {
+                epoch: onchain_outcome.epoch,
+                seed: Summary::random(self.context.as_present_mut()),
+                output: onchain_outcome.output.clone(),
+                share,
+                players: onchain_outcome.next_players,
+                is_full_dkg: onchain_outcome.is_next_full_dkg,
+            }),
+        ))
     }
 
     #[instrument(skip_all, fields(me = %self.config.me.public_key(), %epoch))]
     async fn distribute_shares<TStorageContext, TSender>(
         &self,
-        storage: &mut state::Storage<TStorageContext>,
+        mut storage: state::Storage<TStorageContext>,
         epoch: Epoch,
         dealer_state: &mut Dealer,
         player_state: &mut Option<Player>,
         round_channel: &mut TSender,
-    ) -> eyre::Result<()>
+    ) -> eyre::Result<state::Storage<TStorageContext>>
     where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
         TSender: Sender<PublicKey = PublicKey>,
@@ -929,28 +918,24 @@ where
         for (player, pub_msg, priv_msg) in dealer_state.shares_to_distribute().collect::<Vec<_>>() {
             if player == me {
                 if let Some(player_state) = player_state {
-                    let result: eyre::Result<()> = async {
-                        let ack = player_state
-                            .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
-                            .await
-                            .wrap_err("failed to store our own dealing")?;
+                    let (updated_storage, ack) = player_state
+                        .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
+                        .await
+                        .wrap_err("failed to store our own dealing")?;
+                    storage = updated_storage;
+                    if let Some(ack) = ack {
                         self.metrics.shares_distributed.metric().inc();
                         self.metrics.shares_received.metric().inc();
-                        dealer_state
+                        let (updated_storage, accepted) = dealer_state
                             .receive_ack(storage, epoch, me.clone(), ack)
                             .await
                             .wrap_err("failed to store our own ACK")?;
-                        self.metrics.acks_received.metric().inc();
-                        self.metrics.acks_sent.metric().inc();
-                        info!("stored our own ACK and share");
-                        Ok(())
-                    }
-                    .await;
-                    if let Err(error) = result {
-                        if storage.is_poisoned() {
-                            return Err(error);
+                        storage = updated_storage;
+                        if accepted {
+                            self.metrics.acks_received.metric().inc();
+                            self.metrics.acks_sent.metric().inc();
+                            info!("stored our own ACK and share");
                         }
-                        warn!(%error, "failed to process our own dealing or ACK");
                     }
                 }
             } else {
@@ -963,7 +948,7 @@ where
                 }
             }
         }
-        Ok(())
+        Ok(storage)
     }
 
     #[instrument(
@@ -982,27 +967,36 @@ where
         &self,
         round: &Round,
         round_channel: &mut impl Sender<PublicKey = PublicKey>,
-        storage: &mut state::Storage<TStorageContext>,
+        mut storage: state::Storage<TStorageContext>,
         dealer_state: Option<&mut Dealer>,
         player_state: Option<&mut Player>,
         from: PublicKey,
         mut message: IoBuf,
-    ) -> eyre::Result<()>
+    ) -> eyre::Result<state::Storage<TStorageContext>>
     where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
     {
-        let msg = Message::read_cfg(&mut message, &NZU32!(round.players().len() as u32))
-            .wrap_err("failed reading p2p message")?;
+        let msg = match Message::read_cfg(&mut message, &NZU32!(round.players().len() as u32)) {
+            Ok(msg) => msg,
+            Err(error) => {
+                warn!(%error, "failed reading p2p message");
+                return Ok(storage);
+            }
+        };
 
         match msg {
             Message::Dealer(pub_msg, priv_msg) => {
                 if let Some(player_state) = player_state {
                     info!("received message from a dealer");
                     self.metrics.shares_received.metric().inc();
-                    let ack = player_state
+                    let (updated_storage, ack) = player_state
                         .receive_dealing(storage, round.epoch(), from.clone(), pub_msg, priv_msg)
                         .await
                         .wrap_err("failed storing dealing")?;
+                    storage = updated_storage;
+                    let Some(ack) = ack else {
+                        return Ok(storage);
+                    };
 
                     let sent = round_channel.send(
                         Recipients::One(from.clone()),
@@ -1011,12 +1005,14 @@ where
                     );
 
                     // Follows the doc on the return value of of Sender::send.
-                    ensure!(
-                        !sent.is_empty(),
-                        "failed returning ACK to dealer because it was rate \
-                        limited, the connection was closed, or the message \
-                        otherwise rejected",
-                    );
+                    if sent.is_empty() {
+                        warn!(
+                            "failed returning ACK to dealer because it was rate \
+                            limited, the connection was closed, or the message \
+                            otherwise rejected"
+                        );
+                        return Ok(storage);
+                    }
 
                     info!("returned ACK to dealer");
                     self.metrics.acks_sent.metric().inc();
@@ -1028,7 +1024,7 @@ where
                 if let Some(dealer_state) = dealer_state {
                     info!("received an ACK");
                     self.metrics.acks_received.metric().inc();
-                    dealer_state
+                    (storage, _) = dealer_state
                         .receive_ack(storage, round.epoch(), from, ack)
                         .await
                         .wrap_err("failed storing ACK")?;
@@ -1037,7 +1033,7 @@ where
                 }
             }
         }
-        Ok(())
+        Ok(storage)
     }
 
     /// Attempts to serve a `GetDkgOutcome` request by finalizing the DKG outcome.

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -791,7 +791,8 @@ where
                         player_state,
                         round_channel,
                     )
-                    .await;
+                    .await
+                    .wrap_err("failed distributing shares")?;
                 }
             }
             EpochPhase::Midpoint | EpochPhase::Late => {
@@ -919,27 +920,25 @@ where
         dealer_state: &mut Dealer,
         player_state: &mut Option<Player>,
         round_channel: &mut TSender,
-    ) where
+    ) -> eyre::Result<()>
+    where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
         TSender: Sender<PublicKey = PublicKey>,
     {
         let me = self.config.me.public_key();
         for (player, pub_msg, priv_msg) in dealer_state.shares_to_distribute().collect::<Vec<_>>() {
             if player == me {
-                if let Some(player_state) = player_state
-                    && let Ok(ack) = player_state
+                if let Some(player_state) = player_state {
+                    let ack = player_state
                         .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
                         .await
-                        .inspect(|_| {
-                            self.metrics.shares_distributed.metric().inc();
-                            self.metrics.shares_received.metric().inc();
-                        })
-                        .inspect_err(|error| warn!(%error, "failed to store our own dealing"))
-                    && let Ok(()) = dealer_state
+                        .wrap_err("failed to store our own dealing")?;
+                    self.metrics.shares_distributed.metric().inc();
+                    self.metrics.shares_received.metric().inc();
+                    dealer_state
                         .receive_ack(storage, epoch, me.clone(), ack)
                         .await
-                        .inspect_err(|error| warn!(%error, "failed to store our own ACK"))
-                {
+                        .wrap_err("failed to store our own ACK")?;
                     self.metrics.acks_received.metric().inc();
                     self.metrics.acks_sent.metric().inc();
                     info!("stored our own ACK and share");
@@ -954,6 +953,7 @@ where
                 }
             }
         }
+        Ok(())
     }
 
     #[instrument(

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -929,19 +929,29 @@ where
         for (player, pub_msg, priv_msg) in dealer_state.shares_to_distribute().collect::<Vec<_>>() {
             if player == me {
                 if let Some(player_state) = player_state {
-                    let ack = player_state
-                        .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
-                        .await
-                        .wrap_err("failed to store our own dealing")?;
-                    self.metrics.shares_distributed.metric().inc();
-                    self.metrics.shares_received.metric().inc();
-                    dealer_state
-                        .receive_ack(storage, epoch, me.clone(), ack)
-                        .await
-                        .wrap_err("failed to store our own ACK")?;
-                    self.metrics.acks_received.metric().inc();
-                    self.metrics.acks_sent.metric().inc();
-                    info!("stored our own ACK and share");
+                    let result: eyre::Result<()> = async {
+                        let ack = player_state
+                            .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
+                            .await
+                            .wrap_err("failed to store our own dealing")?;
+                        self.metrics.shares_distributed.metric().inc();
+                        self.metrics.shares_received.metric().inc();
+                        dealer_state
+                            .receive_ack(storage, epoch, me.clone(), ack)
+                            .await
+                            .wrap_err("failed to store our own ACK")?;
+                        self.metrics.acks_received.metric().inc();
+                        self.metrics.acks_sent.metric().inc();
+                        info!("stored our own ACK and share");
+                        Ok(())
+                    }
+                    .await;
+                    if let Err(error) = result {
+                        if storage.is_poisoned() {
+                            return Err(error);
+                        }
+                        warn!(%error, "failed to process our own dealing or ACK");
+                    }
                 }
             } else {
                 // Send to remote player

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -236,6 +236,10 @@ where
         TSender: Sender<PublicKey = PublicKey>,
         TReceiver: Receiver<PublicKey = PublicKey>,
     {
+        ensure!(
+            !storage.is_poisoned(),
+            "DKG storage must be reopened after a failed or cancelled mutation"
+        );
         let state = storage.current();
 
         self.metrics.reset();
@@ -361,7 +365,7 @@ where
                     match network_msg {
                         Ok((sender, message)) => {
                             // Produces an error event.
-                            let _ = self.handle_network_msg(
+                            let result = self.handle_network_msg(
                                 &round,
                                 &mut round_sender,
                                 storage,
@@ -370,6 +374,14 @@ where
                                 sender,
                                 message,
                             ).await;
+                            // Malformed messages and send failures are recoverable,
+                            // but a failed storage mutation consumes its handle.
+                            // Exit with the original I/O error before another message
+                            // can access the poisoned storage.
+                            if storage.is_poisoned() {
+                                result.wrap_err("DKG storage invalidated while handling a network message")?;
+                                bail!("DKG storage invalidated without a reported error");
+                            }
                         }
                         Err(err) => {
                             break Err(err).wrap_err("network p2p subchannel closed")

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -13,7 +13,8 @@ use commonware_cryptography::{
     Signer as _,
     bls12381::{
         dkg::feldman_desmedt::{
-            self as dkg, DealerPrivMsg, DealerPubMsg, Info, Output, PlayerAck, SignedDealerLog,
+            self as dkg, DealerPrivMsg, DealerPubMsg, Info, Output, PlayerAck, Reveal,
+            SignedDealerLog,
         },
         primitives::{
             group::Share,
@@ -22,14 +23,13 @@ use commonware_cryptography::{
         },
     },
     ed25519::{PrivateKey, PublicKey},
-    transcript::{Summary, Transcript},
+    transcript::{Summary, Transcript, Version},
 };
 use commonware_parallel::Strategy;
-use commonware_runtime::{BufferPooler, Clock, Metrics, buffer::paged::CacheRef};
+use commonware_runtime::{BufferPooler, Clock, Metrics, ReadOptions, buffer::paged::CacheRef};
 use commonware_storage::{journal::segmented, metadata};
 use commonware_utils::{N3f1, NZU16, NZU32, NZUsize, ordered};
 use eyre::{OptionExt, WrapErr as _, bail};
-use futures::StreamExt as _;
 use tempo_primitives::TempoHeader;
 use tracing::{debug, info, instrument, warn};
 
@@ -55,8 +55,8 @@ pub(super) struct Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    states: metadata::Metadata<TContext, u64, State>,
-    events: segmented::variable::Journal<TContext, Event>,
+    states: Option<metadata::Metadata<TContext, u64, State>>,
+    events: Option<segmented::variable::Journal<TContext, Event>>,
 
     current: Option<State>,
     cache: BTreeMap<Epoch, Events>,
@@ -84,11 +84,15 @@ where
 
     pub(super) async fn init_verified(self, state: State) -> eyre::Result<Storage<TContext>> {
         let Self { mut storage } = self;
-        storage
-            .states
-            .put_sync(state.epoch.get(), state.clone())
-            .await
-            .wrap_err("unable to write initial state to metadata")?;
+        storage.states = Some(
+            storage
+                .states
+                .take()
+                .expect("DKG states storage is available")
+                .put_sync(state.epoch.get(), state.clone())
+                .await
+                .wrap_err("unable to write initial state to metadata")?,
+        );
         storage.current = Some(state);
         Ok(storage)
     }
@@ -138,10 +142,21 @@ where
 
     /// Persists the outcome of a DKG ceremony to state
     pub(super) async fn set_state(&mut self, state: State) -> eyre::Result<()> {
-        if let Some(old) = self.states.put(state.epoch.get(), state.clone()) {
+        let states = self
+            .states
+            .as_mut()
+            .expect("DKG states storage is available");
+        if let Some(old) = states.put(state.epoch.get(), state.clone()) {
             warn!(epoch = %old.epoch, "overwriting existing state");
         }
-        self.states.sync().await.wrap_err("failed writing state")?;
+        self.states = Some(
+            self.states
+                .take()
+                .expect("DKG states storage is available")
+                .sync()
+                .await
+                .wrap_err("failed writing state")?,
+        );
         self.current = Some(state);
         Ok(())
     }
@@ -171,7 +186,10 @@ where
         }
 
         let section = epoch.get();
-        self.events
+        let (events, _, _) = self
+            .events
+            .take()
+            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Ack {
@@ -181,11 +199,12 @@ where
             )
             .await
             .wrap_err("unable to write event to storage")?;
-
-        self.events
-            .sync(section)
-            .await
-            .wrap_err("unable to sync events journal")?;
+        self.events = Some(
+            events
+                .sync(section)
+                .await
+                .wrap_err("unable to sync events journal")?,
+        );
 
         self.cache
             .entry(epoch)
@@ -222,7 +241,10 @@ where
         }
 
         let section = epoch.get();
-        self.events
+        let (events, _, _) = self
+            .events
+            .take()
+            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Dealing {
@@ -233,11 +255,12 @@ where
             )
             .await
             .wrap_err("unable to write event to storage")?;
-
-        self.events
-            .sync(section)
-            .await
-            .wrap_err("unable to sync events journal")?;
+        self.events = Some(
+            events
+                .sync(section)
+                .await
+                .wrap_err("unable to sync events journal")?,
+        );
 
         self.cache
             .entry(epoch)
@@ -269,7 +292,10 @@ where
         }
 
         let section = epoch.get();
-        self.events
+        let (events, _, _) = self
+            .events
+            .take()
+            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Log {
@@ -279,10 +305,12 @@ where
             )
             .await
             .wrap_err("failed to append log to journal")?;
-        self.events
-            .sync(section)
-            .await
-            .wrap_err("unable to sync journal")?;
+        self.events = Some(
+            events
+                .sync(section)
+                .await
+                .wrap_err("unable to sync journal")?,
+        );
 
         let cache = self.cache.entry(epoch).or_default();
         cache.logs.insert(dealer, log);
@@ -313,7 +341,10 @@ where
         }
 
         let section = epoch.get();
-        self.events
+        let (events, _, _) = self
+            .events
+            .take()
+            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Finalized {
@@ -324,10 +355,12 @@ where
             )
             .await
             .wrap_err("failed to append finalized block to journal")?;
-        self.events
-            .sync(section)
-            .await
-            .wrap_err("unable to sync journal")?;
+        self.events = Some(
+            events
+                .sync(section)
+                .await
+                .wrap_err("unable to sync journal")?,
+        );
 
         let cache = self.cache.entry(epoch).or_default();
         cache.finalized.insert(
@@ -413,7 +446,7 @@ where
         };
 
         let (mut dealer, pub_msg, priv_msgs) = dkg::Dealer::start::<N3f1>(
-            Transcript::resume(seed).noise(b"dealer-rng"),
+            Transcript::resume(seed, Version::V0).noise(b"dealer-rng"),
             round.info.clone(),
             me.clone(),
             share,
@@ -489,15 +522,26 @@ where
 
     #[instrument(skip_all, fields(%up_to_epoch), err)]
     pub(super) async fn prune(&mut self, up_to_epoch: Epoch) -> eyre::Result<()> {
-        self.events
+        let (events, _) = self
+            .events
+            .take()
+            .expect("DKG events storage is available")
             .prune(up_to_epoch.get())
             .await
             .wrap_err("unable to prune events journal")?;
-        self.states.retain(|&key, _| key >= up_to_epoch.get());
+        self.events = Some(events);
         self.states
-            .sync()
-            .await
-            .wrap_err("unable to prune events metadata")?;
+            .as_mut()
+            .expect("DKG states storage is available")
+            .retain(|&key, _| key >= up_to_epoch.get());
+        self.states = Some(
+            self.states
+                .take()
+                .expect("DKG states storage is available")
+                .sync()
+                .await
+                .wrap_err("unable to prune events metadata")?,
+        );
         self.cache.retain(|&epoch, _| epoch >= up_to_epoch);
         Ok(())
     }
@@ -563,11 +607,10 @@ impl Builder {
         // Replay msgs to populate epoch caches
         let mut cache = BTreeMap::<Epoch, Events>::new();
         {
-            let replay = events
-                .replay(0, 0, READ_BUFFER)
+            let mut replay = events
+                .replay(0, 0, READ_BUFFER, ReadOptions::default())
                 .await
                 .wrap_err("unable to start a replay stream to populate events cache")?;
-            futures::pin_mut!(replay);
 
             while let Some(result) = replay.next().await {
                 let (section, _, _, event) =
@@ -576,6 +619,9 @@ impl Builder {
                 let events = cache.entry(epoch).or_default();
                 events.insert(event);
             }
+            events = replay
+                .finish()
+                .wrap_err("unable to finish replaying events journal")?;
         }
 
         eyre::ensure!(
@@ -584,8 +630,8 @@ impl Builder {
         );
         Ok(Unverified {
             storage: Storage {
-                states,
-                events,
+                states: Some(states),
+                events: Some(events),
                 current,
                 cache,
             },
@@ -1049,6 +1095,8 @@ impl Round {
                 state.epoch.get(),
                 previous_output,
                 Mode::NonZeroCounter,
+                #[allow(deprecated)]
+                Reveal::V0,
                 dealers.clone(),
                 players.clone(),
             )
@@ -1116,12 +1164,11 @@ impl Player {
         }
 
         // Otherwise generate a new ack
-        let dkg::Verdict::Valid(ack) =
-            self.player
-                .dealer_message::<N3f1>(dealer.clone(), pub_msg.clone(), priv_msg.clone())
-        else {
-            bail!("applying dealer message to player instance did not result in a usable ack");
-        };
+        let ack = self
+            .player
+            .dealer_message::<N3f1>(dealer.clone(), pub_msg.clone(), priv_msg.clone())
+            .wrap_err("applying dealer message to player instance failed")?
+            .ok_or_eyre("dealer message was already processed without a cached acknowledgement")?;
         storage
             .append_dealing(epoch, dealer.clone(), pub_msg, priv_msg)
             .await
@@ -1140,9 +1187,9 @@ impl Player {
         if self.acks.contains_key(&dealer) {
             return;
         }
-        if let dkg::Verdict::Valid(ack) =
-            self.player
-                .dealer_message::<N3f1>(dealer.clone(), pub_msg, priv_msg)
+        if let Ok(Some(ack)) = self
+            .player
+            .dealer_message::<N3f1>(dealer.clone(), pub_msg, priv_msg)
         {
             self.acks.insert(dealer, ack);
         }
@@ -1154,7 +1201,7 @@ impl Player {
         rng: &mut impl rand_core::CryptoRng,
         logs: dkg::Logs<MinSig, PublicKey, N3f1>,
         strategy: &impl Strategy,
-    ) -> Result<(Output<MinSig, PublicKey>, Share), dkg::Error> {
+    ) -> Result<(Output<MinSig, PublicKey>, Share), dkg::FinalizeError<PublicKey>> {
         self.player
             .finalize::<N3f1, commonware_cryptography::ed25519::Batch>(rng, logs, strategy)
     }
@@ -1366,9 +1413,11 @@ mod tests {
                 "new storage must not contain a state"
             );
 
-            unverified
+            let (events, _, _) = unverified
                 .storage
                 .events
+                .take()
+                .expect("DKG events storage is available")
                 .append(
                     0,
                     &Event::Finalized {
@@ -1379,7 +1428,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            unverified.storage.events.sync(0).await.unwrap();
+            unverified.storage.events = Some(events.sync(0).await.unwrap());
             drop(unverified);
 
             let result = builder()

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -55,6 +55,9 @@ pub(super) struct Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
+    // Commonware mutations consume their handles. These slots are empty while
+    // an operation is in flight, and stay empty after failure or cancellation.
+    // Such storage must be dropped and reopened, never reused by the actor.
     states: Option<metadata::Metadata<TContext, u64, State>>,
     events: Option<segmented::variable::Journal<TContext, Event>>,
 
@@ -102,6 +105,10 @@ impl<TContext> Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
+    pub(super) fn is_poisoned(&self) -> bool {
+        self.states.is_none() || self.events.is_none()
+    }
+
     /// Returns all player acknowledgments received during the given epoch.
     fn acks_for_epoch(
         &self,

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -29,7 +29,7 @@ use commonware_parallel::Strategy;
 use commonware_runtime::{BufferPooler, Clock, Metrics, ReadOptions, buffer::paged::CacheRef};
 use commonware_storage::{journal::segmented, metadata};
 use commonware_utils::{N3f1, NZU16, NZU32, NZUsize, ordered};
-use eyre::{OptionExt, WrapErr as _, bail};
+use eyre::{OptionExt, WrapErr as _};
 use tempo_primitives::TempoHeader;
 use tracing::{debug, info, instrument, warn};
 
@@ -51,15 +51,16 @@ pub(super) fn builder() -> Builder {
     Builder::default()
 }
 
+/// DKG storage. Persistent mutations consume this value and return it
+/// only on success. Failure or cancellation drops the handles, so callers must
+/// reopen storage before continuing; there is no invalid storage value to reuse.
+#[must_use = "persistent mutations return the storage needed for subsequent operations"]
 pub(super) struct Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    // Commonware mutations consume their handles. These slots are empty while
-    // an operation is in flight, and stay empty after failure or cancellation.
-    // Such storage must be dropped and reopened, never reused by the actor.
-    states: Option<metadata::Metadata<TContext, u64, State>>,
-    events: Option<segmented::variable::Journal<TContext, Event>>,
+    states: metadata::Metadata<TContext, u64, State>,
+    events: segmented::variable::Journal<TContext, Event>,
 
     current: Option<State>,
     cache: BTreeMap<Epoch, Events>,
@@ -87,15 +88,11 @@ where
 
     pub(super) async fn init_verified(self, state: State) -> eyre::Result<Storage<TContext>> {
         let Self { mut storage } = self;
-        storage.states = Some(
-            storage
-                .states
-                .take()
-                .expect("DKG states storage is available")
-                .put_sync(state.epoch.get(), state.clone())
-                .await
-                .wrap_err("unable to write initial state to metadata")?,
-        );
+        storage.states = storage
+            .states
+            .put_sync(state.epoch.get(), state.clone())
+            .await
+            .wrap_err("unable to write initial state to metadata")?;
         storage.current = Some(state);
         Ok(storage)
     }
@@ -105,10 +102,6 @@ impl<TContext> Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    pub(super) fn is_poisoned(&self) -> bool {
-        self.states.is_none() || self.events.is_none()
-    }
-
     /// Returns all player acknowledgments received during the given epoch.
     fn acks_for_epoch(
         &self,
@@ -148,24 +141,13 @@ where
     }
 
     /// Persists the outcome of a DKG ceremony to state
-    pub(super) async fn set_state(&mut self, state: State) -> eyre::Result<()> {
-        let states = self
-            .states
-            .as_mut()
-            .expect("DKG states storage is available");
-        if let Some(old) = states.put(state.epoch.get(), state.clone()) {
+    pub(super) async fn set_state(mut self, state: State) -> eyre::Result<Self> {
+        if let Some(old) = self.states.put(state.epoch.get(), state.clone()) {
             warn!(epoch = %old.epoch, "overwriting existing state");
         }
-        self.states = Some(
-            self.states
-                .take()
-                .expect("DKG states storage is available")
-                .sync()
-                .await
-                .wrap_err("failed writing state")?,
-        );
+        self.states = self.states.sync().await.wrap_err("failed writing state")?;
         self.current = Some(state);
-        Ok(())
+        Ok(self)
     }
 
     /// Append a player ACK to the journal.
@@ -178,25 +160,23 @@ where
         err,
     )]
     async fn append_ack(
-        &mut self,
+        mut self,
         epoch: Epoch,
         player: PublicKey,
         ack: PlayerAck<PublicKey>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Self> {
         if self
             .cache
             .get(&epoch)
             .is_some_and(|events| events.acks.contains_key(&player))
         {
             info!(%player, %epoch, "ack for player already found in cache, dropping");
-            return Ok(());
+            return Ok(self);
         }
 
         let section = epoch.get();
         let (events, _, _) = self
             .events
-            .take()
-            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Ack {
@@ -206,12 +186,10 @@ where
             )
             .await
             .wrap_err("unable to write event to storage")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync events journal")?,
-        );
+        self.events = events
+            .sync(section)
+            .await
+            .wrap_err("unable to sync events journal")?;
 
         self.cache
             .entry(epoch)
@@ -219,7 +197,7 @@ where
             .acks
             .insert(player, ack);
 
-        Ok(())
+        Ok(self)
     }
 
     /// Append a dealer's dealing to the journal.
@@ -232,26 +210,24 @@ where
         err,
     )]
     async fn append_dealing(
-        &mut self,
+        mut self,
         epoch: Epoch,
         dealer: PublicKey,
         pub_msg: DealerPubMsg<MinSig>,
         priv_msg: DealerPrivMsg,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Self> {
         if self
             .cache
             .get(&epoch)
             .is_some_and(|events| events.dealings.contains_key(&dealer))
         {
             info!(%dealer, %epoch, "dealing of dealer already found in cache, dropping");
-            return Ok(());
+            return Ok(self);
         }
 
         let section = epoch.get();
         let (events, _, _) = self
             .events
-            .take()
-            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Dealing {
@@ -262,12 +238,10 @@ where
             )
             .await
             .wrap_err("unable to write event to storage")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync events journal")?,
-        );
+        self.events = events
+            .sync(section)
+            .await
+            .wrap_err("unable to sync events journal")?;
 
         self.cache
             .entry(epoch)
@@ -275,16 +249,16 @@ where
             .dealings
             .insert(dealer, (pub_msg, priv_msg));
 
-        Ok(())
+        Ok(self)
     }
 
     /// Appends a dealer log to the journal
     pub(super) async fn append_dealer_log(
-        &mut self,
+        mut self,
         epoch: Epoch,
         dealer: PublicKey,
         log: dkg::DealerLog<MinSig, PublicKey>,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Self> {
         if self
             .cache
             .get(&epoch)
@@ -295,14 +269,12 @@ where
                 %epoch,
                 "dealer log already found in cache; dropping"
             );
-            return Ok(());
+            return Ok(self);
         }
 
         let section = epoch.get();
         let (events, _, _) = self
             .events
-            .take()
-            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Log {
@@ -312,24 +284,22 @@ where
             )
             .await
             .wrap_err("failed to append log to journal")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync journal")?,
-        );
+        self.events = events
+            .sync(section)
+            .await
+            .wrap_err("unable to sync journal")?;
 
         let cache = self.cache.entry(epoch).or_default();
         cache.logs.insert(dealer, log);
-        Ok(())
+        Ok(self)
     }
 
     /// Appends the height, digest, and parent of the finalized header to the journal.
     pub(super) async fn append_finalized_header(
-        &mut self,
+        mut self,
         epoch: Epoch,
         header: TempoHeader,
-    ) -> eyre::Result<()> {
+    ) -> eyre::Result<Self> {
         let height = Height::new(header.number());
         let digest = Digest(header.hash_slow());
         let parent = Digest(header.parent_hash());
@@ -344,14 +314,12 @@ where
                 %parent,
                 "finalized block was already found in cache; dropping",
             );
-            return Ok(());
+            return Ok(self);
         }
 
         let section = epoch.get();
         let (events, _, _) = self
             .events
-            .take()
-            .expect("DKG events storage is available")
             .append(
                 section,
                 &Event::Finalized {
@@ -362,12 +330,10 @@ where
             )
             .await
             .wrap_err("failed to append finalized block to journal")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync journal")?,
-        );
+        self.events = events
+            .sync(section)
+            .await
+            .wrap_err("unable to sync journal")?;
 
         let cache = self.cache.entry(epoch).or_default();
         cache.finalized.insert(
@@ -378,7 +344,7 @@ where
                 parent,
             },
         );
-        Ok(())
+        Ok(self)
     }
 
     pub(super) fn cache_dkg_outcome(
@@ -528,29 +494,21 @@ where
     }
 
     #[instrument(skip_all, fields(%up_to_epoch), err)]
-    pub(super) async fn prune(&mut self, up_to_epoch: Epoch) -> eyre::Result<()> {
+    pub(super) async fn prune(mut self, up_to_epoch: Epoch) -> eyre::Result<Self> {
         let (events, _) = self
             .events
-            .take()
-            .expect("DKG events storage is available")
             .prune(up_to_epoch.get())
             .await
             .wrap_err("unable to prune events journal")?;
-        self.events = Some(events);
-        self.states
-            .as_mut()
-            .expect("DKG states storage is available")
-            .retain(|&key, _| key >= up_to_epoch.get());
-        self.states = Some(
-            self.states
-                .take()
-                .expect("DKG states storage is available")
-                .sync()
-                .await
-                .wrap_err("unable to prune events metadata")?,
-        );
+        self.events = events;
+        self.states.retain(|&key, _| key >= up_to_epoch.get());
+        self.states = self
+            .states
+            .sync()
+            .await
+            .wrap_err("unable to prune events metadata")?;
         self.cache.retain(|&epoch, _| epoch >= up_to_epoch);
-        Ok(())
+        Ok(self)
     }
 }
 
@@ -637,8 +595,8 @@ impl Builder {
         );
         Ok(Unverified {
             storage: Storage {
-                states: Some(states),
-                events: Some(events),
+                states,
+                events,
                 current,
                 cache,
             },
@@ -1005,36 +963,40 @@ impl Dealer {
     /// Handle an incoming ack from a player.
     ///
     /// If the ack is valid and new, persists it to storage.
-    /// Returns true if the ack was successfully processed.
+    /// Returns whether the ack was accepted. Rejected protocol messages retain
+    /// storage; only persistence failures return an error and consume it.
     pub(super) async fn receive_ack<TContext>(
         &mut self,
-        storage: &mut Storage<TContext>,
+        storage: Storage<TContext>,
         epoch: Epoch,
         player: PublicKey,
         ack: PlayerAck<PublicKey>,
-    ) -> eyre::Result<()>
+    ) -> eyre::Result<(Storage<TContext>, bool)>
     where
         TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
     {
         if !self.unsent.contains_key(&player) {
-            bail!("already received an ack from `{player}`");
+            warn!(%player, "already received an ack");
+            return Ok((storage, false));
         }
         match &mut self.dealer {
             Some(dealer) => {
-                dealer
-                    .receive_player_ack(player.clone(), ack.clone())
-                    .wrap_err("unable to receive player ack")?;
-                self.unsent.remove(&player);
-                storage
-                    .append_ack(epoch, player.clone(), ack.clone())
+                if let Err(error) = dealer.receive_player_ack(player.clone(), ack.clone()) {
+                    warn!(%player, %error, "unable to receive player ack");
+                    return Ok((storage, false));
+                }
+                let storage = storage
+                    .append_ack(epoch, player.clone(), ack)
                     .await
                     .wrap_err("unable to append ack to journal")?;
+                self.unsent.remove(&player);
+                Ok((storage, true))
             }
             None => {
-                bail!("dealer was already finalized, dropping ack of player `{player}`");
+                warn!(%player, "dealer was already finalized, dropping ack");
+                Ok((storage, false))
             }
         }
-        Ok(())
     }
 
     /// Finalize the dealer and produce a signed log for inclusion in a block.
@@ -1154,34 +1116,46 @@ impl Player {
     /// Handle an incoming dealer message.
     ///
     /// If this is a new valid dealer message, persists it to storage before returning.
+    /// Rejected protocol messages return no ack and retain storage. Persistence
+    /// failures consume storage and must terminate the round.
     pub(super) async fn receive_dealing<TContext>(
         &mut self,
-        storage: &mut Storage<TContext>,
+        storage: Storage<TContext>,
         epoch: Epoch,
         dealer: PublicKey,
         pub_msg: DealerPubMsg<MinSig>,
         priv_msg: DealerPrivMsg,
-    ) -> eyre::Result<PlayerAck<PublicKey>>
+    ) -> eyre::Result<(Storage<TContext>, Option<PlayerAck<PublicKey>>)>
     where
         TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
     {
         // If we've already generated an ack, return the cached version
         if let Some(ack) = self.acks.get(&dealer) {
-            return Ok(ack.clone());
+            return Ok((storage, Some(ack.clone())));
         }
 
         // Otherwise generate a new ack
-        let ack = self
-            .player
-            .dealer_message::<N3f1>(dealer.clone(), pub_msg.clone(), priv_msg.clone())
-            .wrap_err("applying dealer message to player instance failed")?
-            .ok_or_eyre("dealer message was already processed without a cached acknowledgement")?;
-        storage
+        let ack = match self.player.dealer_message::<N3f1>(
+            dealer.clone(),
+            pub_msg.clone(),
+            priv_msg.clone(),
+        ) {
+            Ok(Some(ack)) => ack,
+            Ok(None) => {
+                warn!(%dealer, "dealer message was already processed without a cached acknowledgement");
+                return Ok((storage, None));
+            }
+            Err(error) => {
+                warn!(%dealer, %error, "applying dealer message to player instance failed");
+                return Ok((storage, None));
+            }
+        };
+        let storage = storage
             .append_dealing(epoch, dealer.clone(), pub_msg, priv_msg)
             .await
             .wrap_err("unable to append dealing to journal")?;
         self.acks.insert(dealer, ack.clone());
-        Ok(ack)
+        Ok((storage, Some(ack)))
     }
 
     /// Replay an already-persisted dealer message (updates in-memory state only).
@@ -1423,8 +1397,6 @@ mod tests {
             let (events, _, _) = unverified
                 .storage
                 .events
-                .take()
-                .expect("DKG events storage is available")
                 .append(
                     0,
                     &Event::Finalized {
@@ -1435,7 +1407,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            unverified.storage.events = Some(events.sync(0).await.unwrap());
+            unverified.storage.events = events.sync(0).await.unwrap();
             drop(unverified);
 
             let result = builder()

--- a/crates/consensus/src/dkg/manager/actor/tests/harness.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/harness.rs
@@ -23,7 +23,11 @@ use commonware_cryptography::{
     Signer as _,
     bls12381::{
         dkg::feldman_desmedt::{self as dkg, Logs, Output, SignedDealerLog},
-        primitives::{group::Share, sharing::Sharing, variant::MinSig},
+        primitives::{
+            group::Share,
+            sharing::{Mode, Sharing},
+            variant::MinSig,
+        },
     },
     ed25519::{Batch, PrivateKey, PublicKey},
     transcript::Summary,
@@ -678,7 +682,7 @@ pub(super) fn dkg_state(
     let players = ordered::Set::try_from_iter(keys.iter().map(|key| key.public_key()))
         .expect("test players should be unique");
     let (output, shares) =
-        dkg::deal::<MinSig, _, N3f1>(&mut *rng, Default::default(), players.clone())
+        dkg::deal::<MinSig, _, N3f1>(&mut *rng, Mode::NonZeroCounter, players.clone())
             .expect("test DKG");
     let shares = keys
         .iter()
@@ -732,13 +736,14 @@ pub(super) fn revealed_recovery_fixture(
                 .find(|key| key.public_key() == player_public_key)
                 .unwrap();
             let mut player = dkg::Player::new(round.info().clone(), player_key.clone()).unwrap();
-            let dkg::Verdict::Valid(ack) = player.dealer_message::<N3f1>(
-                dealer_public_key.clone(),
-                public_message.clone(),
-                private_message,
-            ) else {
-                panic!("test dealing must be valid");
-            };
+            let ack = player
+                .dealer_message::<N3f1>(
+                    dealer_public_key.clone(),
+                    public_message.clone(),
+                    private_message,
+                )
+                .expect("test dealing must be valid")
+                .expect("test dealing must be new");
             dealer.receive_player_ack(player_public_key, ack).unwrap();
         }
 

--- a/crates/consensus/src/dkg/manager/actor/tests/harness.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/harness.rs
@@ -196,6 +196,12 @@ impl Harness {
             .expect("DKG storage is not open while the actor is running")
     }
 
+    pub(super) fn storage_mut(&mut self) -> &mut state::Storage<Context> {
+        self.storage
+            .as_mut()
+            .expect("DKG storage is not open while the actor is running")
+    }
+
     pub(super) async fn start(&mut self) {
         assert!(self.handle.is_none(), "DKG actor is already running");
         drop(self.storage.take());

--- a/crates/consensus/src/dkg/manager/actor/tests/harness.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/harness.rs
@@ -263,10 +263,14 @@ impl Harness {
     }
 
     pub(super) async fn wait_for_exit(&mut self) {
+        self.wait_for_actor_exit().await;
+        self.reopen_storage().await;
+    }
+
+    pub(super) async fn wait_for_actor_exit(&mut self) {
         let handle = self.handle.take().expect("DKG actor is not running");
         handle.await.expect("DKG actor should stop");
         self.mailbox.take();
-        self.reopen_storage().await;
     }
 
     async fn reopen_storage(&mut self) {

--- a/crates/consensus/src/dkg/manager/actor/tests/harness.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/harness.rs
@@ -196,9 +196,9 @@ impl Harness {
             .expect("DKG storage is not open while the actor is running")
     }
 
-    pub(super) fn storage_mut(&mut self) -> &mut state::Storage<Context> {
+    pub(super) fn take_storage(&mut self) -> state::Storage<Context> {
         self.storage
-            .as_mut()
+            .take()
             .expect("DKG storage is not open while the actor is running")
     }
 

--- a/crates/consensus/src/dkg/manager/actor/tests/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/mod.rs
@@ -151,7 +151,7 @@ fn local_share_storage_failures_stop_actor_and_allow_recovery() {
 
             if seed_dealing {
                 let round = Round::from_state(&state, crate::config::NAMESPACE);
-                let storage = harness.storage_mut();
+                let mut storage = harness.take_storage();
                 let dealer = storage
                     .create_dealer_for_round(
                         identity.clone(),
@@ -169,10 +169,11 @@ fn local_share_storage_failures_stop_actor_and_allow_recovery() {
                     .shares_to_distribute()
                     .find(|(recipient, _, _)| *recipient == identity.public_key())
                     .unwrap();
-                player
+                let (_storage, ack) = player
                     .receive_dealing(storage, state.epoch, identity.public_key(), public, private)
                     .await
                     .unwrap();
+                assert!(ack.is_some());
             }
 
             harness.start().await;
@@ -231,6 +232,119 @@ fn local_share_storage_failures_stop_actor_and_allow_recovery() {
             );
         });
     }
+}
+
+#[test]
+fn rejected_and_duplicate_messages_retain_storage() {
+    use commonware_runtime::deterministic::FaultConfig;
+    use commonware_utils::probability;
+
+    Runner::default().start(|mut context| async move {
+        let (state, keys, _) = dkg_state(&mut context, Epoch::new(1), 2, true);
+        let round = Round::from_state(&state, crate::config::NAMESPACE);
+        let mut harness = Harness::builder(context.child("actor"), "recoverable_messages")
+            .initial_state(state.clone())
+            .build()
+            .await;
+        let mut storage = harness.take_storage();
+        let mut dealer = storage
+            .create_dealer_for_round(
+                keys[1].clone(),
+                round.clone(),
+                state.share.clone(),
+                state.seed,
+            )
+            .unwrap()
+            .unwrap();
+        let mut player = storage
+            .create_player_for_round(keys[0].clone(), &round)
+            .unwrap()
+            .unwrap();
+        let (_, public, private) = dealer
+            .shares_to_distribute()
+            .find(|(recipient, _, _)| *recipient == keys[0].public_key())
+            .unwrap();
+        let (_, _, wrong_private) = dealer
+            .shares_to_distribute()
+            .find(|(recipient, _, _)| *recipient == keys[1].public_key())
+            .unwrap();
+
+        let (storage, rejected) = player
+            .receive_dealing(
+                storage,
+                state.epoch,
+                keys[1].public_key(),
+                public.clone(),
+                wrong_private,
+            )
+            .await
+            .unwrap();
+        assert!(rejected.is_none());
+        let (storage, ack) = player
+            .receive_dealing(
+                storage,
+                state.epoch,
+                keys[1].public_key(),
+                public.clone(),
+                private.clone(),
+            )
+            .await
+            .unwrap();
+        let ack = ack.expect("valid dealing after a rejection must be accepted");
+
+        let (storage, accepted) = dealer
+            .receive_ack(storage, state.epoch, keys[1].public_key(), ack.clone())
+            .await
+            .unwrap();
+        assert!(
+            !accepted,
+            "an ACK attributed to the wrong player is rejected"
+        );
+        let (storage, accepted) = dealer
+            .receive_ack(storage, state.epoch, keys[0].public_key(), ack.clone())
+            .await
+            .unwrap();
+        assert!(accepted);
+
+        // Duplicate messages must return usable storage without another write.
+        let faults = context.storage_fault_config();
+        faults.write().sync_rate = Some(probability!(1.0));
+        let (storage, duplicate) = player
+            .receive_dealing(storage, state.epoch, keys[1].public_key(), public, private)
+            .await
+            .unwrap();
+        assert_eq!(duplicate.as_ref(), Some(&ack));
+        let (storage, accepted) = dealer
+            .receive_ack(storage, state.epoch, keys[0].public_key(), ack)
+            .await
+            .unwrap();
+        assert!(!accepted);
+        *faults.write() = FaultConfig::default();
+
+        let storage = storage
+            .append_finalized_header(state.epoch, header(Height::new(10)))
+            .await
+            .unwrap();
+        assert_eq!(
+            *storage
+                .get_latest_finalized_block_for_epoch(&state.epoch)
+                .unwrap()
+                .0,
+            Height::new(10),
+        );
+        drop(storage);
+        harness.stop().await;
+        let dealer = harness
+            .take_storage()
+            .create_dealer_for_round(keys[1].clone(), round, state.share, state.seed)
+            .unwrap()
+            .unwrap();
+        assert!(
+            dealer
+                .shares_to_distribute()
+                .all(|(recipient, _, _)| recipient != keys[0].public_key())
+        );
+    });
 }
 
 #[test]

--- a/crates/consensus/src/dkg/manager/actor/tests/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/mod.rs
@@ -75,8 +75,11 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
 
             // No second message should be needed to discover the missing handle,
             // and the actor must return normally rather than panic on an expect.
-            context
-                .timeout(Duration::from_secs(1), harness.wait_for_actor_exit())
+            let mut harness = context
+                .timeout(Duration::from_secs(1), async move {
+                    harness.wait_for_actor_exit().await;
+                    harness
+                })
                 .await
                 .expect("a network storage failure must terminate the actor immediately");
 
@@ -113,7 +116,7 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
                     .accepted()
             );
             let (_, ack) = context
-                .timeout(Duration::from_secs(1), receiver.recv())
+                .timeout(Duration::from_secs(1), async move { receiver.recv().await })
                 .await
                 .expect("reopened storage must accept the retried dealing")
                 .unwrap();

--- a/crates/consensus/src/dkg/manager/actor/tests/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/mod.rs
@@ -21,6 +21,114 @@ use harness::{
 };
 
 #[test]
+fn network_storage_failures_stop_actor_and_allow_recovery() {
+    use commonware_runtime::deterministic::FaultConfig;
+    use commonware_utils::probability;
+
+    // Exercise both failure while appending to a new journal section and
+    // failure while syncing an appended dealing.
+    for fail_open in [true, false] {
+        Runner::default().start(|mut context| async move {
+            let (state, keys, _) = dkg_state(&mut context, Epoch::new(1), 2, true);
+            let round = Round::from_state(&state, crate::config::NAMESPACE);
+            let (_, public, private) = dkg::Dealer::start::<commonware_utils::N3f1>(
+                &mut context,
+                round.info().clone(),
+                keys[1].clone(),
+                None,
+            )
+            .unwrap();
+            let private = private
+                .into_iter()
+                .find(|(player, _)| player == &keys[0].public_key())
+                .unwrap()
+                .1;
+            let message = Message::Dealer(public, private).encode();
+            let network = TestNetwork::default();
+            let (sender, mut receiver) = network.register(keys[1].public_key());
+            let mut sender = mux::GlobalSender::new(sender);
+            let mut harness = Harness::builder(context.child("actor"), "network_storage_failure")
+                .initial_state(state.clone())
+                .identity(keys[0].clone())
+                .network(network)
+                .build()
+                .await;
+            harness.start().await;
+            assert!(!harness.has_dealer_log(state.epoch).await);
+
+            let faults = context.storage_fault_config();
+            if fail_open {
+                faults.write().open_rate = Some(probability!(1.0));
+            } else {
+                faults.write().sync_rate = Some(probability!(1.0));
+            }
+            assert!(
+                sender
+                    .send(
+                        state.epoch.get(),
+                        Recipients::One(keys[0].public_key()),
+                        message.clone(),
+                        true,
+                    )
+                    .accepted()
+            );
+
+            // No second message should be needed to discover the missing handle,
+            // and the actor must return normally rather than panic on an expect.
+            context
+                .timeout(Duration::from_secs(1), harness.wait_for_actor_exit())
+                .await
+                .expect("a network storage failure must terminate the actor immediately");
+
+            *faults.write() = FaultConfig::default();
+            harness.stop().await;
+            assert_eq!(harness.storage().current(), state);
+            harness.start().await;
+            assert!(!harness.has_dealer_log(state.epoch).await);
+
+            // Invalid peer input must remain recoverable: send a malformed message
+            // before retrying the valid dealing and require its acknowledgement.
+            assert!(
+                sender
+                    .send(
+                        state.epoch.get(),
+                        Recipients::One(keys[0].public_key()),
+                        vec![u8::MAX],
+                        true,
+                    )
+                    .accepted()
+            );
+            // Let the mux deliver the malformed message before filling its
+            // single-slot subchannel again.
+            context.sleep(Duration::from_millis(1)).await;
+            assert!(!harness.has_dealer_log(state.epoch).await);
+            assert!(
+                sender
+                    .send(
+                        state.epoch.get(),
+                        Recipients::One(keys[0].public_key()),
+                        message,
+                        true,
+                    )
+                    .accepted()
+            );
+            let (_, ack) = context
+                .timeout(Duration::from_secs(1), receiver.recv())
+                .await
+                .expect("reopened storage must accept the retried dealing")
+                .unwrap();
+            let (epoch, mut ack) = mux::parse(ack).unwrap();
+            assert_eq!(epoch, state.epoch.get());
+            assert!(matches!(
+                Message::read_cfg(&mut ack, &NZU32!(2)).unwrap(),
+                Message::Ack(_)
+            ));
+            harness.stop().await;
+        });
+    }
+}
+
+#[test]
 fn exhausted_ancestry_releases_pending_outcome_request() {
     Runner::default().start(|_| async move {
         let (response, receiver) = oneshot::channel();

--- a/crates/consensus/src/dkg/manager/actor/tests/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/mod.rs
@@ -132,6 +132,108 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
 }
 
 #[test]
+fn local_share_storage_failures_stop_actor_and_allow_recovery() {
+    use commonware_consensus::Reporter as _;
+    use commonware_runtime::deterministic::FaultConfig;
+    use commonware_utils::probability;
+
+    // Fail opening the dealing's journal section, syncing the dealing, or
+    // syncing the ACK after the dealing has already been persisted.
+    for (fail_open, seed_dealing) in [(true, false), (false, false), (false, true)] {
+        Runner::default().start(|mut context| async move {
+            let (state, keys, _) = dkg_state(&mut context, Epoch::new(1), 2, true);
+            let identity = keys[0].clone();
+            let mut harness = Harness::builder(context.child("actor"), "local_storage_failure")
+                .initial_state(state.clone())
+                .identity(identity.clone())
+                .build()
+                .await;
+
+            if seed_dealing {
+                let round = Round::from_state(&state, crate::config::NAMESPACE);
+                let storage = harness.storage_mut();
+                let dealer = storage
+                    .create_dealer_for_round(
+                        identity.clone(),
+                        round.clone(),
+                        state.share.clone(),
+                        state.seed,
+                    )
+                    .unwrap()
+                    .unwrap();
+                let mut player = storage
+                    .create_player_for_round(identity.clone(), &round)
+                    .unwrap()
+                    .unwrap();
+                let (_, public, private) = dealer
+                    .shares_to_distribute()
+                    .find(|(recipient, _, _)| *recipient == identity.public_key())
+                    .unwrap();
+                player
+                    .receive_dealing(storage, state.epoch, identity.public_key(), public, private)
+                    .await
+                    .unwrap();
+            }
+
+            harness.start().await;
+            assert!(!harness.has_dealer_log(state.epoch).await);
+            let faults = context.storage_fault_config();
+            if fail_open {
+                faults.write().open_rate = Some(probability!(1.0));
+            } else {
+                faults.write().sync_rate = Some(probability!(1.0));
+            }
+
+            // An early finalized block triggers delivery of our own dealing and
+            // ACK before the block's header is persisted.
+            let (ack, waiter) = Exact::handle();
+            assert!(
+                harness
+                    .mailbox()
+                    .clone()
+                    .report(Update::Block(Arc::new(block(header(Height::new(10)))), ack))
+                    .accepted()
+            );
+            let mut harness = context
+                .timeout(Duration::from_secs(1), async move {
+                    harness.wait_for_actor_exit().await;
+                    harness
+                })
+                .await
+                .expect("a local storage failure must terminate the actor without panicking");
+            assert!(
+                waiter.await.is_err(),
+                "the failed block must not be acknowledged"
+            );
+
+            *faults.write() = FaultConfig::default();
+            harness.stop().await;
+            assert_eq!(harness.storage().current(), state);
+            assert!(
+                harness
+                    .storage()
+                    .get_latest_finalized_block_for_epoch(&state.epoch)
+                    .is_none()
+            );
+            harness.start().await;
+            assert!(!harness.has_dealer_log(state.epoch).await);
+            harness
+                .report_finalized_header(header(Height::new(10)))
+                .await;
+            harness.stop().await;
+            assert_eq!(
+                *harness
+                    .storage()
+                    .get_latest_finalized_block_for_epoch(&state.epoch)
+                    .unwrap()
+                    .0,
+                Height::new(10)
+            );
+        });
+    }
+}
+
+#[test]
 fn exhausted_ancestry_releases_pending_outcome_request() {
     Runner::default().start(|_| async move {
         let (response, receiver) = oneshot::channel();

--- a/crates/consensus/src/epoch/manager/actor.rs
+++ b/crates/consensus/src/epoch/manager/actor.rs
@@ -347,7 +347,10 @@ where
                 epoch,
                 floor,
                 scheme,
-                elector: elector::Random,
+                #[allow(deprecated)]
+                elector: elector::Random::<commonware_cryptography::Sha256>::new(
+                    elector::RandomVersion::V0,
+                ),
                 strategy: Sequential,
 
                 reporter: Reporters::<_, crate::subblocks::Mailbox, _>::from((
@@ -370,12 +373,24 @@ where
                 certification_timeout: self.config.time_to_collect_notarizations,
                 timeout_retry: self.config.time_to_retry_nullify_broadcast,
                 fetch_timeout: self.config.time_for_peer_response,
-                activity_timeout: self.config.views_to_track,
-                skip_timeout: self.config.views_until_leader_skip,
+                view_retention: self.config.views_to_track,
+                skip: simplex::config::SkipPolicy::Enabled {
+                    timeout: self
+                        .config
+                        .time_to_collect_notarizations
+                        .max(self.config.time_to_retry_nullify_broadcast)
+                        .saturating_add(
+                            self.config.time_to_propose.saturating_mul(
+                                u32::try_from(self.config.views_until_leader_skip.get())
+                                    .unwrap_or(u32::MAX),
+                            ),
+                        ),
+                    budget: simplex::config::SkipBudget::Participants,
+                },
 
                 mailbox_size: self.config.mailbox_size,
-                fetch_concurrent: crate::config::NUMBER_CONCURRENT_FETCHES,
-                forwarding: commonware_consensus::simplex::config::ForwardingPolicy::Disabled,
+                forward: commonware_consensus::simplex::config::ForwardPolicy::Disabled,
+                track_historical_votes: true,
             },
         );
 

--- a/crates/consensus/src/lib.rs
+++ b/crates/consensus/src/lib.rs
@@ -83,25 +83,16 @@ pub async fn run_consensus_stack(
             .await
             .wrap_err("failed to start network")?;
 
-    let message_backlog = config.message_backlog;
-    let votes = network.register(VOTES_CHANNEL_IDENT, VOTES_LIMIT, message_backlog);
-    let certificates = network.register(
-        CERTIFICATES_CHANNEL_IDENT,
-        CERTIFICATES_LIMIT,
-        message_backlog,
-    );
-    let resolver = network.register(RESOLVER_CHANNEL_IDENT, RESOLVER_LIMIT, message_backlog);
-    let broadcaster = network.register(
-        BROADCASTER_CHANNEL_IDENT,
-        BROADCASTER_LIMIT,
-        message_backlog,
-    );
-    let marshal = network.register(MARSHAL_CHANNEL_IDENT, backfill_quota, message_backlog);
-    let dkg = network.register(DKG_CHANNEL_IDENT, DKG_LIMIT, message_backlog);
+    let votes = network.register(VOTES_CHANNEL_IDENT, VOTES_LIMIT);
+    let certificates = network.register(CERTIFICATES_CHANNEL_IDENT, CERTIFICATES_LIMIT);
+    let resolver = network.register(RESOLVER_CHANNEL_IDENT, RESOLVER_LIMIT);
+    let broadcaster = network.register(BROADCASTER_CHANNEL_IDENT, BROADCASTER_LIMIT);
+    let marshal = network.register(MARSHAL_CHANNEL_IDENT, backfill_quota);
+    let dkg = network.register(DKG_CHANNEL_IDENT, DKG_LIMIT);
     // We create the subblocks channel even though it might not be used to make
     // sure that we don't ban peers that activate subblocks and send messages
     // through this subchannel.
-    let subblocks = network.register(SUBBLOCKS_CHANNEL_IDENT, SUBBLOCKS_LIMIT, message_backlog);
+    let subblocks = network.register(SUBBLOCKS_CHANNEL_IDENT, SUBBLOCKS_LIMIT);
 
     let target_block_time = config.target_block_time.into_duration();
     // Consensus owns the end-to-end local proposal window. The network budget
@@ -263,9 +254,11 @@ async fn instantiate_network(
         allow_private_ips: config.allow_private_ips,
         allow_dns: config.allow_dns,
         tracked_peer_sets: crate::config::PEERSETS_TO_TRACK,
+        max_peers_per_set: config.max_peers_per_set,
         synchrony_bound: config.synchrony_bound.into_duration(),
         max_handshake_age: config.handshake_stale_after.into_duration(),
         handshake_timeout: config.handshake_timeout.into_duration(),
+        dial_timeout: config.dial_timeout.into_duration(),
         max_concurrent_handshakes: config.max_concurrent_handshakes,
         block_duration: config.time_to_unblock_byzantine_peer.into_duration(),
         dial_frequency: config.wait_before_peers_redial.into_duration(),

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -107,7 +107,7 @@ use reth_provider::{
     BlockReader, BlockSource, ProviderError, ProviderResult,
     providers::{BlockchainProvider, ProviderNodeTypes},
 };
-use tracing::{debug, info, instrument, warn};
+use tracing::{info, instrument};
 
 use crate::consensus::{Digest, block::Block};
 
@@ -297,21 +297,22 @@ where
     /// - Eviction tracks the EL's progress monotonically. Once the EL
     ///   finalizes height `H`, the cache may drop everything below
     ///   `H - retention_blocks + 1` on the next put.
-    async fn evict_below_execution_finalized_floor(&mut self) -> Result<(), archive::Error> {
+    async fn evict_below_execution_finalized_floor(mut self) -> Result<Self, archive::Error> {
         // Reth hasn't finalized anything yet (fresh chain) — nothing is
         // safe to evict.
         let Some(execution_finalized) = self.execution_block_provider.finalized_height() else {
-            return Ok(());
+            return Ok(self);
         };
         let Some(min_to_keep) = execution_finalized.checked_sub(self.retention_blocks) else {
-            return Ok(());
+            return Ok(self);
         };
         // `prune(min)` keeps `min` and above, and the archive rounds `min`
         // *down* to a section boundary, so the actual retained window can
         // exceed `retention_blocks` by up to `items_per_section − 1` items.
         // See the module docs ("Section-rounding") for the full story.
         let prune_floor = min_to_keep.saturating_add(1);
-        prunable::Archive::prune(&mut self.prunable, prune_floor).await
+        self.prunable = prunable::Archive::prune(self.prunable, prune_floor).await?;
+        Ok(self)
     }
 }
 
@@ -324,53 +325,18 @@ where
     type Error = Error;
 
     #[instrument(skip_all, err)]
-    async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
+    async fn put(mut self, block: Self::Block) -> Result<Self, Self::Error> {
         let height = block.height();
         let digest = block.digest();
-        match archive::Archive::put(&mut self.prunable, height.get(), digest, block).await {
-            Ok(()) => {}
-            // The prunable cache has already evicted this height — but
-            // by the cache's eviction invariant
-            // (`oldest_allowed ≤ section_aligned(execution_finalized − retention + 1)
-            // ≤ execution_finalized`), `height < oldest_allowed` implies
-            // `height ≤ execution_finalized`. The EL's finality contract
-            // guarantees every block at or below `execution_finalized` is
-            // durably persisted, so the marshal's subsequent
-            // `Blocks::get(height)` will be served out of the execution
-            // layer fallback path. We can't write to EL ourselves (it owns
-            // its own storage), but we don't have to — the block is
-            // already durable. Treat the put as a successful no-op so
-            // we don't trip the marshal's "failed to finalize" panic
-            // on a perfectly recoverable condition.
-            Err(archive::Error::AlreadyPrunedTo(oldest_allowed)) => {
-                debug!(
-                    %height,
-                    oldest_allowed,
-                    execution_finalized = ?self.execution_block_provider.finalized_height(),
-                    "finalized block below prunable cache window; trusting the \
-                    execution layer's finalized storage and treating put as a \
-                    no-op"
-                );
-            }
-            Err(other) => return Err(other.into()),
-        }
+        self.prunable = archive::Archive::put(self.prunable, height.get(), digest, block).await?;
 
-        if let Err(err) = self.evict_below_execution_finalized_floor().await {
-            // Eviction failures are not fatal; the next put will retry.
-            // We log because they may indicate disk-level issues.
-            warn!(
-                %err,
-                %height,
-                retention = self.retention_blocks,
-                "failed to evict prunable finalized blocks cache after put"
-            );
-        }
-        Ok(())
+        self = self.evict_below_execution_finalized_floor().await?;
+        Ok(self)
     }
 
-    async fn sync(&mut self) -> Result<(), Self::Error> {
-        archive::Archive::sync(&mut self.prunable).await?;
-        Ok(())
+    async fn sync(mut self) -> Result<Self, Self::Error> {
+        self.prunable = archive::Archive::sync(self.prunable).await?;
+        Ok(self)
     }
 
     /// Attempts to read `id` from the prunable archive, falling back to EL on miss.
@@ -398,8 +364,8 @@ where
     }
 
     /// No-op: Cache eviction is EL-driven (see [`Self::evict_below_execution_finalized_floor`]).
-    async fn prune(&mut self, _min: Height) -> Result<(), Self::Error> {
-        Ok(())
+    async fn prune(self, _min: Height) -> Result<Self, Self::Error> {
+        Ok(self)
     }
 
     fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {

--- a/crates/consensus/src/storage/hybrid/mod.rs
+++ b/crates/consensus/src/storage/hybrid/mod.rs
@@ -41,14 +41,13 @@
 //!
 //! # Stale puts
 //!
-//! [`Hybrid::put`] absorbs the prunable archive's
-//! [`archive::Error::AlreadyPrunedTo`] as a silent success. The
-//! eviction invariant
+//! The prunable archive silently ignores puts below its prune floor, so
+//! [`Hybrid::put`] treats them as successful no-ops. The eviction invariant
 //! `oldest_allowed ≤ section_aligned(reth.finalized − retention + 1)
 //! ≤ reth.finalized` guarantees that a put at `H < oldest_allowed`
 //! also has `H ≤ reth.finalized`, so the block is durable in reth and
-//! a subsequent [`Blocks::get`] will hit the reth fallback. Surfacing
-//! the error would crash the node on a recoverable condition (e.g.
+//! a subsequent [`Blocks::get`] will hit the reth fallback. Rejecting
+//! the put would crash the node on a recoverable condition (e.g.
 //! follow-mode catching up while reth has synced past the cache
 //! window).
 //!

--- a/crates/consensus/src/storage/hybrid/test/mod.rs
+++ b/crates/consensus/src/storage/hybrid/test/mod.rs
@@ -71,7 +71,7 @@ fn get_returns_block_from_prunable_archive() {
 
         let blocks = make_chain(1, 3);
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
 
         // By index.
@@ -112,7 +112,7 @@ fn get_falls_back_to_reth_on_prunable_miss() {
         // Also put one block into the prunable archive so we can assert
         // the prunable hit path was tried first.
         let in_prunable = chain[4].clone();
-        hybrid.put(in_prunable.clone()).await.expect("put");
+        hybrid = hybrid.put(in_prunable.clone()).await.expect("put");
 
         // Index path: prunable miss → reth hit.
         let height = only_in_reth.height();
@@ -216,7 +216,7 @@ fn put_trims_prunable_archive_to_retention() {
         let blocks = make_chain(1, (RETENTION as usize) + 3);
         let highest = blocks.last().unwrap().height().get();
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
 
         // Phase 2: advance reth's watermark to `highest` and trigger
@@ -225,7 +225,7 @@ fn put_trims_prunable_archive_to_retention() {
         // section overshoot, so the cache snaps to that floor.
         provider.set_reth_finalized(highest);
         let trigger = make_block(highest + 1, blocks.last().unwrap().block_hash());
-        hybrid.put(trigger).await.expect("put trigger");
+        hybrid = hybrid.put(trigger).await.expect("put trigger");
 
         // The newest `RETENTION` seeded blocks plus the trigger must
         // remain.
@@ -277,7 +277,7 @@ fn gap_tracking_treats_reth_finalized_as_covered_prefix() {
         let blocks = make_chain(6, 7); // heights 6..=12
         for offset in [0, 1, 4, 6] {
             let block = blocks[offset].clone();
-            hybrid.put(block).await.expect("put block");
+            hybrid = hybrid.put(block).await.expect("put block");
         }
 
         // Heights 1..=5 are covered by reth and 6..=7 by prunable, so
@@ -319,7 +319,7 @@ fn gap_tracking_merges_prunable_run_overlapping_reth_watermark() {
         provider.set_reth_finalized(5);
         let blocks = make_chain(3, 8); // heights 3..=10
         for offset in [0, 1, 2, 3, 4, 7] {
-            hybrid.put(blocks[offset].clone()).await.expect("put block");
+            hybrid = hybrid.put(blocks[offset].clone()).await.expect("put block");
         }
 
         assert_eq!(
@@ -370,8 +370,8 @@ fn next_gap_upholds_blocks_trait_behavior_contract() {
         // `current_range_end` will be `None`" — and `next_range_start`
         // points at the first range.
         let blocks = make_chain(4, 6); // heights 4..=9
-        hybrid.put(blocks[4].clone()).await.expect("put 8");
-        hybrid.put(blocks[5].clone()).await.expect("put 9");
+        hybrid = hybrid.put(blocks[4].clone()).await.expect("put 8");
+        hybrid = hybrid.put(blocks[5].clone()).await.expect("put 9");
         assert_eq!(
             hybrid.next_gap(Height::new(2)),
             (None, Some(Height::new(8)))
@@ -380,8 +380,8 @@ fn next_gap_upholds_blocks_trait_behavior_contract() {
         // Coverage is now [0..=5] (reth 0..=3 merged with prunable 4..=5)
         // and [8..=9].
         provider.set_reth_finalized(3);
-        hybrid.put(blocks[0].clone()).await.expect("put 4");
-        hybrid.put(blocks[1].clone()).await.expect("put 5");
+        hybrid = hybrid.put(blocks[0].clone()).await.expect("put 4");
+        hybrid = hybrid.put(blocks[1].clone()).await.expect("put 5");
 
         // "If `value` falls within an existing range `[r_start, r_end]`,
         // `current_range_end` will be `Some(r_end)`."
@@ -446,7 +446,7 @@ fn sync_flushes_prunable_archive() {
 
         let blocks = make_chain(1, 2);
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
         hybrid
             .sync()
@@ -462,8 +462,8 @@ fn put_at_existing_index_is_idempotent() {
         let (mut hybrid, _) = SetupHybrid::default().build(&context).await;
 
         let blocks = make_chain(1, 1);
-        hybrid.put(blocks[0].clone()).await.expect("first put");
-        hybrid.put(blocks[0].clone()).await.expect("idempotent put");
+        hybrid = hybrid.put(blocks[0].clone()).await.expect("first put");
+        hybrid = hybrid.put(blocks[0].clone()).await.expect("idempotent put");
 
         let stored = hybrid
             .get(Identifier::Index(1))
@@ -489,7 +489,7 @@ fn put_below_retention_silently_succeeds_when_reth_covers_the_height() {
         // (no eviction yet).
         let blocks = make_chain(1, 6);
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
 
         // Phase 2: advance reth's watermark and trigger eviction with
@@ -498,7 +498,7 @@ fn put_below_retention_silently_succeeds_when_reth_covers_the_height() {
         // <5 are dropped.
         provider.set_reth_finalized(6);
         let trigger = make_block(7, blocks.last().unwrap().block_hash());
-        hybrid.put(trigger).await.expect("put trigger");
+        hybrid = hybrid.put(trigger).await.expect("put trigger");
 
         // Phase 3: model "reth has the evicted height" by seeding the
         // stub provider with the original block. The marshal would
@@ -506,7 +506,7 @@ fn put_below_retention_silently_succeeds_when_reth_covers_the_height() {
         // in reth's storage at or below its finalized boundary, so
         // re-putting it must succeed silently.
         provider.add_block(&blocks[0]);
-        hybrid
+        hybrid = hybrid
             .put(blocks[0].clone())
             .await
             .expect("re-put of an already-durable height must be a no-op success");
@@ -540,7 +540,7 @@ fn prune_respects_section_boundary() {
         // (no eviction yet).
         let blocks = make_chain(1, 30);
         for block in &blocks {
-            hybrid.put(block.clone()).await.unwrap();
+            hybrid = hybrid.put(block.clone()).await.unwrap();
         }
 
         // Phase 1: advance reth's watermark to 23. Requested eviction
@@ -549,7 +549,7 @@ fn prune_respects_section_boundary() {
         // [0, 7] are dropped and the cache holds heights 8..=31.
         provider.set_reth_finalized(23);
         let next31 = make_block(31, blocks.last().unwrap().block_hash());
-        hybrid.put(next31.clone()).await.expect("put 31");
+        hybrid = hybrid.put(next31.clone()).await.expect("put 31");
 
         for height in 8..=31 {
             assert!(
@@ -576,13 +576,13 @@ fn prune_respects_section_boundary() {
         // so 7 is below it) must succeed silently — the block is below
         // the cache window, and reth's finality contract guarantees
         // it's durable in reth's storage.
-        hybrid
+        hybrid = hybrid
             .put(blocks[6].clone())
             .await
             .expect("stale put at height 7 must silently succeed (reth covers it)");
         // A re-put at the section boundary still succeeds (silent
         // dedupe inside the prunable archive itself).
-        hybrid
+        hybrid = hybrid
             .put(blocks[7].clone())
             .await
             .expect("re-put at oldest_allowed should dedupe, not error");
@@ -593,7 +593,7 @@ fn prune_respects_section_boundary() {
         // cache snaps to heights 16..=32.
         provider.set_reth_finalized(31);
         let next32 = make_block(32, next31.block_hash());
-        hybrid.put(next32).await.expect("put 32");
+        hybrid = hybrid.put(next32).await.expect("put 32");
 
         for height in 16..=32 {
             assert!(
@@ -641,7 +641,7 @@ fn mid_section_prune_floor_keeps_live_tail_in_cache() {
         // (no eviction yet).
         let blocks = make_chain(1, 10);
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
 
         // Phase 1: advance reth to 10 → requested floor = 6, which sits
@@ -649,7 +649,7 @@ fn mid_section_prune_floor_keeps_live_tail_in_cache() {
         // only section [0, 3]. Trigger eviction with one more put.
         provider.set_reth_finalized(10);
         let trigger = make_block(11, blocks.last().unwrap().block_hash());
-        hybrid.put(trigger).await.expect("put trigger");
+        hybrid = hybrid.put(trigger).await.expect("put trigger");
 
         // Make the reth fallback fail loudly so we can distinguish
         // prunable hits from reth hits — anything that survives the
@@ -704,18 +704,18 @@ fn mid_section_silent_no_op_floor_is_section_aligned_not_requested() {
         // requested_floor=6.
         let blocks = make_chain(1, 10);
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
         provider.set_reth_finalized(10);
         let trigger = make_block(11, blocks.last().unwrap().block_hash());
-        hybrid.put(trigger).await.expect("put trigger");
+        hybrid = hybrid.put(trigger).await.expect("put trigger");
 
         // Heights 1..=3 sit below the section-aligned `oldest_allowed`
         // (4) and must silently no-op — surfacing the prunable's
         // `AlreadyPrunedTo` here would crash the marshal on a
         // perfectly recoverable condition.
         for height in 1..=3 {
-            hybrid
+            hybrid = hybrid
                 .put(blocks[(height - 1) as usize].clone())
                 .await
                 .unwrap_or_else(|err| {
@@ -729,7 +729,7 @@ fn mid_section_silent_no_op_floor_is_section_aligned_not_requested() {
         // branch even though they are below the requested retention
         // floor of 6.
         for height in 4..=5 {
-            hybrid
+            hybrid = hybrid
                 .put(blocks[(height - 1) as usize].clone())
                 .await
                 .unwrap_or_else(|err| {
@@ -756,14 +756,14 @@ fn eviction_no_op_when_advancing_reth_within_same_section() {
         // Phase 0: seed heights 1..=15 with reth's watermark unset.
         let blocks = make_chain(1, 15);
         for block in &blocks {
-            hybrid.put(block.clone()).await.expect("put");
+            hybrid = hybrid.put(block.clone()).await.expect("put");
         }
 
         // Phase 1: reth=10 → rounded floor = 4 → drop section [0, 3].
         // Trigger eviction with put at 16; cache now spans 4..=16.
         provider.set_reth_finalized(10);
         let next16 = make_block(16, blocks.last().unwrap().block_hash());
-        hybrid.put(next16.clone()).await.expect("put 16");
+        hybrid = hybrid.put(next16.clone()).await.expect("put 16");
         for height in 4..=16 {
             assert!(
                 hybrid
@@ -780,7 +780,7 @@ fn eviction_no_op_when_advancing_reth_within_same_section() {
         // must still be in the cache.
         provider.set_reth_finalized(11);
         let next17 = make_block(17, next16.block_hash());
-        hybrid.put(next17.clone()).await.expect("put 17");
+        hybrid = hybrid.put(next17.clone()).await.expect("put 17");
         for height in 4..=17 {
             assert!(
                 hybrid
@@ -796,7 +796,7 @@ fn eviction_no_op_when_advancing_reth_within_same_section() {
         // Trigger with put at 18; cache snaps to 8..=18.
         provider.set_reth_finalized(12);
         let next18 = make_block(18, next17.block_hash());
-        hybrid.put(next18).await.expect("put 18");
+        hybrid = hybrid.put(next18).await.expect("put 18");
         for height in 8..=18 {
             assert!(
                 hybrid

--- a/crates/consensus/src/storage/hybrid/test/mod.rs
+++ b/crates/consensus/src/storage/hybrid/test/mod.rs
@@ -711,8 +711,8 @@ fn mid_section_silent_no_op_floor_is_section_aligned_not_requested() {
         hybrid = hybrid.put(trigger).await.expect("put trigger");
 
         // Heights 1..=3 sit below the section-aligned `oldest_allowed`
-        // (4) and must silently no-op — surfacing the prunable's
-        // `AlreadyPrunedTo` here would crash the marshal on a
+        // (4) and must silently no-op — rejecting these puts
+        // here would crash the marshal on a
         // perfectly recoverable condition.
         for height in 1..=3 {
             hybrid = hybrid
@@ -725,8 +725,8 @@ fn mid_section_silent_no_op_floor_is_section_aligned_not_requested() {
 
         // Heights 4 and 5 sit in the live tail of the partially-evicted
         // section. The archive accepts these puts directly (4 ≥
-        // oldest_allowed=4); they do NOT take the `AlreadyPrunedTo`
-        // branch even though they are below the requested retention
+        // oldest_allowed=4); they do NOT take the silent no-op
+        // path even though they are below the requested retention
         // floor of 6.
         for height in 4..=5 {
             hybrid = hybrid

--- a/crates/consensus/src/storage/hybrid/test/utils.rs
+++ b/crates/consensus/src/storage/hybrid/test/utils.rs
@@ -203,6 +203,7 @@ where
             key_partition: format!("{TEST_PARTITION_PREFIX}-prunable-key"),
             key_page_cache: cache,
             value_partition: format!("{TEST_PARTITION_PREFIX}-prunable-value"),
+            metadata_partition: format!("{TEST_PARTITION_PREFIX}-prunable-metadata"),
             // Tests use blocks small enough that compression overhead would
             // dominate; mirror production's compression to keep the codec
             // path identical.

--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -186,6 +186,7 @@ where
             key_partition: format!("{partition_prefix}-{PRUNABLE_FINALIZED_BLOCKS}-key"),
             key_page_cache: page_cache,
             value_partition: format!("{partition_prefix}-{PRUNABLE_FINALIZED_BLOCKS}-value"),
+            metadata_partition: format!("{partition_prefix}-{PRUNABLE_FINALIZED_BLOCKS}-metadata"),
             compression: FREEZER_VALUE_COMPRESSION,
             codec_config: (),
             items_per_section: PRUNABLE_ITEMS_PER_SECTION,

--- a/crates/consensus/src/storage/snapshot.rs
+++ b/crates/consensus/src/storage/snapshot.rs
@@ -156,7 +156,7 @@ where
                     finalization,
                 } = *cert;
                 let key = finalization.proposal.payload;
-                finalizations
+                finalizations = finalizations
                     .put(height, key, finalization)
                     .await
                     .wrap_err_with(|| {
@@ -168,7 +168,7 @@ where
             ArchiveEntryKind::Block(block) => {
                 let height = block.height().get();
                 let key = block.digest();
-                blocks.put(height, key, *block).await.wrap_err_with(|| {
+                blocks = blocks.put(height, key, *block).await.wrap_err_with(|| {
                     format!("failed writing snapshot finalized block at height `{height}`")
                 })?;
             }
@@ -182,6 +182,7 @@ where
     blocks
         .sync()
         .await
+        .map(|_| ())
         .wrap_err("failed syncing snapshot prunable finalized blocks archive")
 }
 
@@ -482,33 +483,37 @@ mod tests {
     }
 
     async fn put_cert(
-        finalizations: &mut FinalizationsArchive<deterministic::Context>,
+        finalizations: FinalizationsArchive<deterministic::Context>,
         height: u64,
         digest: Digest,
-    ) {
+    ) -> FinalizationsArchive<deterministic::Context> {
         finalizations
             .put(height, digest, make_finalization(height, digest))
             .await
-            .expect("put finalization certificate");
+            .expect("put finalization certificate")
     }
 
     /// Seed a certificate for every block in `blocks`, keyed by the block's
     /// digest — mirroring production where a certificate's payload is the
     /// finalized block's hash.
     async fn put_certs_for(
-        finalizations: &mut FinalizationsArchive<deterministic::Context>,
+        mut finalizations: FinalizationsArchive<deterministic::Context>,
         blocks: &[Block],
-    ) {
+    ) -> FinalizationsArchive<deterministic::Context> {
         for block in blocks {
-            put_cert(finalizations, block.height().get(), block.digest()).await;
+            finalizations = put_cert(finalizations, block.height().get(), block.digest()).await;
         }
+        finalizations
     }
 
-    async fn put_block(prunable: &mut Prunable<deterministic::Context>, block: &Block) {
+    async fn put_block(
+        prunable: Prunable<deterministic::Context>,
+        block: &Block,
+    ) -> Prunable<deterministic::Context> {
         prunable
             .put(block.height().get(), block.digest(), block.clone())
             .await
-            .expect("put prunable finalized block");
+            .expect("put prunable finalized block")
     }
 
     /// A digest for heights that have a certificate but no backing test block.
@@ -539,7 +544,7 @@ mod tests {
         executor.start(|context| async move {
             let (mut finalizations, prunable) = fresh_archives(&context).await;
             for height in 1..=5 {
-                put_cert(&mut finalizations, height, synthetic_digest(height)).await;
+                finalizations = put_cert(finalizations, height, synthetic_digest(height)).await;
             }
 
             // Execution finalized is ahead of the certificate tip; the tip is
@@ -561,11 +566,11 @@ mod tests {
         executor.start(|context| async move {
             let (mut finalizations, mut prunable) = fresh_archives(&context).await;
             let chain = make_chain(1, 10);
-            put_certs_for(&mut finalizations, &chain).await;
+            finalizations = put_certs_for(finalizations, &chain).await;
             // Blocks 4..=10 are present: a contiguous path from execution
             // finalized (3) up to the tip.
             for block in &chain[3..] {
-                put_block(&mut prunable, block).await;
+                prunable = put_block(prunable, block).await;
             }
 
             let selected = find_anchor_and_tip_finalizations(&finalizations, &prunable, 3)
@@ -584,14 +589,14 @@ mod tests {
         executor.start(|context| async move {
             let (mut finalizations, mut prunable) = fresh_archives(&context).await;
             let chain = make_chain(1, 10);
-            put_certs_for(&mut finalizations, &chain).await;
+            finalizations = put_certs_for(finalizations, &chain).await;
             // Only blocks at or below execution finalized (3) are present.
             // The hole search never probes at or below the floor, so these
             // blocks are irrelevant: selection must behave exactly as with an
             // empty prunable archive and fall back to the certificate at the
             // floor.
             for block in &chain[..3] {
-                put_block(&mut prunable, block).await;
+                prunable = put_block(prunable, block).await;
             }
 
             let selected = find_anchor_and_tip_finalizations(&finalizations, &prunable, 3)
@@ -614,7 +619,7 @@ mod tests {
             // Blocks 1..=5 straddle execution finalized (3): only 4 and 5 may
             // end up in the snapshot archive.
             for block in &chain[..5] {
-                put_block(&mut prunable, block).await;
+                prunable = put_block(prunable, block).await;
             }
 
             let (entries_tx, mut entries_rx) = tokio::sync::mpsc::channel(16);
@@ -640,7 +645,7 @@ mod tests {
         executor.start(|context| async move {
             let (mut finalizations, prunable) = fresh_archives(&context).await;
             let chain = make_chain(1, 10);
-            put_certs_for(&mut finalizations, &chain).await;
+            finalizations = put_certs_for(finalizations, &chain).await;
 
             // No blocks at all: the descent must walk certificate by
             // certificate down to the execution finalized floor.
@@ -663,9 +668,9 @@ mod tests {
             // Certificates at 2 and 5..=10; nothing at 3 and 4, so with
             // execution finalized at 4 the descent must skip past the gap
             // and anchor at 2.
-            put_cert(&mut finalizations, 2, synthetic_digest(2)).await;
+            finalizations = put_cert(finalizations, 2, synthetic_digest(2)).await;
             for height in 5..=10 {
-                put_cert(&mut finalizations, height, synthetic_digest(height)).await;
+                finalizations = put_cert(finalizations, height, synthetic_digest(height)).await;
             }
 
             let selected = find_anchor_and_tip_finalizations(&finalizations, &prunable, 4)
@@ -684,15 +689,15 @@ mod tests {
         executor.start(|context| async move {
             let (mut finalizations, mut prunable) = fresh_archives(&context).await;
             let chain = make_chain(1, 10);
-            put_certs_for(&mut finalizations, &chain).await;
+            finalizations = put_certs_for(finalizations, &chain).await;
             // Blocks 4..=6 and 8..=10 are present; 7 is a hole. The path from
             // the tip breaks at 7, so the anchor must drop to the certificate
             // at 6, from which the path down to the floor (3) is contiguous.
             for block in &chain[3..6] {
-                put_block(&mut prunable, block).await;
+                prunable = put_block(prunable, block).await;
             }
             for block in &chain[7..] {
-                put_block(&mut prunable, block).await;
+                prunable = put_block(prunable, block).await;
             }
 
             let selected = find_anchor_and_tip_finalizations(&finalizations, &prunable, 3)
@@ -714,7 +719,7 @@ mod tests {
             // Certificates only above the floor, and no blocks to build a
             // path with: no anchor can be selected.
             for height in 5..=10 {
-                put_cert(&mut finalizations, height, synthetic_digest(height)).await;
+                finalizations = put_cert(finalizations, height, synthetic_digest(height)).await;
             }
 
             let err = find_anchor_and_tip_finalizations(&finalizations, &prunable, 3)

--- a/crates/consensus/src/subblocks.rs
+++ b/crates/consensus/src/subblocks.rs
@@ -7,7 +7,7 @@ use commonware_codec::DecodeExt;
 use commonware_consensus::{
     Epochable, Reporter, Viewable,
     simplex::{
-        elector::Random,
+        elector::{Random, RandomVersion},
         scheme::bls12381_threshold::vrf::{Certificate, Scheme},
         types::Activity,
     },
@@ -319,11 +319,13 @@ impl<TContext: Spawner + Metrics + Pacer> Actor<TContext> {
             Round::new(epoch_of_next_block, View::new(1))
         };
 
-        let next_proposer = Random::select_leader::<MinSig>(
-            next_round,
-            scheme.participants().len() as u32,
-            certificate.get().map(|signature| signature.seed_signature),
-        );
+        #[allow(deprecated)]
+        let next_proposer = Random::<commonware_cryptography::Sha256>::new(RandomVersion::V0)
+            .select_leader::<MinSig>(
+                next_round,
+                scheme.participants().len() as u32,
+                certificate.get().map(|signature| signature.seed_signature),
+            );
         let next_proposer = scheme.participants()[next_proposer.get() as usize].clone();
 
         debug!(?next_proposer, ?next_round, "determined next proposer");

--- a/crates/consensus/src/test_utils.rs
+++ b/crates/consensus/src/test_utils.rs
@@ -15,7 +15,10 @@ use commonware_consensus::{
 };
 use commonware_cryptography::{
     Signer as _,
-    bls12381::{dkg::feldman_desmedt as dkg, primitives::variant::MinSig},
+    bls12381::{
+        dkg::feldman_desmedt as dkg,
+        primitives::{sharing::Mode, variant::MinSig},
+    },
     ed25519::{PrivateKey, PublicKey},
 };
 use commonware_math::algebra::Random as _;
@@ -44,7 +47,7 @@ pub(crate) fn dkg_fixture(rng: &mut impl CryptoRng, epoch: Epoch) -> DkgFixture 
     .expect("test players should be unique");
 
     let (output, shares) =
-        dkg::deal::<_, _, N3f1>(&mut *rng, Default::default(), players).expect("test DKG");
+        dkg::deal::<_, _, N3f1>(&mut *rng, Mode::NonZeroCounter, players).expect("test DKG");
 
     let schemes = shares
         .into_iter()
@@ -82,6 +85,10 @@ pub(crate) fn make_certificate(
         .map(|scheme| Finalize::sign(scheme, proposal.clone()).expect("signer should sign"))
         .collect::<Vec<_>>();
 
-    Finalization::from_finalizes(&schemes[0], &votes, &Sequential)
-        .expect("all test signers form a quorum")
+    Finalization::from_finalizes(
+        &schemes[0],
+        commonware_utils::non_empty![@&votes],
+        &Sequential,
+    )
+    .expect("all test signers form a quorum")
 }

--- a/crates/dkg-onchain-artifacts/src/lib.rs
+++ b/crates/dkg-onchain-artifacts/src/lib.rs
@@ -110,7 +110,9 @@ mod tests {
     use commonware_codec::{Encode as _, ReadExt as _};
     use commonware_consensus::types::Epoch;
     use commonware_cryptography::{
-        Signer as _, bls12381::dkg::feldman_desmedt as dkg, ed25519::PrivateKey,
+        Signer as _,
+        bls12381::{dkg::feldman_desmedt as dkg, primitives::sharing::Mode},
+        ed25519::PrivateKey,
     };
     use commonware_math::algebra::Random as _;
     use commonware_utils::{N3f1, TryFromIterator as _, ordered};
@@ -128,7 +130,7 @@ mod tests {
         player_keys.sort_by_key(|key| key.public_key());
         let (output, _shares) = dkg::deal::<_, _, N3f1>(
             &mut rng,
-            Default::default(),
+            Mode::NonZeroCounter,
             ordered::Set::try_from_iter(player_keys.iter().map(|key| key.public_key())).unwrap(),
         )
         .unwrap();

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -161,7 +161,7 @@ impl Setup {
             linkage: Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: commonware_utils::probability!(1.0),
             },
             epoch_length: 20,
             proposal_return_budget: Duration::from_millis(300),
@@ -263,6 +263,10 @@ pub async fn setup_validators(
             max_size: MAX_MESSAGE_SIZE,
             disconnect_on_block: true,
             tracked_peer_sets: commonware_utils::NZUsize!(3),
+            max_peers_per_set: std::num::NonZeroUsize::new(
+                (how_many_signers + how_many_verifiers).max(1) as usize,
+            )
+            .expect("maximum peers per set is non-zero"),
         },
     );
     network.start();

--- a/crates/e2e/src/testing_node.rs
+++ b/crates/e2e/src/testing_node.rs
@@ -690,7 +690,7 @@ mod tests {
                     .linkage(Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: 1.0,
+                        success_rate: commonware_utils::probability!(1.0),
                     })
                     .epoch_length(100);
 

--- a/crates/e2e/src/tests/linkage.rs
+++ b/crates/e2e/src/tests/linkage.rs
@@ -41,7 +41,7 @@ fn many_bad_links() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: 0.75,
+        success_rate: commonware_utils::probability!(0.75),
     };
 
     // FIXME(janis): figure out how to run this test in a loop.
@@ -83,7 +83,7 @@ fn reach_height_20_with_a_few_bad_links() {
     let link = Link {
         latency: Duration::from_millis(80),
         jitter: Duration::from_millis(10),
-        success_rate: 0.98,
+        success_rate: commonware_utils::probability!(0.98),
     };
 
     let setup = Setup::new()

--- a/crates/e2e/src/tests/simple.rs
+++ b/crates/e2e/src/tests/simple.rs
@@ -28,7 +28,7 @@ fn many_bad_links() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: 0.75,
+        success_rate: commonware_utils::probability!(0.75),
     };
 
     let setup = Setup::new().seed(42).epoch_length(100).linkage(link);
@@ -43,7 +43,7 @@ fn reach_height_20_with_a_few_bad_links() {
     let link = Link {
         latency: Duration::from_millis(80),
         jitter: Duration::from_millis(10),
-        success_rate: 0.98,
+        success_rate: commonware_utils::probability!(0.98),
     };
 
     let setup = Setup::new()

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -859,7 +859,9 @@ mod tests {
     use commonware_codec::Encode as _;
     use commonware_consensus::types::Epoch;
     use commonware_cryptography::{
-        Signer, bls12381::dkg::feldman_desmedt as dkg, ed25519::PrivateKey,
+        Signer,
+        bls12381::{dkg::feldman_desmedt as dkg, primitives::sharing::Mode},
+        ed25519::PrivateKey,
     };
     use commonware_math::algebra::Random as _;
     use commonware_utils::{N3f1, TryFromIterator as _, ordered};
@@ -926,7 +928,7 @@ mod tests {
         let player_set =
             ordered::Set::try_from_iter(player_keys.iter().map(|key| key.public_key())).unwrap();
         let (output, shares) =
-            dkg::deal::<_, _, N3f1>(&mut rng, Default::default(), player_set).unwrap();
+            dkg::deal::<_, _, N3f1>(&mut rng, Mode::NonZeroCounter, player_set).unwrap();
 
         OnchainDkgOutcome {
             epoch: Epoch::new(epoch),

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -25,6 +25,9 @@ echo "Testing: $TEMPO"
 run_ok "tempo --version" "$TEMPO" --version
 run_ok "tempo --help" "$TEMPO" --help
 run_ok "tempo node --help" "$TEMPO" node --help
+if ! grep -A 2 -- '--consensus.message-backlog' <<<"$OUT" | grep -q 'Deprecated:'; then
+    fail "message-backlog help must mark the flag as deprecated"
+fi
 
 # --- node --follow: verify it stays alive for 15s with no crashes ---
 echo "--- Test: tempo node --follow (no crash)"
@@ -47,6 +50,9 @@ for i in $(seq 1 15); do
 done
 
 if [[ $NODE_EXITED -eq 0 ]]; then
+    if grep -q -- '--consensus.message-backlog' "$NODE_LOG"; then
+        dump_log "$NODE_LOG"; fail "omitted message-backlog must not emit a warning"
+    fi
     if grep -qiE "panicked|SIGSEGV|SIGABRT|thread.*panicked" "$NODE_LOG"; then
         dump_log "$NODE_LOG"; fail "node output contains panic/crash indicators"
     else
@@ -67,6 +73,7 @@ EXPECTED_OWNER="0x9858effd232b4033e47d90003d41ec34ecaeda94"
 EXPECTED_FACTORY_OWNER="0x000000000000000000000000${EXPECTED_OWNER#0x}"
 RPC_URL="http://127.0.0.1:18546"
 $TEMPO node --dev --dev.mnemonic "$DEV_MNEMONIC" --datadir "$DATADIR" \
+    --consensus.message-backlog 16384 \
     --http --http.port 18546 --http.api eth --disable-discovery --ipcdisable \
     --port 0 --authrpc.port 0 --log.file.max-files 0 >"$NODE_LOG" 2>&1 &
 NODE_PID=$!
@@ -92,6 +99,10 @@ if [[ $RPC_READY -eq 0 && $FAILED -eq 0 ]]; then
     dump_log "$NODE_LOG"
     fail "dev node RPC did not become ready"
 elif [[ $RPC_READY -eq 1 ]]; then
+    if [[ $(grep -c -- 'deprecated flag ignored.*--consensus.message-backlog.*16384' "$NODE_LOG" || true) != 1 ]]; then
+        dump_log "$NODE_LOG"
+        fail "explicit message-backlog must emit exactly one deprecation event with its value"
+    fi
     ACCOUNTS=$(curl -sf -H "content-type: application/json" \
         --data '{"jsonrpc":"2.0","id":1,"method":"eth_accounts","params":[]}' \
         "$RPC_URL")

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -1133,6 +1133,7 @@ fn seed_consensus_state(
                 states
                     .put_sync(SHADOW_EPOCH, state)
                     .await
+                    .map(|_| ())
                     .map_err(eyre::Report::from)
                     .wrap_err("unable to write shadow DKG state metadata")
             })

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -1095,8 +1095,17 @@ fn seed_consensus_state(
     std::thread::Builder::new()
         .name("shadowfork-bootstrap-commonware".to_string())
         .spawn(move || {
+            #[expect(
+                deprecated,
+                reason = "Keep bootstrapped consensus storage readable until all nodes have \
+                          been updated; V1 blob creation will be enabled in a followup."
+            )]
             let runner = commonware_runtime::tokio::Runner::new(
-                commonware_runtime::tokio::Config::default().with_storage_directory(consensus_dir),
+                commonware_runtime::tokio::Config::default()
+                    .with_storage_directory(consensus_dir)
+                    .with_storage_blob_layouts(
+                        commonware_runtime::BlobLayout::V0..=commonware_runtime::BlobLayout::V0,
+                    ),
             );
 
             runner.start(|context| async move {

--- a/xtask/src/get_dkg_outcome.rs
+++ b/xtask/src/get_dkg_outcome.rs
@@ -7,7 +7,7 @@ use alloy::{
 use commonware_codec::{Encode as _, ReadExt as _};
 use commonware_consensus::types::{Epoch, Epocher as _, FixedEpocher};
 use commonware_cryptography::ed25519::PublicKey;
-use commonware_utils::{N3f1, NZU64};
+use commonware_utils::NZU64;
 use eyre::{Context as _, eyre};
 use serde::Serialize;
 use tempo_dkg_onchain_artifacts::OnchainDkgOutcome;
@@ -121,7 +121,7 @@ impl GetDkgOutcome {
             next_players: outcome.next_players().iter().map(pubkey_to_hex).collect(),
             is_next_full_dkg: outcome.is_next_full_dkg,
             network_identity: Bytes::copy_from_slice(&sharing.public().encode()),
-            threshold: sharing.required::<N3f1>(),
+            threshold: sharing.required(),
             total_participants: sharing.total().get(),
         };
 


### PR DESCRIPTION
Stacked on [#7450](https://github.com/tempoxyz/tempo/pull/7450). Make DKG persistent mutations consume and return `Storage`, so ownership prevents reuse after failed or cancelled writes and removes the optional handle slots and `is_poisoned()` checks. Rejected peer input and failed ACK sends retain storage, while persistence errors propagate out of the actor before acknowledging work.

Validation: all 27 focused DKG actor tests pass locally, along with nightly formatting and whitespace checks. The full [CI test workflow](https://github.com/tempoxyz/tempo/actions/runs/34236652255) and [CI lint workflow](https://github.com/tempoxyz/tempo/actions/runs/34236653028) passed at [5d0c5e91f8](https://github.com/tempoxyz/tempo/commit/5d0c5e91f8ed294ae7e6ba4c3fb73bd6c3bcf2b4). New regression coverage exercises rejected dealings/ACKs, duplicate messages without writes, continued persistence, and replay after reopening.

Prompted by: @SuperFluffy
