### PR TITLE
feat(primitives): add journaled account commitments

### DIFF
--- a/crates/precompiles/src/error.rs
+++ b/crates/precompiles/src/error.rs
@@ -119,6 +119,10 @@ pub enum TempoPrecompileError {
     #[error("Gas limit exceeded")]
     OutOfGas,
 
+    /// A commitment write is zero, predates T12, or occurs in a read-only context.
+    #[error("invalid account commitment write")]
+    InvalidConfigCommitmentWrite,
+
     /// The calldata's 4-byte selector does not match any known precompile function.
     #[error("Unknown function selector: {0:?}")]
     UnknownFunctionSelector([u8; 4]),
@@ -182,7 +186,7 @@ impl TempoPrecompileError {
             Self::ZoneFactoryError(e) => e.selector(),
             Self::UnknownFunctionSelector(selector) => *selector,
             Self::Panic(_) | Self::StorageDeltaUnderflow(_) => Panic::SELECTOR,
-            Self::OutOfGas | Self::Fatal(_) => [0, 0, 0, 0],
+            Self::OutOfGas | Self::Fatal(_) | Self::InvalidConfigCommitmentWrite => [0, 0, 0, 0],
         }
         .into()
     }
@@ -212,7 +216,8 @@ impl TempoPrecompileError {
             | Self::StorageCreditsError(_)
             | Self::CurrentCommitteeError(_)
             | Self::ZoneFactoryError(_)
-            | Self::UnknownFunctionSelector(_) => false,
+            | Self::UnknownFunctionSelector(_)
+            | Self::InvalidConfigCommitmentWrite => false,
         }
     }
 
@@ -286,6 +291,7 @@ impl TempoPrecompileError {
             Self::Fatal(msg) => {
                 return Err(PrecompileError::Fatal(msg));
             }
+            Self::InvalidConfigCommitmentWrite => Default::default(),
         };
         Ok(PrecompileOutput::revert(gas, bytes, reservoir))
     }

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -393,6 +393,31 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
         })
     }
 
+    fn set_config_commitment(
+        &mut self,
+        address: Address,
+        commitment: B256,
+        gas: super::ConfigCommitmentWriteGas,
+    ) -> Result<(), TempoPrecompileError> {
+        if !self.spec.is_t12() || self.is_static || commitment.is_zero() {
+            return Err(TempoPrecompileError::InvalidConfigCommitmentWrite);
+        }
+        // The authorization read already charged account access (or was intrinsic).
+        let previous = {
+            let account = self.internals.load_account_mut(address)?;
+            tempo_primitives::account::decode_config_commitment(
+                &account.data.account().info.extension,
+                true,
+            )
+            .map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?
+        };
+        self.deduct_gas(gas.cost(previous))?;
+        self.internals
+            .load_account_mut(address)?
+            .set_extension(tempo_primitives::account::encode_config_commitment(commitment).into());
+        Ok(())
+    }
+
     #[inline]
     fn sstore(
         &mut self,
@@ -745,6 +770,60 @@ mod tests {
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_evm::{TempoEvmFactory, evm::TempoEvm};
     use tempo_revm::gas_params::tempo_gas_params_with_amsterdam;
+
+    #[test]
+    fn commitment_nested_journal_rollback() {
+        let mut evm = TestEvm::new(TempoHardfork::T12);
+        super::super::tests::exercise_rollback(&mut evm.provider_max_gas());
+    }
+
+    #[test]
+    fn commitment_intrinsic_write_and_static_rejection() {
+        use crate::storage::ConfigCommitmentWriteGas as WriteGas;
+
+        let mut evm = TestEvm::new(TempoHardfork::T12);
+        let mut provider = evm.provider_max_gas();
+        let address = Address::repeat_byte(1);
+        let commitment = B256::repeat_byte(2);
+        provider
+            .set_config_commitment(address, commitment, WriteGas::Intrinsic)
+            .unwrap();
+        assert_eq!(provider.gas_used(), 0);
+        assert_eq!(provider.state_gas_used(), 0);
+        {
+            let mut account = provider.internals.load_account_mut(address).unwrap();
+            account.set_balance(U256::from(7));
+            account.bump_nonce();
+        }
+        assert_eq!(provider.config_commitment(address).unwrap(), commitment);
+        let after_read = provider.gas_used();
+        provider
+            .set_config_commitment(address, commitment, WriteGas::Precompile)
+            .unwrap();
+        assert_eq!(provider.gas_used() - after_read, 5_000);
+        let fresh = Address::repeat_byte(4);
+        assert_eq!(provider.config_commitment(fresh).unwrap(), B256::ZERO);
+        let after_read = provider.gas_used();
+        provider
+            .set_config_commitment(fresh, commitment, WriteGas::Precompile)
+            .unwrap();
+        assert_eq!(provider.gas_used() - after_read, 20_000);
+        assert_eq!(provider.state_gas_used(), 0);
+        assert_eq!(provider.gas_refunded(), 0);
+        provider.is_static = true;
+        let error = provider
+            .set_config_commitment(address, commitment, WriteGas::Precompile)
+            .unwrap_err();
+        assert_eq!(error, TempoPrecompileError::InvalidConfigCommitmentWrite);
+        assert!(!error.is_system_error());
+        assert!(
+            error
+                .into_precompile_result(0, 0)
+                .unwrap()
+                .status
+                .is_revert()
+        );
+    }
 
     struct TestEvm(TempoEvm<CacheDB<EmptyDB>>);
 

--- a/crates/precompiles/src/storage/evm.rs
+++ b/crates/precompiles/src/storage/evm.rs
@@ -411,7 +411,7 @@ impl<'a> PrecompileStorageProvider for EvmPrecompileStorageProvider<'a> {
             )
             .map_err(|e| TempoPrecompileError::Fatal(e.to_string()))?
         };
-        self.deduct_gas(gas.cost(previous))?;
+        self.deduct_gas(gas.cost(previous)?)?;
         self.internals
             .load_account_mut(address)?
             .set_extension(tempo_primitives::account::encode_config_commitment(commitment).into());

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -118,7 +118,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
             return Err(TempoPrecompileError::InvalidConfigCommitmentWrite);
         }
         let previous = self.config_commitment(address)?;
-        self.deduct_gas(gas.cost(previous))?;
+        self.deduct_gas(gas.cost(previous)?)?;
         self.accounts
             .entry(address)
             .or_default()

--- a/crates/precompiles/src/storage/hashmap.rs
+++ b/crates/precompiles/src/storage/hashmap.rs
@@ -44,6 +44,7 @@ pub struct HashMapStorageProvider {
 ///
 /// PERF: naive cloning strategy due to its limited usage.
 struct Snapshot {
+    accounts: HashMap<Address, AccountInfo>,
     internals: HashMap<(Address, U256), U256>,
     transient: HashMap<(Address, U256), U256>,
     events: HashMap<Address, Vec<LogData>>,
@@ -107,6 +108,24 @@ impl HashMapStorageProvider {
 }
 
 impl PrecompileStorageProvider for HashMapStorageProvider {
+    fn set_config_commitment(
+        &mut self,
+        address: Address,
+        commitment: B256,
+        gas: super::ConfigCommitmentWriteGas,
+    ) -> Result<(), TempoPrecompileError> {
+        if !self.spec.is_t12() || self.is_static || commitment.is_zero() {
+            return Err(TempoPrecompileError::InvalidConfigCommitmentWrite);
+        }
+        let previous = self.config_commitment(address)?;
+        self.deduct_gas(gas.cost(previous))?;
+        self.accounts
+            .entry(address)
+            .or_default()
+            .set_extension(tempo_primitives::account::encode_config_commitment(commitment).into());
+        Ok(())
+    }
+
     fn chain_id(&self) -> u64 {
         self.chain_id
     }
@@ -251,6 +270,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
     fn checkpoint(&mut self) -> JournalCheckpoint {
         let idx = self.snapshots.len();
         self.snapshots.push(Snapshot {
+            accounts: self.accounts.clone(),
             internals: self.internals.clone(),
             transient: self.transient.clone(),
             events: self.events.clone(),
@@ -278,6 +298,7 @@ impl PrecompileStorageProvider for HashMapStorageProvider {
             "out-of-order checkpoint revert (expected top of stack)"
         );
         if let Some(snapshot) = self.snapshots.drain(checkpoint.journal_i..).next() {
+            self.accounts = snapshot.accounts;
             self.internals = snapshot.internals;
             self.transient = snapshot.transient;
             self.events = snapshot.events;

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -4,6 +4,8 @@
 //! including persistent (SLOAD/SSTORE) and transient (TLOAD/TSTORE) operations.
 
 pub mod actions;
+#[cfg(test)]
+mod tests;
 pub use actions::{StorageAction, StorageActions};
 
 pub mod evm;
@@ -32,6 +34,25 @@ use tempo_primitives::TempoBlockEnv;
 
 use crate::error::{Result, TempoPrecompileError};
 
+/// Determines where TIP-1108's field-write charge is paid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConfigCommitmentWriteGas {
+    /// Registration was charged once in transaction intrinsic gas.
+    Intrinsic,
+    /// Charge the explicit precompile operation here.
+    Precompile,
+}
+
+impl ConfigCommitmentWriteGas {
+    fn cost(self, previous: B256) -> u64 {
+        match self {
+            Self::Intrinsic => 0,
+            Self::Precompile if previous.is_zero() => 20_000,
+            Self::Precompile => 5_000,
+        }
+    }
+}
+
 /// Low-level storage provider for interacting with the EVM.
 ///
 /// # Implementations
@@ -58,6 +79,29 @@ pub trait PrecompileStorageProvider {
         &mut self,
         address: Address,
         f: &mut dyn FnMut(&AccountInfo),
+    ) -> Result<()>;
+
+    /// Reads the commitment with normal account-access gas. Already-loaded authorization
+    /// code should decode its account info directly instead.
+    fn config_commitment(&mut self, address: Address) -> Result<B256> {
+        let active = self.spec().is_t12();
+        let mut result = Ok(B256::ZERO);
+        self.with_account_info(address, &mut |info| {
+            result = tempo_primitives::account::decode_config_commitment(&info.extension, active)
+                .map_err(|e| TempoPrecompileError::Fatal(e.to_string()));
+        })?;
+        result
+    }
+
+    /// Writes an authorized nonzero commitment through the account journal.
+    /// Callers must validate registration, rotation, or migration authority first.
+    /// Account-access gas belongs to that authorization read; this method charges
+    /// only the field write, or nothing when registration was charged intrinsically.
+    fn set_config_commitment(
+        &mut self,
+        address: Address,
+        commitment: B256,
+        gas: ConfigCommitmentWriteGas,
     ) -> Result<()>;
 
     /// Returns `EXTCODEHASH(address)` and the account's runtime bytecode.

--- a/crates/precompiles/src/storage/mod.rs
+++ b/crates/precompiles/src/storage/mod.rs
@@ -37,18 +37,19 @@ use crate::error::{Result, TempoPrecompileError};
 /// Determines where TIP-1108's field-write charge is paid.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigCommitmentWriteGas {
-    /// Registration was charged once in transaction intrinsic gas.
+    /// First registration was charged once in transaction intrinsic gas.
     Intrinsic,
     /// Charge the explicit precompile operation here.
     Precompile,
 }
 
 impl ConfigCommitmentWriteGas {
-    fn cost(self, previous: B256) -> u64 {
+    fn cost(self, previous: B256) -> Result<u64> {
         match self {
-            Self::Intrinsic => 0,
-            Self::Precompile if previous.is_zero() => 20_000,
-            Self::Precompile => 5_000,
+            Self::Intrinsic if previous.is_zero() => Ok(0),
+            Self::Intrinsic => Err(TempoPrecompileError::InvalidConfigCommitmentWrite),
+            Self::Precompile if previous.is_zero() => Ok(20_000),
+            Self::Precompile => Ok(5_000),
         }
     }
 }

--- a/crates/precompiles/src/storage/tests.rs
+++ b/crates/precompiles/src/storage/tests.rs
@@ -1,0 +1,68 @@
+use super::{
+    ConfigCommitmentWriteGas as WriteGas, PrecompileStorageProvider,
+    hashmap::HashMapStorageProvider,
+};
+use alloy::primitives::{Address, B256};
+use revm::state::Bytecode;
+use tempo_chainspec::hardfork::TempoHardfork;
+
+pub(super) fn exercise_rollback(provider: &mut impl PrecompileStorageProvider) {
+    let address = Address::repeat_byte(1);
+    let initial = B256::repeat_byte(2);
+    let rotated = B256::repeat_byte(3);
+    let outer = provider.checkpoint();
+    provider
+        .set_config_commitment(address, initial, WriteGas::Intrinsic)
+        .unwrap();
+    let inner = provider.checkpoint();
+    provider
+        .set_config_commitment(address, rotated, WriteGas::Precompile)
+        .unwrap();
+    assert_eq!(provider.config_commitment(address).unwrap(), rotated);
+    provider.checkpoint_revert(inner);
+    assert_eq!(provider.config_commitment(address).unwrap(), initial);
+    provider.set_code(address, Bytecode::default()).unwrap();
+    assert_eq!(provider.config_commitment(address).unwrap(), initial);
+    let inner = provider.checkpoint();
+    provider
+        .set_config_commitment(address, rotated, WriteGas::Precompile)
+        .unwrap();
+    provider.checkpoint_commit(inner);
+    provider.checkpoint_revert(outer);
+    assert_eq!(provider.config_commitment(address).unwrap(), B256::ZERO);
+}
+
+#[test]
+fn hashmap_commitment_nested_rollback() {
+    exercise_rollback(&mut HashMapStorageProvider::new_with_spec(
+        1,
+        TempoHardfork::T12,
+    ));
+}
+
+#[test]
+fn commitment_write_validation() {
+    let mut provider = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T12);
+    let address = Address::repeat_byte(1);
+    let hash = B256::repeat_byte(2);
+    provider
+        .set_config_commitment(address, hash, WriteGas::Precompile)
+        .unwrap();
+    provider
+        .set_config_commitment(address, hash, WriteGas::Precompile)
+        .unwrap();
+    provider
+        .set_config_commitment(address, hash, WriteGas::Intrinsic)
+        .unwrap();
+    assert!(
+        provider
+            .set_config_commitment(address, B256::ZERO, WriteGas::Intrinsic)
+            .is_err()
+    );
+    let mut historical = HashMapStorageProvider::new_with_spec(1, TempoHardfork::T11);
+    assert!(
+        historical
+            .set_config_commitment(address, hash, WriteGas::Intrinsic)
+            .is_err()
+    );
+}

--- a/crates/precompiles/src/storage/tests.rs
+++ b/crates/precompiles/src/storage/tests.rs
@@ -14,6 +14,13 @@ pub(super) fn exercise_rollback(provider: &mut impl PrecompileStorageProvider) {
     provider
         .set_config_commitment(address, initial, WriteGas::Intrinsic)
         .unwrap();
+    for commitment in [initial, rotated] {
+        assert!(matches!(
+            provider.set_config_commitment(address, commitment, WriteGas::Intrinsic),
+            Err(crate::error::TempoPrecompileError::InvalidConfigCommitmentWrite)
+        ));
+        assert_eq!(provider.config_commitment(address).unwrap(), initial);
+    }
     let inner = provider.checkpoint();
     provider
         .set_config_commitment(address, rotated, WriteGas::Precompile)
@@ -51,9 +58,10 @@ fn commitment_write_validation() {
     provider
         .set_config_commitment(address, hash, WriteGas::Precompile)
         .unwrap();
-    provider
-        .set_config_commitment(address, hash, WriteGas::Intrinsic)
-        .unwrap();
+    assert!(matches!(
+        provider.set_config_commitment(address, hash, WriteGas::Intrinsic),
+        Err(crate::error::TempoPrecompileError::InvalidConfigCommitmentWrite)
+    ));
     assert!(
         provider
             .set_config_commitment(address, B256::ZERO, WriteGas::Intrinsic)

--- a/crates/precompiles/src/storage/thread_local.rs
+++ b/crates/precompiles/src/storage/thread_local.rs
@@ -39,6 +39,21 @@ scoped_thread_local!(static STORAGE: RefCell<&mut dyn PrecompileStorageProvider>
 pub struct StorageCtx;
 
 impl StorageCtx {
+    /// Reads the account commitment with normal account-access gas.
+    pub fn config_commitment(&self, address: Address) -> Result<B256> {
+        Self::try_with_storage(|s| s.config_commitment(address))
+    }
+
+    /// Writes an authorized commitment using the provider's account journal.
+    pub fn set_config_commitment(
+        &mut self,
+        address: Address,
+        commitment: B256,
+        gas: super::ConfigCommitmentWriteGas,
+    ) -> Result<()> {
+        Self::try_with_storage(|s| s.set_config_commitment(address, commitment, gas))
+    }
+
     /// Enter storage context. All storage operations must happen within the closure.
     ///
     /// # IMPORTANT

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -1,31 +1,29 @@
 //! TIP-1108 configuration commitments in the opaque account extension payload.
 
 use alloy_primitives::{B256, Bytes};
-use alloy_rlp::{Decodable, Error};
+use alloy_rlp::Error;
 
-/// Encodes the optional fifth account-leaf field. Zero preserves the legacy leaf.
+/// Returns the raw fifth-field payload; the trie adds RLP framing. Zero omits the field.
 pub fn encode_config_commitment(hash: B256) -> Bytes {
     if hash.is_zero() {
         Bytes::new()
     } else {
-        alloy_rlp::encode(hash).into()
+        Bytes::copy_from_slice(hash.as_slice())
     }
 }
 
 /// Validates the entire extension at the requested block's hardfork.
-pub fn decode_config_commitment(mut payload: &[u8], t12_active: bool) -> alloy_rlp::Result<B256> {
+pub fn decode_config_commitment(payload: &[u8], t12_active: bool) -> alloy_rlp::Result<B256> {
     if payload.is_empty() {
         return Ok(B256::ZERO);
     }
     if !t12_active {
         return Err(Error::Custom("account commitment before T12"));
     }
-    let hash = B256::decode(&mut payload)?;
+    let hash = B256::try_from(payload)
+        .map_err(|_| Error::Custom("account commitment must be 32 bytes"))?;
     if hash.is_zero() {
         return Err(Error::Custom("explicit zero account commitment"));
-    }
-    if !payload.is_empty() {
-        return Err(Error::Custom("trailing account extension fields"));
     }
     Ok(hash)
 }

--- a/crates/primitives/src/account.rs
+++ b/crates/primitives/src/account.rs
@@ -1,0 +1,34 @@
+//! TIP-1108 configuration commitments in the opaque account extension payload.
+
+use alloy_primitives::{B256, Bytes};
+use alloy_rlp::{Decodable, Error};
+
+/// Encodes the optional fifth account-leaf field. Zero preserves the legacy leaf.
+pub fn encode_config_commitment(hash: B256) -> Bytes {
+    if hash.is_zero() {
+        Bytes::new()
+    } else {
+        alloy_rlp::encode(hash).into()
+    }
+}
+
+/// Validates the entire extension at the requested block's hardfork.
+pub fn decode_config_commitment(mut payload: &[u8], t12_active: bool) -> alloy_rlp::Result<B256> {
+    if payload.is_empty() {
+        return Ok(B256::ZERO);
+    }
+    if !t12_active {
+        return Err(Error::Custom("account commitment before T12"));
+    }
+    let hash = B256::decode(&mut payload)?;
+    if hash.is_zero() {
+        return Err(Error::Custom("explicit zero account commitment"));
+    }
+    if !payload.is_empty() {
+        return Err(Error::Custom("trailing account extension fields"));
+    }
+    Ok(hash)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/primitives/src/account/tests.rs
+++ b/crates/primitives/src/account/tests.rs
@@ -1,0 +1,72 @@
+use super::*;
+
+#[test]
+fn commitment_roundtrip_and_historical_gate() {
+    assert!(encode_config_commitment(B256::ZERO).is_empty());
+    for active in [false, true] {
+        assert_eq!(decode_config_commitment(&[], active), Ok(B256::ZERO));
+    }
+    let hash = B256::repeat_byte(7);
+    let payload = encode_config_commitment(hash);
+    assert_eq!(payload.len(), 33);
+    assert_eq!(payload[0], 0xa0);
+    assert_eq!(decode_config_commitment(&payload, true), Ok(hash));
+    assert!(decode_config_commitment(&payload, false).is_err());
+}
+
+#[test]
+fn rejects_malformed_and_noncanonical_extensions() {
+    let mut trailing = encode_config_commitment(B256::repeat_byte(7)).to_vec();
+    trailing.push(0x80);
+    let mut noncanonical = vec![0xb8, 32];
+    noncanonical.extend([7; 32]);
+    for payload in [
+        alloy_rlp::encode(B256::ZERO),
+        alloy_rlp::encode(&[7u8; 31][..]),
+        alloy_rlp::encode(&[7u8; 33][..]),
+        vec![0xc0],
+        vec![0xa0, 7],
+        trailing,
+        noncanonical,
+    ] {
+        assert!(
+            decode_config_commitment(&payload, true).is_err(),
+            "{payload:?}"
+        );
+    }
+}
+
+#[cfg(all(feature = "reth", feature = "evm", feature = "reth-codec"))]
+#[test]
+fn commitment_survives_account_representations() {
+    use reth_codecs::Compact;
+    use reth_primitives_traits::Account;
+    use revm::state::AccountInfo;
+
+    let commitment = B256::repeat_byte(9);
+    let mut info = AccountInfo::default().with_extension(encode_config_commitment(commitment));
+    assert!(!info.is_empty());
+    info.nonce = 3;
+    info.balance = alloy_primitives::U256::from(7);
+    let account = Account::from(info);
+    let mut encoded = Vec::new();
+    let len = account.to_compact(&mut encoded);
+    let (decoded, rest) = Account::from_compact(&encoded, len);
+    assert!(rest.is_empty());
+    assert_eq!(decoded, account);
+    let trie = decoded.into_trie_account(B256::repeat_byte(4));
+    assert_eq!(
+        decode_config_commitment(&trie.extension, true),
+        Ok(commitment)
+    );
+    let mut reloaded: AccountInfo = Account::from(trie).into();
+    assert_eq!(reloaded.nonce, 3);
+    assert_eq!(reloaded.balance, alloy_primitives::U256::from(7));
+    reloaded.nonce = 0;
+    reloaded.balance = alloy_primitives::U256::ZERO;
+    assert!(!reloaded.is_empty());
+    assert_eq!(
+        decode_config_commitment(&reloaded.extension, true),
+        Ok(commitment)
+    );
+}

--- a/crates/primitives/src/account/tests.rs
+++ b/crates/primitives/src/account/tests.rs
@@ -8,8 +8,7 @@ fn commitment_roundtrip_and_historical_gate() {
     }
     let hash = B256::repeat_byte(7);
     let payload = encode_config_commitment(hash);
-    assert_eq!(payload.len(), 33);
-    assert_eq!(payload[0], 0xa0);
+    assert_eq!(payload.as_ref(), hash.as_slice());
     assert_eq!(decode_config_commitment(&payload, true), Ok(hash));
     assert!(decode_config_commitment(&payload, false).is_err());
 }
@@ -18,16 +17,14 @@ fn commitment_roundtrip_and_historical_gate() {
 fn rejects_malformed_and_noncanonical_extensions() {
     let mut trailing = encode_config_commitment(B256::repeat_byte(7)).to_vec();
     trailing.push(0x80);
-    let mut noncanonical = vec![0xb8, 32];
-    noncanonical.extend([7; 32]);
     for payload in [
-        alloy_rlp::encode(B256::ZERO),
-        alloy_rlp::encode(&[7u8; 31][..]),
-        alloy_rlp::encode(&[7u8; 33][..]),
+        vec![0; 32],
+        vec![7; 31],
+        vec![7; 33],
         vec![0xc0],
         vec![0xa0, 7],
         trailing,
-        noncanonical,
+        alloy_rlp::encode(B256::repeat_byte(7)),
     ] {
         assert!(
             decode_config_commitment(&payload, true).is_err(),
@@ -55,6 +52,27 @@ fn commitment_survives_account_representations() {
     assert!(rest.is_empty());
     assert_eq!(decoded, account);
     let trie = decoded.into_trie_account(B256::repeat_byte(4));
+    // The opaque payload is raw, but the consensus leaf contains exactly one RLP string.
+    let encoded = alloy_rlp::encode(&trie);
+    let mut fields = encoded.as_slice();
+    let header = alloy_rlp::Header::decode(&mut fields).unwrap();
+    assert!(header.list);
+    assert_eq!(header.payload_length, fields.len());
+    for _ in 0..4 {
+        alloy_rlp::Header::decode_bytes(&mut fields, false).unwrap();
+    }
+    assert_eq!(fields, alloy_rlp::encode(commitment));
+    let mut legacy = trie.clone();
+    legacy.extension = Default::default();
+    let legacy = alloy_rlp::encode(&legacy);
+    let mut fields = legacy.as_slice();
+    let header = alloy_rlp::Header::decode(&mut fields).unwrap();
+    assert!(header.list);
+    assert_eq!(header.payload_length, fields.len());
+    for _ in 0..4 {
+        alloy_rlp::Header::decode_bytes(&mut fields, false).unwrap();
+    }
+    assert!(fields.is_empty());
     assert_eq!(
         decode_config_commitment(&trie.extension, true),
         Ok(commitment)

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub use alloy_consensus::Header;
 
+pub mod account;
+
 mod address;
 pub use address::{MasterId, TempoAddressExt, UserTag, is_tip20_prefix};
 pub mod ed25519;

--- a/crates/revm/src/common.rs
+++ b/crates/revm/src/common.rs
@@ -396,6 +396,15 @@ where
     }
 
     // Write operations are not supported in read-only context
+    fn set_config_commitment(
+        &mut self,
+        _: Address,
+        _: B256,
+        _: tempo_precompiles::storage::ConfigCommitmentWriteGas,
+    ) -> TempoResult<()> {
+        Err(TempoPrecompileError::InvalidConfigCommitmentWrite)
+    }
+
     fn sstore(&mut self, _: Address, _: U256, _: U256) -> TempoResult<()> {
         unreachable!("'sstore' not supported in read-only context")
     }

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -504,6 +504,15 @@ where
         Ok(())
     }
 
+    fn set_config_commitment(
+        &mut self,
+        _address: Address,
+        _commitment: B256,
+        _gas: tempo_precompiles::storage::ConfigCommitmentWriteGas,
+    ) -> Result<(), TempoPrecompileError> {
+        Err(TempoPrecompileError::InvalidConfigCommitmentWrite)
+    }
+
     fn account_code(
         &mut self,
         _address: Address,


### PR DESCRIPTION
Adds the strict optional account commitment codec and journal-backed storage operations required by TIP-1108 in #7510. Keeps absent commitments compatible with legacy accounts and separates intrinsic registration charges from precompile writes.