### PR TITLE
feat(bench): expose public-mix in multi-region workflow

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -139,6 +139,7 @@ on:
           - tip20_key_authorization
           - mpp
           - mix
+          - public-mix
           - dex
       duration:
         description: Benchmark duration in seconds.


### PR DESCRIPTION
Adds `public-mix` to the manual multi-region benchmark preset choices. Requires https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/393 to merge first so the runner accepts the preset.

Validation: `git diff --check` passed. The companion runner branch completed this [multi-region benchmark](https://github.com/tempoxyz/tempo-multi-region-benchmark/actions/runs/34254830976), including infrastructure teardown, with 10 validators across five AWS regions, 1 GiB state, and one 90-second baseline/feature pair on Tempo main. Artifacts confirm `public-mix` and its expected 25:40:1:15 weights. Observed chain throughput was 5,222 / 5,061 TPS against a 50,000 TPS target; sender failed counters were nonzero (10,274 / 12,082). Telemetry and ValScope were disabled for the direct runner-repository test; this Tempo workflow has not been dispatched because it requires the companion runner change on main.

Prompted by: @shekhirin
