### PR TITLE
chore(release): bump Cargo version to v1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13293,7 +13293,7 @@ dependencies = [
 
 [[package]]
 name = "tempo"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-consensus",
@@ -13457,7 +13457,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "age",
  "alloy-consensus",
@@ -13530,7 +13530,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-consensus-config"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "age",
  "commonware-codec",
@@ -13560,7 +13560,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-dkg-onchain-artifacts"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "bytes",
  "commonware-codec",
@@ -13574,7 +13574,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-e2e"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13626,7 +13626,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-evm"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13678,7 +13678,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-ext"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "clap",
  "dirs-next",
@@ -13697,7 +13697,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-eyre"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "eyre",
  "indenter",
@@ -13705,7 +13705,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-faucet"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -13730,7 +13730,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-node"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-eips",
@@ -13808,7 +13808,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-builder"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -13846,7 +13846,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-payload-types"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -13866,7 +13866,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-evm",
@@ -13902,7 +13902,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-precompiles-macros"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "proc-macro2",
@@ -13951,7 +13951,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-revm"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -13984,7 +13984,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-sidecar"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "clap",
@@ -14009,7 +14009,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-telemetry-util"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "eyre",
  "jiff",
@@ -14018,7 +14018,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-transaction-pool"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -14061,7 +14061,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-validator-config"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy-primitives",
  "commonware-codec",
@@ -14073,7 +14073,7 @@ dependencies = [
 
 [[package]]
 name = "tempo-xtask"
-version = "1.13.2"
+version = "1.14.0"
 dependencies = [
  "alloy",
  "alloy-consensus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.13.2"
+version = "1.14.0"
 edition = "2024"
 rust-version = "1.95.0"
 authors = ["Tempo Contributors"]


### PR DESCRIPTION
Bumps the workspace Cargo version and its 20 lockfile package entries to `1.14.0` on main. The release workflow could not open this PR because the `release/*` ruleset rejected its branch push.

Validated with `cargo metadata --locked --offline --no-deps --format-version 1` and `git diff --check`.

Prompted by: @jenpaff
