### PR TITLE
feat(txpool): limit transactions per 2D nonce lane

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -54,6 +54,7 @@ use tempo_transaction_pool::{
     amm::AmmLiquidityCache,
     ordering::TempoTipOrdering,
     transaction::TempoPooledTransaction,
+    tt_2d_pool::DEFAULT_MAX_TXS_PER_LANE,
     validator::{
         DEFAULT_AA_VALID_AFTER_MAX_SECS, DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
         TempoTransactionValidator,
@@ -73,6 +74,11 @@ pub struct TempoNodeArgs {
     /// Maximum number of authorizations allowed in an AA transaction.
     #[arg(long = "txpool.max-tempo-authorizations", default_value_t = DEFAULT_MAX_TEMPO_AUTHORIZATIONS)]
     pub max_tempo_authorizations: usize,
+
+    /// Maximum pending and queued transactions per regular 2D nonce lane (sender, nonce key).
+    /// The current on-chain nonce is admitted even at capacity to allow gap filling.
+    #[arg(long = "txpool.max-txs-per-lane", default_value_t = DEFAULT_MAX_TXS_PER_LANE)]
+    pub max_txs_per_lane: usize,
 
     /// Comma-separated addresses or a file containing comma/newline-separated addresses used for
     /// transaction sender and direct call target checks.
@@ -123,6 +129,7 @@ impl Default for TempoNodeArgs {
         Self {
             aa_valid_after_max_secs: DEFAULT_AA_VALID_AFTER_MAX_SECS,
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
             txpool_filter: None,
             builder_state_provider_metrics: false,
             builder_disable_prewarming: false,
@@ -140,6 +147,7 @@ impl TempoNodeArgs {
         TempoPoolBuilder {
             aa_valid_after_max_secs: self.aa_valid_after_max_secs,
             max_tempo_authorizations: self.max_tempo_authorizations,
+            max_txs_per_lane: self.max_txs_per_lane,
             address_filter: self.txpool_filter.clone().unwrap_or_default(),
             ..Default::default()
         }
@@ -592,6 +600,8 @@ pub struct TempoPoolBuilder {
     pub aa_valid_after_max_secs: u64,
     /// Maximum number of authorizations allowed in an AA transaction.
     pub max_tempo_authorizations: usize,
+    /// Maximum pending and queued transactions per regular 2D nonce lane.
+    pub max_txs_per_lane: usize,
     /// Whether to skip the FeeAMM liquidity check during pool admission.
     pub disable_fee_amm_check: bool,
     /// Addresses checked against transaction senders and direct call targets.
@@ -603,6 +613,12 @@ pub struct TempoPoolBuilder {
 }
 
 impl TempoPoolBuilder {
+    /// Sets the maximum number of transactions per regular 2D nonce lane.
+    pub const fn with_max_txs_per_lane(mut self, max: usize) -> Self {
+        self.max_txs_per_lane = max;
+        self
+    }
+
     /// Sets the maximum allowed `valid_after` offset for AA txs.
     pub const fn with_aa_tx_valid_after_max_secs(mut self, secs: u64) -> Self {
         self.aa_valid_after_max_secs = secs;
@@ -701,6 +717,7 @@ impl core::fmt::Debug for TempoPoolBuilder {
         f.debug_struct("TempoPoolBuilder")
             .field("aa_valid_after_max_secs", &self.aa_valid_after_max_secs)
             .field("max_tempo_authorizations", &self.max_tempo_authorizations)
+            .field("max_txs_per_lane", &self.max_txs_per_lane)
             .field("disable_fee_amm_check", &self.disable_fee_amm_check)
             .field("address_filter", &self.address_filter)
             .field(
@@ -720,6 +737,7 @@ impl Default for TempoPoolBuilder {
         Self {
             aa_valid_after_max_secs: DEFAULT_AA_VALID_AFTER_MAX_SECS,
             max_tempo_authorizations: DEFAULT_MAX_TEMPO_AUTHORIZATIONS,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
             disable_fee_amm_check: false,
             address_filter: AddressFilter::default(),
             additional_stateless_validation: None,
@@ -763,6 +781,7 @@ where
             pending_limit: pool_config.pending_limit,
             queued_limit: pool_config.queued_limit,
             max_txs_per_sender: pool_config.max_account_slots,
+            max_txs_per_lane: self.max_txs_per_lane,
         };
         let aa_2d_pool = AA2dPool::new(aa_2d_config);
         let amm_liquidity_cache = AmmLiquidityCache::new(ctx.provider())?;
@@ -770,6 +789,7 @@ where
         let Self {
             aa_valid_after_max_secs,
             max_tempo_authorizations,
+            max_txs_per_lane: _,
             disable_fee_amm_check,
             address_filter,
             additional_stateless_validation,
@@ -903,6 +923,30 @@ mod tests {
         AddressFilter, TempoNode, TempoNodeArgs, TempoPayloadBuilderBuilder, TempoPoolBuilder,
     };
     use alloy_primitives::Address;
+
+    #[test]
+    fn lane_limit_cli_reaches_pool_builder() {
+        use clap::Parser;
+        #[derive(Parser)]
+        struct Args {
+            #[command(flatten)]
+            node: TempoNodeArgs,
+        }
+        let defaults = Args::try_parse_from(["tempo"]).unwrap();
+        assert_eq!(
+            defaults.node.max_txs_per_lane,
+            super::DEFAULT_MAX_TXS_PER_LANE
+        );
+        let args = Args::try_parse_from(["tempo", "--txpool.max-txs-per-lane", "64"]).unwrap();
+        assert_eq!(args.node.pool_builder().max_txs_per_lane, 64);
+        assert_eq!(
+            args.node
+                .pool_builder()
+                .with_max_txs_per_lane(32)
+                .max_txs_per_lane,
+            32
+        );
+    }
 
     #[test]
     fn tempo_node_maps_pool_builder() {

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -119,6 +119,8 @@ pub struct AA2dPool {
     /// Bounded by pool size (max unique senders = pending_limit + queued_limit).
     /// Entries are removed when count reaches 0 via `decrement_sender_count`.
     txs_by_sender: AddressMap<usize>,
+    /// Pending and queued regular transactions per `(sender, nonce_key)` lane.
+    txs_by_lane: HashMap<AASequenceId, usize>,
     /// Number of pending transactions, including expiring nonce transactions.
     pending_count: usize,
     /// Number of queued regular 2D nonce transactions.
@@ -158,6 +160,7 @@ impl AA2dPool {
             queued_eviction_order: Default::default(),
             base_fee: 0,
             txs_by_sender: Default::default(),
+            txs_by_lane: Default::default(),
             pending_count: 0,
             queued_count: 0,
             pending_size: Default::default(),
@@ -263,6 +266,18 @@ impl AA2dPool {
             ));
         }
 
+        let lane_count = self
+            .txs_by_lane
+            .get(&tx_id.seq_id)
+            .copied()
+            .unwrap_or_default();
+        if lane_count >= self.config.max_txs_per_lane && tx_id.nonce > on_chain_nonce {
+            return Err(PoolError::new(
+                *transaction.hash(),
+                PoolErrorKind::SpammerExceededCapacity(transaction.sender()),
+            ));
+        }
+
         // assume the transaction is not pending, will get updated later
         let tx = Arc::new(AA2dInternalTransaction {
             inner: AA2dStoredTransaction::new(self.next_id(), transaction.clone()),
@@ -317,6 +332,7 @@ impl AA2dPool {
                 }
 
                 entry.insert(Arc::clone(&tx));
+                *self.txs_by_lane.entry(tx_id.seq_id).or_default() += 1;
                 self.queued_count += 1;
                 None
             }
@@ -851,6 +867,12 @@ impl AA2dPool {
         id: &AA2dTransactionId,
     ) -> Option<Arc<ValidPoolTransaction<TempoPooledTransaction>>> {
         let tx = self.by_id.remove(id)?;
+        if let hash_map::Entry::Occupied(mut entry) = self.txs_by_lane.entry(id.seq_id) {
+            *entry.get_mut() -= 1;
+            if *entry.get() == 0 {
+                entry.remove();
+            }
+        }
 
         // Remove from eviction set
         self.remove_eviction_key(&tx);
@@ -1492,6 +1514,12 @@ impl AA2dPool {
     /// Asserts that all assumptions are valid.
     #[cfg(test)]
     pub(crate) fn assert_invariants(&self) {
+        let mut lane_counts = HashMap::default();
+        for id in self.by_id.keys() {
+            *lane_counts.entry(id.seq_id).or_insert(0usize) += 1;
+        }
+        assert_eq!(self.txs_by_lane, lane_counts);
+
         // Basic size constraints
         assert!(
             self.independent_transactions.len() <= self.by_id.len(),
@@ -1913,6 +1941,9 @@ impl IndependentTransactions {
 /// This limit prevents a single sender from monopolizing pool capacity.
 pub const DEFAULT_MAX_TXS_PER_SENDER: usize = 16;
 
+/// Default maximum number of pending and queued transactions in one regular 2D nonce lane.
+pub const DEFAULT_MAX_TXS_PER_LANE: usize = 1024;
+
 /// Settings for the [`AA2dPoolConfig`]
 #[derive(Debug, Clone)]
 pub struct AA2dPoolConfig {
@@ -1926,6 +1957,10 @@ pub struct AA2dPoolConfig {
     ///
     /// Prevents a single sender from monopolizing pool capacity (DoS protection).
     pub max_txs_per_sender: usize,
+    /// Admission limit for pending plus queued transactions per `(sender, nonce_key)` lane.
+    /// The current on-chain nonce is admitted even at capacity to allow gap filling.
+    /// Expiring nonce transactions are independent and do not use this limit.
+    pub max_txs_per_lane: usize,
 }
 
 impl Default for AA2dPoolConfig {
@@ -1935,6 +1970,7 @@ impl Default for AA2dPoolConfig {
             pending_limit: SubPoolLimit::default(),
             queued_limit: SubPoolLimit::default(),
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         }
     }
 }
@@ -4943,6 +4979,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
 
@@ -5150,6 +5187,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let sender = Address::random();
@@ -5218,6 +5256,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
 
@@ -5260,6 +5299,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
 
@@ -5297,6 +5337,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
 
@@ -5332,6 +5373,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let max_fee = 30_000_000_000u128;
@@ -5423,6 +5465,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
 
@@ -5483,6 +5526,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: DEFAULT_MAX_TXS_PER_SENDER,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
 
@@ -5586,6 +5630,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: 3,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let sender = Address::random();
@@ -5646,6 +5691,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: 2,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let sender = Address::random();
@@ -5698,6 +5744,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: 2,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let sender = Address::random();
@@ -5743,6 +5790,117 @@ mod tests {
         pool.assert_invariants();
     }
 
+    #[test]
+    fn lane_limit_allows_on_chain_nonce_without_eviction() {
+        let mut pool = AA2dPool::new(AA2dPoolConfig {
+            max_txs_per_lane: 3,
+            ..Default::default()
+        });
+        let sender = Address::random();
+        let nonce_key = U256::from(1);
+        let seq_id = AASequenceId::new(sender, nonce_key);
+        let make_tx = |nonce, fee| {
+            Arc::new(wrap_valid_tx(
+                TxBuilder::aa(sender)
+                    .nonce_key(nonce_key)
+                    .nonce(nonce)
+                    .max_priority_fee(fee)
+                    .max_fee(fee * 2)
+                    .build(),
+                TransactionOrigin::External,
+            ))
+        };
+        let mut hashes = Vec::new();
+        for nonce in 1..=3 {
+            let tx = make_tx(nonce, 1_000_000_000);
+            hashes.push(*tx.hash());
+            pool.add_transaction(tx, 0, TempoHardfork::T1).unwrap();
+        }
+
+        // Both new future nonces and future-nonce replacements are rejected at capacity.
+        for nonce in [1, 4] {
+            assert!(
+                pool.add_transaction(make_tx(nonce, 2_000_000_000), 0, TempoHardfork::T1)
+                    .is_err()
+            );
+        }
+        let added = pool
+            .add_transaction(make_tx(0, 1_000_000_000), 0, TempoHardfork::T1)
+            .unwrap();
+        let pending = added.as_pending().unwrap();
+        assert_eq!(pending.promoted.len(), 3);
+        assert!(pending.discarded.is_empty());
+        assert!(hashes.iter().all(|hash| pool.contains(hash)));
+        assert_eq!(pool.txs_by_lane[&seq_id], 4);
+        pool.assert_invariants();
+
+        // The on-chain nonce remains replaceable, subject to the usual price bump.
+        assert!(
+            pool.add_transaction(make_tx(0, 900_000_000), 0, TempoHardfork::T1)
+                .is_err()
+        );
+        let replacement = pool
+            .add_transaction(make_tx(0, 2_000_000_000), 0, TempoHardfork::T1)
+            .unwrap();
+        assert_eq!(pool.txs_by_lane[&seq_id], 4);
+        pool.remove_transactions(std::iter::once(&hashes[2]));
+        assert!(
+            pool.add_transaction(make_tx(4, 1_000_000_000), 0, TempoHardfork::T1)
+                .is_err()
+        );
+        pool.remove_transactions(std::iter::once(replacement.hash()));
+        pool.add_transaction(make_tx(4, 1_000_000_000), 0, TempoHardfork::T1)
+            .unwrap();
+        pool.assert_invariants();
+
+        pool.on_nonce_changes(HashMap::from_iter([(seq_id, 5)]));
+        assert!(!pool.txs_by_lane.contains_key(&seq_id));
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn lane_limit_is_scoped_to_sender_and_nonce_key() {
+        let mut pool = AA2dPool::new(AA2dPoolConfig {
+            max_txs_per_lane: 1,
+            ..Default::default()
+        });
+        let sender = Address::random();
+        for (sender, key) in [(sender, 1), (sender, 2), (Address::random(), 1)] {
+            let tx = TxBuilder::aa(sender).nonce_key(U256::from(key)).build();
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(tx, TransactionOrigin::External)),
+                0,
+                TempoHardfork::T1,
+            )
+            .unwrap();
+        }
+        assert_eq!(pool.txs_by_lane.len(), 3);
+        pool.assert_invariants();
+    }
+
+    #[test]
+    fn zero_lane_limit_does_not_limit_expiring_nonces() {
+        let mut pool = AA2dPool::new(AA2dPoolConfig {
+            max_txs_per_lane: 0,
+            ..Default::default()
+        });
+        let sender = Address::random();
+        for key in [U256::from(1), U256::MAX] {
+            let tx = TxBuilder::aa(sender)
+                .nonce_key(key)
+                .nonce(u64::from(key != U256::MAX))
+                .build();
+            let result = pool.add_transaction(
+                Arc::new(wrap_valid_tx(tx, TransactionOrigin::External)),
+                0,
+                TempoHardfork::T1,
+            );
+            assert_eq!(result.is_ok(), key == U256::MAX);
+        }
+        assert!(pool.txs_by_lane.is_empty());
+        pool.assert_invariants();
+    }
+
     /// Tests that expiring nonce transactions also respect per-sender limits.
     #[test]
     fn test_per_sender_limit_includes_expiring_nonce_txs() {
@@ -5757,6 +5915,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: 2,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let sender = Address::random();
@@ -7625,6 +7784,7 @@ mod tests {
                 max_size: usize::MAX,
             },
             max_txs_per_sender: 1,
+            max_txs_per_lane: DEFAULT_MAX_TXS_PER_LANE,
         };
         let mut pool = AA2dPool::new(config);
         let sender = Address::random();


### PR DESCRIPTION
Adds `--txpool.max-txs-per-lane` (default 1024) to cap pending and queued transactions per regular 2D nonce lane. At capacity, future nonces and their replacements are rejected, while the current on-chain nonce remains eligible for admission to fill gaps; expiring nonces are unaffected.
