### PR TITLE
feat(ci): expose optional benchmark metrics collection

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -11,11 +11,6 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
-      skip-receipt-wait:
-        description: Skip workload receipt waits; setup still confirms receipts.
-        type: boolean
-        required: false
-        default: false
       skip-metrics:
         description: Skip benchmark scraping, latency samples, and metric exports.
         type: boolean
@@ -180,7 +175,6 @@ jobs:
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '5000' }}
       run-pairs: ${{ inputs['run-pairs'] || '3' }}
       clickhouse-run: feature-1
-      skip-receipt-wait: ${{ inputs['skip-receipt-wait'] || false }}
       skip-metrics: ${{ inputs['skip-metrics'] || false }}
       otlp: true
       valscope: true

--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -11,6 +11,16 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
+      skip-receipt-wait:
+        description: Skip workload receipt waits; setup still confirms receipts.
+        type: boolean
+        required: false
+        default: false
+      skip-metrics:
+        description: Skip benchmark scraping, latency samples, and metric exports.
+        type: boolean
+        required: false
+        default: false
       cloud:
         description: Cloud provider used for disposable benchmark infrastructure.
         type: choice
@@ -170,6 +180,8 @@ jobs:
       max-concurrent-requests: ${{ inputs['max-concurrent-requests'] || '5000' }}
       run-pairs: ${{ inputs['run-pairs'] || '3' }}
       clickhouse-run: feature-1
+      skip-receipt-wait: ${{ inputs['skip-receipt-wait'] || false }}
+      skip-metrics: ${{ inputs['skip-metrics'] || false }}
       otlp: true
       valscope: true
     secrets:

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -3,11 +3,6 @@ name: bench-e2e-multi-region
 on:
   workflow_call:
     inputs:
-      skip-receipt-wait:
-        description: Skip workload receipt waits; setup still confirms receipts.
-        type: boolean
-        required: false
-        default: false
       skip-metrics:
         description: Skip benchmark scraping, latency samples, and metric exports.
         type: boolean
@@ -241,7 +236,7 @@ on:
         required: true
         default: false
       bench-args:
-        description: Extra generator args; accepts --skip-receipt-wait and --skip-metrics independently.
+        description: Extra generator args; accepts --skip-metrics to disable benchmark metrics collection.
         type: string
         required: false
         default: ""
@@ -298,7 +293,6 @@ jobs:
       BENCH_INPUT_TXGEN_REF: ${{ inputs['txgen-ref'] || '' }}
       BENCH_INPUT_TOKEN_COUNT: ${{ inputs['token-count'] || '4' }}
       BENCH_INPUT_PROFILING: ${{ inputs.profiling || 'off' }}
-      BENCH_INPUT_SKIP_RECEIPT_WAIT: ${{ inputs['skip-receipt-wait'] && 'true' || 'false' }}
       BENCH_INPUT_SKIP_METRICS: ${{ inputs['skip-metrics'] && 'true' || 'false' }}
       BENCH_INPUT_OTLP: ${{ format('{0}', github.event_name != 'workflow_dispatch' || inputs.otlp) }}
       BENCH_INPUT_VALSCOPE: ${{ (inputs.valscope == true || inputs.valscope == 'true') && 'true' || 'false' }}
@@ -550,7 +544,6 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
-            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
             --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
@@ -606,7 +599,6 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
-            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
             --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
@@ -655,7 +647,6 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
-            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
             --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
@@ -704,7 +695,6 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
-            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
             --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \

--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -3,6 +3,16 @@ name: bench-e2e-multi-region
 on:
   workflow_call:
     inputs:
+      skip-receipt-wait:
+        description: Skip workload receipt waits; setup still confirms receipts.
+        type: boolean
+        required: false
+        default: false
+      skip-metrics:
+        description: Skip benchmark scraping, latency samples, and metric exports.
+        type: boolean
+        required: false
+        default: false
       cloud:
         type: string
         required: false
@@ -231,7 +241,7 @@ on:
         required: true
         default: false
       bench-args:
-        description: Extra bench args.
+        description: Extra generator args; accepts --skip-receipt-wait and --skip-metrics independently.
         type: string
         required: false
         default: ""
@@ -288,6 +298,8 @@ jobs:
       BENCH_INPUT_TXGEN_REF: ${{ inputs['txgen-ref'] || '' }}
       BENCH_INPUT_TOKEN_COUNT: ${{ inputs['token-count'] || '4' }}
       BENCH_INPUT_PROFILING: ${{ inputs.profiling || 'off' }}
+      BENCH_INPUT_SKIP_RECEIPT_WAIT: ${{ inputs['skip-receipt-wait'] && 'true' || 'false' }}
+      BENCH_INPUT_SKIP_METRICS: ${{ inputs['skip-metrics'] && 'true' || 'false' }}
       BENCH_INPUT_OTLP: ${{ format('{0}', github.event_name != 'workflow_dispatch' || inputs.otlp) }}
       BENCH_INPUT_VALSCOPE: ${{ (inputs.valscope == true || inputs.valscope == 'true') && 'true' || 'false' }}
       BENCH_INPUT_BASELINE_ARGS: ${{ inputs['baseline-args'] || '' }}
@@ -538,6 +550,8 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
+            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
+            --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
@@ -592,6 +606,8 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
+            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
+            --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
@@ -639,6 +655,8 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
+            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
+            --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \
@@ -686,6 +704,8 @@ jobs:
             --profiling "$BENCH_INPUT_PROFILING" \
             --otlp "$BENCH_INPUT_OTLP" \
             --valscope "$BENCH_INPUT_VALSCOPE" \
+            --skip-receipt-wait "$BENCH_INPUT_SKIP_RECEIPT_WAIT" \
+            --skip-metrics "$BENCH_INPUT_SKIP_METRICS" \
             --baseline-args "$BENCH_INPUT_BASELINE_ARGS" \
             --feature-args "$BENCH_INPUT_FEATURE_ARGS" \
             --gas-limit "$BENCH_INPUT_GAS_LIMIT" \


### PR DESCRIPTION
Expose an opt-out `skip-metrics` control for multi-region benchmarks: reusable/scheduled workflows take a boolean, and the main manual workflow accepts `--skip-metrics` in `bench-args` because its 25 dispatch inputs are occupied; receipt waiting is unchanged and no txgen changes are required.

Depends only on [runner #399](https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/399), which must merge first.

Workflow parsing, dispatch input limits, and four-stage forwarding pass locally; kept in draft pending metrics-only cloud validation because cleanup of the earlier cancelled smoke run is unconfirmed, as detailed in the runner PR.

Prompted by: @shekhirin
