### PR TITLE
fix(consensus): report finalized startup floors and archive bounds

### DIFF
--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -134,6 +134,21 @@ pub(crate) mod marshal {
         .await
         .wrap_err("failed to initialize finalizations by height archive")?;
 
+        let first = finalizations_by_height.first_index();
+        let contiguous_end = first.and_then(|first| finalizations_by_height.next_gap(first).0);
+        info!(
+            finalizations_archive.empty = first.is_none(),
+            finalizations_archive.first_block = first,
+            finalizations_archive.last_block = finalizations_by_height.last_index(),
+            finalizations_archive.first_contiguous_end = contiguous_end,
+            execution_layer.finalized_height = ?execution_node
+                .provider
+                .canonical_in_memory_state()
+                .get_finalized_num_hash()
+                .map(|block| block.number),
+            "restored consensus startup state"
+        );
+
         let FinalizationRange {
             floor: finalized_floor,
             tip: finalized_tip,
@@ -215,8 +230,9 @@ pub(crate) mod marshal {
 
         info!(
             marshal_stored = ?marshal_stored_height,
-            selected_floor = %startup_floor_height,
-            "setting marshal sync floor"
+            archive_floor = %startup_floor_height,
+            selected_floor = %last_finalized_height,
+            "selected marshal finalized floor"
         );
 
         Ok(Initialized {

--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -144,16 +144,18 @@ where
             .wrap_err("failed to initialize prunable finalized blocks archive")?;
 
     // Contiguous run of blocks starting at the prunable archive's first index.
-    let start_range = prunable.first_index().and_then(|first| {
-        prunable
-            .next_gap(first)
-            .0
-            .map(|end| format!("{first}..={end}"))
-    });
+    let first = prunable.first_index();
+    let contiguous_end = first.and_then(|first| prunable.next_gap(first).0);
+    let start_range = first
+        .zip(contiguous_end)
+        .map(|(first, end)| format!("{first}..={end}"));
 
     info!(
+        consensus_cache.empty = first.is_none(),
         consensus_cache.start_range = start_range,
+        consensus_cache.first_block = first,
         consensus_cache.last_block = prunable.last_index(),
+        consensus_cache.first_contiguous_end = contiguous_end,
         execution_layer.finalized_height = provider.finalized_height(),
         "initialized finalized blocks store",
     );


### PR DESCRIPTION
Report the effective marshal finalized floor separately from its stored height and archive floor during shared CL startup. Log the EL finalized watermark and finalization-certificate archive bounds before startup validation, and expose numeric first/last heights and the inclusive end of the first contiguous range for both the certificate archive and finalized-block cache; empty archives are explicit.

Validation: nightly formatting and `git diff --check` pass. `cargo check -p tempo-consensus --locked` is still resolving dependencies; node startup has not been exercised.

Prompted by: @SuperFluffy
