### PR TITLE
fix(ci): use automation branch for Cargo version bump PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,7 +314,7 @@ jobs:
           set -euo pipefail
 
           cargo_version="${VERSION#v}"
-          branch="release/bump-cargo-${VERSION}"
+          branch="automation/bump-cargo-${VERSION}"
           current_version=$(cargo metadata --locked --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tempo").version')
 
           if [ "$current_version" = "$cargo_version" ]; then


### PR DESCRIPTION
Uses `automation/bump-cargo-${VERSION}` for the Cargo version-bump PR branch. The previous `release/*` prefix matches the protected-branch ruleset and caused the [v1.14.0 job](https://github.com/tempoxyz/tempo/actions/runs/34137616818/job/101799495525) to fail when pushing the branch before opening a PR; PRs into main still receive the usual protections.

Validated the diff and confirmed through GitHub's live branch-rules API that the new prefix does not match the required-status-check ruleset.

Prompted by: @jenpaff
