### PR TITLE
docs(tip-1108): specify account extension RPC behavior

### DIFF
--- a/tips/tip-1108.md
+++ b/tips/tip-1108.md
@@ -124,13 +124,7 @@ Where `debug_accountAt` and `debug_accountInfoAt` are exposed, their account obj
 
 ### Account proofs
 
-`eth_getProof` and, where exposed, `eth_getMultiProof` support accounts with configuration commitments. They must return proofs for extended accounts, without rejecting them or stripping the commitment. Both methods retain their existing response schemas: the extension is carried in the authenticated account leaf rather than a separate JSON `extension` field.
-
-Each `accountProof` contains the trie nodes authenticating the complete account leaf, including the fifth field when present. `eth_getMultiProof` applies the same rules to every returned account proof, including requests mixing accounts with and without commitments and missing accounts. Storage proofs and the existing balance, nonce, code-hash, and storage-root summary fields are unchanged.
-
-Proof verifiers must authenticate the full leaf against the selected block's state root and decode it using the account-leaf rules above. Reconstructing a four-field leaf from the response summary fields is insufficient for an account with a commitment. An absence proof has no account commitment; a proof of an account with only a nonzero commitment is an inclusion proof, not an absence proof.
-
-Tools reconstructing account state from either proof method must recover the commitment from the authenticated leaf and preserve it alongside the ordinary account fields. They must verify inclusion for the requested address before treating a leaf's fifth field as that account's commitment; an absence proof can contain a leaf belonging to another account.
+`eth_getProof` and, where exposed, `eth_getMultiProof` encode account leaves with their extensions in the proof nodes. Proof summary fields remain unchanged and do not include a separate `extension` field.
 
 ### Compatibility
 

--- a/tips/tip-1108.md
+++ b/tips/tip-1108.md
@@ -107,6 +107,53 @@ The hash is part of the account's authenticated state. Every representation of t
 - Hashing, calldata, events, and ordinary precompile costs are charged separately.
 - There is no clearing refund.
 
+## JSON-RPC
+
+Request parameters and existing response fields are unchanged. All values below refer to the state selected by the request, including historical reads; they must not be taken from the latest state instead.
+
+### Account responses
+
+`eth_getAccount` and `eth_getAccountInfo` expose the configuration commitment through an optional `extension` field in their account response object:
+
+- For a nonzero `config_hash`, `extension` is the hash itself, encoded as `0x` followed by exactly 64 hexadecimal digits (32 bytes of JSON-RPC `DATA`). It is not RLP-encoded or a JSON-RPC `QUANTITY`.
+- For a zero `config_hash`, omit `extension`. Do not emit `null`, `"0x"`, or a zero-filled hash. Accounts without a commitment retain their existing response shape.
+- Before T12, omit `extension` for every account. After T12, accounts without a registered configuration still omit it.
+- Clients interpret an absent `extension` as no registered configuration when reading from an endpoint that supports this TIP.
+
+For example, an `eth_getAccountInfo` result for an account with a commitment but no balance, nonce, or code is:
+
+```json
+{
+  "balance": "0x0",
+  "nonce": "0x0",
+  "code": "0x",
+  "extension": "0x1111111111111111111111111111111111111111111111111111111111111111"
+}
+```
+
+Missing-account behavior is unchanged: `eth_getAccount` returns `null`, while `eth_getAccountInfo` returns zero balance, zero nonce, and empty code, without `extension`. An account with a nonzero commitment is not missing, even if its balance, nonce, and code are otherwise empty.
+
+Where `debug_accountAt` and `debug_accountInfoAt` are exposed, their account objects follow the same extension rules at the requested transaction boundary. Their existing `null` behavior is unchanged.
+
+`eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, and `eth_getStorageAt` retain their existing results. They do not expose the commitment, and combining their results is not sufficient to reconstruct an extended account.
+
+### Account proofs
+
+`eth_getProof` and, where exposed, `eth_getMultiProof` retain their existing response schemas. No separate `extension` response field is added to these methods. Each `accountProof` contains the trie nodes authenticating the complete account leaf, including the fifth field when present. Storage proofs and the existing balance, nonce, code-hash, and storage-root summary fields are unchanged.
+
+Proof verifiers must authenticate the full leaf against the selected block's state root and decode it using the account-leaf rules above. Reconstructing a four-field leaf from the response summary fields is insufficient for an account with a commitment. An absence proof has no account commitment; a proof of an account with only a nonzero commitment is an inclusion proof, not an absence proof.
+
+### Compatibility
+
+Clients that ignore unknown account-response fields can continue using the existing fields. Proof verifiers that assume every account leaf has four fields must be updated before verifying extended accounts. RPC-backed execution and state-reconstruction tools must use an extension-aware endpoint; a legacy endpoint can omit a stored commitment, so an absent JSON field alone is not evidence of endpoint support.
+
+### RPC test cases
+
+- Check unchanged responses and proofs for missing accounts and accounts without a commitment, both before and after T12.
+- Round-trip a nonzero commitment through both account methods and verify it through both proof methods, including an account whose other fields are empty.
+- Verify historical reads before registration and across commitment updates and reorgs against the corresponding state roots.
+- Reject account proofs with a modified commitment or a fifth field that violates the account-leaf encoding rules.
+
 # Tooling
 
 - Account-proof readers must understand the optional fifth field.

--- a/tips/tip-1108.md
+++ b/tips/tip-1108.md
@@ -109,33 +109,18 @@ The hash is part of the account's authenticated state. Every representation of t
 
 ## JSON-RPC
 
-Request parameters and existing response fields are unchanged. All values below refer to the state selected by the request, including historical reads; they must not be taken from the latest state instead.
+Request parameters and existing response fields are unchanged. All values below refer to the state selected by the request, including historical reads.
 
 ### Account responses
 
 `eth_getAccount` and `eth_getAccountInfo` expose the configuration commitment through an optional `extension` field in their account response object:
 
-- For a nonzero `config_hash`, `extension` is the hash itself, encoded as `0x` followed by exactly 64 hexadecimal digits (32 bytes of JSON-RPC `DATA`). It is not RLP-encoded or a JSON-RPC `QUANTITY`.
-- For a zero `config_hash`, omit `extension`. Do not emit `null`, `"0x"`, or a zero-filled hash. Accounts without a commitment retain their existing response shape.
-- Before T12, omit `extension` for every account. After T12, accounts without a registered configuration still omit it.
-- Clients interpret an absent `extension` as no registered configuration when reading from an endpoint that supports this TIP.
+- For a nonzero `config_hash`, `extension` is the hash itself, encoded as `0x` followed by exactly 64 hexadecimal digits (32 bytes of JSON-RPC `DATA`).
+- For a zero `config_hash`, omit `extension`.
 
-For example, an `eth_getAccountInfo` result for an account with a commitment but no balance, nonce, or code is:
+Missing-account behavior is unchanged. An account with a nonzero commitment is not missing, even if its balance, nonce, and code are otherwise empty.
 
-```json
-{
-  "balance": "0x0",
-  "nonce": "0x0",
-  "code": "0x",
-  "extension": "0x1111111111111111111111111111111111111111111111111111111111111111"
-}
-```
-
-Missing-account behavior is unchanged: `eth_getAccount` returns `null`, while `eth_getAccountInfo` returns zero balance, zero nonce, and empty code, without `extension`. An account with a nonzero commitment is not missing, even if its balance, nonce, and code are otherwise empty.
-
-Where `debug_accountAt` and `debug_accountInfoAt` are exposed, their account objects follow the same extension rules at the requested transaction boundary. Their existing `null` behavior is unchanged.
-
-`eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, and `eth_getStorageAt` retain their existing results. They do not expose the commitment, and combining their results is not sufficient to reconstruct an extended account.
+Where `debug_accountAt` and `debug_accountInfoAt` are exposed, their account objects follow the same extension rules at the requested transaction boundary.
 
 ### Account proofs
 
@@ -146,13 +131,6 @@ Proof verifiers must authenticate the full leaf against the selected block's sta
 ### Compatibility
 
 Clients that ignore unknown account-response fields can continue using the existing fields. Proof verifiers that assume every account leaf has four fields must be updated before verifying extended accounts. RPC-backed execution and state-reconstruction tools must use an extension-aware endpoint; a legacy endpoint can omit a stored commitment, so an absent JSON field alone is not evidence of endpoint support.
-
-### RPC test cases
-
-- Check unchanged responses and proofs for missing accounts and accounts without a commitment, both before and after T12.
-- Round-trip a nonzero commitment through both account methods and verify it through both proof methods, including an account whose other fields are empty.
-- Verify historical reads before registration and across commitment updates and reorgs against the corresponding state roots.
-- Reject account proofs with a modified commitment or a fifth field that violates the account-leaf encoding rules.
 
 # Tooling
 

--- a/tips/tip-1108.md
+++ b/tips/tip-1108.md
@@ -126,10 +126,6 @@ Where `debug_accountAt` and `debug_accountInfoAt` are exposed, their account obj
 
 `eth_getProof` and, where exposed, `eth_getMultiProof` encode account leaves with their extensions in the proof nodes. Proof summary fields remain unchanged and do not include a separate `extension` field.
 
-### Compatibility
-
-Clients that ignore unknown account-response fields can continue using the existing fields. Proof verifiers that assume every account leaf has four fields must be updated before verifying extended accounts. RPC-backed execution and state-reconstruction tools must use an extension-aware endpoint; a legacy endpoint can omit a stored commitment, so an absent JSON field alone is not evidence of endpoint support.
-
 # Tooling
 
 - Account-proof readers must understand the optional fifth field.

--- a/tips/tip-1108.md
+++ b/tips/tip-1108.md
@@ -139,9 +139,13 @@ Where `debug_accountAt` and `debug_accountInfoAt` are exposed, their account obj
 
 ### Account proofs
 
-`eth_getProof` and, where exposed, `eth_getMultiProof` retain their existing response schemas. No separate `extension` response field is added to these methods. Each `accountProof` contains the trie nodes authenticating the complete account leaf, including the fifth field when present. Storage proofs and the existing balance, nonce, code-hash, and storage-root summary fields are unchanged.
+`eth_getProof` and, where exposed, `eth_getMultiProof` support accounts with configuration commitments. They must return proofs for extended accounts, without rejecting them or stripping the commitment. Both methods retain their existing response schemas: the extension is carried in the authenticated account leaf rather than a separate JSON `extension` field.
+
+Each `accountProof` contains the trie nodes authenticating the complete account leaf, including the fifth field when present. `eth_getMultiProof` applies the same rules to every returned account proof, including requests mixing accounts with and without commitments and missing accounts. Storage proofs and the existing balance, nonce, code-hash, and storage-root summary fields are unchanged.
 
 Proof verifiers must authenticate the full leaf against the selected block's state root and decode it using the account-leaf rules above. Reconstructing a four-field leaf from the response summary fields is insufficient for an account with a commitment. An absence proof has no account commitment; a proof of an account with only a nonzero commitment is an inclusion proof, not an absence proof.
+
+Tools reconstructing account state from either proof method must recover the commitment from the authenticated leaf and preserve it alongside the ordinary account fields. They must verify inclusion for the requested address before treating a leaf's fifth field as that account's commitment; an absence proof can contain a leaf belonging to another account.
 
 ### Compatibility
 


### PR DESCRIPTION
Specifies the optional configuration commitment field in account RPC responses and extended account-leaf handling in proofs. Preserves missing-account behavior and documents historical reads, client compatibility, and RPC test cases.