### PR TITLE
fix(scripts): propagate cargo docs failure in build-cargo-docs.sh

### DIFF
--- a/scripts/build-cargo-docs.sh
+++ b/scripts/build-cargo-docs.sh
@@ -10,5 +10,10 @@ echo "Building cargo docs..."
 # Build the documentation
 export RUSTDOCFLAGS="--cfg docsrs --show-type-layout --generate-link-to-definition --enable-index-page -Zunstable-options"
 cargo docs
+status=$?
+if [ "$status" -ne 0 ]; then
+    echo "Failed to build cargo docs" >&2
+    exit "$status"
+fi
 
 echo "Cargo docs built successfully at ./target/doc"


### PR DESCRIPTION
## Summary

Fixes #7533.

`scripts/build-cargo-docs.sh` ran `cargo docs` without checking its exit status and then unconditionally printed a success message, so the script exited `0` even when the documentation build failed. Any caller (local automation or CI) would treat a failed docs build as successful.

Capture the `cargo docs` exit status and, on failure, print an error to stderr and exit with that status, so the failure propagates.
