### PR TITLE
fix(bench): use state-bloat recipients for public-mix

### DIFF
--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -683,7 +683,8 @@ def txgen-run-preset-pipeline [
     }
     let existing_recipient_start = ($env | get --optional TXGEN_EXISTING_RECIPIENTS_START | default "0" | into int)
     let existing_recipient_end = ($env | get --optional TXGEN_EXISTING_RECIPIENTS_END | default "0" | into int)
-    let recipient_accounts = if $existing_recipient_end > $existing_recipient_start {
+    let uses_existing_recipients = (txgen-spec-effective-text $spec_path) =~ '(?m)^\s*existing_recipients:\s*$'
+    let recipient_accounts = if $uses_existing_recipients and $existing_recipient_end > $existing_recipient_start {
         $existing_recipient_end - $existing_recipient_start
     } else {
         0
@@ -752,6 +753,7 @@ def txgen-run-preset-pipeline [
         "-m" $"build_profile=($build_profile)"
         "-m" $"mode=($benchmark_mode)"
     ]
+        | append (if $recipient_accounts > 0 { ["-m" $"recipient_accounts=($recipient_accounts)"] } else { [] })
         | append (if $benchmark_id != "" { ["-m" $"benchmark_id=($benchmark_id)"] } else { [] })
         | append (if $benchmark_run != "" { ["-m" $"benchmark_run=($benchmark_run)"] } else { [] })
         | append (if $run_type != "" { ["-m" $"run_type=($run_type)"] } else { [] })

--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -3,7 +3,7 @@
 # Normalized: approximately 30.86%, 49.38%, 1.23%, and 18.52%, respectively.
 # These are benchmark assumptions, not a replay of mainnet activity.
 # Uses the native MPP open-only preset with txgen main.
-# Transfers target prepopulated state-bloat accounts; requires nonzero bloat.
+# Transfers and mints target prepopulated state-bloat accounts; requires nonzero bloat.
 include: mpp.yml
 
 address_pools:
@@ -62,7 +62,7 @@ templates:
       abi: ERC20
       function: mint
       args:
-        - {pool: {pool: users, select: random}}
+        - {address_pool: {pool: existing_recipients, select: random}}
         - 1
 
 # Each selection emits one transaction, including MPP.

--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -3,7 +3,16 @@
 # Normalized: approximately 30.86%, 49.38%, 1.23%, and 18.52%, respectively.
 # These are benchmark assumptions, not a replay of mainnet activity.
 # Uses the native MPP open-only preset with txgen main.
+# Transfers target prepopulated state-bloat accounts; requires nonzero bloat.
 include: mpp.yml
+
+address_pools:
+  existing_recipients:
+    fast:
+      seed: "test test test test test test test test test test test junk"
+      range:
+        - ${TXGEN_EXISTING_RECIPIENTS_START}
+        - ${TXGEN_EXISTING_RECIPIENTS_END}
 
 artifacts:
   ERC20: ../tip20.abi.json
@@ -22,7 +31,7 @@ templates:
       abi: ERC20
       function: transfer
       args:
-        - {pool: {pool: users, select: random}}
+        - {address_pool: {pool: existing_recipients, select: random}}
         - 1
   public_transfer_memo:
     type: tempo
@@ -37,7 +46,7 @@ templates:
       abi: ERC20
       function: transferWithMemo
       args:
-        - {pool: {pool: users, select: random}}
+        - {address_pool: {pool: existing_recipients, select: random}}
         - 1
         - {random_bytes: 32}
   public_mint:


### PR DESCRIPTION
Make plain TIP-20 transfers, transfers with memo, and mints in `public-mix` choose random recipients from the prepopulated state-bloat address range instead of the sender pool. Sender selection, MPP participants, and workload weights stay unchanged; mints are still signed by the issuer at `users[0]`, and the preset now requires nonzero state bloat.

Merge https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/396 first so multi-region runners supply the required recipient bounds.

Validation: YAML parsing and recipient/weight checks pass; the existing local Nushell helper detects the pool and computes `[10000, 4194302)` for 1 GiB without code changes. Live benchmark validation is pending regional capacity, tracked in the companion PR.

Prompted by: @shekhirin
