### PR TITLE
feat(consensus): report finalized startup state

### DIFF
--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -126,6 +126,16 @@ pub(crate) mod marshal {
         TContext:
             Clock + Metrics + Spawner + Storage + BufferPooler + Rng + CryptoRng + Send + 'static,
     {
+        let execution_finalized = execution_node
+            .provider
+            .canonical_in_memory_state()
+            .get_finalized_num_hash();
+        info!(
+            execution_layer.finalized_height = ?execution_finalized.map(|point| point.number),
+            execution_layer.finalized_hash = ?execution_finalized.map(|point| point.hash),
+            "execution layer finalized watermark at consensus startup"
+        );
+
         let finalizations_by_height = storage::init_finalizations_archive(
             &context,
             &config.partition_prefix,
@@ -216,6 +226,7 @@ pub(crate) mod marshal {
         info!(
             marshal_stored = ?marshal_stored_height,
             selected_floor = %startup_floor_height,
+            finalized_floor = %last_finalized_height,
             "setting marshal sync floor"
         );
 

--- a/crates/consensus/src/storage/mod.rs
+++ b/crates/consensus/src/storage/mod.rs
@@ -144,17 +144,19 @@ where
             .wrap_err("failed to initialize prunable finalized blocks archive")?;
 
     // Contiguous run of blocks starting at the prunable archive's first index.
-    let start_range = prunable.first_index().and_then(|first| {
-        prunable
-            .next_gap(first)
-            .0
-            .map(|end| format!("{first}..={end}"))
-    });
+    // Use the archive's range index, without reading blocks or including EL coverage.
+    let first_block = prunable.first_index();
+    let contiguous_end = first_block.and_then(|first| prunable.next_gap(first).0);
+    let start_range = first_block
+        .zip(contiguous_end)
+        .map(|(first, end)| format!("{first}..={end}"));
 
     info!(
         consensus_cache.start_range = start_range,
-        consensus_cache.last_block = prunable.last_index(),
-        execution_layer.finalized_height = provider.finalized_height(),
+        consensus_cache.first_block = ?first_block,
+        consensus_cache.last_block = ?prunable.last_index(),
+        consensus_cache.contiguous_end = ?contiguous_end,
+        execution_layer.finalized_height = ?provider.finalized_height(),
         "initialized finalized blocks store",
     );
 


### PR DESCRIPTION
Report the effective marshal finalized floor alongside its persisted and selected startup heights, and log the EL finalized watermark before archive recovery. Expose the finalized block cache's first/last heights and inclusive contiguous-prefix endpoint, including explicit empty/unset values, using the existing range index shared by consensus and follow startup.

Validation: local `cargo +nightly fmt --all -- --check` and `git diff --check` pass. [CI Clippy and formatting](https://github.com/tempoxyz/tempo/actions/runs/34384312715) pass for this commit; the redundant local compile check was stopped while building RocksDB. Broader CI tests are still running.

Prompted by: @SuperFluffy
