### PR TITLE
fix(ci): repin rust-deny workflow so fork PRs pass Harden Runner

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,7 +164,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: tempoxyz/gh-actions/.github/workflows/rust-deny.yml@3a9189ec4c3d19f2863398822c73edd06b33fba3
+    uses: tempoxyz/gh-actions/.github/workflows/rust-deny.yml@5338a3746a2ac2ddd88cbede733c79f907aca3a0
     with:
       rust-toolchain: nightly
 


### PR DESCRIPTION
GitHub never issues an OIDC token to `pull_request` runs from forks, whatever permissions the workflow declares. The `deny` job's Harden Runner pre step therefore failed with `ACTIONS_ID_TOKEN_REQUEST_TOKEN is missing` on every fork PR, for example [#7532's Lint run](https://github.com/tempoxyz/tempo/actions/runs/34353177494/job/102471306781?pr=7532), where the run header shows only `Contents: read` and `Metadata: read` despite both this workflow and the reusable one granting `id-token: write`.

## Change

Move `rust-deny.yml` from `tempoxyz/gh-actions@3a9189ec` to `@5338a374`. That commit's `rust-lint.yml` pins the `secure-runner` revision that handles OIDC-less `pull_request` runs (tempoxyz/gh-actions#150, #153, #154, #155):

- Harden Runner emits a warning and applies the workflow's inline egress policy (audit mode here) instead of the StepSecurity policy store.
- Socket Firewall installs the Free edition instead of Enterprise: known-malware blocking with Socket's default policy, no organization policies.
- Any other event without an OIDC token still fails, naming the missing `id-token: write`.

The only difference in `rust-deny.yml` and `rust-lint.yml` between the two refs is the switch from the `harden-runner` wrapper to `secure-runner`, so same-repo runs (push to `main`, merge queue, internal PRs) keep the policy store and additionally get Socket Firewall Enterprise in front of `cargo`.

`pr-audit.yml` and `scan-github-actions.yml` keep their current refs. Bumping the scanner would pull in the new `ensure-secure-runner` check, which is a separate decision.

## Validation

- `actionlint .github/workflows/lint.yml`, `git diff --check`.
- This PR comes from a same-repo branch, so its own `deny` job exercises the authenticated path. The fallback path is exercised by the next fork PR.
