### PR TITLE
fix(deps): pin reth to read-only overlay revert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,7 +8984,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9011,7 +9011,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9042,7 +9042,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9062,7 +9062,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9075,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9160,7 +9160,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9170,7 +9170,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9223,7 +9223,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9240,7 +9240,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9254,7 +9254,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9267,7 +9267,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9292,7 +9292,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9321,7 +9321,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9347,7 +9347,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9377,7 +9377,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9392,7 +9392,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9417,7 +9417,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9441,7 +9441,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9465,7 +9465,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9502,7 +9502,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9561,7 +9561,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9588,7 +9588,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9611,7 +9611,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9638,7 +9638,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9694,7 +9694,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9724,7 +9724,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9742,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9782,7 +9782,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9793,7 +9793,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9821,7 +9821,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9844,7 +9844,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9885,7 +9885,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "clap",
  "eyre",
@@ -9908,7 +9908,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9924,7 +9924,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9940,7 +9940,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9953,7 +9953,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9983,7 +9983,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9997,7 +9997,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10007,7 +10007,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10033,7 +10033,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10053,7 +10053,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10071,7 +10071,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10084,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10103,7 +10103,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10141,7 +10141,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10155,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "serde",
  "serde_json",
@@ -10165,7 +10165,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10191,7 +10191,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "bytes",
  "futures",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10228,7 +10228,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "bindgen",
  "cc",
@@ -10237,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "futures",
  "libc",
@@ -10251,7 +10251,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10260,7 +10260,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10274,7 +10274,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10333,7 +10333,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10358,7 +10358,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10382,7 +10382,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10397,7 +10397,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10411,7 +10411,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10429,7 +10429,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10453,7 +10453,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10521,7 +10521,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10576,7 +10576,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10629,7 +10629,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10653,7 +10653,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10677,7 +10677,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "bytes",
  "eyre",
@@ -10707,7 +10707,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10719,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10743,7 +10743,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10755,7 +10755,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10778,7 +10778,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10821,7 +10821,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10871,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10898,7 +10898,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10914,7 +10914,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10929,7 +10929,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11005,7 +11005,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11035,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11078,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11098,7 +11098,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11129,7 +11129,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11176,7 +11176,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11226,7 +11226,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11242,7 +11242,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11273,7 +11273,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11325,7 +11325,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11353,7 +11353,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11367,7 +11367,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11387,7 +11387,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11402,7 +11402,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11445,7 +11445,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11473,7 +11473,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11494,7 +11494,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11510,7 +11510,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11520,7 +11520,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "clap",
  "eyre",
@@ -11540,7 +11540,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11559,7 +11559,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11602,7 +11602,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11628,7 +11628,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11656,7 +11656,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11672,7 +11672,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11696,7 +11696,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=280a763#280a76318d7ab933f4a1536d1942ffeb4c742d1a"
+source = "git+https://github.com/paradigmxyz/reth?rev=2ae9f1dc751dad2d512686a30887385788b3f85d#2ae9f1dc751dad2d512686a30887385788b3f85d"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "280a763" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "280a763", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "2ae9f1dc751dad2d512686a30887385788b3f85d", features = [
   "std",
   "optional-checks",
 ] }


### PR DESCRIPTION
Pins Reth to [a branch](https://github.com/paradigmxyz/reth/tree/centaur/revert-read-only-overlays-1788950746) based on Tempo's current [`280a763`](https://github.com/paradigmxyz/reth/commit/280a76318d7ab933f4a1536d1942ffeb4c742d1a), with only the exact revert of [reth#26986](https://github.com/paradigmxyz/reth/pull/26986) applied as [`2ae9f1d`](https://github.com/paradigmxyz/reth/commit/2ae9f1dc751dad2d512686a30887385788b3f85d). This restores trie changeset reads for read-only overlays to test the suspected historical proof regression; resolution of the reported mismatch has not been verified.

Validation: the Reth diff matches the inverse patch exactly, and Tempo's manifest and lockfile contain only Reth revision substitutions. Locked Cargo dependency resolution and formatting checks passed. The modified overlay library compiled during the local unit-test build, but the test run was stopped while building native database dependencies; CI results are pending.

Prompted by: @shekhirin
