### PR TITLE
feat(primitives): add configurable account signatures

### DIFF
--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -3645,7 +3645,9 @@ mod tests {
                 .as_slice()
             )
         );
-        let PrimitiveSignature::WebAuthn(signature) = &authorization.signature else {
+        let TempoSignature::Primitive(PrimitiveSignature::WebAuthn(signature)) =
+            &authorization.signature
+        else {
             panic!("expected WebAuthn root signature")
         };
         assert_eq!(signature.webauthn_data.as_ref(), webauthn_data);

--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -1847,7 +1847,10 @@ impl TryFrom<AccountsRpcKeyAuthorization> for SignedKeyAuthorization {
             is_admin: false,
             account: None,
         };
-        Ok(Self::new(authorization, value.signature.try_into()?))
+        Ok(Self::new(
+            authorization,
+            PrimitiveSignature::try_from(value.signature)?,
+        ))
     }
 }
 
@@ -1993,7 +1996,10 @@ impl TryFrom<PersistedSignedKeyAuthorization> for SignedKeyAuthorization {
             is_admin,
             account,
         };
-        Ok(Self::new(authorization, signature.try_into()?))
+        Ok(Self::new(
+            authorization,
+            PrimitiveSignature::try_from(signature)?,
+        ))
     }
 }
 
@@ -2489,8 +2495,13 @@ fn writable_b256(value: B256) -> String {
 }
 
 fn writable_signature(
-    signature: &PrimitiveSignature,
+    signature: &TempoSignature,
 ) -> Result<WritablePrimitiveSignature, TempoAccountsError> {
+    let TempoSignature::Primitive(signature) = signature else {
+        return Err(TempoAccountsError::InvalidAuthorization(
+            "the Accounts store does not support nonprimitive authorization signatures",
+        ));
+    };
     Ok(match signature {
         PrimitiveSignature::Secp256k1(signature) => WritablePrimitiveSignature::Secp256k1 {
             signature: WritableSecpSignature {

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -281,7 +281,8 @@ mod tests {
         // Attempt to create a signature with u32::MAX size (would be ~4GB without fix)
         let malicious_key_data = Bytes::from(0xFFFFFFFFu32.to_be_bytes().to_vec());
         let sig =
-            create_mock_primitive_signature(&SignatureType::WebAuthn, Some(malicious_key_data));
+            create_mock_primitive_signature(&SignatureType::WebAuthn, Some(malicious_key_data))
+                .unwrap();
 
         // Extract webauthn_data and verify it's clamped to MAX_WEBAUTHN_SIZE (8192)
         let PrimitiveSignature::WebAuthn(webauthn_sig) = sig else {
@@ -300,7 +301,8 @@ mod tests {
     fn test_webauthn_size_respects_minimum() {
         // Attempt to create a signature with size 0
         let key_data = Bytes::from(vec![0u8]);
-        let sig = create_mock_primitive_signature(&SignatureType::WebAuthn, Some(key_data));
+        let sig =
+            create_mock_primitive_signature(&SignatureType::WebAuthn, Some(key_data)).unwrap();
 
         let PrimitiveSignature::WebAuthn(webauthn_sig) = sig else {
             panic!("Expected WebAuthn signature");
@@ -317,7 +319,7 @@ mod tests {
     #[test]
     fn test_webauthn_default_size() {
         // No key_data should use default size (800)
-        let sig = create_mock_primitive_signature(&SignatureType::WebAuthn, None);
+        let sig = create_mock_primitive_signature(&SignatureType::WebAuthn, None).unwrap();
 
         let PrimitiveSignature::WebAuthn(webauthn_sig) = sig else {
             panic!("Expected WebAuthn signature");

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -34,6 +34,26 @@ impl TempoTransactionRequest {
             return Err(ValueError::new(self, "empty calls list"));
         }
 
+        let mock_signature = if is_aa {
+            match create_mock_tempo_sig(
+                &self.key_type.unwrap_or(SignatureType::Secp256k1),
+                self.key_data.as_ref(),
+                self.key_id,
+                caller_addr,
+                is_t1c,
+            ) {
+                Some(signature) => Some(signature),
+                None => {
+                    return Err(ValueError::new(
+                        self,
+                        "multisig simulation requires a configuration witness",
+                    ));
+                }
+            }
+        } else {
+            None
+        };
+
         let fee_payer = if self.fee_payer_signature.is_some() {
             // Try to recover the fee payer address from the signature. A dummy or incomplete
             // simulation request retains the failed recovery for normal validation downstream.
@@ -51,8 +71,8 @@ impl TempoTransactionRequest {
             inner,
             fee_token,
             calls,
-            key_type,
-            key_data,
+            key_type: _,
+            key_data: _,
             key_id,
             tempo_authorization_list,
             nonce_key,
@@ -68,10 +88,6 @@ impl TempoTransactionRequest {
         tx_env.unique_tx_identifier = Some(RPC_SIMULATION_UNIQUE_TX_IDENTIFIER);
         tx_env.fee_payer = fee_payer;
         tx_env.tempo_tx_env = if is_aa {
-            let key_type = key_type.unwrap_or(SignatureType::Secp256k1);
-            let mock_signature =
-                create_mock_tempo_sig(&key_type, key_data.as_ref(), key_id, caller_addr, is_t1c);
-
             let mut calls = calls;
             if let Some(to) = &inner.to {
                 calls.push(Call {
@@ -83,7 +99,8 @@ impl TempoTransactionRequest {
 
             Some(Box::new(TempoBatchCallEnv {
                 aa_calls: calls,
-                signature: mock_signature,
+                signature: mock_signature
+                    .expect("AA mock signature validated before consuming request"),
                 tempo_authorization_list: tempo_authorization_list
                     .into_iter()
                     .map(RecoveredTempoAuthorization::new)
@@ -112,10 +129,10 @@ pub(super) fn create_mock_tempo_sig(
     key_id: Option<Address>,
     caller_addr: Address,
     is_t1c: bool,
-) -> TempoSignature {
+) -> Option<TempoSignature> {
     use tempo_primitives::transaction::tt_signature::{KeychainSignature, TempoSignature};
 
-    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned());
+    let inner_sig = create_mock_primitive_signature(key_type, key_data.cloned())?;
 
     if key_id.is_some() {
         let keychain_sig = if is_t1c {
@@ -123,9 +140,9 @@ pub(super) fn create_mock_tempo_sig(
         } else {
             KeychainSignature::new_v1(caller_addr, inner_sig)
         };
-        TempoSignature::Keychain(keychain_sig)
+        Some(TempoSignature::Keychain(keychain_sig))
     } else {
-        TempoSignature::Primitive(inner_sig)
+        Some(TempoSignature::Primitive(inner_sig))
     }
 }
 
@@ -133,12 +150,13 @@ pub(super) fn create_mock_tempo_sig(
 pub(super) fn create_mock_primitive_signature(
     sig_type: &SignatureType,
     key_data: Option<Bytes>,
-) -> tempo_primitives::transaction::tt_signature::PrimitiveSignature {
+) -> Option<tempo_primitives::transaction::tt_signature::PrimitiveSignature> {
     use tempo_primitives::transaction::tt_signature::{
         P256SignatureWithPreHash, PrimitiveSignature, WebAuthnSignature,
     };
 
-    match sig_type {
+    Some(match sig_type {
+        SignatureType::Multisig => return None,
         SignatureType::Secp256k1 => PrimitiveSignature::Secp256k1(Signature::new(
             alloy_primitives::U256::ZERO,
             alloy_primitives::U256::ZERO,
@@ -191,7 +209,7 @@ pub(super) fn create_mock_primitive_signature(
                 pub_key_y: B256::ZERO,
             })
         }
-    }
+    })
 }
 
 #[cfg(test)]
@@ -199,6 +217,23 @@ mod tests {
     use super::*;
     use alloy_primitives::{TxKind, address};
     use alloy_rpc_types_eth::TransactionRequest;
+
+    #[test]
+    fn multisig_key_type_cannot_fabricate_a_primitive_simulation_signature() {
+        assert!(create_mock_primitive_signature(&SignatureType::Multisig, None).is_none());
+        let request = TempoTransactionRequest {
+            inner: TransactionRequest {
+                to: Some(TxKind::Call(Address::repeat_byte(1))),
+                ..Default::default()
+            },
+            key_type: Some(SignatureType::Multisig),
+            ..Default::default()
+        };
+        let error = request
+            .try_into_tempo_tx_env(TempoTxEnv::default(), true)
+            .unwrap_err();
+        assert!(error.to_string().contains("configuration witness"));
+    }
 
     #[test]
     fn access_key_request_populates_typed_simulation_env() {

--- a/crates/contracts/src/precompiles/account_keychain.rs
+++ b/crates/contracts/src/precompiles/account_keychain.rs
@@ -25,6 +25,7 @@ crate::sol! {
             Secp256k1,
             P256,
             WebAuthn,
+            Multisig,
         }
 
         /// Legacy token spending limit structure used before T3.

--- a/crates/node/tests/it/tempo_transaction/helpers.rs
+++ b/crates/node/tests/it/tempo_transaction/helpers.rs
@@ -496,7 +496,9 @@ fn create_key_authorization_inner(
     witness: Option<B256>,
 ) -> eyre::Result<SignedKeyAuthorization> {
     // Infer key_type from the access key signature
-    let key_type = access_key_signature.signature_type();
+    let key_type = access_key_signature
+        .signature_type()
+        .expect("primitive access-key fixture");
 
     let mut key_auth = KeyAuthorization::unrestricted(chain_id, key_type, access_key_addr);
     key_auth.expiry = expiry;

--- a/crates/node/tests/it/tempo_transaction/runners.rs
+++ b/crates/node/tests/it/tempo_transaction/runners.rs
@@ -612,7 +612,8 @@ pub(super) async fn run_estimate_gas_matrix<E: TestEnv>(
                     signer
                         .sign_hash_sync(&auth.authorization.signature_hash())
                         .expect("signing should succeed"),
-                );
+                )
+                .into();
                 request.key_authorization = Some(auth);
             }
         }

--- a/crates/precompiles/src/signature_verifier/mod.rs
+++ b/crates/precompiles/src/signature_verifier/mod.rs
@@ -4,9 +4,8 @@ use crate::{SIGNATURE_VERIFIER_ADDRESS, account_keychain::AccountKeychain, error
 use alloy::primitives::{Address, B256, Bytes};
 use tempo_contracts::precompiles::SignatureVerifierError;
 use tempo_precompiles_macros::contract;
-use tempo_primitives::transaction::{
-    SignatureType,
-    tt_signature::{KeychainSignature, PrimitiveSignature, TempoSignature},
+use tempo_primitives::transaction::tt_signature::{
+    KeychainSignature, PrimitiveSignature, TempoSignature,
 };
 
 /// Gas cost for secp256k1 signature verification.
@@ -32,10 +31,10 @@ impl SignatureVerifier {
             .map_err(|_| SignatureVerifierError::invalid_format())?;
 
         // Charge verification gas before performing verification.
-        let verify_gas = match sig.signature_type() {
-            SignatureType::Secp256k1 => SECP256K1_VERIFY_GAS,
-            SignatureType::P256 => P256_VERIFY_GAS,
-            SignatureType::WebAuthn => WEBAUTHN_VERIFY_GAS,
+        let verify_gas = match &sig {
+            PrimitiveSignature::Secp256k1(_) => SECP256K1_VERIFY_GAS,
+            PrimitiveSignature::P256(_) => P256_VERIFY_GAS,
+            PrimitiveSignature::WebAuthn(_) => WEBAUTHN_VERIFY_GAS,
         };
         self.storage.deduct_gas(verify_gas)?;
 

--- a/crates/primitives/src/transaction/key_authorization.rs
+++ b/crates/primitives/src/transaction/key_authorization.rs
@@ -1,5 +1,5 @@
 use super::SignatureType;
-use crate::transaction::PrimitiveSignature;
+use crate::transaction::TempoSignature;
 use alloc::vec::Vec;
 use alloy_consensus::crypto::RecoveryError;
 use alloy_primitives::{Address, B256, U256, keccak256};
@@ -356,7 +356,7 @@ impl KeyAuthorization {
     }
 
     /// Convert the key authorization into a [`SignedKeyAuthorization`] with a signature.
-    pub fn into_signed(self, signature: PrimitiveSignature) -> SignedKeyAuthorization {
+    pub fn into_signed(self, signature: impl Into<TempoSignature>) -> SignedKeyAuthorization {
         SignedKeyAuthorization::new(self, signature)
     }
 
@@ -409,7 +409,7 @@ pub struct KeyAuthorizationChainIdError {
 }
 
 /// Signed key authorization that can be attached to a transaction.
-#[derive(Clone, Debug, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable, derive_more::Deref)]
+#[derive(Clone, Debug, alloy_rlp::RlpEncodable, derive_more::Deref)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
@@ -420,8 +420,13 @@ pub struct SignedKeyAuthorization {
     #[deref]
     pub authorization: KeyAuthorization,
 
-    /// Signature authorizing this key (signed by root key)
-    pub signature: PrimitiveSignature,
+    /// Direct primitive or multisig signature authorizing this key.
+    #[cfg_attr(
+        feature = "serde",
+        serde(deserialize_with = "deserialize_authorization_signature")
+    )]
+    #[cfg_attr(any(test, feature = "arbitrary"), arbitrary(with = arbitrary_authorization_signature))]
+    pub signature: TempoSignature,
 
     /// Cached signer recovered from `signature`.
     ///
@@ -434,26 +439,39 @@ pub struct SignedKeyAuthorization {
 
 impl SignedKeyAuthorization {
     /// Create a signed key authorization with an empty signer cache.
-    pub fn new(authorization: KeyAuthorization, signature: PrimitiveSignature) -> Self {
+    pub fn new(authorization: KeyAuthorization, signature: impl Into<TempoSignature>) -> Self {
         Self {
             authorization,
-            signature,
+            signature: signature.into(),
             signer: OnceLock::new(),
         }
     }
 
     /// Recover the signer of the [`KeyAuthorization`].
     pub fn recover_signer(&self) -> Result<Address, RecoveryError> {
+        let TempoSignature::Primitive(signature) = &self.signature else {
+            return Err(RecoveryError::new());
+        };
         if let Some(signer) = self.signer.get() {
             return Ok(*signer);
         }
 
-        let signer = self
-            .signature
-            .recover_signer(&self.authorization.signature_hash())?;
+        let signer = signature.recover_signer(&self.authorization.signature_hash())?;
         self.cache_signer(signer);
 
         Ok(signer)
+    }
+
+    /// Recovers a primitive signer or returns the named multisig account.
+    ///
+    /// Callers must check that this account is the parent granting access, then validate its
+    /// configuration and owner quorum against state before granting access.
+    pub fn recover_account(&self) -> Result<Address, RecoveryError> {
+        match &self.signature {
+            TempoSignature::Primitive(_) => self.recover_signer(),
+            TempoSignature::Multisig(signature) => Ok(signature.account()),
+            TempoSignature::Keychain(_) => Err(RecoveryError::new()),
+        }
     }
 
     #[cfg(feature = "std")]
@@ -469,6 +487,33 @@ impl SignedKeyAuthorization {
     /// Calculates a heuristic for the in-memory size of the signed key authorization
     pub fn size(&self) -> usize {
         self.authorization.size() + self.signature.size()
+    }
+}
+
+impl alloy_rlp::Decodable for SignedKeyAuthorization {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (mut fields, rest) = buf.split_at(header.payload_length);
+        let authorization = KeyAuthorization::decode(&mut fields)?;
+        let signature = TempoSignature::decode(&mut fields)?;
+        if signature.is_keychain() {
+            return Err(alloy_rlp::Error::Custom(
+                "keychain signatures cannot authorize access keys",
+            ));
+        }
+        if !fields.is_empty() {
+            return Err(alloy_rlp::Error::Custom(
+                "trailing key authorization fields",
+            ));
+        }
+        *buf = rest;
+        Ok(Self::new(authorization, signature))
     }
 }
 
@@ -488,13 +533,39 @@ impl Hash for SignedKeyAuthorization {
 }
 
 #[cfg(any(test, feature = "arbitrary"))]
+fn arbitrary_authorization_signature(
+    u: &mut arbitrary::Unstructured<'_>,
+) -> arbitrary::Result<TempoSignature> {
+    Ok(if u.arbitrary()? {
+        TempoSignature::Primitive(u.arbitrary()?)
+    } else {
+        TempoSignature::Multisig(u.arbitrary()?)
+    })
+}
+
+#[cfg(feature = "serde")]
+fn deserialize_authorization_signature<'de, D>(deserializer: D) -> Result<TempoSignature, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::{Deserialize, de::Error};
+    let signature = TempoSignature::deserialize(deserializer)?;
+    if signature.is_keychain() {
+        return Err(D::Error::custom(
+            "keychain signatures cannot authorize access keys",
+        ));
+    }
+    Ok(signature)
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for KeyAuthorization {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             chain_id: u.arbitrary()?,
             key_type: u.arbitrary()?,
             key_id: u.arbitrary()?,
-            expiry: u.arbitrary()?,
+            expiry: u.arbitrary::<Option<u64>>()?.and_then(NonZeroU64::new),
             limits: u.arbitrary()?,
             allowed_calls: u.arbitrary()?,
             witness: u.arbitrary::<Option<[u8; 32]>>()?.map(B256::from),
@@ -780,6 +851,59 @@ mod tests {
         NonZeroU64::new(value).expect("test expiry must be non-zero")
     }
 
+    #[test]
+    fn arbitrary_expiry_exhausted_input() {
+        use arbitrary::{Arbitrary, Unstructured};
+        // The first 32 bytes encode chain_id, key_type and key_id. Selecting Some
+        // with no remaining expiry bytes previously returned IncorrectFormat.
+        let mut input = [0; 33];
+        input[32] = 1;
+        let mut fields = Unstructured::new(&input);
+        let _: u64 = fields.arbitrary().unwrap();
+        let _: SignatureType = fields.arbitrary().unwrap();
+        let _: Address = fields.arbitrary().unwrap();
+        assert_eq!(fields.arbitrary::<Option<u64>>().unwrap(), Some(0));
+        let auth = KeyAuthorization::arbitrary(&mut Unstructured::new(&input)).unwrap();
+        assert_eq!(auth.expiry, None);
+        let encoded = alloy_rlp::encode(&auth);
+        assert_eq!(
+            KeyAuthorization::decode(&mut encoded.as_slice()).unwrap(),
+            auth
+        );
+    }
+
+    #[test]
+    fn test_multisig_delegate_key_type_roundtrip() {
+        let auth =
+            KeyAuthorization::unrestricted(1, SignatureType::Multisig, Address::repeat_byte(1));
+        let encoded = alloy_rlp::encode(&auth);
+        assert_eq!(
+            KeyAuthorization::decode(&mut encoded.as_slice()).unwrap(),
+            auth
+        );
+        assert_eq!(u8::from(auth.key_type), 3);
+        assert_eq!(
+            SignatureType::try_from(
+                tempo_contracts::precompiles::IAccountKeychain::SignatureType::Multisig
+            ),
+            Ok(auth.key_type)
+        );
+        let primitive_auth = KeyAuthorization {
+            key_type: SignatureType::Secp256k1,
+            ..auth.clone()
+        };
+        assert_ne!(auth.signature_hash(), primitive_auth.signature_hash());
+        #[cfg(feature = "serde")]
+        {
+            let json = serde_json::to_value(&auth).unwrap();
+            assert_eq!(json["keyType"], "multisig");
+            assert_eq!(
+                serde_json::from_value::<KeyAuthorization>(json).unwrap(),
+                auth
+            );
+        }
+    }
+
     fn make_auth(expiry: Option<u64>, limits: Option<Vec<TokenLimit>>) -> KeyAuthorization {
         KeyAuthorization {
             chain_id: 1,
@@ -929,6 +1053,73 @@ mod tests {
         let decoded =
             <KeyAuthorization as Decodable>::decode(&mut encoded.as_slice()).expect("decode auth");
         assert_eq!(decoded.witness(), Some(B256::ZERO));
+    }
+
+    #[test]
+    fn direct_authorization_signature_roles_and_legacy_wire_encoding() {
+        use crate::transaction::PrimitiveSignature;
+        let auth = make_auth(None, None);
+        let primitive =
+            PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature());
+        let signed = auth.clone().into_signed(primitive.clone());
+        #[derive(alloy_rlp::RlpEncodable)]
+        struct Legacy {
+            authorization: KeyAuthorization,
+            signature: PrimitiveSignature,
+        }
+        assert_eq!(
+            alloy_rlp::encode(&signed),
+            alloy_rlp::encode(Legacy {
+                authorization: auth.clone(),
+                signature: primitive.clone()
+            })
+        );
+        let account = Address::repeat_byte(0x11);
+        let config = crate::transaction::MultisigConfig {
+            salt: B256::ZERO,
+            version: 0,
+            threshold: 1,
+            owners: vec![crate::transaction::MultisigOwner {
+                owner: Address::repeat_byte(0x22),
+                weight: 1,
+            }],
+        };
+        let multisig = crate::transaction::MultisigSignature::try_new(
+            account,
+            config,
+            vec![primitive.clone()],
+        )
+        .unwrap();
+        let signed = auth.clone().into_signed(TempoSignature::Multisig(multisig));
+        assert_eq!(signed.recover_account().unwrap(), account);
+        assert!(signed.recover_signer().is_err());
+        let encoded = alloy_rlp::encode(&signed);
+        assert_eq!(
+            SignedKeyAuthorization::decode(&mut encoded.as_slice()).unwrap(),
+            signed
+        );
+        #[cfg(feature = "serde")]
+        assert_eq!(
+            serde_json::from_value::<SignedKeyAuthorization>(
+                serde_json::to_value(&signed).unwrap()
+            )
+            .unwrap(),
+            signed
+        );
+
+        let invalid = auth.into_signed(TempoSignature::Keychain(
+            crate::transaction::KeychainSignature::new(account, primitive),
+        ));
+        assert!(invalid.recover_account().is_err());
+        let encoded = alloy_rlp::encode(&invalid);
+        assert!(SignedKeyAuthorization::decode(&mut encoded.as_slice()).is_err());
+        #[cfg(feature = "serde")]
+        assert!(
+            serde_json::from_value::<SignedKeyAuthorization>(
+                serde_json::to_value(invalid).unwrap()
+            )
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/primitives/src/transaction/mod.rs
+++ b/crates/primitives/src/transaction/mod.rs
@@ -1,5 +1,8 @@
 pub mod envelope;
 pub mod key_authorization;
+pub mod multisig;
+pub use multisig::*;
+pub use tt_signature::AccessKeySignature;
 pub mod tempo_transaction;
 pub mod tt_authorization;
 pub mod tt_signature;

--- a/crates/primitives/src/transaction/multisig/mod.rs
+++ b/crates/primitives/src/transaction/multisig/mod.rs
@@ -1,0 +1,792 @@
+use super::{tempo_transaction::MAX_WEBAUTHN_SIGNATURE_LENGTH, tt_signature::PrimitiveSignature};
+use alloc::vec::Vec;
+#[cfg(any(test, feature = "serde"))]
+use alloy_primitives::Bytes;
+use alloy_primitives::{Address, B256, b256, keccak256};
+use alloy_rlp::Encodable as _;
+use core::mem::size_of;
+use tempo_contracts::SAFE_DEPLOYER_ADDRESS;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
+
+/// Tempo signature type byte for native multisig signatures.
+pub const SIGNATURE_TYPE_MULTISIG: u8 = 0x05;
+
+/// Domain prefix for native multisig owner approvals.
+pub const MULTISIG_SIGNATURE_DOMAIN: &[u8] = b"tempo:multisig:signature";
+
+/// Maximum number of owners allowed in a native multisig config.
+pub const MAX_MULTISIG_OWNERS: usize = 48;
+
+/// Maximum threshold accepted by a native multisig config.
+pub const MAX_MULTISIG_THRESHOLD: u8 = 8;
+
+/// Maximum number of owner approvals allowed in one native multisig signature.
+pub const MAX_MULTISIG_SIGNATURES: usize = 8;
+
+/// Maximum encoded byte length for one primitive owner approval.
+pub const MAX_MULTISIG_OWNER_SIGNATURE_BYTES: usize = 1 + MAX_WEBAUTHN_SIGNATURE_LENGTH;
+
+/// Domain prefix for native multisig account CREATE2 salt derivation.
+pub const MULTISIG_ACCOUNT_DOMAIN: &[u8] = b"tempo:multisig:account";
+
+/// Safe Singleton Factory used to deploy the dedicated recovery factory.
+pub const MULTISIG_RECOVERY_SINGLETON_FACTORY: Address = SAFE_DEPLOYER_ADDRESS;
+
+/// Expected runtime-code hash of [`MULTISIG_RECOVERY_SINGLETON_FACTORY`].
+pub const MULTISIG_RECOVERY_SINGLETON_FACTORY_RUNTIME_HASH: B256 =
+    b256!("2fa86add0aed31f33a762c9d88e807c475bd51d0f52bd0955754b2608f7e4989");
+
+/// Keccak-256 of the dedicated recovery factory creation code.
+pub const MULTISIG_RECOVERY_FACTORY_INIT_CODE_HASH: B256 =
+    b256!("32c2f9b9926477ca22da4308d7efa1b92a2c2db3f434a0afa77fc32bdecbe48b");
+
+/// Keccak-256 of the dedicated recovery factory runtime code.
+pub const MULTISIG_RECOVERY_FACTORY_RUNTIME_HASH: B256 =
+    b256!("e74489073cf29a2000b643988575b615febec333a826512de4e1e8db10228a60");
+
+/// Keccak-256 of the canonical recovery wallet creation code.
+pub const MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH: B256 =
+    b256!("583cc63a2e37f645b43eac911b1a6d6de08b83abdc308c61364edda8cfc3bd37");
+
+/// CREATE2 preimage length: 1-byte `0xff` + 20-byte factory + 32-byte salt +
+/// 32-byte init-code hash.
+pub const MULTISIG_ACCOUNT_CREATE2_PREIMAGE_LEN: usize = 1 + 20 + 32 + 32;
+
+/// Domain prefix for native multisig configuration commitments.
+pub const MULTISIG_CONFIG_DOMAIN: &[u8] = b"tempo:multisig:config";
+
+/// Native multisig owner entry.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable, alloy_rlp::RlpDecodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(test, reth_codecs::add_arbitrary_tests(rlp))]
+pub struct MultisigOwner {
+    /// Address recovered from a primitive signature.
+    pub owner: Address,
+    /// Nonzero owner weight.
+    pub weight: u8,
+}
+
+/// Native multisig configuration carried by an account signature.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, alloy_rlp::RlpEncodable)]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+#[cfg_attr(test, reth_codecs::add_arbitrary_tests(rlp))]
+pub struct MultisigConfig {
+    /// Caller-chosen salt that establishes the account identity.
+    pub salt: B256,
+    /// Configuration version. Zero identifies the initial configuration.
+    pub version: u64,
+    /// Minimum total owner weight required to authorize a transaction.
+    pub threshold: u8,
+    /// Sorted weighted owner list.
+    pub owners: Vec<MultisigOwner>,
+}
+
+impl MultisigConfig {
+    /// Validates owner count, ordering, addresses, weights, and threshold reachability, returning
+    /// the total owner weight.
+    pub fn validate(&self) -> Result<u8, MultisigConfigError> {
+        self.validate_inner(None)
+    }
+
+    /// Performs [`Self::validate`] and rejects initial self-ownership.
+    pub fn validate_for_account(&self, account: Address) -> Result<u8, MultisigConfigError> {
+        self.validate_inner(Some(account))
+    }
+
+    /// Derives the CREATE2 salt for this configuration's initial account identity.
+    pub fn account_salt(&self) -> Result<B256, MultisigConfigError> {
+        self.validate()?;
+        Ok(self.account_salt_validated())
+    }
+
+    /// Derives the account using the caller's committed recovery factory address.
+    ///
+    /// TIP-1110 has not selected the production factory address. No default is supplied here.
+    /// Reserved namespace checks belong to the caller's chain context.
+    pub fn derive_account(&self, factory: Address) -> Result<Address, MultisigConfigError> {
+        self.validate()?;
+        self.derive_account_validated(factory)
+    }
+
+    /// Computes the persisted commitment for this configuration.
+    pub fn commitment(&self) -> Result<B256, MultisigConfigError> {
+        self.validate()?;
+        Ok(self.commitment_validated())
+    }
+
+    /// Returns the configured weight for an owner, if present.
+    pub fn owner_weight(&self, owner: Address) -> Option<u8> {
+        self.owners
+            .binary_search_by_key(&owner, |entry| entry.owner)
+            .ok()
+            .map(|idx| self.owners[idx].weight)
+    }
+    /// Byte length of the account-salt preimage: domain, 32-byte salt, 1-byte threshold,
+    /// 1-byte owner count, and a 20-byte address plus 1-byte weight per owner.
+    pub fn account_salt_preimage_len(&self) -> usize {
+        MULTISIG_ACCOUNT_DOMAIN.len() + 32 + 2 + self.owners.len() * 21
+    }
+
+    /// Byte length of the commitment preimage: domain, 32-byte salt, 8-byte version, 1-byte
+    /// threshold, 1-byte owner count, and a 20-byte address plus 1-byte weight per owner.
+    pub fn commitment_preimage_len(&self) -> usize {
+        MULTISIG_CONFIG_DOMAIN.len() + 32 + 8 + 2 + self.owners.len() * 21
+    }
+
+    /// Encodes the canonical account-salt preimage.
+    ///
+    /// This checks that the owner count is encodable; callers must separately validate the config
+    /// before relying on the resulting hash.
+    pub fn account_salt_preimage(&self) -> Result<Vec<u8>, MultisigConfigError> {
+        let owner_count = self.encoded_owner_count()?;
+        let mut input = Vec::with_capacity(self.account_salt_preimage_len());
+        input.extend_from_slice(MULTISIG_ACCOUNT_DOMAIN);
+        input.extend_from_slice(self.salt.as_slice());
+        self.append_owner_set(&mut input, owner_count);
+        Ok(input)
+    }
+
+    /// Encodes the canonical configuration-commitment preimage.
+    ///
+    /// This checks that the owner count is encodable; callers must separately validate the config
+    /// before relying on the resulting hash.
+    pub fn commitment_preimage(&self) -> Result<Vec<u8>, MultisigConfigError> {
+        let owner_count = self.encoded_owner_count()?;
+        let mut input = Vec::with_capacity(self.commitment_preimage_len());
+        input.extend_from_slice(MULTISIG_CONFIG_DOMAIN);
+        input.extend_from_slice(self.salt.as_slice());
+        input.extend_from_slice(&self.version.to_be_bytes());
+        self.append_owner_set(&mut input, owner_count);
+        Ok(input)
+    }
+
+    /// Returns a heuristic for the in-memory size of the config.
+    pub fn size(&self) -> usize {
+        size_of::<Self>() + self.owners.capacity() * size_of::<MultisigOwner>()
+    }
+
+    fn validate_inner(&self, account: Option<Address>) -> Result<u8, MultisigConfigError> {
+        if self.owners.is_empty() {
+            return Err(MultisigConfigError::EmptyOwners);
+        }
+        if self.owners.len() > MAX_MULTISIG_OWNERS {
+            return Err(MultisigConfigError::TooManyOwners);
+        }
+        if self.threshold == 0 {
+            return Err(MultisigConfigError::ZeroThreshold);
+        }
+        if self.threshold > MAX_MULTISIG_THRESHOLD {
+            return Err(MultisigConfigError::ThresholdExceedsMax);
+        }
+        // TIP-1109 orders errors across the entire owner list, not within each owner.
+        for owner in &self.owners {
+            if owner.owner.is_zero() {
+                return Err(MultisigConfigError::ZeroOwner);
+            }
+            if self.version == 0 && account == Some(owner.owner) {
+                return Err(MultisigConfigError::AccountIsOwner);
+            }
+        }
+        if self.owners.iter().any(|owner| owner.weight == 0) {
+            return Err(MultisigConfigError::ZeroWeight);
+        }
+        if self
+            .owners
+            .windows(2)
+            .any(|pair| pair[0].owner >= pair[1].owner)
+        {
+            // Only invalid ordering needs this bounded scan for nonadjacent duplicates.
+            // Valid sorted configurations retain linear, allocation-free validation.
+            if self.owners.iter().enumerate().any(|(index, owner)| {
+                self.owners[..index]
+                    .iter()
+                    .any(|previous| previous.owner == owner.owner)
+            }) {
+                return Err(MultisigConfigError::DuplicateOwner);
+            }
+            return Err(MultisigConfigError::OwnersNotAscending);
+        }
+        let total_weight: u16 = self
+            .owners
+            .iter()
+            .map(|owner| u16::from(owner.weight))
+            .sum();
+        if total_weight > u16::from(u8::MAX) {
+            return Err(MultisigConfigError::TotalWeightExceedsMax);
+        }
+        if u16::from(self.threshold) > total_weight {
+            return Err(MultisigConfigError::ThresholdExceedsWeight);
+        }
+
+        Ok(total_weight as u8)
+    }
+
+    fn account_salt_validated(&self) -> B256 {
+        keccak256(
+            self.account_salt_preimage()
+                .expect("validated multisig config has an encodable owner count"),
+        )
+    }
+
+    fn derive_account_validated(&self, factory: Address) -> Result<Address, MultisigConfigError> {
+        let account = multisig_account_address(factory, self.account_salt_validated());
+        if account.is_zero() {
+            return Err(MultisigConfigError::DerivedAccountZero);
+        }
+        if self.owner_weight(account).is_some() {
+            return Err(MultisigConfigError::AccountIsOwner);
+        }
+        Ok(account)
+    }
+
+    fn commitment_validated(&self) -> B256 {
+        keccak256(
+            self.commitment_preimage()
+                .expect("validated multisig config has an encodable owner count"),
+        )
+    }
+
+    fn encoded_owner_count(&self) -> Result<u8, MultisigConfigError> {
+        if self.owners.len() > MAX_MULTISIG_OWNERS {
+            return Err(MultisigConfigError::TooManyOwners);
+        }
+        Ok(self.owners.len() as u8)
+    }
+
+    fn append_owner_set(&self, input: &mut Vec<u8>, owner_count: u8) {
+        input.push(self.threshold);
+        input.push(owner_count);
+        for owner in &self.owners {
+            input.extend_from_slice(owner.owner.as_slice());
+            input.push(owner.weight);
+        }
+    }
+}
+
+// This cannot use `RlpDecodable`: the derived `Vec` decoder has no element limit and would decode
+// an unbounded owner list before validation.
+impl alloy_rlp::Decodable for MultisigConfig {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let header = alloy_rlp::Header::decode(buf)?;
+        if !header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        if buf.len() < header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let body = *buf;
+        let (mut fields, rest) = body.split_at(header.payload_length);
+        let salt = <B256 as alloy_rlp::Decodable>::decode(&mut fields)?;
+        let version = <u64 as alloy_rlp::Decodable>::decode(&mut fields)?;
+        let threshold = <u8 as alloy_rlp::Decodable>::decode(&mut fields)?;
+
+        let owners_header = alloy_rlp::Header::decode(&mut fields)?;
+        if !owners_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        if fields.len() < owners_header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (mut owner_fields, trailing_fields) = fields.split_at(owners_header.payload_length);
+        let mut owners = Vec::new();
+        while !owner_fields.is_empty() {
+            if owners.len() == MAX_MULTISIG_OWNERS {
+                return Err(alloy_rlp::Error::Custom("too many multisig owners"));
+            }
+            owners.push(<MultisigOwner as alloy_rlp::Decodable>::decode(
+                &mut owner_fields,
+            )?);
+        }
+        if !trailing_fields.is_empty() {
+            return Err(alloy_rlp::Error::Custom(
+                "unexpected trailing multisig config fields",
+            ));
+        }
+
+        *buf = rest;
+        Ok(Self {
+            salt,
+            version,
+            threshold,
+            owners,
+        })
+    }
+}
+
+/// Native multisig transaction signature.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(test, reth_codecs::add_arbitrary_tests(rlp))]
+pub struct MultisigSignature {
+    /// Native multisig account authorized by this signature.
+    ///
+    /// This is explicit because a versioned configuration cannot derive the account's stable
+    /// address.
+    account: Address,
+    /// Complete applicable account configuration.
+    config: MultisigConfig,
+    /// Owner approvals over the multisig digest.
+    ///
+    /// Each approval is a primitive signature; recursive authorization is not supported.
+    signatures: Vec<PrimitiveSignature>,
+}
+
+impl MultisigSignature {
+    /// Constructs a bounded primitive-owner witness.
+    ///
+    /// The named account remains untrusted: factory-derived identity or the stored commitment,
+    /// account code, and the owner quorum must be checked against state.
+    pub fn try_new(
+        account: Address,
+        config: MultisigConfig,
+        signatures: Vec<PrimitiveSignature>,
+    ) -> Result<Self, MultisigSignatureError> {
+        let signature = Self {
+            account,
+            config,
+            signatures,
+        };
+        signature.validate_shape()?;
+        Ok(signature)
+    }
+
+    /// Returns the native multisig account address.
+    pub const fn account(&self) -> Address {
+        self.account
+    }
+
+    /// Returns the complete applicable account configuration.
+    pub const fn config(&self) -> &MultisigConfig {
+        &self.config
+    }
+
+    /// Returns encoded owner approvals.
+    pub fn signatures(&self) -> &[PrimitiveSignature] {
+        &self.signatures
+    }
+
+    /// Returns the multisig owner-approval digest for this signature.
+    pub fn digest(&self, inner_digest: B256) -> B256 {
+        multisig_digest(inner_digest, self.account(), self.config.version)
+    }
+
+    /// Computes the commitment of the configuration validated at construction or decoding.
+    pub fn config_commitment(&self) -> B256 {
+        self.config.commitment_validated()
+    }
+
+    /// Returns a heuristic for the in-memory size of the signature.
+    pub fn size(&self) -> usize {
+        size_of::<Self>()
+            + self.config.size()
+            + self.signatures.capacity() * size_of::<PrimitiveSignature>()
+            + self
+                .signatures
+                .iter()
+                .map(PrimitiveSignature::size)
+                .sum::<usize>()
+    }
+
+    fn validate_shape(&self) -> Result<(), MultisigSignatureError> {
+        if self.account().is_zero() {
+            return Err(MultisigSignatureError::ZeroAccount);
+        }
+        self.config.validate_for_account(self.account())?;
+        if self.signatures.is_empty() {
+            return Err(MultisigSignatureError::EmptySignatures);
+        }
+        if self.signatures.len() > MAX_MULTISIG_SIGNATURES {
+            return Err(MultisigSignatureError::TooManySignatures);
+        }
+        for signature in &self.signatures {
+            if signature.encoded_length() > MAX_MULTISIG_OWNER_SIGNATURE_BYTES {
+                return Err(MultisigSignatureError::OwnerSignatureTooLarge);
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    fn decode_exact(bytes: &[u8]) -> alloy_rlp::Result<Self> {
+        let mut input = bytes;
+        let signature = Self::decode_rlp(&mut input)?;
+        if !input.is_empty() {
+            return Err(alloy_rlp::Error::Custom(
+                "trailing native multisig signature bytes",
+            ));
+        }
+        Ok(signature)
+    }
+
+    /// Decodes bounded primitive approvals before any cryptographic work.
+    pub(crate) fn decode_rlp(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        let outer = alloy_rlp::Header::decode(buf)?;
+        if !outer.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        if buf.len() < outer.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+
+        let body = *buf;
+        let (mut fields, rest) = body.split_at(outer.payload_length);
+
+        let account = <Address as alloy_rlp::Decodable>::decode(&mut fields)?;
+        let config = <MultisigConfig as alloy_rlp::Decodable>::decode(&mut fields)?;
+
+        let sig_header = alloy_rlp::Header::decode(&mut fields)?;
+        if !sig_header.list {
+            return Err(alloy_rlp::Error::UnexpectedString);
+        }
+        if fields.len() < sig_header.payload_length {
+            return Err(alloy_rlp::Error::InputTooShort);
+        }
+        let (mut sig_fields, sig_rest) = fields.split_at(sig_header.payload_length);
+        let mut signatures = Vec::new();
+        while !sig_fields.is_empty() {
+            if signatures.len() == MAX_MULTISIG_SIGNATURES {
+                return Err(alloy_rlp::Error::Custom("too many multisig signatures"));
+            }
+            let bytes = alloy_rlp::Header::decode_bytes(&mut sig_fields, false)?;
+            if bytes.len() > MAX_MULTISIG_OWNER_SIGNATURE_BYTES {
+                return Err(alloy_rlp::Error::Custom(
+                    "multisig owner signature too large",
+                ));
+            }
+            signatures
+                .push(PrimitiveSignature::from_bytes(bytes).map_err(alloy_rlp::Error::Custom)?);
+        }
+        if !sig_rest.is_empty() {
+            return Err(alloy_rlp::Error::Custom(
+                "unexpected trailing native multisig signature fields",
+            ));
+        }
+
+        *buf = rest;
+        Self::try_new(account, config, signatures)
+            .map_err(|error| alloy_rlp::Error::Custom(error.as_str()))
+    }
+
+    fn rlp_payload_length(&self) -> usize {
+        self.account.length() + self.config.length() + self.signatures.length()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for MultisigSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut encoded = Vec::with_capacity(self.length());
+        self.encode(&mut encoded);
+        Bytes::from(encoded).serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> Deserialize<'de> for MultisigSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let encoded = Bytes::deserialize(deserializer)?;
+        Self::decode_exact(&encoded).map_err(D::Error::custom)
+    }
+}
+
+impl alloy_rlp::Decodable for MultisigSignature {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Self::decode_rlp(buf)
+    }
+}
+
+impl alloy_rlp::Encodable for MultisigSignature {
+    fn encode(&self, out: &mut dyn alloy_rlp::BufMut) {
+        let payload_length = self.rlp_payload_length();
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .encode(out);
+        self.account.encode(out);
+        self.config.encode(out);
+        self.signatures.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        let payload_length = self.rlp_payload_length();
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .length()
+            + payload_length
+    }
+}
+
+#[cfg(any(test, feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for MultisigSignature {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let len = u.int_in_range(1..=MAX_MULTISIG_SIGNATURES)?;
+        let mut signatures = Vec::new();
+        for _ in 0..len {
+            let mut signature = PrimitiveSignature::arbitrary(u)?;
+            if let PrimitiveSignature::WebAuthn(signature) = &mut signature {
+                // Standalone primitive generation is unbounded; an owner approval is not.
+                let len = signature
+                    .webauthn_data
+                    .len()
+                    .min(MAX_WEBAUTHN_SIGNATURE_LENGTH - 128);
+                signature.webauthn_data = signature.webauthn_data.slice(..len);
+            }
+            signatures.push(signature);
+        }
+
+        let mut owner = Address::arbitrary(u)?;
+        if owner.is_zero() {
+            owner = Address::repeat_byte(1);
+        }
+        let config = MultisigConfig {
+            salt: u.arbitrary()?,
+            version: 0,
+            threshold: 1,
+            owners: vec![MultisigOwner { owner, weight: 1 }],
+        };
+        let account = config
+            .derive_account(Address::repeat_byte(0x99))
+            .map_err(|_| arbitrary::Error::IncorrectFormat)?;
+
+        Self::try_new(account, config, signatures).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+/// Native multisig config validation error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MultisigConfigError {
+    /// The owner list is empty.
+    EmptyOwners,
+    /// The owner list exceeds [`MAX_MULTISIG_OWNERS`].
+    TooManyOwners,
+    /// The threshold is zero.
+    ZeroThreshold,
+    /// The threshold exceeds the protocol cap.
+    ThresholdExceedsMax,
+    /// An owner address is zero.
+    ZeroOwner,
+    /// An owner weight is zero.
+    ZeroWeight,
+    /// The owner list contains a duplicate owner.
+    DuplicateOwner,
+    /// The owner list is not strictly ascending.
+    OwnersNotAscending,
+    /// Total owner weight exceeds `u8::MAX`.
+    TotalWeightExceedsMax,
+    /// The threshold exceeds the weight reachable within the approval limit.
+    ThresholdExceedsWeight,
+    /// The derived multisig account address is zero.
+    DerivedAccountZero,
+    /// The multisig account is included in its own owner set.
+    AccountIsOwner,
+}
+
+impl MultisigConfigError {
+    /// Returns the stable validation message for this error.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::EmptyOwners => "multisig owners cannot be empty",
+            Self::TooManyOwners => "too many multisig owners",
+            Self::ZeroThreshold => "multisig threshold cannot be zero",
+            Self::ThresholdExceedsMax => "multisig threshold exceeds maximum",
+            Self::ZeroOwner => "multisig owner cannot be zero",
+            Self::ZeroWeight => "multisig owner weight cannot be zero",
+            Self::DuplicateOwner => "multisig owners cannot contain duplicates",
+            Self::OwnersNotAscending => "multisig owners must be strictly ascending",
+            Self::TotalWeightExceedsMax => "multisig total owner weight exceeds u8::MAX",
+            Self::ThresholdExceedsWeight => {
+                "multisig threshold cannot be reached within the owner approval limit"
+            }
+            Self::DerivedAccountZero => "multisig account cannot be zero",
+            Self::AccountIsOwner => "multisig account cannot own itself",
+        }
+    }
+}
+
+impl core::fmt::Display for MultisigConfigError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Native multisig signature construction and shape validation error.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MultisigSignatureError {
+    /// The supplied config is invalid.
+    InvalidConfig(MultisigConfigError),
+    /// The claimed multisig account is zero.
+    ZeroAccount,
+    /// The owner approval list is empty.
+    EmptySignatures,
+    /// The owner approval list exceeds [`MAX_MULTISIG_SIGNATURES`].
+    TooManySignatures,
+    /// An encoded primitive owner approval exceeds [`MAX_MULTISIG_OWNER_SIGNATURE_BYTES`].
+    OwnerSignatureTooLarge,
+}
+
+impl MultisigSignatureError {
+    /// Returns the stable validation message for this error.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::InvalidConfig(error) => error.as_str(),
+            Self::ZeroAccount => "multisig account cannot be zero",
+            Self::EmptySignatures => "multisig signatures cannot be empty",
+            Self::TooManySignatures => "too many multisig signatures",
+            Self::OwnerSignatureTooLarge => "multisig owner signature too large",
+        }
+    }
+}
+
+impl core::fmt::Display for MultisigSignatureError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<MultisigConfigError> for MultisigSignatureError {
+    fn from(error: MultisigConfigError) -> Self {
+        Self::InvalidConfig(error)
+    }
+}
+
+/// Native multisig quorum validation error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum MultisigQuorumError {
+    /// The configured threshold is zero.
+    ZeroThreshold,
+    /// The signature list is empty.
+    EmptySignatures,
+    /// The signature list exceeds [`MAX_MULTISIG_SIGNATURES`].
+    TooManySignatures,
+    /// The signature list has entries after quorum is reached.
+    ExcessSignatures,
+    /// A recovered signer is not a configured owner.
+    SignerNotOwner,
+    /// Recovered signers are not strictly ascending.
+    SignersNotAscending,
+    /// Recovered signer weight does not meet the threshold.
+    WeightBelowThreshold,
+}
+
+impl MultisigQuorumError {
+    /// Returns the stable validation message for this error.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ZeroThreshold => "multisig threshold cannot be zero",
+            Self::EmptySignatures => "multisig signatures cannot be empty",
+            Self::TooManySignatures => "too many multisig signatures",
+            Self::ExcessSignatures => "excess multisig owner signatures",
+            Self::SignerNotOwner => "multisig signer is not an owner",
+            Self::SignersNotAscending => "multisig recovered owners must be strictly ascending",
+            Self::WeightBelowThreshold => "multisig signature weight below threshold",
+        }
+    }
+}
+
+impl core::fmt::Display for MultisigQuorumError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Accumulates recovered native multisig owner weights while enforcing owner ordering.
+pub struct MultisigWeightAccumulator {
+    threshold: u8,
+    prev_owner: Option<Address>,
+    recovered_weight: u16,
+    signer_count: usize,
+}
+
+impl MultisigWeightAccumulator {
+    /// Creates a new accumulator for a native multisig threshold.
+    pub const fn new(threshold: u8) -> Result<Self, MultisigQuorumError> {
+        if threshold == 0 {
+            return Err(MultisigQuorumError::ZeroThreshold);
+        }
+        Ok(Self {
+            threshold,
+            prev_owner: None,
+            recovered_weight: 0,
+            signer_count: 0,
+        })
+    }
+
+    /// Records one recovered owner address and its configured weight.
+    pub fn record_owner(&mut self, owner: Address, weight: u8) -> Result<(), MultisigQuorumError> {
+        if self.has_quorum() {
+            return Err(MultisigQuorumError::ExcessSignatures);
+        }
+        if weight == 0 {
+            return Err(MultisigQuorumError::SignerNotOwner);
+        }
+        self.signer_count = self
+            .signer_count
+            .checked_add(1)
+            .ok_or(MultisigQuorumError::TooManySignatures)?;
+        if self.signer_count > MAX_MULTISIG_SIGNATURES {
+            return Err(MultisigQuorumError::TooManySignatures);
+        }
+
+        if self.prev_owner.is_some_and(|prev| prev >= owner) {
+            return Err(MultisigQuorumError::SignersNotAscending);
+        }
+        self.prev_owner = Some(owner);
+
+        self.recovered_weight += u16::from(weight);
+        Ok(())
+    }
+
+    /// Returns whether the accumulated weight satisfies the configured threshold.
+    pub fn has_quorum(&self) -> bool {
+        self.signer_count > 0 && self.recovered_weight >= u16::from(self.threshold)
+    }
+
+    /// Enforces that at least one signer reached the configured threshold.
+    pub fn finish(self) -> Result<(), MultisigQuorumError> {
+        if self.signer_count == 0 {
+            return Err(MultisigQuorumError::EmptySignatures);
+        }
+        if self.recovered_weight < u16::from(self.threshold) {
+            return Err(MultisigQuorumError::WeightBelowThreshold);
+        }
+        Ok(())
+    }
+}
+
+/// Returns the native multisig account for a committed factory and precomputed account salt.
+pub fn multisig_account_address(factory: Address, account_salt: B256) -> Address {
+    factory.create2(account_salt, MULTISIG_RECOVERY_WALLET_INIT_CODE_HASH)
+}
+
+/// Computes the digest that native multisig owners approve.
+///
+/// This free function is also used while constructing a signature, before a [`MultisigSignature`]
+/// exists; [`MultisigSignature::digest`] supplies the account and version from an existing value.
+pub fn multisig_digest(inner_digest: B256, account: Address, config_version: u64) -> B256 {
+    let mut input = [0u8; MULTISIG_SIGNATURE_DOMAIN.len() + 32 + 20 + 8];
+    let mut offset = 0;
+    input[offset..offset + MULTISIG_SIGNATURE_DOMAIN.len()]
+        .copy_from_slice(MULTISIG_SIGNATURE_DOMAIN);
+    offset += MULTISIG_SIGNATURE_DOMAIN.len();
+    input[offset..offset + 32].copy_from_slice(inner_digest.as_slice());
+    offset += 32;
+    input[offset..offset + 20].copy_from_slice(account.as_slice());
+    offset += 20;
+    input[offset..].copy_from_slice(&config_version.to_be_bytes());
+    keccak256(input)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/primitives/src/transaction/multisig/mod.rs
+++ b/crates/primitives/src/transaction/multisig/mod.rs
@@ -380,12 +380,12 @@ impl MultisigSignature {
     /// Returns a heuristic for the in-memory size of the signature.
     pub fn size(&self) -> usize {
         size_of::<Self>()
-            + self.config.size()
+            + self.config.owners.capacity() * size_of::<MultisigOwner>()
             + self.signatures.capacity() * size_of::<PrimitiveSignature>()
             + self
                 .signatures
                 .iter()
-                .map(PrimitiveSignature::size)
+                .map(|signature| signature.size() - size_of::<PrimitiveSignature>())
                 .sum::<usize>()
     }
 

--- a/crates/primitives/src/transaction/multisig/tests.rs
+++ b/crates/primitives/src/transaction/multisig/tests.rs
@@ -1,0 +1,862 @@
+use super::*;
+use crate::transaction::{
+    AccessKeySignature, KeychainSignature, PrimitiveSignature, TempoSignature, derive_p256_address,
+    tt_authorization::tests::generate_secp256k1_keypair,
+    tt_signature::{P256SignatureWithPreHash, WebAuthnSignature, normalize_p256_s},
+};
+use alloy_rlp::{Decodable, Encodable};
+use p256::{
+    ecdsa::{SigningKey as P256SigningKey, signature::hazmat::PrehashSigner},
+    elliptic_curve::rand_core::OsRng,
+};
+use proptest::prelude::*;
+use sha2::{Digest, Sha256};
+
+// Deliberately non-production factory fixture: TIP-1110 has not selected its public address.
+const TEST_FACTORY: Address = Address::repeat_byte(0x99);
+
+#[test]
+fn arbitrary_bounded_approvals() {
+    use arbitrary::{Arbitrary, Unstructured};
+    let mut primitive_types = [false; 3];
+    let mut approval_counts = [false; MAX_MULTISIG_SIGNATURES];
+    let mut saw_max_webauthn = false;
+    // 0xab repeated 10,000 times previously produced an oversized WebAuthn approval.
+    for size in [0, 1, 256, 10_000] {
+        for byte in 0..=u8::MAX {
+            let input = vec![byte; size];
+            let signature = MultisigSignature::arbitrary(&mut Unstructured::new(&input)).unwrap();
+            approval_counts[signature.signatures().len() - 1] = true;
+            for approval in signature.signatures() {
+                assert!(approval.encoded_length() <= MAX_MULTISIG_OWNER_SIGNATURE_BYTES);
+                match approval {
+                    PrimitiveSignature::Secp256k1(_) => primitive_types[0] = true,
+                    PrimitiveSignature::P256(_) => primitive_types[1] = true,
+                    PrimitiveSignature::WebAuthn(_) => {
+                        primitive_types[2] = true;
+                        saw_max_webauthn |=
+                            approval.encoded_length() == MAX_MULTISIG_OWNER_SIGNATURE_BYTES;
+                    }
+                }
+            }
+            let bytes = alloy_rlp::encode(&signature);
+            assert_eq!(
+                MultisigSignature::decode(&mut bytes.as_slice()).unwrap(),
+                signature
+            );
+        }
+    }
+    assert!(primitive_types.into_iter().all(|seen| seen));
+    assert!(approval_counts.into_iter().all(|seen| seen));
+    assert!(saw_max_webauthn);
+}
+
+fn sign_hash(signer: &alloy_signer_local::PrivateKeySigner, digest: &B256) -> PrimitiveSignature {
+    match crate::transaction::tt_authorization::tests::sign_hash(signer, digest) {
+        TempoSignature::Primitive(signature) => signature,
+        _ => unreachable!(),
+    }
+}
+
+fn sorted_secp_config(owners: &[(Address, u8)], threshold: u8) -> MultisigConfig {
+    let mut owners = owners
+        .iter()
+        .map(|(owner, weight)| MultisigOwner {
+            owner: *owner,
+            weight: *weight,
+        })
+        .collect::<Vec<_>>();
+    owners.sort_by_key(|owner| owner.owner);
+    MultisigConfig {
+        salt: B256::ZERO,
+        version: 0,
+        threshold,
+        owners,
+    }
+}
+
+fn indexed_owner(index: u16) -> Address {
+    let mut bytes = [0u8; 20];
+    bytes[18..].copy_from_slice(&index.to_be_bytes());
+    Address::from(bytes)
+}
+
+fn valid_owner_signature_bytes() -> Bytes {
+    valid_owner_signature().to_bytes()
+}
+
+fn valid_owner_signature() -> PrimitiveSignature {
+    PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature())
+}
+
+fn initial_multisig_signature() -> MultisigSignature {
+    let config = sorted_secp_config(&[(indexed_owner(2), 1)], 1);
+    MultisigSignature::try_new(
+        config.derive_account(TEST_FACTORY).unwrap(),
+        config,
+        vec![PrimitiveSignature::default()],
+    )
+    .unwrap()
+}
+
+fn current_config(owner: Address) -> MultisigConfig {
+    MultisigConfig {
+        salt: B256::ZERO,
+        version: 1,
+        threshold: 1,
+        owners: vec![MultisigOwner { owner, weight: 1 }],
+    }
+}
+
+fn generate_p256_keypair() -> (P256SigningKey, B256, B256, Address) {
+    let signing_key = P256SigningKey::random(&mut OsRng);
+    let verifying_key = signing_key.verifying_key();
+    let encoded_point = verifying_key.to_encoded_point(false);
+    let pub_key_x = B256::from_slice(encoded_point.x().unwrap().as_ref());
+    let pub_key_y = B256::from_slice(encoded_point.y().unwrap().as_ref());
+    let owner = derive_p256_address(&pub_key_x, &pub_key_y);
+    (signing_key, pub_key_x, pub_key_y, owner)
+}
+
+fn sign_p256_owner_approval_with_prehash(
+    signing_key: &P256SigningKey,
+    digest: B256,
+    pub_key_x: B256,
+    pub_key_y: B256,
+) -> Bytes {
+    let prehashed = B256::from_slice(Sha256::digest(digest).as_ref());
+    let signature: p256::ecdsa::Signature = signing_key.sign_prehash(prehashed.as_slice()).unwrap();
+    let sig_bytes = signature.to_bytes();
+    PrimitiveSignature::P256(P256SignatureWithPreHash {
+        r: B256::from_slice(&sig_bytes[..32]),
+        s: normalize_p256_s(&sig_bytes[32..64]).expect("p256 crate produces valid s"),
+        pub_key_x,
+        pub_key_y,
+        pre_hash: true,
+    })
+    .to_bytes()
+}
+
+fn encoded_multisig(
+    account: Address,
+    config: &MultisigConfig,
+    signatures: Vec<Vec<u8>>,
+) -> Vec<u8> {
+    let signatures = signatures.into_iter().map(Bytes::from).collect::<Vec<_>>();
+    let payload_length = account.length() + config.length() + signatures.length();
+    let mut encoded = Vec::new();
+    alloy_rlp::Header {
+        list: true,
+        payload_length,
+    }
+    .encode(&mut encoded);
+    account.encode(&mut encoded);
+    config.encode(&mut encoded);
+    signatures.encode(&mut encoded);
+    encoded
+}
+
+/// Builds `levels` of nested current-configuration multisig signatures, where the innermost
+/// approval is primitive and each outer level has a single nested multisig owner.
+fn nested_multisig_encoding(levels: usize) -> Vec<u8> {
+    let mut current = encoded_multisig(
+        indexed_owner(100),
+        &current_config(indexed_owner(200)),
+        vec![valid_owner_signature_bytes().to_vec()],
+    );
+    for level in 1..levels {
+        let mut owner_approval = vec![SIGNATURE_TYPE_MULTISIG];
+        owner_approval.extend_from_slice(&current);
+        current = encoded_multisig(
+            indexed_owner(100 + level as u16),
+            &current_config(indexed_owner(200 + level as u16)),
+            vec![owner_approval],
+        );
+    }
+    current
+}
+
+fn assert_multisig_decode_rejected(encoded: &[u8]) {
+    let mut input = encoded;
+    assert!(MultisigSignature::decode(&mut input).is_err());
+
+    let tempo_encoded = [SIGNATURE_TYPE_MULTISIG]
+        .into_iter()
+        .chain(encoded.iter().copied())
+        .collect::<Vec<_>>();
+    assert!(TempoSignature::from_bytes(&tempo_encoded).is_err());
+}
+
+#[cfg(feature = "serde")]
+fn malformed_multisig_encodings() -> [Vec<u8>; 2] {
+    [
+        encoded_multisig(
+            indexed_owner(1),
+            &current_config(indexed_owner(2)),
+            vec![valid_owner_signature_bytes().to_vec(); MAX_MULTISIG_SIGNATURES + 1],
+        ),
+        nested_multisig_encoding(4_096),
+    ]
+}
+
+#[test]
+fn validates_owner_order() {
+    let owner_a = Address::from([0x11; 20]);
+    let owner_b = Address::from([0x22; 20]);
+    let config = sorted_secp_config(&[(owner_b, 2), (owner_a, 1)], 2);
+
+    config.validate().expect("config is valid");
+
+    let unsorted = MultisigConfig {
+        salt: B256::ZERO,
+        version: 0,
+        threshold: 1,
+        owners: vec![
+            MultisigOwner {
+                owner: owner_b,
+                weight: 1,
+            },
+            MultisigOwner {
+                owner: owner_a,
+                weight: 1,
+            },
+        ],
+    };
+    assert!(unsorted.validate().is_err());
+}
+
+#[test]
+fn rejects_nested_and_keychain_owner_encodings() {
+    for depth in [2, 3, 4096] {
+        assert_multisig_decode_rejected(&nested_multisig_encoding(depth));
+    }
+    for keychain in [
+        KeychainSignature::new(indexed_owner(2), PrimitiveSignature::default()),
+        KeychainSignature::new_v1(indexed_owner(2), PrimitiveSignature::default()),
+    ] {
+        let encoded = encoded_multisig(
+            indexed_owner(1),
+            &current_config(indexed_owner(2)),
+            vec![TempoSignature::Keychain(keychain).to_bytes().to_vec()],
+        );
+        assert_multisig_decode_rejected(&encoded);
+    }
+}
+
+#[test]
+fn positive_versions_allow_primitive_self_ownership() {
+    let account = indexed_owner(1);
+    for version in [0, 1, u64::MAX] {
+        let mut config = current_config(account);
+        config.version = version;
+        assert_eq!(config.validate_for_account(account).is_ok(), version > 0);
+    }
+}
+
+#[test]
+fn quorum_rejects_approvals_after_threshold() {
+    let mut accumulator = MultisigWeightAccumulator::new(1).unwrap();
+    accumulator.record_owner(indexed_owner(1), 1).unwrap();
+    assert_eq!(
+        accumulator.record_owner(indexed_owner(2), 1),
+        Err(MultisigQuorumError::ExcessSignatures)
+    );
+}
+
+#[test]
+fn bounded_access_key_envelope_roundtrips_and_rejects_v1() {
+    let multisig = initial_multisig_signature();
+    let parent = indexed_owner(3);
+    let envelope = TempoSignature::Keychain(KeychainSignature::new(parent, multisig.clone()));
+    let encoded = envelope.to_bytes();
+    assert_eq!(TempoSignature::from_bytes(&encoded).unwrap(), envelope);
+    assert_eq!(
+        envelope.as_keychain().unwrap().key_id(&B256::ZERO).unwrap(),
+        multisig.account()
+    );
+    assert!(
+        envelope
+            .as_keychain()
+            .unwrap()
+            .signature
+            .recover_signer(&B256::ZERO)
+            .is_err()
+    );
+    let mut legacy = encoded.to_vec();
+    legacy[0] = crate::transaction::tt_signature::SIGNATURE_TYPE_KEYCHAIN;
+    assert!(TempoSignature::from_bytes(&legacy).is_err());
+    assert!(AccessKeySignature::from_bytes(&encoded).is_err());
+    #[cfg(feature = "serde")]
+    {
+        let mut json = serde_json::to_value(&envelope).unwrap();
+        assert_eq!(
+            serde_json::from_value::<TempoSignature>(json.clone()).unwrap(),
+            envelope
+        );
+        json["version"] = serde_json::to_value(crate::transaction::KeychainVersion::V1).unwrap();
+        assert!(serde_json::from_value::<TempoSignature>(json).is_err());
+    }
+}
+
+#[test]
+fn access_key_digest_binds_parent_before_multisig_domain() {
+    let signature = initial_multisig_signature();
+    let inner = B256::repeat_byte(0x42);
+    let digest_a = signature.digest(KeychainSignature::signing_hash(inner, indexed_owner(3)));
+    let digest_b = signature.digest(KeychainSignature::signing_hash(inner, indexed_owner(4)));
+    assert_ne!(digest_a, digest_b);
+}
+
+#[test]
+fn sixty_five_byte_owners_remain_untyped() {
+    for first in [0x03, 0x04, 0x05] {
+        let mut primitive = valid_owner_signature_bytes().to_vec();
+        primitive[0] = first;
+        let encoded = encoded_multisig(
+            indexed_owner(1),
+            &current_config(indexed_owner(2)),
+            vec![primitive],
+        );
+        let decoded = MultisigSignature::decode(&mut encoded.as_slice()).unwrap();
+        assert!(matches!(
+            decoded.signatures()[0],
+            PrimitiveSignature::Secp256k1(_)
+        ));
+    }
+}
+
+#[test]
+fn account_derivation_includes_salt() {
+    let owner = Address::from([0x11; 20]);
+    let zero_salt = sorted_secp_config(&[(owner, 1)], 1);
+    let mut nonzero_salt = zero_salt.clone();
+    nonzero_salt.salt = B256::repeat_byte(0x42);
+
+    assert_ne!(
+        zero_salt.derive_account(TEST_FACTORY).unwrap(),
+        nonzero_salt.derive_account(TEST_FACTORY).unwrap()
+    );
+    zero_salt.validate().expect("zero salt is valid");
+}
+
+#[test]
+fn multisig_domains_match_spec_vectors() {
+    let mut config = sorted_secp_config(&[(Address::repeat_byte(0x11), 1)], 1);
+    let account_salt = config.account_salt().unwrap();
+    let digest_account = alloy_primitives::address!("91847576f406d0842ad7c1a0c97c22a122e64278");
+
+    assert_eq!(
+        account_salt,
+        alloy_primitives::b256!("7162e370e58784e6b33d61878820d1497eeaf4f68e00b2cfc00a2f3b1dbb00da")
+    );
+    // Independently reproduced with raw CREATE2 hashing and the canonical Solidity factory.
+    let expected = alloy_primitives::address!("d62b59cb4e41a0dd9000c71c6663df05e2bb910d");
+    assert_eq!(
+        multisig_account_address(TEST_FACTORY, account_salt),
+        expected
+    );
+    assert_eq!(config.derive_account(TEST_FACTORY).unwrap(), expected);
+    assert_eq!(
+        multisig_digest(B256::repeat_byte(0x42), digest_account, 0),
+        alloy_primitives::b256!("7a62ef46efdf76a6a0ab6c38c5fdeda2169d6a0de3643bb9912a4fbce881a870")
+    );
+
+    assert_eq!(
+        config.commitment().unwrap(),
+        alloy_primitives::b256!("a9e7d1e2ad25e227a4de5f38f3bba31d854ffc8efec46aaa8649097a516bb4ee")
+    );
+    config.version = 1;
+    assert_eq!(
+        config.commitment().unwrap(),
+        alloy_primitives::b256!("6237ca5930f2265d4fb70a0305dd6ceea4df227053b4a62c304489ede946a2f8")
+    );
+    assert_eq!(
+        multisig_digest(B256::repeat_byte(0x42), digest_account, 1),
+        alloy_primitives::b256!("cceb022fd342beddcf6583e680c18a34936212276a680f026e52728b5ebb722b")
+    );
+}
+
+#[test]
+fn config_accepts_max_owners() {
+    let owners = (1..=MAX_MULTISIG_OWNERS as u16)
+        .map(|index| (indexed_owner(index), 1))
+        .collect::<Vec<_>>();
+    let config = sorted_secp_config(&owners, MAX_MULTISIG_SIGNATURES as u8);
+
+    assert_eq!(config.validate(), Ok(MAX_MULTISIG_OWNERS as u8));
+    assert!(config.derive_account(TEST_FACTORY).is_ok());
+}
+
+#[test]
+fn config_rejects_more_than_max_owners() {
+    let owners = (1..=MAX_MULTISIG_OWNERS as u16 + 1)
+        .map(|index| (indexed_owner(index), 1))
+        .collect::<Vec<_>>();
+    let config = sorted_secp_config(&owners, 1);
+
+    assert_eq!(config.validate(), Err(MultisigConfigError::TooManyOwners));
+}
+
+#[test]
+fn config_total_weight_is_capped_at_u8_max() {
+    let owner_a = Address::from([0x11; 20]);
+    let owner_b = Address::from([0x22; 20]);
+    let config = sorted_secp_config(&[(owner_a, 128), (owner_b, 128)], 1);
+
+    assert_eq!(
+        config.validate(),
+        Err(MultisigConfigError::TotalWeightExceedsMax)
+    );
+}
+
+#[test]
+fn config_accepts_max_threshold() {
+    let owner = Address::from([0x11; 20]);
+    let threshold = MAX_MULTISIG_THRESHOLD;
+    let config = sorted_secp_config(&[(owner, threshold)], threshold);
+
+    assert_eq!(config.validate(), Ok(threshold));
+}
+
+#[test]
+fn config_rejects_threshold_requiring_too_many_approvals() {
+    let owners = (1..=MAX_MULTISIG_SIGNATURES as u16 + 1)
+        .map(|index| (indexed_owner(index), 1))
+        .collect::<Vec<_>>();
+    let config = sorted_secp_config(&owners, owners.len() as u8);
+
+    assert_eq!(
+        config.validate(),
+        Err(MultisigConfigError::ThresholdExceedsMax)
+    );
+}
+
+#[test]
+fn config_rejects_own_account_as_owner() {
+    let account = indexed_owner(1);
+    let config = sorted_secp_config(&[(account, 1)], 1);
+
+    assert_eq!(
+        config.validate_for_account(account),
+        Err(MultisigConfigError::AccountIsOwner)
+    );
+
+    let config = sorted_secp_config(&[(account, 0)], 1);
+    assert_eq!(
+        config.validate_for_account(account),
+        Err(MultisigConfigError::AccountIsOwner)
+    );
+}
+
+#[test]
+fn shared_quorum_helpers_verify_order_and_threshold() {
+    let owner_a = indexed_owner(1);
+    let owner_b = indexed_owner(2);
+    let owner_c = indexed_owner(3);
+    let config = sorted_secp_config(&[(owner_a, 1), (owner_b, 3), (owner_c, 2)], 4);
+
+    // Reproduce the weight-accounting the native multisig verifier performs: look up each
+    // recovered owner's configured weight and feed it to the shared accumulator in order.
+    let ordered_weights = |owners: &[Address]| -> Result<(), MultisigQuorumError> {
+        let mut accumulator = MultisigWeightAccumulator::new(config.threshold)?;
+        for &owner in owners {
+            let weight = config
+                .owner_weight(owner)
+                .ok_or(MultisigQuorumError::SignerNotOwner)?;
+            accumulator.record_owner(owner, weight)?;
+        }
+        accumulator.finish()
+    };
+
+    assert_eq!(ordered_weights(&[owner_a, owner_b]), Ok(()));
+    assert_eq!(
+        ordered_weights(&[owner_b]),
+        Err(MultisigQuorumError::WeightBelowThreshold)
+    );
+    assert_eq!(
+        ordered_weights(&[owner_b, owner_a]),
+        Err(MultisigQuorumError::SignersNotAscending)
+    );
+    assert_eq!(
+        ordered_weights(&[indexed_owner(4)]),
+        Err(MultisigQuorumError::SignerNotOwner)
+    );
+
+    assert_eq!(
+        MultisigWeightAccumulator::new(0).err(),
+        Some(MultisigQuorumError::ZeroThreshold)
+    );
+}
+
+#[test]
+fn owner_signature_cannot_replay_across_accounts_with_same_owners() {
+    let (signer, owner) = generate_secp256k1_keypair();
+    let mut config_a = sorted_secp_config(&[(owner, 1)], 1);
+    config_a.salt = B256::repeat_byte(0x11);
+    let mut config_b = sorted_secp_config(&[(owner, 1)], 1);
+    config_b.salt = B256::repeat_byte(0x22);
+
+    let account_a = config_a.derive_account(TEST_FACTORY).unwrap();
+    let account_b = config_b.derive_account(TEST_FACTORY).unwrap();
+    assert_ne!(account_a, account_b);
+
+    let inner_digest = B256::repeat_byte(0x42);
+    let digest_a = multisig_digest(inner_digest, account_a, 0);
+    let digest_b = multisig_digest(inner_digest, account_b, 0);
+    assert_ne!(digest_a, digest_b, "digest is domain-separated by account");
+
+    // An owner approval recovers the owner only against the account it was signed for; replaying
+    // it against another account's digest recovers a different address that is not an owner.
+    let signature = sign_hash(&signer, &digest_a);
+    assert_eq!(signature.recover_signer(&digest_a).unwrap(), owner);
+    assert_ne!(signature.recover_signer(&digest_b).unwrap(), owner);
+}
+
+#[test]
+fn owner_signature_cannot_replay_across_config_versions() {
+    let (signer, owner) = generate_secp256k1_keypair();
+    let config = sorted_secp_config(&[(owner, 1)], 1);
+    let account = config.derive_account(TEST_FACTORY).unwrap();
+    let inner_digest = B256::repeat_byte(0x42);
+    let initial_digest = multisig_digest(inner_digest, account, 0);
+    let rotated_digest = multisig_digest(inner_digest, account, 1);
+
+    assert_ne!(initial_digest, rotated_digest);
+    let signature = sign_hash(&signer, &initial_digest);
+    assert_eq!(signature.recover_signer(&initial_digest).unwrap(), owner);
+    assert_ne!(signature.recover_signer(&rotated_digest).unwrap(), owner);
+}
+
+#[test]
+fn verifies_weighted_owner_signatures_in_sorted_order() {
+    let (signer_a, owner_a) = generate_secp256k1_keypair();
+    let (signer_b, owner_b) = generate_secp256k1_keypair();
+    let config = sorted_secp_config(&[(owner_a, 1), (owner_b, 1)], 2);
+    let account = config.derive_account(TEST_FACTORY).unwrap();
+    let digest = multisig_digest(B256::repeat_byte(0x42), account, 0);
+
+    let mut signed = [
+        (owner_a, sign_hash(&signer_a, &digest)),
+        (owner_b, sign_hash(&signer_b, &digest)),
+    ];
+    signed.sort_by_key(|(owner, _)| *owner);
+
+    // Feed the recovered owners through the shared accumulator, as the verifier does.
+    let quorum_weight = |approvals: &[&PrimitiveSignature]| -> Result<(), MultisigQuorumError> {
+        let mut accumulator = MultisigWeightAccumulator::new(config.threshold)?;
+        for approval in approvals {
+            let owner = approval.recover_signer(&digest).unwrap();
+            let weight = config
+                .owner_weight(owner)
+                .ok_or(MultisigQuorumError::SignerNotOwner)?;
+            accumulator.record_owner(owner, weight)?;
+        }
+        accumulator.finish()
+    };
+
+    let both = [&signed[0].1, &signed[1].1];
+    assert_eq!(quorum_weight(&both), Ok(()));
+
+    // A single owner falls short of the threshold of 2.
+    assert!(quorum_weight(&[&signed[0].1]).is_err());
+}
+
+#[test]
+fn noncanonical_p256_owner_prehash_flag_canonicalizes() {
+    // A P256 owner approval carrying a noncanonical pre_hash flag byte decodes to the same
+    // signature and re-encodes with the canonical flag, so it cannot malleate the transaction
+    // hash even though the raw wire byte differs. This structural canonicalization replaces the
+    // (STF-breaking) strict-flag rejection that was previously attempted at decode time.
+    let (signer, pub_key_x, pub_key_y, owner) = generate_p256_keypair();
+    let config = sorted_secp_config(&[(owner, 1)], 1);
+    let account = config.derive_account(TEST_FACTORY).unwrap();
+    let digest = multisig_digest(B256::repeat_byte(0x42), account, 0);
+
+    let canonical_signature =
+        sign_p256_owner_approval_with_prehash(&signer, digest, pub_key_x, pub_key_y);
+    assert_eq!(
+        canonical_signature[canonical_signature.len() - 1],
+        1,
+        "test setup should use canonical pre_hash=true encoding"
+    );
+
+    let mut noncanonical_signature = canonical_signature.to_vec();
+    let flag_index = noncanonical_signature.len() - 1;
+    noncanonical_signature[flag_index] = 2;
+
+    let decoded = TempoSignature::from_bytes(&noncanonical_signature)
+        .expect("noncanonical pre_hash flag decodes leniently");
+    assert_eq!(
+        decoded.to_bytes(),
+        canonical_signature,
+        "noncanonical owner approval re-encodes to the canonical signature bytes"
+    );
+}
+
+#[test]
+fn multisig_signature_encodes_complete_config() {
+    let config = current_config(indexed_owner(2));
+    let account = Address::repeat_byte(0x11);
+    let signatures = [valid_owner_signature_bytes()];
+    let signature =
+        MultisigSignature::try_new(account, config.clone(), vec![valid_owner_signature()]).unwrap();
+
+    let mut encoded = Vec::new();
+    signature.encode(&mut encoded);
+    assert_eq!(
+        encoded,
+        encoded_multisig(
+            account,
+            &config,
+            signatures
+                .iter()
+                .map(|signature| signature.to_vec())
+                .collect(),
+        )
+    );
+
+    let mut input = encoded.as_slice();
+    let decoded = MultisigSignature::decode(&mut input).unwrap();
+    assert!(input.is_empty());
+    assert_eq!(decoded, signature);
+}
+
+#[test]
+fn multisig_signature_decode_rejects_invalid_config() {
+    let invalid_config = MultisigConfig {
+        salt: B256::ZERO,
+        version: 0,
+        threshold: 0,
+        owners: Vec::new(),
+    };
+    let encoded = encoded_multisig(
+        Address::repeat_byte(0x11),
+        &invalid_config,
+        vec![valid_owner_signature_bytes().to_vec()],
+    );
+
+    assert_multisig_decode_rejected(&encoded);
+}
+
+#[test]
+fn multisig_config_decode_bounds_owner_count() {
+    let config = MultisigConfig {
+        salt: B256::ZERO,
+        version: 0,
+        threshold: MAX_MULTISIG_THRESHOLD,
+        owners: (1..=MAX_MULTISIG_OWNERS as u16 + 1)
+            .map(|index| MultisigOwner {
+                owner: Address::from_word(B256::from(alloy_primitives::U256::from(index))),
+                weight: 1,
+            })
+            .collect(),
+    };
+    let mut encoded = Vec::new();
+    config.encode(&mut encoded);
+
+    let mut input = encoded.as_slice();
+    assert!(matches!(
+        MultisigConfig::decode(&mut input),
+        Err(alloy_rlp::Error::Custom("too many multisig owners"))
+    ));
+}
+
+#[test]
+fn multisig_signature_decode_bounds_approval_count() {
+    let encoded = encoded_multisig(
+        Address::repeat_byte(0x11),
+        &current_config(indexed_owner(2)),
+        vec![valid_owner_signature_bytes().to_vec(); MAX_MULTISIG_SIGNATURES + 1],
+    );
+
+    let mut input = encoded.as_slice();
+    assert!(matches!(
+        MultisigSignature::decode(&mut input),
+        Err(alloy_rlp::Error::Custom("too many multisig signatures"))
+    ));
+}
+
+#[test]
+fn multisig_signature_shape_rejects_oversized_owner_signature() {
+    let signature = MultisigSignature::try_new(
+        Address::repeat_byte(0x11),
+        current_config(indexed_owner(2)),
+        vec![PrimitiveSignature::WebAuthn(WebAuthnSignature {
+            webauthn_data: Bytes::from(vec![0; MAX_WEBAUTHN_SIGNATURE_LENGTH + 1]),
+            r: B256::ZERO,
+            s: B256::ZERO,
+            pub_key_x: B256::ZERO,
+            pub_key_y: B256::ZERO,
+        })],
+    );
+
+    assert_eq!(
+        signature,
+        Err(MultisigSignatureError::OwnerSignatureTooLarge)
+    );
+}
+
+#[test]
+fn multisig_signature_decode_rejects_oversized_owner_signature() {
+    let encoded = encoded_multisig(
+        Address::repeat_byte(0x11),
+        &current_config(indexed_owner(2)),
+        vec![vec![0xaa; MAX_MULTISIG_OWNER_SIGNATURE_BYTES + 1]],
+    );
+    assert_multisig_decode_rejected(&encoded);
+}
+
+#[test]
+fn multisig_signature_roundtrips_complete_encoding() {
+    let (signer, owner) = generate_secp256k1_keypair();
+    let mut config = sorted_secp_config(&[(owner, 1)], 1);
+    config.salt = B256::repeat_byte(0x33);
+    let account = config.derive_account(TEST_FACTORY).unwrap();
+    let signature_hash = B256::ZERO;
+    let digest = multisig_digest(signature_hash, account, 0);
+    let signatures = vec![sign_hash(&signer, &digest)];
+    let signature =
+        MultisigSignature::try_new(account, config.clone(), signatures.clone()).unwrap();
+    let tempo_signature = TempoSignature::Multisig(signature.clone());
+
+    let encoded = tempo_signature.to_bytes();
+    assert_eq!(encoded[0], SIGNATURE_TYPE_MULTISIG);
+    assert_eq!(
+        &encoded[1..],
+        encoded_multisig(
+            account,
+            &config,
+            signatures
+                .iter()
+                .map(|signature| signature.to_bytes().to_vec())
+                .collect(),
+        )
+    );
+    let decoded = TempoSignature::from_bytes(&encoded).unwrap();
+    assert_eq!(decoded.as_multisig(), Some(&signature));
+    assert_eq!(
+        decoded.recover_signer(&signature_hash).unwrap(),
+        signature.account()
+    );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn multisig_signature_serde_roundtrips_rlp_bytes() {
+    let (signer, owner) = generate_secp256k1_keypair();
+    let config = sorted_secp_config(&[(owner, 1)], 1);
+    let account = config.derive_account(TEST_FACTORY).unwrap();
+    let digest = multisig_digest(B256::ZERO, account, 0);
+    let owner_signature = sign_hash(&signer, &digest);
+    let signatures = vec![owner_signature];
+
+    let signature = MultisigSignature::try_new(account, config, signatures).unwrap();
+    let mut encoded = Vec::with_capacity(signature.length());
+    signature.encode(&mut encoded);
+    let json = serde_json::to_value(&signature).unwrap();
+    assert_eq!(
+        json,
+        serde_json::to_value(Bytes::from(encoded.clone())).unwrap()
+    );
+    assert_eq!(
+        serde_json::from_value::<MultisigSignature>(json.clone()).unwrap(),
+        signature
+    );
+    assert_eq!(
+        serde_json::from_value::<TempoSignature>(json).unwrap(),
+        TempoSignature::Multisig(signature)
+    );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn multisig_signature_json_bytes_reject_malformed_shapes() {
+    for encoded in malformed_multisig_encodings() {
+        let json = serde_json::to_value(Bytes::from(encoded)).unwrap();
+        assert!(serde_json::from_value::<TempoSignature>(json).is_err());
+    }
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn multisig_signature_json_rejects_structured_form() {
+    let json = serde_json::json!({
+        "account": Address::repeat_byte(0x11),
+        "signatures": [],
+    });
+    let error = serde_json::from_value::<TempoSignature>(json)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("did not match any variant") || error.contains("missing field"),
+        "unexpected error: {error}"
+    );
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn binary_multisig_deserializer_roundtrips_bytes() {
+    let primitive = PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature());
+    let signature = TempoSignature::Multisig(
+        MultisigSignature::try_new(
+            indexed_owner(2),
+            current_config(indexed_owner(3)),
+            vec![primitive],
+        )
+        .unwrap(),
+    );
+    let signature = signature.as_multisig().unwrap();
+
+    let mut encoded = Vec::new();
+    signature.encode(&mut encoded);
+    let decoded = MultisigSignature::deserialize(serde::de::value::BorrowedBytesDeserializer::<
+        serde::de::value::Error,
+    >::new(&encoded))
+    .unwrap();
+
+    assert_eq!(&decoded, signature);
+}
+
+#[cfg(feature = "serde")]
+#[test]
+fn binary_multisig_deserializer_bounds_shape_before_typed_recursion() {
+    fn decode(bytes: &[u8]) -> Result<MultisigSignature, serde::de::value::Error> {
+        MultisigSignature::deserialize(serde::de::value::BorrowedBytesDeserializer::new(bytes))
+    }
+
+    for encoded in malformed_multisig_encodings() {
+        assert!(decode(&encoded).is_err());
+    }
+}
+
+proptest! {
+    #[test]
+    fn proptest_multisig_signature_decode_encode_canonicalizes_accepted_raw_bytes(
+        raw in prop_oneof![
+            proptest::collection::vec(any::<u8>(), 0..256),
+            (
+                any::<Address>(),
+                proptest::collection::vec(proptest::collection::vec(any::<u8>(), 0..128), 0..=MAX_MULTISIG_SIGNATURES),
+            ).prop_map(|(account, signatures)| {
+                encoded_multisig(account, &current_config(indexed_owner(2)), signatures)
+            }),
+        ],
+    ) {
+        let mut input = raw.as_slice();
+        if let Ok(decoded) = MultisigSignature::decode(&mut input) {
+            prop_assert!(input.is_empty());
+
+            let mut reencoded = Vec::new();
+            decoded.encode(&mut reencoded);
+
+            let mut canonical_input = reencoded.as_slice();
+            let canonical_decoded = MultisigSignature::decode(&mut canonical_input).unwrap();
+            prop_assert!(canonical_input.is_empty());
+            prop_assert_eq!(&canonical_decoded, &decoded);
+
+            let mut canonical_reencoded = Vec::new();
+            canonical_decoded.encode(&mut canonical_reencoded);
+            prop_assert_eq!(canonical_reencoded, reencoded);
+        }
+    }
+}

--- a/crates/primitives/src/transaction/multisig/tests.rs
+++ b/crates/primitives/src/transaction/multisig/tests.rs
@@ -16,6 +16,36 @@ use sha2::{Digest, Sha256};
 const TEST_FACTORY: Address = Address::repeat_byte(0x99);
 
 #[test]
+fn signature_size_counts_each_allocation_once() {
+    for count in [1, MAX_MULTISIG_SIGNATURES] {
+        for data_len in [0, 64] {
+            let mut signature = initial_multisig_signature();
+            let primitive = if data_len == 0 {
+                valid_owner_signature()
+            } else {
+                PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                    webauthn_data: vec![0xff; data_len].into(),
+                    r: B256::ZERO,
+                    s: B256::ZERO,
+                    pub_key_x: B256::ZERO,
+                    pub_key_y: B256::ZERO,
+                })
+            };
+            signature.signatures = vec![primitive; count];
+            signature.signatures.reserve(1);
+            signature.config.owners.reserve(1);
+            assert_eq!(
+                signature.size(),
+                size_of::<MultisigSignature>()
+                    + signature.config.owners.capacity() * size_of::<MultisigOwner>()
+                    + signature.signatures.capacity() * size_of::<PrimitiveSignature>()
+                    + count * data_len,
+            );
+        }
+    }
+}
+
+#[test]
 fn arbitrary_bounded_approvals() {
     use arbitrary::{Arbitrary, Unstructured};
     let mut primitive_types = [false; 3];

--- a/crates/primitives/src/transaction/tempo_transaction.rs
+++ b/crates/primitives/src/transaction/tempo_transaction.rs
@@ -42,6 +42,8 @@ pub enum SignatureType {
     Secp256k1 = 0,
     P256 = 1,
     WebAuthn = 2,
+    /// A configurable delegate authenticated by its primitive owner quorum (T12).
+    Multisig = 3,
 }
 
 impl From<SignatureType> for u8 {
@@ -50,6 +52,7 @@ impl From<SignatureType> for u8 {
             SignatureType::Secp256k1 => 0,
             SignatureType::P256 => 1,
             SignatureType::WebAuthn => 2,
+            SignatureType::Multisig => 3,
         }
     }
 }
@@ -62,6 +65,7 @@ impl From<SignatureType> for AbiSignatureType {
             SignatureType::Secp256k1 => Self::Secp256k1,
             SignatureType::P256 => Self::P256,
             SignatureType::WebAuthn => Self::WebAuthn,
+            SignatureType::Multisig => Self::Multisig,
         }
     }
 }
@@ -74,6 +78,7 @@ impl TryFrom<AbiSignatureType> for SignatureType {
             AbiSignatureType::Secp256k1 => Ok(Self::Secp256k1),
             AbiSignatureType::P256 => Ok(Self::P256),
             AbiSignatureType::WebAuthn => Ok(Self::WebAuthn),
+            AbiSignatureType::Multisig => Ok(Self::Multisig),
             _ => Err(sig_type as u8),
         }
     }
@@ -96,6 +101,7 @@ impl alloy_rlp::Decodable for SignatureType {
             0 => Ok(Self::Secp256k1),
             1 => Ok(Self::P256),
             2 => Ok(Self::WebAuthn),
+            3 => Ok(Self::Multisig),
             _ => Err(alloy_rlp::Error::Custom("Invalid signature type")),
         }
     }
@@ -902,14 +908,15 @@ impl<'a> arbitrary::Arbitrary<'a> for TempoTransaction {
         let fee_payer_signature = u.arbitrary()?;
 
         // Ensure valid_before > valid_after if both are set.
-        let valid_after: Option<NonZeroU64> = u.arbitrary()?;
+        // Exhausted input zero-fills integers; zero represents an absent validity bound.
+        let valid_after = u.arbitrary::<Option<u64>>()?.and_then(NonZeroU64::new);
         let valid_before: Option<NonZeroU64> = match valid_after {
             Some(after) => {
                 // Generate a value greater than valid_after
                 let offset: u64 = u.int_in_range(1..=1000)?;
                 Some(NonZeroU64::new(after.get().saturating_add(offset)).unwrap())
             }
-            None => u.arbitrary()?,
+            None => u.arbitrary::<Option<u64>>()?.and_then(NonZeroU64::new),
         };
 
         Ok(Self {
@@ -1031,6 +1038,35 @@ mod tests {
     use alloy_eips::{Decodable2718, Encodable2718, eip7702::Authorization};
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256, address, bytes, hex};
     use alloy_rlp::{Decodable, EMPTY_LIST_CODE, Encodable, Header as RlpHeader};
+    use arbitrary::{Arbitrary, Unstructured};
+
+    #[test]
+    fn arbitrary_exhausted_validity_bounds() {
+        // These trailing Some selectors previously rejected the zero-filled NonZeroU64.
+        for len in [98, 99] {
+            let mut input = vec![0; len];
+            input[len - 1] = 1;
+            let tx = TempoTransaction::arbitrary(&mut Unstructured::new(&input)).unwrap();
+            assert_eq!(tx.valid_after, None);
+            assert_eq!(tx.valid_before, None);
+        }
+    }
+
+    #[test]
+    fn arbitrary_envelope_exhausted_validity_regression() {
+        // Captured at case 2412 of a xorshift64 stream seeded with 1 (256 bytes per case).
+        let mut state = 1u64;
+        let mut input = [0; 256];
+        for _ in 0..=2412 {
+            for byte in &mut input {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                *byte = state as u8;
+            }
+        }
+        TempoTxEnvelope::arbitrary(&mut Unstructured::new(&input)).unwrap();
+    }
 
     fn nz(value: u64) -> NonZeroU64 {
         NonZeroU64::new(value).expect("test timestamp must be non-zero")
@@ -1187,19 +1223,19 @@ mod tests {
         // Secp256k1 (detected by 65-byte length, no type identifier)
         let sig1_bytes = vec![0u8; SECP256K1_SIGNATURE_LENGTH];
         let sig1 = TempoSignature::from_bytes(&sig1_bytes).unwrap();
-        assert_eq!(sig1.signature_type(), SignatureType::Secp256k1);
+        assert_eq!(sig1.signature_type(), Some(SignatureType::Secp256k1));
 
         // P256
         let mut sig2_bytes = vec![SIGNATURE_TYPE_P256];
         sig2_bytes.extend_from_slice(&[0u8; P256_SIGNATURE_LENGTH]);
         let sig2 = TempoSignature::from_bytes(&sig2_bytes).unwrap();
-        assert_eq!(sig2.signature_type(), SignatureType::P256);
+        assert_eq!(sig2.signature_type(), Some(SignatureType::P256));
 
         // WebAuthn
         let mut sig3_bytes = vec![SIGNATURE_TYPE_WEBAUTHN];
         sig3_bytes.extend_from_slice(&[0u8; 200]);
         let sig3 = TempoSignature::from_bytes(&sig3_bytes).unwrap();
-        assert_eq!(sig3.signature_type(), SignatureType::WebAuthn);
+        assert_eq!(sig3.signature_type(), Some(SignatureType::WebAuthn));
     }
 
     #[test]
@@ -2423,6 +2459,7 @@ mod compact_tests {
             (SignatureType::Secp256k1, 0x00u8),
             (SignatureType::P256, 0x01),
             (SignatureType::WebAuthn, 0x02),
+            (SignatureType::Multisig, 0x03),
         ] {
             let mut buf = vec![];
             let len = variant.to_compact(&mut buf);

--- a/crates/primitives/src/transaction/tt_authorization.rs
+++ b/crates/primitives/src/transaction/tt_authorization.rs
@@ -81,6 +81,9 @@ impl TempoSignedAuthorization {
     ///
     /// Implementers should check that the authority has no code.
     pub fn recover_authority(&self) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        if self.signature.is_multisig() {
+            return Err(alloy_consensus::crypto::RecoveryError::new());
+        }
         let sig_hash = self.signature_hash();
         self.signature.recover_signer(&sig_hash)
     }

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -653,6 +653,14 @@ impl AccessKeySignature {
         }
     }
 
+    /// Returns the stored access-key type, including multisig.
+    pub fn key_type(&self) -> SignatureType {
+        match self {
+            Self::Primitive(signature) => signature.signature_type(),
+            Self::Multisig(_) => SignatureType::Multisig,
+        }
+    }
+
     /// Returns the primitive algorithm, when applicable.
     pub fn signature_type(&self) -> Option<SignatureType> {
         match self {
@@ -2277,7 +2285,7 @@ mod tests {
     }
 
     #[test]
-    fn test_signature_type_is_none_for_multisig() {
+    fn test_access_key_signature_types() {
         let config = MultisigConfig {
             salt: B256::ZERO,
             version: 1,
@@ -2297,6 +2305,44 @@ mod tests {
         );
 
         assert_eq!(signature.signature_type(), None);
+        let TempoSignature::Multisig(multisig) = signature else {
+            unreachable!()
+        };
+        for (signature, key_type, primitive_type) in [
+            (
+                AccessKeySignature::Primitive(PrimitiveSignature::default()),
+                SignatureType::Secp256k1,
+                Some(SignatureType::Secp256k1),
+            ),
+            (
+                PrimitiveSignature::P256(P256SignatureWithPreHash {
+                    r: B256::ZERO,
+                    s: B256::ZERO,
+                    pub_key_x: B256::ZERO,
+                    pub_key_y: B256::ZERO,
+                    pre_hash: false,
+                })
+                .into(),
+                SignatureType::P256,
+                Some(SignatureType::P256),
+            ),
+            (
+                PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                    r: B256::ZERO,
+                    s: B256::ZERO,
+                    pub_key_x: B256::ZERO,
+                    pub_key_y: B256::ZERO,
+                    webauthn_data: Bytes::new(),
+                })
+                .into(),
+                SignatureType::WebAuthn,
+                Some(SignatureType::WebAuthn),
+            ),
+            (multisig.into(), SignatureType::Multisig, None),
+        ] {
+            assert_eq!(signature.key_type(), key_type);
+            assert_eq!(signature.signature_type(), primitive_type);
+        }
     }
 
     #[test]

--- a/crates/primitives/src/transaction/tt_signature.rs
+++ b/crates/primitives/src/transaction/tt_signature.rs
@@ -1,8 +1,15 @@
-use super::tempo_transaction::{
-    MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH, SignatureType,
+#[cfg(test)]
+use super::multisig::MultisigConfig;
+use super::{
+    multisig::{MultisigSignature, SIGNATURE_TYPE_MULTISIG},
+    tempo_transaction::{
+        MAX_WEBAUTHN_SIGNATURE_LENGTH, P256_SIGNATURE_LENGTH, SECP256K1_SIGNATURE_LENGTH,
+        SignatureType,
+    },
 };
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, Bytes, Signature, U256, keccak256, uint};
+use alloy_rlp::Encodable;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use sha2::{Digest, Sha256};
 
@@ -416,13 +423,13 @@ pub enum KeychainVersionError {
 /// The inner signature proves an authorized access key signed the transaction.
 /// The handler validates that user_address has authorized the access key in the KeyChain precompile.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "camelCase"))]
 pub struct KeychainSignature {
     /// Root account address that this transaction is being executed for
     pub user_address: Address,
-    /// The actual signature from the access key (can be Secp256k1, P256, or WebAuthn, but NOT another Keychain)
-    pub signature: PrimitiveSignature,
+    /// Direct primitive approval or multisig owner quorum from the access key.
+    pub signature: AccessKeySignature,
     /// Keychain signature version (V1 = legacy, V2 = includes user_address in sig hash)
     #[cfg_attr(feature = "serde", serde(default))]
     pub version: KeychainVersion,
@@ -445,10 +452,10 @@ impl KeychainSignature {
     /// Create a new V2 KeychainSignature (recommended).
     ///
     /// V2 signatures include the user_address in the signature hash.
-    pub fn new(user_address: Address, signature: PrimitiveSignature) -> Self {
+    pub fn new(user_address: Address, signature: impl Into<AccessKeySignature>) -> Self {
         Self {
             user_address,
-            signature,
+            signature: signature.into(),
             version: KeychainVersion::V2,
             cached_key_id: OnceLock::new(),
         }
@@ -461,7 +468,7 @@ impl KeychainSignature {
     pub fn new_v1(user_address: Address, signature: PrimitiveSignature) -> Self {
         Self {
             user_address,
-            signature,
+            signature: signature.into(),
             version: KeychainVersion::V1,
             cached_key_id: OnceLock::new(),
         }
@@ -480,15 +487,17 @@ impl KeychainSignature {
 
     /// Get the access key ID for Keychain signatures.
     ///
-    /// For Keychain signatures, this returns the access key address that signed the transaction.
-    /// The key_id is recovered from the inner signature on first access and cached for
-    /// subsequent calls. Returns None for non-Keychain signatures.
+    /// Verifies a primitive approval or returns the named multisig delegate, caching its ID.
+    /// A multisig ID requires account binding, state, and owner-quorum checks by the caller.
     ///
     /// This follows the pattern used in alloy for lazy hash computation.
     pub fn key_id(
         &self,
         sig_hash: &B256,
     ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        if self.is_legacy() && self.signature.as_multisig().is_some() {
+            return Err(alloy_consensus::crypto::RecoveryError::new());
+        }
         // Check if already cached
         if let Some(cached) = self.cached_key_id.get() {
             return Ok(*cached);
@@ -496,7 +505,7 @@ impl KeychainSignature {
 
         // Not cached - recover and cache
         let effective_hash = self.effective_sig_hash(sig_hash);
-        let key_id = self.signature.recover_signer(&effective_hash)?;
+        let key_id = self.signature.recover_account(&effective_hash)?;
         #[allow(clippy::useless_conversion)]
         let _ = self.cached_key_id.set(key_id.into());
         Ok(key_id)
@@ -519,6 +528,32 @@ impl KeychainSignature {
         buf[1..33].copy_from_slice(sig_hash.as_slice());
         buf[33..].copy_from_slice(user_address.as_slice());
         keccak256(buf)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for KeychainSignature {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Fields {
+            user_address: Address,
+            signature: AccessKeySignature,
+            #[serde(default)]
+            version: KeychainVersion,
+        }
+        let fields = Fields::deserialize(deserializer)?;
+        if fields.version == KeychainVersion::V1 && fields.signature.as_multisig().is_some() {
+            return Err(serde::de::Error::custom(
+                "multisig access keys require keychain V2",
+            ));
+        }
+        Ok(Self {
+            user_address: fields.user_address,
+            signature: fields.signature,
+            version: fields.version,
+            cached_key_id: OnceLock::new(),
+        })
     }
 }
 
@@ -546,12 +581,143 @@ impl core::hash::Hash for KeychainSignature {
 #[cfg(any(test, feature = "arbitrary"))]
 impl<'a> arbitrary::Arbitrary<'a> for KeychainSignature {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let version = u.arbitrary()?;
         Ok(Self {
             user_address: u.arbitrary()?,
-            signature: u.arbitrary()?,
-            version: u.arbitrary()?,
+            signature: if version == KeychainVersion::V1 {
+                AccessKeySignature::Primitive(u.arbitrary()?)
+            } else {
+                u.arbitrary()?
+            },
+            version,
             cached_key_id: OnceLock::new(), // Always start with empty cache
         })
+    }
+}
+
+/// Bounded direct approval used inside a V2 access-key envelope.
+///
+/// Multisig owner approvals are primitive, and neither variant can contain a keychain.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+#[cfg_attr(any(test, feature = "arbitrary"), derive(arbitrary::Arbitrary))]
+pub enum AccessKeySignature {
+    /// An existing primitive approval.
+    Primitive(PrimitiveSignature),
+    /// A configurable delegate's direct owner quorum.
+    Multisig(MultisigSignature),
+}
+
+impl AccessKeySignature {
+    /// Decodes a direct approval, rejecting recursive keychain envelopes.
+    pub fn from_bytes(data: &[u8]) -> Result<Self, &'static str> {
+        if data.len() != SECP256K1_SIGNATURE_LENGTH
+            && matches!(
+                data.first(),
+                Some(&SIGNATURE_TYPE_KEYCHAIN | &SIGNATURE_TYPE_KEYCHAIN_V2)
+            )
+        {
+            return Err("recursive keychain signature");
+        }
+        match TempoSignature::from_bytes(data)? {
+            TempoSignature::Primitive(signature) => Ok(Self::Primitive(signature)),
+            TempoSignature::Multisig(signature) => Ok(Self::Multisig(signature)),
+            TempoSignature::Keychain(_) => Err("recursive keychain signature"),
+        }
+    }
+
+    /// Returns the direct approval's existing wire encoding.
+    pub fn to_bytes(&self) -> Bytes {
+        let mut bytes = Vec::with_capacity(self.encoded_length());
+        self.encode_bytes_into(&mut bytes);
+        bytes.into()
+    }
+
+    /// Writes the direct approval without allocating an intermediate buffer.
+    pub fn encode_bytes_into(&self, out: &mut dyn alloy_rlp::BufMut) {
+        match self {
+            Self::Primitive(signature) => signature.encode_bytes_into(out),
+            Self::Multisig(signature) => {
+                out.put_u8(SIGNATURE_TYPE_MULTISIG);
+                signature.encode(out);
+            }
+        }
+    }
+
+    /// Returns the encoded byte length.
+    pub fn encoded_length(&self) -> usize {
+        match self {
+            Self::Primitive(signature) => signature.encoded_length(),
+            Self::Multisig(signature) => 1 + signature.length(),
+        }
+    }
+
+    /// Returns the primitive algorithm, when applicable.
+    pub fn signature_type(&self) -> Option<SignatureType> {
+        match self {
+            Self::Primitive(signature) => Some(signature.signature_type()),
+            Self::Multisig(_) => None,
+        }
+    }
+
+    /// Returns the primitive approval, when applicable.
+    pub fn as_primitive(&self) -> Option<&PrimitiveSignature> {
+        match self {
+            Self::Primitive(signature) => Some(signature),
+            Self::Multisig(_) => None,
+        }
+    }
+
+    /// Returns the configurable delegate witness, when applicable.
+    pub fn as_multisig(&self) -> Option<&MultisigSignature> {
+        match self {
+            Self::Multisig(signature) => Some(signature),
+            Self::Primitive(_) => None,
+        }
+    }
+
+    /// Verifies and recovers a primitive signer. Multisig requires stateful validation.
+    pub fn recover_signer(
+        &self,
+        digest: &B256,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        self.as_primitive()
+            .ok_or_else(alloy_consensus::crypto::RecoveryError::new)?
+            .recover_signer(digest)
+    }
+
+    /// Recovers a primitive signer or returns the shape-validated multisig account.
+    ///
+    /// A returned multisig account is untrusted until state and owner quorum are checked.
+    pub fn recover_account(
+        &self,
+        digest: &B256,
+    ) -> Result<Address, alloy_consensus::crypto::RecoveryError> {
+        match self {
+            Self::Primitive(signature) => signature.recover_signer(digest),
+            Self::Multisig(signature) => Ok(signature.account()),
+        }
+    }
+
+    /// Returns a heuristic in-memory size.
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Primitive(signature) => signature.size(),
+            Self::Multisig(signature) => signature.size(),
+        }
+    }
+}
+
+impl From<PrimitiveSignature> for AccessKeySignature {
+    fn from(signature: PrimitiveSignature) -> Self {
+        Self::Primitive(signature)
+    }
+}
+
+impl From<MultisigSignature> for AccessKeySignature {
+    fn from(signature: MultisigSignature) -> Self {
+        Self::Multisig(signature)
     }
 }
 
@@ -568,11 +734,12 @@ pub enum TempoSignature {
     /// Primitive signature types: Secp256k1, P256, or WebAuthn
     Primitive(PrimitiveSignature),
 
-    /// Keychain signature - wraps another signature with a key identifier
-    /// Format: key_id (20 bytes) + inner signature
-    /// IMP: The inner signature MUST NOT be another Keychain (validated at runtime)
-    /// Note: Recursion is prevented by KeychainSignature's custom Arbitrary impl
+    /// Parent address plus a direct primitive or multisig approval.
+    /// The inner signature type and decoder exclude nested keychains.
     Keychain(KeychainSignature),
+
+    /// Native multisig signature.
+    Multisig(MultisigSignature),
 }
 
 impl TempoSignature {
@@ -586,10 +753,22 @@ impl TempoSignature {
             return Err("Signature data is empty");
         }
 
-        // Check if this is a Keychain signature (type identifier 0x03 or 0x04)
-        // We need to handle this specially before delegating to PrimitiveSignature
+        if data.len() == SECP256K1_SIGNATURE_LENGTH {
+            return PrimitiveSignature::from_bytes(data).map(Self::Primitive);
+        }
+
+        if data.len() > 1 && data[0] == SIGNATURE_TYPE_MULTISIG {
+            let mut sig_data = &data[1..];
+            match MultisigSignature::decode_rlp(&mut sig_data) {
+                Ok(signature) if sig_data.is_empty() => return Ok(Self::Multisig(signature)),
+                _ => return Err("Invalid Multisig signature RLP"),
+            }
+        }
+
+        // Check if this is a Keychain signature before delegating to
+        // PrimitiveSignature. The exact 65-byte secp256k1 path remains untyped for
+        // backwards compatibility.
         if data.len() > 1
-            && data.len() != SECP256K1_SIGNATURE_LENGTH
             && (data[0] == SIGNATURE_TYPE_KEYCHAIN || data[0] == SIGNATURE_TYPE_KEYCHAIN_V2)
         {
             let version = if data[0] == SIGNATURE_TYPE_KEYCHAIN {
@@ -607,9 +786,11 @@ impl TempoSignature {
             let user_address = Address::from_slice(&sig_data[0..20]);
             let inner_sig_bytes = &sig_data[20..];
 
-            // Parse inner signature using PrimitiveSignature (which doesn't support Keychain)
-            // This automatically prevents recursive keychain signatures at compile time
-            let inner_signature = PrimitiveSignature::from_bytes(inner_sig_bytes)?;
+            // A bounded direct approval cannot contain another keychain.
+            let inner_signature = AccessKeySignature::from_bytes(inner_sig_bytes)?;
+            if version == KeychainVersion::V1 && inner_signature.as_multisig().is_some() {
+                return Err("multisig access keys require keychain V2");
+            }
 
             return Ok(Self::Keychain(KeychainSignature {
                 user_address,
@@ -632,7 +813,7 @@ impl TempoSignature {
     pub fn to_bytes(&self) -> Bytes {
         match self {
             Self::Primitive(primitive_sig) => primitive_sig.to_bytes(),
-            Self::Keychain(_) => {
+            Self::Keychain(_) | Self::Multisig(_) => {
                 let mut bytes = Vec::with_capacity(self.encoded_length());
                 self.encode_bytes_into(&mut bytes);
                 Bytes::from(bytes)
@@ -655,6 +836,10 @@ impl TempoSignature {
                 out.put_slice(keychain_sig.user_address.as_slice());
                 keychain_sig.signature.encode_bytes_into(out);
             }
+            Self::Multisig(multisig_sig) => {
+                out.put_u8(SIGNATURE_TYPE_MULTISIG);
+                multisig_sig.encode(out);
+            }
         }
     }
 
@@ -667,14 +852,16 @@ impl TempoSignature {
         match self {
             Self::Primitive(primitive_sig) => primitive_sig.encoded_length(),
             Self::Keychain(keychain_sig) => 1 + 20 + keychain_sig.signature.encoded_length(),
+            Self::Multisig(multisig_sig) => 1 + multisig_sig.length(),
         }
     }
 
-    /// Get signature type
-    pub fn signature_type(&self) -> SignatureType {
+    /// Get the primitive signature type, if the outer signature has one.
+    pub fn signature_type(&self) -> Option<SignatureType> {
         match self {
-            Self::Primitive(primitive_sig) => primitive_sig.signature_type(),
+            Self::Primitive(primitive_sig) => Some(primitive_sig.signature_type()),
             Self::Keychain(keychain_sig) => keychain_sig.signature.signature_type(),
+            Self::Multisig(_) => None,
         }
     }
 
@@ -683,6 +870,7 @@ impl TempoSignature {
         match self {
             Self::Primitive(primitive_sig) => primitive_sig.size(),
             Self::Keychain(keychain_sig) => 1 + 20 + keychain_sig.signature.size(),
+            Self::Multisig(multisig_sig) => 1 + multisig_sig.size(),
         }
     }
 
@@ -694,12 +882,16 @@ impl TempoSignature {
     /// - WebAuthn: Parses WebAuthn data, verifies P256 signature, derives address
     /// - Keychain: Validates inner signature and returns user_address
     ///
-    /// For Keychain signatures, this performs full validation of the inner signature.
+    /// For primitive Keychain signatures, this verifies the inner signature.
+    /// A multisig delegate only supplies its claimed ID here and requires stateful validation.
     /// The access key address is cached in the KeychainSignature for later use.
     /// Note: This pattern has a big footgun, that someone using recover_signer, cannot assume
     /// that the signature is valid for the keychain. They also need to check the access key is authorized
     /// in the keychain precompile.
     /// We cannot check this here, as we don't have access to the keychain precompile.
+    ///
+    /// - Multisig: returns the account from the shape-validated signature. Versioned configs remain
+    ///   untrusted until stateful validation matches the commitment and verifies owner quorum.
     pub fn recover_signer(
         &self,
         sig_hash: &B256,
@@ -713,12 +905,18 @@ impl TempoSignature {
                 // Return the user_address - the root account this transaction is for
                 Ok(keychain_sig.user_address)
             }
+            Self::Multisig(multisig_sig) => Ok(multisig_sig.account()),
         }
     }
 
     /// Check if this is a Keychain signature
     pub fn is_keychain(&self) -> bool {
         matches!(self, Self::Keychain(_))
+    }
+
+    /// Check if this is a native multisig signature.
+    pub fn is_multisig(&self) -> bool {
+        matches!(self, Self::Multisig(_))
     }
 
     /// Check if this is a legacy V1 Keychain signature (deprecated at T1C).
@@ -755,6 +953,14 @@ impl TempoSignature {
     pub fn as_keychain(&self) -> Option<&KeychainSignature> {
         match self {
             Self::Keychain(keychain_sig) => Some(keychain_sig),
+            _ => None,
+        }
+    }
+
+    /// Get the native multisig signature if this is a multisig signature.
+    pub fn as_multisig(&self) -> Option<&MultisigSignature> {
+        match self {
+            Self::Multisig(multisig_sig) => Some(multisig_sig),
             _ => None,
         }
     }
@@ -795,6 +1001,12 @@ impl alloy_rlp::Decodable for TempoSignature {
 impl From<Signature> for TempoSignature {
     fn from(signature: Signature) -> Self {
         Self::Primitive(PrimitiveSignature::Secp256k1(signature))
+    }
+}
+
+impl From<PrimitiveSignature> for TempoSignature {
+    fn from(signature: PrimitiveSignature) -> Self {
+        Self::Primitive(signature)
     }
 }
 
@@ -1045,6 +1257,10 @@ mod tests {
         let pub_key_x = B256::from_slice(encoded_point.x().unwrap().as_ref());
         let pub_key_y = B256::from_slice(encoded_point.y().unwrap().as_ref());
         (signing_key, pub_key_x, pub_key_y)
+    }
+
+    fn valid_multisig_owner_signature() -> PrimitiveSignature {
+        PrimitiveSignature::Secp256k1(alloy_primitives::Signature::test_signature())
     }
 
     /// Sign a message hash with P256, normalize s, return (r, s)
@@ -1554,6 +1770,28 @@ mod tests {
     }
 
     #[test]
+    fn test_tempo_signature_65_byte_multisig_shape_decodes_as_secp256k1() {
+        let account = Address::repeat_byte(0x11);
+        let signatures = vec![Bytes::from(vec![0x33; 39])];
+        let payload_length = account.length() + signatures.length();
+
+        let mut sig_bytes = vec![SIGNATURE_TYPE_MULTISIG];
+        alloy_rlp::Header {
+            list: true,
+            payload_length,
+        }
+        .encode(&mut sig_bytes);
+        account.encode(&mut sig_bytes);
+        signatures.encode(&mut sig_bytes);
+
+        assert_eq!(sig_bytes.len(), SECP256K1_SIGNATURE_LENGTH);
+        assert!(matches!(
+            TempoSignature::from_bytes(&sig_bytes).unwrap(),
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(_))
+        ));
+    }
+
+    #[test]
     fn test_tempo_signature_from_bytes_p256() {
         use super::{P256_SIGNATURE_LENGTH, SIGNATURE_TYPE_P256};
 
@@ -1567,6 +1805,27 @@ mod tests {
         } else {
             panic!("Expected Primitive(P256) variant");
         }
+    }
+
+    #[test]
+    fn test_p256_from_bytes_canonicalizes_prehash_flag() {
+        // Decoding is lenient (any nonzero flag byte means pre_hash=true), matching the deployed
+        // network, and re-encoding is canonical, so noncanonical flag bytes cannot malleate hashes.
+        let mut sig_bytes = vec![SIGNATURE_TYPE_P256];
+        sig_bytes.extend_from_slice(&[0u8; P256_SIGNATURE_LENGTH]);
+
+        sig_bytes[1 + P256_SIGNATURE_LENGTH - 1] = 0;
+        let decoded = TempoSignature::from_bytes(&sig_bytes).expect("flag 0 decodes");
+        assert_eq!(decoded.to_bytes(), Bytes::from(sig_bytes.clone()));
+
+        sig_bytes[1 + P256_SIGNATURE_LENGTH - 1] = 2;
+        let decoded = TempoSignature::from_bytes(&sig_bytes).expect("noncanonical flag decodes");
+        let reencoded = decoded.to_bytes();
+        assert_eq!(
+            reencoded[reencoded.len() - 1],
+            1,
+            "noncanonical pre_hash flag re-encodes to the canonical 0x01"
+        );
     }
 
     #[test]
@@ -1646,7 +1905,9 @@ mod tests {
 
         // Test P256
         let mut sig2_bytes = vec![SIGNATURE_TYPE_P256];
-        sig2_bytes.extend_from_slice(&[2u8; P256_SIGNATURE_LENGTH]);
+        let mut p256_payload = [2u8; P256_SIGNATURE_LENGTH];
+        p256_payload[128] = 1;
+        sig2_bytes.extend_from_slice(&p256_payload);
         let sig2 = TempoSignature::from_bytes(&sig2_bytes).unwrap();
         let encoded2 = sig2.to_bytes();
         assert_eq!(encoded2.len(), 1 + P256_SIGNATURE_LENGTH);
@@ -2013,6 +2274,55 @@ mod tests {
             key_id_a, key_id_b,
             "V2 should recover different key_ids for different user_addresses"
         );
+    }
+
+    #[test]
+    fn test_signature_type_is_none_for_multisig() {
+        let config = MultisigConfig {
+            salt: B256::ZERO,
+            version: 1,
+            threshold: 1,
+            owners: vec![crate::transaction::MultisigOwner {
+                owner: Address::repeat_byte(0x22),
+                weight: 1,
+            }],
+        };
+        let signature = TempoSignature::Multisig(
+            MultisigSignature::try_new(
+                Address::repeat_byte(0x11),
+                config,
+                vec![valid_multisig_owner_signature()],
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(signature.signature_type(), None);
+    }
+
+    #[test]
+    fn test_recover_signer_multisig_only_recovers_account() {
+        use crate::transaction::MultisigOwner;
+
+        let config = MultisigConfig {
+            salt: B256::repeat_byte(0x42),
+            version: 0,
+            threshold: 1,
+            owners: vec![MultisigOwner {
+                owner: Address::repeat_byte(0x11),
+                weight: 1,
+            }],
+        };
+        let account = config.derive_account(Address::repeat_byte(0x99)).unwrap();
+        let inner_hash = B256::repeat_byte(0x24);
+        let signature = TempoSignature::Multisig(
+            MultisigSignature::try_new(account, config, vec![valid_multisig_owner_signature()])
+                .unwrap(),
+        );
+
+        // recover_signer returns the claimed account after stateless shape checks only; it does
+        // not verify owner approvals. Stateful owner-threshold verification is exercised by the
+        // native multisig precompile tests.
+        assert_eq!(signature.recover_signer(&inner_hash).unwrap(), account);
     }
 
     #[test]

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -1259,7 +1259,9 @@ mod tests {
         // Verify the inner signature is WebAuthn
         assert!(matches!(
             keychain_sig.signature,
-            PrimitiveSignature::WebAuthn(_)
+            tempo_primitives::transaction::AccessKeySignature::Primitive(
+                PrimitiveSignature::WebAuthn(_)
+            )
         ));
 
         // Verify key_id recovery works correctly using the transaction signature hash

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -61,9 +61,7 @@ use tempo_primitives::{
 
 use crate::{
     ProtocolFeeContext, TempoBatchCallEnv, TempoEvm, TempoInvalidTransaction,
-    error::FeePaymentError,
-    evm::TempoContext,
-    gas_credits,
+    error::FeePaymentError, evm::TempoContext, gas_credits,
     signature_gas::tempo_signature_verification_gas,
 };
 

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -64,7 +64,7 @@ use crate::{
     error::FeePaymentError,
     evm::TempoContext,
     gas_credits,
-    signature_gas::{primitive_signature_verification_gas, tempo_signature_verification_gas},
+    signature_gas::tempo_signature_verification_gas,
 };
 
 /// Base gas for KeyAuthorization (22k storage + 5k buffer), signature gas added at runtime
@@ -300,7 +300,7 @@ fn calculate_key_authorization_gas(
     // All signature types pay ECRECOVER_GAS (3k) as the baseline since
     // primitive_signature_verification_gas assumes ecrecover is already in base 21k.
     // For KeyAuthorization, we're doing an additional signature verification.
-    let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+    let sig_gas = ECRECOVER_GAS + tempo_signature_verification_gas(&key_auth.signature);
 
     let num_limits = key_auth
         .authorization
@@ -1316,7 +1316,7 @@ where
                         // type to authenticate as a key registered with a different type.
                         // Only validate signature type on T1+ to maintain backward compatibility
                         // with historical blocks during re-execution.
-                        let tx_sig_type = keychain_sig.signature.signature_type().into();
+                        let tx_sig_type = keychain_sig.signature.key_type().into();
                         let sig_type = (key_auth.is_some() || spec.is_t1()).then_some(tx_sig_type);
 
                         let key = keychain
@@ -1369,7 +1369,13 @@ where
                 .map_err(|_| TempoInvalidTransaction::KeyAuthorizationSignatureRecoveryFailed)?;
 
             if auth_signer != tx.caller {
-                let key_auth_sig_type: u8 = key_auth.signature.signature_type().into();
+                let key_auth_sig_type: u8 = key_auth
+                    .signature
+                    .signature_type()
+                    .ok_or_else(|| TempoInvalidTransaction::KeychainValidationFailed {
+                        reason: "multisig signatures are not supported".into(),
+                    })?
+                    .into();
                 let signer_is_admin = match loaded_tx_access_key {
                     Some(loaded_key)
                         if loaded_key.key_id == auth_signer
@@ -1550,6 +1556,7 @@ where
                     SignatureType::Secp256k1 => PrecompileSignatureType::Secp256k1,
                     SignatureType::P256 => PrecompileSignatureType::P256,
                     SignatureType::WebAuthn => PrecompileSignatureType::WebAuthn,
+                    SignatureType::Multisig => PrecompileSignatureType::Multisig,
                 };
 
                 // Handle expiry: None means never expires (store as u64::MAX)
@@ -1794,6 +1801,32 @@ where
             if tempo_primitives::subblock::has_sub_block_nonce_key_prefix(&aa_env.nonce_key) {
                 return Err(TempoInvalidTransaction::SubblockTransactionsDisabled.into());
             }
+            // Naming a native account is not owner authentication. Until native
+            // execution is available, reject every such role, including simulations.
+            let native = |signature: &tempo_primitives::transaction::TempoSignature| {
+                signature.as_multisig().is_some()
+                    || signature
+                        .as_keychain()
+                        .is_some_and(|key| key.signature.as_multisig().is_some())
+            };
+            if native(&aa_env.signature)
+                || aa_env
+                    .tempo_authorization_list
+                    .iter()
+                    .any(|auth| native(auth.signature()))
+                || aa_env.key_authorization.as_ref().is_some_and(|auth| {
+                    auth.key_type == SignatureType::Multisig
+                        || !matches!(
+                            auth.signature,
+                            tempo_primitives::transaction::TempoSignature::Primitive(_)
+                        )
+                })
+            {
+                return Err(TempoInvalidTransaction::KeychainValidationFailed {
+                    reason: "multisig signatures are not supported".into(),
+                }
+                .into());
+            }
             // Validate AA transaction structure (calls list, CREATE rules)
             validate_calls(
                 &aa_env.aa_calls,
@@ -1853,7 +1886,7 @@ where
 
                     if same_tx_auth_use
                         && cfg.spec.is_t3()
-                        && key_auth.key_type != keychain_sig.signature.signature_type()
+                        && key_auth.key_type != keychain_sig.signature.key_type()
                     {
                         return Err(TempoInvalidTransaction::KeychainValidationFailed {
                                 reason: "key authorization key_type does not match the keychain signature type"

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::{
     FeeTokenResolver, ProtocolFeeManager, TempoBlockEnv, TempoFeeManager, TempoTxEnv,
-    evm::TempoEvm, gas_params::tempo_gas_params, signature_gas::P256_VERIFY_GAS,
+    evm::TempoEvm,
+    gas_params::tempo_gas_params,
+    signature_gas::{P256_VERIFY_GAS, primitive_signature_verification_gas},
     tx::TempoBatchCallEnv,
 };
 use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
@@ -33,6 +35,124 @@ use tempo_primitives::transaction::{
 fn create_test_journal() -> Journal<CacheDB<EmptyDB>> {
     let db = CacheDB::new(EmptyDB::default());
     Journal::new(db)
+}
+
+#[test]
+fn unsupported_multisig_roles_fail_closed() {
+    use tempo_primitives::transaction::{
+        KeyAuthorization, KeychainSignature, MultisigConfig, MultisigOwner, MultisigSignature,
+    };
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum Role {
+        Primitive,
+        Direct,
+        Delegate,
+        Grant,
+        GrantRecipient,
+        AuthorizationList,
+        DelegatedAuthorizationList,
+        KeychainGrant,
+    }
+    let account = Address::repeat_byte(0x22);
+    let native = TempoSignature::Multisig(
+        MultisigSignature::try_new(
+            account,
+            MultisigConfig {
+                salt: B256::ZERO,
+                version: 0,
+                threshold: 1,
+                owners: vec![MultisigOwner {
+                    owner: Address::repeat_byte(0x33),
+                    weight: 1,
+                }],
+            },
+            vec![PrimitiveSignature::default()],
+        )
+        .unwrap(),
+    );
+    let delegated = TempoSignature::Keychain(KeychainSignature::new(
+        account,
+        native.as_multisig().unwrap().clone(),
+    ));
+    for simulation in [false, true] {
+        for role in [
+            Role::Primitive,
+            Role::Direct,
+            Role::Delegate,
+            Role::Grant,
+            Role::GrantRecipient,
+            Role::AuthorizationList,
+            Role::DelegatedAuthorizationList,
+            Role::KeychainGrant,
+        ] {
+            let mut aa = TempoBatchCallEnv {
+                aa_calls: vec![Call {
+                    to: TxKind::Call(Address::repeat_byte(0x44)),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                }],
+                override_key_id: simulation.then_some(account),
+                ..Default::default()
+            };
+            match role {
+                Role::Direct => aa.signature = native.clone(),
+                Role::Delegate => aa.signature = delegated.clone(),
+                Role::Grant | Role::GrantRecipient | Role::KeychainGrant => {
+                    aa.key_authorization = Some(
+                        KeyAuthorization::unrestricted(
+                            1,
+                            if role == Role::GrantRecipient {
+                                SignatureType::Multisig
+                            } else {
+                                SignatureType::Secp256k1
+                            },
+                            account,
+                        )
+                        .into_signed(if role == Role::Grant {
+                            native.clone()
+                        } else if role == Role::KeychainGrant {
+                            delegated.clone()
+                        } else {
+                            TempoSignature::default()
+                        }),
+                    );
+                }
+                Role::AuthorizationList | Role::DelegatedAuthorizationList => aa
+                    .tempo_authorization_list
+                    .push(RecoveredTempoAuthorization::new(
+                        TempoSignedAuthorization::new_unchecked(
+                            alloy_eips::eip7702::Authorization {
+                                chain_id: U256::ONE,
+                                address: account,
+                                nonce: 0,
+                            },
+                            if role == Role::AuthorizationList {
+                                native.clone()
+                            } else {
+                                delegated.clone()
+                            },
+                        ),
+                    )),
+                Role::Primitive => {}
+            }
+            let mut test =
+                TestHandlerEvm::aa(TempoHardfork::T12, aa, |tx| tx.gas_limit = 1_000_000);
+            let result = test.handler.validate_env(&mut test.evm);
+            if role == Role::Primitive {
+                result.unwrap();
+            } else {
+                assert!(
+                    matches!(
+                        result,
+                        Err(EVMError::Transaction(
+                            TempoInvalidTransaction::KeychainValidationFailed { .. }
+                        ))
+                    ),
+                    "{role:?}, simulation={simulation}: {result:?}"
+                );
+            }
+        }
+    }
 }
 
 #[test_case::test_case(TempoHardfork::T1A; "historical")]
@@ -1309,7 +1429,7 @@ fn test_t4_key_authorization_matches_tip1016_sstore_regular_cost() {
     // TIP-1016 is opt-in via amsterdam_eip8037; manually enable for this test.
     let gas_params = crate::gas_params::tempo_gas_params_with_amsterdam(TempoHardfork::T4, true);
 
-    let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+    let sig_gas = ECRECOVER_GAS + tempo_signature_verification_gas(&key_auth.signature);
     let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
     let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
     let (regular_gas, state_gas) =
@@ -1331,7 +1451,7 @@ fn test_t7_key_authorization_intrinsic_includes_storage_credit_value() {
         ));
 
     let gas_params = crate::gas_params::tempo_gas_params(TempoHardfork::T7);
-    let sig_gas = ECRECOVER_GAS + primitive_signature_verification_gas(&key_auth.signature);
+    let sig_gas = ECRECOVER_GAS + tempo_signature_verification_gas(&key_auth.signature);
     let sload = gas_params.warm_storage_read_cost() + gas_params.cold_storage_additional_cost();
     let scope_extra_gas = call_scope_extra_gas(&key_auth.authorization);
     let (regular_gas, state_gas) =

--- a/crates/revm/src/signature_gas.rs
+++ b/crates/revm/src/signature_gas.rs
@@ -1,7 +1,7 @@
 use revm::interpreter::gas::{
     COLD_SLOAD_COST, STANDARD_TOKEN_COST, get_tokens_in_calldata_istanbul,
 };
-use tempo_primitives::transaction::{PrimitiveSignature, TempoSignature};
+use tempo_primitives::transaction::{AccessKeySignature, PrimitiveSignature, TempoSignature};
 
 /// Additional gas for P256 signature verification.
 ///
@@ -39,7 +39,16 @@ pub(crate) fn tempo_signature_verification_gas(signature: &TempoSignature) -> u6
     match signature {
         TempoSignature::Primitive(prim_sig) => primitive_signature_verification_gas(prim_sig),
         TempoSignature::Keychain(keychain_sig) => {
-            primitive_signature_verification_gas(&keychain_sig.signature) + KEYCHAIN_VALIDATION_GAS
+            match &keychain_sig.signature {
+                AccessKeySignature::Primitive(signature) => {
+                    primitive_signature_verification_gas(signature) + KEYCHAIN_VALIDATION_GAS
+                }
+                // Native pricing is unavailable here. validate_env rejects these signatures
+                // before gas calculation, so zero is unreachable for accepted transactions.
+                AccessKeySignature::Multisig(_) => 0,
+            }
         }
+        // The same validate_env rejection applies to direct native signatures.
+        TempoSignature::Multisig(_) => 0,
     }
 }


### PR DESCRIPTION
Adds bounded primitive-owner multisig signatures and configurable access-key encoding for TIP-1111 and TIP-1114 in #7510. Preserves existing primitive and V1 encodings while rejecting recursive keychain authorization forms.