### PR TITLE
fix(bench): default multi-region benchmarks to one run pair

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -68,7 +68,7 @@ on:
         description: Number of baseline/feature run pairs.
         type: string
         required: true
-        default: "3"
+        default: "1"
 
 permissions: {}
 
@@ -168,7 +168,7 @@ jobs:
       tps: ${{ inputs.tps || '50000' }}
       accounts: ${{ inputs.accounts || '1000' }}
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '5000' }}
-      run-pairs: ${{ inputs['run-pairs'] || '3' }}
+      run-pairs: ${{ inputs['run-pairs'] || '1' }}
       clickhouse-run: feature-1
       otlp: true
       valscope: true

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -58,7 +58,7 @@ on:
       run-pairs:
         type: string
         required: false
-        default: "3"
+        default: "1"
       clickhouse-run:
         type: string
         required: false
@@ -239,7 +239,7 @@ on:
         description: Number of baseline/feature run pairs.
         type: string
         required: true
-        default: "3"
+        default: "1"
       clickhouse-run:
         description: Benchmark phase that may use the direct ClickHouse reporter.
         type: string
@@ -296,7 +296,7 @@ jobs:
       BENCH_INPUT_GENERAL_GAS_LIMIT: ${{ inputs['general-gas-limit'] || '' }}
       BENCH_INPUT_NO_CACHE: ${{ github.event_name == 'workflow_dispatch' && (inputs['no-cache'] == true || inputs['no-cache'] == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BENCH_ARGS: ${{ inputs['bench-args'] || '' }}
-      BENCH_INPUT_RUN_PAIRS: ${{ inputs['run-pairs'] || (github.event_name == 'pull_request' && '1') || '3' }}
+      BENCH_INPUT_RUN_PAIRS: ${{ inputs['run-pairs'] || '1' }}
       BENCH_INPUT_CLICKHOUSE_RUN: ${{ inputs['clickhouse-run'] || 'feature-1' }}
       CLICKHOUSE_URL: ${{ secrets.CLICKHOUSE_URL }}
       CLICKHOUSE_USER: ${{ secrets.CLICKHOUSE_USER }}


### PR DESCRIPTION
Default manual, reusable, and scheduled multi-region benchmarks to one baseline/feature pair instead of three. Explicit run-pairs overrides remain supported.

Companion runner change: https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/395.

Validation: both changed workflows parse as YAML and diff checks pass. Runner smoke validation is tracked in the companion PR.

Prompted by: @shekhirin
