### PR TITLE
feat(bench): add public mixed workload preset

### DIFF
--- a/contrib/bench/txgen/presets/mix.yml
+++ b/contrib/bench/txgen/presets/mix.yml
@@ -12,7 +12,7 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 artifacts:
-  ERC20: ../erc20.abi.json
+  ERC20: ../tip20.abi.json
   MPPChannel:
     abi: ../mpp-channel.json
     bytecode: ../mpp-channel.json

--- a/contrib/bench/txgen/presets/mpp.yml
+++ b/contrib/bench/txgen/presets/mpp.yml
@@ -12,7 +12,7 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 artifacts:
-  ERC20: ../erc20.abi.json
+  ERC20: ../tip20.abi.json
   MPPChannel:
     abi: ../mpp-channel.json
     bytecode: ../mpp-channel.json

--- a/contrib/bench/txgen/presets/mpp.yml
+++ b/contrib/bench/txgen/presets/mpp.yml
@@ -1,3 +1,9 @@
+# Native TIP-20 Channel Reserve open -> signed settlement: two transactions per channel.
+# Fund the users with pathUSD for fees and token 1 for channel deposits.
+# The native reserve pulls deposits directly; no ERC-20 approval is needed.
+# Settlement pays the full deposit to the payee; the settled channel state remains.
+# Requires txgen sequence `save` and Tempo `mpp_settle` support.
+
 chain_id: 1337
 
 gas:
@@ -12,125 +18,58 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 artifacts:
-  ERC20: ../tip20.abi.json
-  MPPChannel:
-    abi: ../mpp-channel.json
-    bytecode: ../mpp-channel.json
-
-setup:
-  steps:
-    - id: channel
-      deploy:
-        type: eip1559
-        from:
-          pool: users
-          select: { index: 0 }
-        artifact: MPPChannel
-        gas_limit: 20000000
-        constructor_args: []
+  TIP20ChannelReserve: ../tip20-channel-reserve.abi.json
 
 templates:
-  mpp_approve:
-    type: tempo
-    gas_limit: 2000000
-    max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
-    fee_token: "0x20c0000000000000000000000000000000000000"
-    call:
-      to: "0x20c0000000000000000000000000000000000001"
-      abi: ERC20
-      function: approve
-      args: []
-
   mpp_open:
     type: tempo
-    gas_limit: 2000000
-    max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    from: { var: payer.ref }
+    gas_limit: 1000000
     fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 25
     call:
-      abi: MPPChannel
+      to: "0x4d50500000000000000000000000000000000000"
+      abi: TIP20ChannelReserve
       function: open
-      args: []
+      args:
+        - { var: payee.address }
+        - "0x0000000000000000000000000000000000000000"
+        - "0x20c0000000000000000000000000000000000001"
+        - 1
+        - random_bytes: 32
+        - "0x0000000000000000000000000000000000000000"
 
-  mpp_close:
+  mpp_settle:
     type: tempo
-    gas_limit: 2000000
-    max_fee_per_gas: 100000000000
-    max_priority_fee_per_gas: 100000000000
+    from: { var: payee.ref }
+    gas_limit: 1000000
     fee_token: "0x20c0000000000000000000000000000000000000"
-    call:
-      abi: MPPChannel
-      function: close
-      args: []
+    expiring_nonce: true
+    valid_for_secs: 25
+    mpp_settle:
+      open_transaction: { var: opened.raw }
+      voucher_signer: { var: payer.ref }
+      cumulative_amount: 1
 
 sequences:
-  mpp_approve_open_close:
+  mpp_open_settle:
     bindings:
       payer:
         account:
           pool: users
           select: random
-      token:
-        address:
-          const: "0x20c0000000000000000000000000000000000001"
-      authorized_signer:
-        address:
-          const: "0x0000000000000000000000000000000000000000"
-      salt:
-        bytes32:
-          random_bytes: 32
-      channel_id:
-        abi_hash:
-          types: [address, address, address, bytes32, address, address, uint256]
-          values:
-            - { var: payer.address }
-            - { var: payer.address }
-            - { var: token }
-            - { var: salt }
-            - { var: authorized_signer }
-            - { var: setup.channel.address }
-            - { var: chain_id }
-      channel_key:
-        abi_encode_packed:
-          types: [bytes32, address, address, bytes32]
-          values:
-            - { var: channel_id }
-            - { var: token }
-            - { var: authorized_signer }
-            - { var: salt }
+      payee:
+        account:
+          pool: users
+          select: random
     steps:
-      - name: approve
-        template: mpp_approve
-        with:
-          from: { var: payer.ref }
-          call:
-            args:
-              - { var: setup.channel.address }
-              - 1
       - name: open
         template: mpp_open
-        with:
-          from: { var: payer.ref }
-          call:
-            to: { var: setup.channel.address }
-            args:
-              - { var: payer.address }
-              - { var: token }
-              - 1
-              - { var: salt }
-              - { var: authorized_signer }
-      - name: close
-        template: mpp_close
-        with:
-          from: { var: payer.ref }
-          call:
-            to: { var: setup.channel.address }
-            args:
-              - { var: channel_key }
-              - 0
-              - "0x"
+        save: opened
+      - name: settle
+        template: mpp_settle
 
 mix:
-  - sequence: mpp_approve_open_close
+  - sequence: mpp_open_settle
     weight: 100

--- a/contrib/bench/txgen/presets/mpp.yml
+++ b/contrib/bench/txgen/presets/mpp.yml
@@ -1,8 +1,7 @@
-# Native TIP-20 Channel Reserve open -> signed settlement: two transactions per channel.
+# Native TIP-20 Channel Reserve opens: one transaction per channel.
 # Fund the users with pathUSD for fees and token 1 for channel deposits.
 # The native reserve pulls deposits directly; no ERC-20 approval is needed.
-# Settlement pays the full deposit to the payee; the settled channel state remains.
-# Requires txgen sequence `save` and Tempo `mpp_settle` support.
+# TODO: Add signed settlement after open once https://github.com/tempoxyz/txgen/pull/200 lands.
 
 chain_id: 1337
 
@@ -40,20 +39,8 @@ templates:
         - random_bytes: 32
         - "0x0000000000000000000000000000000000000000"
 
-  mpp_settle:
-    type: tempo
-    from: { var: payee.ref }
-    gas_limit: 1000000
-    fee_token: "0x20c0000000000000000000000000000000000000"
-    expiring_nonce: true
-    valid_for_secs: 25
-    mpp_settle:
-      open_transaction: { var: opened.raw }
-      voucher_signer: { var: payer.ref }
-      cumulative_amount: 1
-
 sequences:
-  mpp_open_settle:
+  mpp_open_only:
     bindings:
       payer:
         account:
@@ -66,10 +53,7 @@ sequences:
     steps:
       - name: open
         template: mpp_open
-        save: opened
-      - name: settle
-        template: mpp_settle
 
 mix:
-  - sequence: mpp_open_settle
+  - sequence: mpp_open_only
     weight: 100

--- a/contrib/bench/txgen/presets/neobank-swap.yml
+++ b/contrib/bench/txgen/presets/neobank-swap.yml
@@ -20,7 +20,7 @@ accounts:
     index: 100000
 
 artifacts:
-  ERC20: ../erc20.abi.json
+  ERC20: ../tip20.abi.json
   DirectSwapABI: ../directswap.abi.json
   ERC4626Vault: ../erc4626-vault.abi.json
   DirectSwap:

--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -1,0 +1,69 @@
+# Forward-looking public workload, weighted by submitted transactions (not gas).
+# Relative transaction shares: plain transfer 25, memo transfer 40, mint 1, MPP 15.
+# Normalized: approximately 30.86%, 49.38%, 1.23%, and 18.52%, respectively.
+# These are benchmark assumptions, not a replay of mainnet activity.
+# Requires the native MPP open/settle preset and a settlement-capable txgen.
+include: mpp.yml
+
+artifacts:
+  ERC20: ../tip20.abi.json
+
+templates:
+  public_transfer:
+    type: tempo
+    from: {pool: users, select: random}
+    gas_limit: 300000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
+      abi: ERC20
+      function: transfer
+      args:
+        - {pool: {pool: users, select: random}}
+        - 1
+  public_transfer_memo:
+    type: tempo
+    from: {pool: users, select: random}
+    gas_limit: 300000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to:
+        choice: ${TXGEN_TIP20_TOKENS}
+      abi: ERC20
+      function: transferWithMemo
+      args:
+        - {pool: {pool: users, select: random}}
+        - 1
+        - {random_bytes: 32}
+  public_mint:
+    type: tempo
+    # Dev genesis grants the pathUSD issuer role to users[0].
+    from: {pool: users, select: {index: 0}}
+    gas_limit: 300000
+    fee_token: "0x20c0000000000000000000000000000000000000"
+    expiring_nonce: true
+    valid_for_secs: 25
+    call:
+      to: "0x20c0000000000000000000000000000000000000"
+      abi: ERC20
+      function: mint
+      args:
+        - {pool: {pool: users, select: random}}
+        - 1
+
+# Selection weights: MPP emits two transactions per selection; all others emit one.
+# Preserve the relative allocations of the four retained workloads.
+mix:
+  - template: public_transfer
+    weight: 50
+  - template: public_transfer_memo
+    weight: 80
+  - template: public_mint
+    weight: 2
+  - sequence: mpp_open_settle
+    weight: 15

--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -2,7 +2,7 @@
 # Relative transaction shares: plain transfer 25, memo transfer 40, mint 1, MPP 15.
 # Normalized: approximately 30.86%, 49.38%, 1.23%, and 18.52%, respectively.
 # These are benchmark assumptions, not a replay of mainnet activity.
-# Requires the native MPP open/settle preset and a settlement-capable txgen.
+# Uses the native MPP open-only preset with txgen main.
 include: mpp.yml
 
 artifacts:
@@ -56,14 +56,14 @@ templates:
         - {pool: {pool: users, select: random}}
         - 1
 
-# Selection weights: MPP emits two transactions per selection; all others emit one.
+# Each selection emits one transaction, including MPP.
 # Preserve the relative allocations of the four retained workloads.
 mix:
   - template: public_transfer
-    weight: 50
+    weight: 25
   - template: public_transfer_memo
-    weight: 80
+    weight: 40
   - template: public_mint
-    weight: 2
-  - sequence: mpp_open_settle
+    weight: 1
+  - sequence: mpp_open_only
     weight: 15

--- a/contrib/bench/txgen/presets/tip20.yml
+++ b/contrib/bench/txgen/presets/tip20.yml
@@ -12,7 +12,7 @@ accounts:
       - ${TXGEN_ACCOUNTS}
 
 artifacts:
-  ERC20: ../erc20.abi.json
+  ERC20: ../tip20.abi.json
 
 templates:
   tip20_transfer:

--- a/contrib/bench/txgen/presets/tip20/base.yml
+++ b/contrib/bench/txgen/presets/tip20/base.yml
@@ -13,7 +13,7 @@ merge:
         - ${TXGEN_ACCOUNTS}
 
   artifacts:
-    ERC20: "../../erc20.abi.json"
+    ERC20: "../../tip20.abi.json"
 
   templates:
     tip20_transfer:

--- a/contrib/bench/txgen/tip20-channel-reserve.abi.json
+++ b/contrib/bench/txgen/tip20-channel-reserve.abi.json
@@ -1,0 +1,39 @@
+[
+  {
+    "type": "function",
+    "name": "open",
+    "inputs": [
+      {
+        "name": "payee",
+        "type": "address"
+      },
+      {
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "name": "deposit",
+        "type": "uint96"
+      },
+      {
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "name": "authorizedSigner",
+        "type": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "channelId",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  }
+]

--- a/contrib/bench/txgen/tip20.abi.json
+++ b/contrib/bench/txgen/tip20.abi.json
@@ -25,6 +25,35 @@
   },
   {
     "type": "function",
+    "name": "transferWithMemo",
+    "inputs": [
+      {
+        "name": "to",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "memo",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "approve",
     "inputs": [
       {


### PR DESCRIPTION
Adds `public-mix.yml` with plain TIP-20 transfers, memo transfers, mints, and native MPP opens in relative submitted-transaction shares of 25:40:1:15. Renames the shared ABI to `tip20.abi.json`, adds `transferWithMemo`, and updates its preset references.

MPP uses an ordinary single-step open sequence supported by txgen main. A TODO links [txgen #200](https://github.com/tempoxyz/txgen/pull/200) for adding signed settlement later. The multi-region runner separately needs `public-mix` added to its preset allowlist.

Validation: checked the open-only sequence against txgen main's sequence schema, removal of settlement/save fields, preserved transaction shares, ABI arguments, references, and the linked TODO. Nushell resolution for both presets and `git diff --check` passed. The [earlier 60-second benchmark](https://github.com/tempoxyz/tempo/actions/runs/34240689460) passed with settlement enabled; this open-only revision has not been benchmarked again.

Prompted by: @shekhirin
