### PR TITLE
fix(ci): run scheduled multi-region benchmarks with public-mix

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -161,6 +161,7 @@ jobs:
       baseline-name: ${{ needs.resolve-refs.outputs.baseline-name }}
       feature: ${{ needs.resolve-refs.outputs.feature-ref }}
       feature-name: ${{ needs.resolve-refs.outputs.feature-name }}
+      preset: public-mix
       duration: ${{ inputs.duration || '90' }}
       bloat: ${{ inputs.bloat || '100' }}
       validator-count: ${{ inputs['validator-count'] || '10' }}

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -23,6 +23,10 @@ on:
         type: string
         required: false
         default: ""
+      preset:
+        type: string
+        required: false
+        default: "tip20_existing_recipients"
       duration:
         type: string
         required: false


### PR DESCRIPTION
Run scheduled multi-region benchmarks exclusively with `public-mix` by passing an explicit preset to the reusable workflow. Add the reusable preset input while preserving its existing default for other callers.

Validated workflow YAML, caller/input compatibility, and preset availability; `git diff --check` passed. The cloud benchmark was not run.

Prompted by: @shekhirin
