### PR TITLE
chore(deps): update reth from main (2026-09-09)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8986,7 +8986,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9044,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9162,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9323,9 +9323,10 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
+ "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "arrayvec",
@@ -9349,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9379,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9394,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9419,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9443,7 +9444,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9467,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9504,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9563,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9590,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9613,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9640,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9696,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9726,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9744,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9760,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9784,7 +9785,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9795,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9823,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9846,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9887,7 +9888,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "clap",
  "eyre",
@@ -9910,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9926,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9942,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9955,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9985,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9999,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10009,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10035,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10055,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10073,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10086,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10105,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10143,7 +10144,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10157,7 +10158,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "serde",
  "serde_json",
@@ -10167,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10193,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "bytes",
  "futures",
@@ -10213,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10230,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "bindgen",
  "cc",
@@ -10239,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "futures",
  "libc",
@@ -10253,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10262,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10276,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10335,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10360,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10384,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10399,7 +10400,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10413,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10431,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10455,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10523,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10578,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10631,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10655,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10679,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "bytes",
  "eyre",
@@ -10709,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10721,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10745,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10757,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10780,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10823,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10873,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10900,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10916,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10931,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11007,7 +11008,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11037,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11080,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11100,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11131,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11178,7 +11179,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11228,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11244,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11275,7 +11276,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11327,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11355,7 +11356,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11369,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11389,7 +11390,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11404,7 +11405,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11430,7 +11431,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11447,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11475,7 +11476,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11496,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11512,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11522,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "clap",
  "eyre",
@@ -11542,7 +11543,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11561,7 +11562,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11604,7 +11605,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11630,7 +11631,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11658,7 +11659,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11674,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11698,7 +11699,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
+source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8986,7 +8986,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9044,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9162,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9323,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9350,7 +9350,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9380,7 +9380,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9395,7 +9395,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9420,7 +9420,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9444,7 +9444,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9468,7 +9468,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9505,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9564,7 +9564,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9591,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9614,7 +9614,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9641,7 +9641,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9697,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9727,7 +9727,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9745,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9761,7 +9761,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9785,7 +9785,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9796,7 +9796,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9824,7 +9824,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9888,7 +9888,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "clap",
  "eyre",
@@ -9911,7 +9911,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9927,7 +9927,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9943,7 +9943,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9956,7 +9956,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9986,7 +9986,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10000,7 +10000,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10010,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10036,7 +10036,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10056,7 +10056,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10074,7 +10074,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10087,7 +10087,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10106,7 +10106,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10144,7 +10144,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10158,7 +10158,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "serde",
  "serde_json",
@@ -10168,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10194,7 +10194,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "bytes",
  "futures",
@@ -10214,7 +10214,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10231,7 +10231,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "bindgen",
  "cc",
@@ -10240,7 +10240,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "futures",
  "libc",
@@ -10254,7 +10254,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10263,7 +10263,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10277,7 +10277,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10336,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10361,7 +10361,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10385,7 +10385,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10400,7 +10400,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10414,7 +10414,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10432,7 +10432,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10456,7 +10456,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10579,7 +10579,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10632,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10656,7 +10656,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "bytes",
  "eyre",
@@ -10710,7 +10710,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10722,7 +10722,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10746,7 +10746,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10758,7 +10758,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10824,7 +10824,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10874,7 +10874,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10901,7 +10901,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10917,7 +10917,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10932,7 +10932,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11008,7 +11008,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11038,7 +11038,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11081,7 +11081,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11101,7 +11101,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11132,7 +11132,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11179,7 +11179,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11229,7 +11229,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11245,7 +11245,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11276,7 +11276,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11328,7 +11328,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11356,7 +11356,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11370,7 +11370,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11390,7 +11390,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11405,7 +11405,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11431,7 +11431,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11448,7 +11448,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11476,7 +11476,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11497,7 +11497,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11513,7 +11513,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11523,7 +11523,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "clap",
  "eyre",
@@ -11543,7 +11543,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11562,7 +11562,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11605,7 +11605,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11631,7 +11631,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11659,7 +11659,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11675,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11699,7 +11699,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=038c782#038c782fecb1bec0896df7af1408588a6eeb9a01"
+source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11727,9 +11727,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc210dfb3b45482a9f7c8806f737f7848fb7054b04235e6816480e515c1fe2d5"
+checksum = "55f2322f5ea197fac72c2cdc88cb501b2a7db0b0009911133fd3dda45bfceedd"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11821,9 +11821,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8d988f896e22b19962658bc1afcd0989f727d48b2860a8bd7ceaecbf72ce34"
+checksum = "73a7409031d87ec281b74efff65d7a4dbea9d80727a55dbc7e4b3fd77b5e03fb"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11840,9 +11840,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2584990403728b2e13fb5522510b61e4bb217c6a4c8f4d063447a6ddd7dd7cc"
+checksum = "7a56f37224afd628f7244aa6965609ada04b440ed8ab7a19f55e4291df5a0112"
 dependencies = [
  "auto_impl",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
+checksum = "63c01387073b598705167c9dd88447d39b99306a1f7572b3b7a20ea107ecbb90"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
+checksum = "0b836b372d3b742b7c083d2617d6e68563cd5dadbd8752c461a935a756551e69"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
+checksum = "b1befb37485ea71e8599e32ffd76c98af7c3720a34741d30abd87f41c3148407"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86722084d6d07822a6c67e39ae794d437fb9de12fa4127d4f9fd93f89651121"
+checksum = "b432cf09e307820b39ec5b856b25f396d8fde6089358f0c1d96d9654ad1e0b7d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
+checksum = "fdd59d7221d384c46771ffbf6f18f70aa7753326351277857016bed5127b888f"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
+checksum = "ca3e76d47e8de277cb55e7e77fa38adde835162fc01cddbe1b258b5e0a86035b"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be9aa797694e7c55b007aa8f172daef76a83272cbedb8800bdc7038eed3bdb1a"
+checksum = "ba0713a3460cfb8754790034ed5edc5e7f61bba8bc0b7ac8984a084e643fd9d0"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
+checksum = "0680a2f7d4bbc6f48c0cb43368fa544918a1fa291e772bdb47c834ade338f363"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
+checksum = "2a523ca087dda941e53f6ecde5bf5df78b9dbe760f3f77488e13dbf355de4a84"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -471,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
+checksum = "f263c8d752b15e19b7c2d3cbad00338ec2d7cc923a46cd1ff98aea2fa333166b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
+checksum = "8795eecf50374a0dd942caff57922c59333c9991ead9eccbbc1709f55d73c7c2"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -542,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386124639a5c386329b9f2ef2b42969badbf7bba40422b513e3e5739c516dc34"
+checksum = "ef487e44dfae9c87cb732989d3f43682f65aefb11a0f56045b26be357f671fcf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -573,6 +573,7 @@ dependencies = [
  "either",
  "futures",
  "futures-utils-wasm",
+ "http 1.4.0",
  "lru 0.18.2",
  "parking_lot",
  "pin-project",
@@ -588,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2c32b323d8001b6e883444b7433804be0e6d55e4dbfd64e3bd2ba025282b77"
+checksum = "18662bde9be7d5218bed6e6fcb472caac3a65ea31730654678b6bba7c1b0553a"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -632,9 +633,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfd3ebc1756426a6a9e17979d4467632aff01f359136c50e5320ac6e32d6b8d"
+checksum = "98267c2d47f9c185b575bac3f772a8ca66bcbd712693535e50980c12eab80a42"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -658,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "417dc664965e36fc43a4f9c8eb8b2d14067a29c430e23470d2c923c1c977bac7"
+checksum = "637fed69eda26e19fb42314006570519003c1bfc338c54165e610a657e3b46ff"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -675,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-admin"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfdc2a2cde178ad3a79594b4fabbc0f2f11be5a98a3363083e91575fc95335c"
+checksum = "f91f1a1fa4d3c95ea5dba30c02d8987f0c052137dd7f1d55086cf36270517cbc"
 dependencies = [
  "alloy-genesis",
  "alloy-primitives",
@@ -687,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07bb602ee07767e393b5862f719a1d061deca15e617fbb1f7af49cd49576e4"
+checksum = "848bfe2315338ec605863073aae54a90fcea9cec7e6855a9e93d988bf42e9740"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -699,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
+checksum = "1176430031ba27abfb51b95516cf71e8ce3ff4172c72f3136627f0f89813a739"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -714,9 +715,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905e705ef91d2ed6cf08afbec0f9d79318175785eb146656441e8c644786ee5f"
+checksum = "c20f226662436bbdc221c9156a1f445c257da5e695b39a26878aa8b2644f710e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -734,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f6d7c9462a3cf3bb046d0b870b86f1ce8c6892157491abebba62913e6f53cb"
+checksum = "2a97960aa11b9984a18580b8dfbfc3eacfce1befa0d588b03ccc0bc5563d01f8"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -747,9 +748,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e23b5864b3ed3479285ae9af1924266d60cac839dc559d50da868a0734c1d3"
+checksum = "0a43d7b6b86be4885c7a76f1dfcde9651af2d419ff571e8ee7257de47101203b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -767,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
+checksum = "756eb5803e70985be4066b636194ccb5f6629e5d141817c1f0c50cea8350bf5c"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -789,9 +790,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-mev"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97bfdac1ec57f53ab2a0dacfedf382aeba1245ecb4ad7ecd8aeb4438a6c3b9b"
+checksum = "c833a9b946d827d2b2aa8cad8e92279a4340ec1b7cf666f3e1ee6ef4684e0159"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -804,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d45ae3eadb97bf7933086205b4be0fef82c208bfc3007759e9afdcb6efa74c5"
+checksum = "1933d60c2f51b8906103484ea2ca2218357264dbf16f948f7c2dd4ac5818e1d8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -818,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0d7a9ab748d011daac12902ab9aedf8232d9b070bec6344cadd8509d8a6798"
+checksum = "2eb5d708e45799bd963d7e3bd8d04110e90983833ed02f91a9099811ed39ce6d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -830,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
+checksum = "cc142e40df0c3eb5983b1637a68ab33471d8d22b8f402c9ed8260411a4e89d86"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -842,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
+checksum = "b4c84f88f8a29d2607f98993687ed55a5943ba06819bc2126bb078dca54be943"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -857,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495d56d8b67d1d656d50053cf6263e4191bd626952f0401197eeb755b390924e"
+checksum = "546b952d800b39d864db5aa4d21490204424809b01f9c8e2e3f86c9ac91984ac"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -876,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c81d27fc6d869e0a1c1bd2c69d072d56c3b4f4aae0670ad85f4b6d373df064"
+checksum = "fb83214b1e09902a70d7417ea82ab893f6b55f1d31987b4a4ba8514e0292f500"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -894,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29eedbaa8de81b8c204572a783ac90eeaf7ae6e67fe2f8c2cc3c13c53eb1f1e0"
+checksum = "d769ff3b333280d136ddbf3ca9fe15a7cfa33759ae4213c87cbb12d71f572b05"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -912,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
+checksum = "58c81472fb0b73cbb18106e323e33e3f249f56318a330a8e0f6aa6e913e3519a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -931,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-trezor"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ef14606034a850914aa4d2b641b2d89d47e62b5eec6087c4f645bc834aec6d5"
+checksum = "5501c044cd89c5a2c299c26310dcfccd93a09a33fe9783b16bb4c03f07db3442"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -1021,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06f4ca8484d6295d5165f67de8fdb00ae630ba585efb606f003171286b56441c"
+checksum = "6576826236d84590b037e333bfc3643ae0a90cb325ca9da565419102047b3b81"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -1044,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8342aa5a7f8dee6d606307eebbc847d9799a823c7e4f37b9c1e32b08715f73c8"
+checksum = "e38c841f63141cad3f1a4378cedf121914b32932cf09b66c6006d4a906112136"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -1060,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "184e03e1845edd5534f309d3169d93969a819ad1609108d9378fd33059de7547"
+checksum = "03044aa44ec1da9468adf6a6e8c27d2bbaafd7a854ae14ac3e093b214139816d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -1070,6 +1071,7 @@ dependencies = [
  "bytes",
  "futures",
  "interprocess",
+ "memchr",
  "pin-project",
  "serde",
  "serde_json",
@@ -1080,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee146fb5859e612e95570642a29def87c060c7ce47d14a0caa5ab7ee8570ec2c"
+checksum = "55691c488ab3c88f664b6ffcaf9027f106b4642e6ff220502b6f645543a9efe8"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1119,9 +1121,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
+checksum = "25484345e4d89c259235e200d4f895eba33e70f125f4e8bb37a7aa69a97bd656"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1180,7 +1182,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1191,7 +1193,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,7 +4486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6098,7 +6100,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7271,7 +7273,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8984,7 +8986,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10009,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10073,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10213,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10230,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10262,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10276,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10335,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10360,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10578,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10629,7 +10631,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10653,7 +10655,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10677,7 +10679,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "bytes",
  "eyre",
@@ -10707,7 +10709,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10719,7 +10721,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10743,7 +10745,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10755,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10778,7 +10780,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10821,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10871,7 +10873,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10898,7 +10900,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10914,7 +10916,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10929,7 +10931,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11005,7 +11007,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11035,7 +11037,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11078,7 +11080,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11098,7 +11100,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11129,7 +11131,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11176,7 +11178,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11226,7 +11228,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11242,7 +11244,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11273,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11325,7 +11327,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11353,7 +11355,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11367,7 +11369,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11387,7 +11389,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11402,7 +11404,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11430,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11447,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11473,7 +11475,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11494,7 +11496,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11510,7 +11512,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11520,7 +11522,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "clap",
  "eyre",
@@ -11540,7 +11542,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11559,7 +11561,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11604,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11628,7 +11630,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11656,7 +11658,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11672,7 +11674,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11696,7 +11698,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=b733171#b7331716b1f9f8bc32cfdd8465a875a87b127ad1"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",
@@ -11724,9 +11726,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d1681d52ee61171b838db4924827f63d659d4c3ad559aa3a57003f3dda3f7c"
+checksum = "fc210dfb3b45482a9f7c8806f737f7848fb7054b04235e6816480e515c1fe2d5"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -11755,9 +11757,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85bce65cc8969955309d5c4c37a63612209c720d040f1982dda6b59e39ab059"
+checksum = "c16835bc2ead203219a18fcc84c2c71879ad6b890e8a71150cf7f10e4e355dc4"
 dependencies = [
  "bitvec",
  "cfg-if",
@@ -11772,9 +11774,9 @@ dependencies = [
 
 [[package]]
 name = "revm-context-interface"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97d0c7f8bdf65601d35ed27cf6b0f0bd436087f0a97a52aa767a49bbcea8373"
+checksum = "e3b4109bdceaca5ee6e27bf41f6b156f2b15892dc5bb47d3530bc4d3b3060077"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -11818,9 +11820,9 @@ dependencies = [
 
 [[package]]
 name = "revm-handler"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0b5923be8784704d119be5381d76a602f65e4a9991650bb87291565bd0d8ec"
+checksum = "7b8d988f896e22b19962658bc1afcd0989f727d48b2860a8bd7ceaecbf72ce34"
 dependencies = [
  "auto_impl",
  "derive-where",
@@ -11837,9 +11839,9 @@ dependencies = [
 
 [[package]]
 name = "revm-inspector"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a988ad0879bd81b269cad53c235a8ce87cd44a7c1de7d21a6ff3dd9e9f3e70a9"
+checksum = "e2584990403728b2e13fb5522510b61e4bb217c6a4c8f4d063447a6ddd7dd7cc"
 dependencies = [
  "auto_impl",
  "either",
@@ -11875,9 +11877,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "43.0.0"
+version = "43.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddc442e3c5006ebb65f479e9e8fded7fc10f300c040276e825eee81e00c94cc"
+checksum = "932f7fe05a2cdeb08195dd7e88a09a4da7c3660cdc6e62720839c77ba77f65aa"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -11888,9 +11890,9 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "43.0.1"
+version = "43.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e22eb3326b44ec0bc47a874966a562390e1613f1f0ba4dc4a1056e525e0f628"
+checksum = "ac4dc0279f2a44770faa8c93d008df684440cf573c91b8e0e39d0d581abf7b3d"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -12248,7 +12250,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12328,7 +12330,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13008,7 +13010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13288,7 +13290,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -15373,7 +15375,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,74 +146,74 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", features = [
   "std",
   "optional-checks",
 ] }
-revm = { version = "43.0.1", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "43.0.2", features = ["optional_fee_charge"], default-features = false }
 revm-inspectors = "0.43.0"
 
 alloy-json-abi = { version = "1.7.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,37 +213,37 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", feat
   "std",
   "optional-checks",
 ] }
-revm = { version = "43.0.0", features = ["optional_fee_charge"], default-features = false }
+revm = { version = "43.0.1", features = ["optional_fee_charge"], default-features = false }
 revm-inspectors = "0.43.0"
 
 alloy-json-abi = { version = "1.7.2", default-features = false }
 alloy-primitives = { version = "1.7.2", default-features = false }
 alloy-sol-types = { version = "1.7.2", default-features = false }
 
-alloy = { version = "2.4.1", default-features = false }
-alloy-consensus = { version = "2.4.1", default-features = false }
-alloy-contract = { version = "2.4.1", default-features = false }
-alloy-eip7928 = { version = "0.4.5", default-features = false }
-alloy-eips = { version = "2.4.1", default-features = false }
+alloy = { version = "2.4.2", default-features = false }
+alloy-consensus = { version = "2.4.2", default-features = false }
+alloy-contract = { version = "2.4.2", default-features = false }
+alloy-eip7928 = { version = "0.4.9", default-features = false }
+alloy-eips = { version = "2.4.2", default-features = false }
 alloy-evm = { version = "0.39.0", default-features = false }
-alloy-genesis = { version = "2.4.1", default-features = false }
-alloy-hardforks = "0.4.7"
-alloy-json-rpc = "2.4.1"
-alloy-network = { version = "2.4.1", default-features = false }
-alloy-provider = { version = "2.4.1", default-features = false }
+alloy-genesis = { version = "2.4.2", default-features = false }
+alloy-hardforks = "0.4.8"
+alloy-json-rpc = "2.4.2"
+alloy-network = { version = "2.4.2", default-features = false }
+alloy-provider = { version = "2.4.2", default-features = false }
 alloy-rlp = { version = "0.3.16", default-features = false }
-alloy-rpc-client = { version = "2.4.1", default-features = false }
-alloy-rpc-types-admin = "2.4.1"
-alloy-rpc-types-engine = "2.4.1"
-alloy-rpc-types-eth = { version = "2.4.1" }
-alloy-serde = { version = "2.4.1", default-features = false }
-alloy-signer = "2.4.1"
-alloy-signer-aws = "2.4.1"
-alloy-signer-gcp = "2.4.1"
-alloy-signer-ledger = "2.4.1"
-alloy-signer-local = "2.4.1"
-alloy-signer-trezor = "2.4.1"
-alloy-transport = "2.4.1"
+alloy-rpc-client = { version = "2.4.2", default-features = false }
+alloy-rpc-types-admin = "2.4.2"
+alloy-rpc-types-engine = "2.4.2"
+alloy-rpc-types-eth = { version = "2.4.2" }
+alloy-serde = { version = "2.4.2", default-features = false }
+alloy-signer = "2.4.2"
+alloy-signer-aws = "2.4.2"
+alloy-signer-gcp = "2.4.2"
+alloy-signer-ledger = "2.4.2"
+alloy-signer-local = "2.4.2"
+alloy-signer-trezor = "2.4.2"
+alloy-transport = "2.4.2"
 
 commonware-actor = "2026.7.1"
 commonware-broadcast = "2026.7.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "b733171" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "038c782" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "b733171", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "038c782", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/node/tests/it/key_authorization.rs
+++ b/crates/node/tests/it/key_authorization.rs
@@ -6,6 +6,7 @@ use alloy::{
 };
 use alloy_eips::Encodable2718;
 use alloy_primitives::TxKind;
+use reth_node_api::PayloadKind;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20};
 use tempo_primitives::{
@@ -216,10 +217,10 @@ async fn test_pre_t1b_keyauth_oog_replay() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Pre-T1B single poisoned tx: the poisoned KeyAuth CREATE tx is the only
-/// user tx in the block. The block still produces (the builder skips the
-/// invalid tx or handles the OOG gracefully), but the protocol nonce is
-/// NOT bumped — the signed tx remains valid in the pool indefinitely.
+/// Pre-T1B single poisoned tx: when the poisoned KeyAuth CREATE tx is the
+/// only user tx, its OOG state also makes the seal-block system transaction
+/// run out of gas, so the builder cannot produce a payload. The protocol nonce
+/// is not bumped and the signed tx remains valid in the pool indefinitely.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pre_t1b_keyauth_oog_single_tx_nonce_not_bumped() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -247,10 +248,32 @@ async fn test_pre_t1b_keyauth_oog_single_tx_nonce_not_bumped() -> eyre::Result<(
 
     let _ = provider.send_raw_transaction(&encoded).await?;
 
-    // Block is produced — the builder handles the poisoned tx gracefully.
-    setup.node.advance_block().await?;
+    let attributes = setup.node.payload.next_attributes();
+    let payload_id = setup
+        .node
+        .inner
+        .add_ons_handle
+        .beacon_engine_handle
+        .fork_choice_updated(
+            setup.node.current_forkchoice_state()?,
+            Some(attributes.clone()),
+        )
+        .await?
+        .payload_id
+        .expect("forkchoice update should start a payload job");
+    setup.node.payload.expect_attr_event(attributes).await?;
 
-    // Protocol nonce NOT bumped — CREATE frame was never reached.
+    let payload_result = setup
+        .node
+        .inner
+        .payload_builder_handle
+        .resolve_kind(payload_id, PayloadKind::WaitForPending)
+        .await
+        .expect("payload job should exist");
+    let err = payload_result.expect_err("the poisoned tx should prevent payload construction");
+    assert_eq!(err.to_string(), "missing payload");
+
+    // Protocol nonce NOT bumped — no payload was committed and CREATE was never reached.
     let nonce_after = provider.get_transaction_count(signer_addr).await?;
     assert_eq!(
         nonce_after, nonce,

--- a/crates/node/tests/it/key_authorization.rs
+++ b/crates/node/tests/it/key_authorization.rs
@@ -6,7 +6,6 @@ use alloy::{
 };
 use alloy_eips::Encodable2718;
 use alloy_primitives::TxKind;
-use reth_node_api::PayloadKind;
 use tempo_chainspec::spec::TEMPO_T1_BASE_FEE;
 use tempo_contracts::precompiles::{DEFAULT_FEE_TOKEN, ITIP20};
 use tempo_primitives::{
@@ -217,10 +216,10 @@ async fn test_pre_t1b_keyauth_oog_replay() -> eyre::Result<()> {
     Ok(())
 }
 
-/// Pre-T1B single poisoned tx: when the poisoned KeyAuth CREATE tx is the
-/// only user tx, its OOG state also makes the seal-block system transaction
-/// run out of gas, so the builder cannot produce a payload. The protocol nonce
-/// is not bumped and the signed tx remains valid in the pool indefinitely.
+/// Pre-T1B single poisoned tx: the poisoned KeyAuth CREATE tx is the only
+/// user tx in the block. The block still produces (the builder skips the
+/// invalid tx or handles the OOG gracefully), but the protocol nonce is
+/// NOT bumped — the signed tx remains valid in the pool indefinitely.
 #[tokio::test(flavor = "multi_thread")]
 async fn test_pre_t1b_keyauth_oog_single_tx_nonce_not_bumped() -> eyre::Result<()> {
     reth_tracing::init_test_tracing();
@@ -248,32 +247,10 @@ async fn test_pre_t1b_keyauth_oog_single_tx_nonce_not_bumped() -> eyre::Result<(
 
     let _ = provider.send_raw_transaction(&encoded).await?;
 
-    let attributes = setup.node.payload.next_attributes();
-    let payload_id = setup
-        .node
-        .inner
-        .add_ons_handle
-        .beacon_engine_handle
-        .fork_choice_updated(
-            setup.node.current_forkchoice_state()?,
-            Some(attributes.clone()),
-        )
-        .await?
-        .payload_id
-        .expect("forkchoice update should start a payload job");
-    setup.node.payload.expect_attr_event(attributes).await?;
+    // Block is produced — the builder handles the poisoned tx gracefully.
+    setup.node.advance_block().await?;
 
-    let payload_result = setup
-        .node
-        .inner
-        .payload_builder_handle
-        .resolve_kind(payload_id, PayloadKind::WaitForPending)
-        .await
-        .expect("payload job should exist");
-    let err = payload_result.expect_err("the poisoned tx should prevent payload construction");
-    assert_eq!(err.to_string(), "missing payload");
-
-    // Protocol nonce NOT bumped — no payload was committed and CREATE was never reached.
+    // Protocol nonce NOT bumped — CREATE frame was never reached.
     let nonce_after = provider.get_transaction_count(signer_addr).await?;
     assert_eq!(
         nonce_after, nonce,

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1255,13 +1255,13 @@ where
     fn get_blobs_for_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        indices_bitarray: alloy_primitives::B128,
+        cell_mask: alloy_eips::eip7594::BlobCellMask,
     ) -> Result<
         Vec<Option<alloy_eips::eip4844::BlobCellsAndProofsV1>>,
         reth_transaction_pool::blobstore::BlobStoreError,
     > {
         self.protocol_pool
-            .get_blobs_for_versioned_hashes_v4(versioned_hashes, indices_bitarray)
+            .get_blobs_for_versioned_hashes_v4(versioned_hashes, cell_mask)
     }
 
     fn blob_store(&self) -> Box<dyn reth_transaction_pool::BlobStore> {


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`280a763...8e55cc5`](https://github.com/paradigmxyz/reth/compare/280a763...8e55cc5)

🔗 Amp thread: https://ampcode.com/threads/T-01a08609-9c49-7628-be4f-0d6c3cc398dd
- **Engine**
  - Reused Alloy BAL state, index, hash-validation, and prewarming helpers; optimized BAL capacity and cleanup paths ([#27051](https://github.com/paradigmxyz/reth/pull/27051), [#27053](https://github.com/paradigmxyz/reth/pull/27053), [#27052](https://github.com/paradigmxyz/reth/pull/27052), [#27079](https://github.com/paradigmxyz/reth/pull/27079), [#27074](https://github.com/paradigmxyz/reth/pull/27074)).
  - Stop transaction recovery when its channel disconnects ([#27092](https://github.com/paradigmxyz/reth/pull/27092)).

- **Snap Sync**
  - Scaffolded the `snap-sync` crate with a minimal pivot module and added download-attempt tracking to prevent premature completion ([#27054](https://github.com/paradigmxyz/reth/pull/27054), [#27108](https://github.com/paradigmxyz/reth/pull/27108)).

- **RPC**
  - Strengthened blob and builder validation with non-empty V2 fixtures and early rejection of raw `BidTrace` mismatches ([#26997](https://github.com/paradigmxyz/reth/pull/26997), [#27026](https://github.com/paradigmxyz/reth/pull/27026)).
  - Suppress synthetic transfer logs when EIP-7708 is active ([#27110](https://github.com/paradigmxyz/reth/pull/27110)).

- **Trie**
  - Reset cursors on `root_node` and preserve changesets for read-only overlays ([#27019](https://github.com/paradigmxyz/reth/pull/27019), [#27114](https://github.com/paradigmxyz/reth/pull/27114)).
  - Reduced proof and storage overhead by evaluating retention once per committed child and avoiding staging drained storage addresses ([#26973](https://github.com/paradigmxyz/reth/pull/26973), [#27080](https://github.com/paradigmxyz/reth/pull/27080)).

- **Overlay**
  - Added support for overlaying a pending block ([#27056](https://github.com/paradigmxyz/reth/pull/27056)).

- **Networking**
  - Decode wire bitvectors into typed blob-cell masks ([#27089](https://github.com/paradigmxyz/reth/pull/27089)).

- **Testing**
  - Stabilized gossip-disconnect and testing-RPC tests ([#27087](https://github.com/paradigmxyz/reth/pull/27087)).

- **Dependencies**
  - Upgraded Alloy to 2.4.2, revm to 43.0.2, and refreshed the Cargo weekly dependency group ([#27115](https://github.com/paradigmxyz/reth/pull/27115), [#27073](https://github.com/paradigmxyz/reth/pull/27073), [#27096](https://github.com/paradigmxyz/reth/pull/27096), [#27027](https://github.com/paradigmxyz/reth/pull/27027)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-01a08609-d7ad-748d-8f21-af82b9a7a8af
- Upgraded Reth from `280a763` to `8e55cc5` and aligned Revm/Alloy dependencies with its updated APIs.
- Migrated blob retrieval from a raw `B128` indices bitarray to the typed `BlobCellMask` parameter required by Reth’s updated `get_blobs_for_versioned_hashes_v4` API.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/34347942218)
