### PR TITLE
feat(rpc): support configurable account simulation

### DIFF
--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -325,15 +325,10 @@ impl TempoAccessKey {
                 "chain ID does not match the selected key",
             ));
         }
-        if authorization
-            .account
-            .is_some_and(|account| account != self.account)
-        {
-            return Err(TempoAccessKeyError::InvalidAuthorization(
-                "account does not match the selected key",
-            ));
-        }
+        validate_authorization_for_account(self.account, authorization)
+            .map_err(TempoAccessKeyError::AuthorizationAccount)?;
         if authorization.account.is_none()
+            && matches!(authorization.signature, TempoSignature::Primitive(_))
             && authorization.recover_signer().ok() != Some(self.account)
         {
             return Err(TempoAccessKeyError::InvalidAuthorization(
@@ -675,6 +670,8 @@ enum TempoAccessKeyError {
     AuthorizationMismatch,
     #[error("invalid pending Tempo key authorization: {0}")]
     InvalidAuthorization(&'static str),
+    #[error("invalid pending Tempo key authorization: {0}")]
+    AuthorizationAccount(String),
     #[error(
         "Tempo key authorization for {key_id} on account {account} and chain {chain_id} is already in flight"
     )]
@@ -747,6 +744,9 @@ pub enum TempoAccountsError {
     /// A supplied authorization did not describe the access key being stored.
     #[error("invalid Tempo Accounts access-key authorization: {0}")]
     InvalidAuthorization(&'static str),
+    /// An authorization names another parent account.
+    #[error("invalid Tempo Accounts access-key authorization: {0}")]
+    AuthorizationAccount(String),
     /// The active account selector was missing or invalid.
     #[error("Tempo Accounts active account is missing or invalid")]
     ActiveAccount,
@@ -1798,7 +1798,14 @@ struct PersistedSignedKeyAuthorization {
     account: Option<Address>,
     #[serde(rename = "type")]
     key_type: PersistedKeyType,
-    signature: PersistedPrimitiveSignature,
+    signature: PersistedAuthorizationSignature,
+}
+
+#[derive(Clone, Deserialize)]
+#[serde(untagged)]
+enum PersistedAuthorizationSignature {
+    Primitive(PersistedPrimitiveSignature),
+    Multisig(tempo_primitives::transaction::MultisigSignature),
 }
 
 #[derive(Clone, Deserialize)]
@@ -1996,10 +2003,15 @@ impl TryFrom<PersistedSignedKeyAuthorization> for SignedKeyAuthorization {
             is_admin,
             account,
         };
-        Ok(Self::new(
-            authorization,
-            PrimitiveSignature::try_from(signature)?,
-        ))
+        let signature = match signature {
+            PersistedAuthorizationSignature::Primitive(signature) => {
+                TempoSignature::Primitive(PrimitiveSignature::try_from(signature)?)
+            }
+            PersistedAuthorizationSignature::Multisig(signature) => {
+                TempoSignature::Multisig(signature)
+            }
+        };
+        Ok(Self::new(authorization, signature))
     }
 }
 
@@ -2278,9 +2290,6 @@ fn stored_access_key(key: &PersistedAccessKey) -> Result<TempoStoredAccessKey, T
         authorization.key_id != key.address
             || authorization.chain_id != key.chain_id
             || authorization.key_type != key_type
-            || authorization
-                .account
-                .is_some_and(|account| account != key.access)
     }) {
         return Err(TempoAccountsError::InvalidAccessKey {
             address: key.address,
@@ -2288,6 +2297,14 @@ fn stored_access_key(key: &PersistedAccessKey) -> Result<TempoStoredAccessKey, T
         });
     }
 
+    if let Some(authorization) = &key_authorization {
+        validate_authorization_for_account(key.access, authorization).map_err(|reason| {
+            TempoAccountsError::InvalidAccessKey {
+                address: key.address,
+                reason,
+            }
+        })?;
+    }
     let allowed_calls =
         effective_allowed_calls(key, key_authorization.as_ref()).map_err(|error| {
             TempoAccountsError::InvalidAccessKey {
@@ -2341,15 +2358,34 @@ fn validate_stored_authorization(
             "the authorization key ID does not match the local signer",
         ));
     }
-    if authorization
-        .account
-        .is_some_and(|authorized| authorized != account)
+    validate_authorization_for_account(account, authorization)
+        .map_err(TempoAccountsError::AuthorizationAccount)
+}
+
+/// Checks explicit parent metadata and the named multisig account.
+/// Does not verify signatures or on-chain authority.
+fn validate_authorization_for_account(
+    account: Address,
+    authorization: &SignedKeyAuthorization,
+) -> Result<(), String> {
+    if let Some(actual) = authorization.account
+        && actual != account
     {
-        return Err(TempoAccountsError::InvalidAuthorization(
-            "the authorization targets a different account",
+        return Err(format!(
+            "authorization account mismatch: expected {account}, actual {actual}"
         ));
     }
-    Ok(())
+    match &authorization.signature {
+        TempoSignature::Primitive(_) => Ok(()),
+        TempoSignature::Multisig(signature) if signature.account() == account => Ok(()),
+        TempoSignature::Multisig(signature) => Err(format!(
+            "multisig signature account mismatch: expected {account}, actual {}",
+            signature.account()
+        )),
+        TempoSignature::Keychain(_) => {
+            Err("key authorization signatures cannot use keychain encoding".into())
+        }
+    }
 }
 
 struct EditableTempoCliStore {
@@ -2433,7 +2469,14 @@ struct WritableSignedKeyAuthorization {
     account: Option<Address>,
     #[serde(rename = "type")]
     key_type: &'static str,
-    signature: WritablePrimitiveSignature,
+    signature: WritableAuthorizationSignature,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum WritableAuthorizationSignature {
+    Primitive(WritablePrimitiveSignature),
+    Multisig(tempo_primitives::transaction::MultisigSignature),
 }
 
 #[derive(Serialize)]
@@ -2496,13 +2539,19 @@ fn writable_b256(value: B256) -> String {
 
 fn writable_signature(
     signature: &TempoSignature,
-) -> Result<WritablePrimitiveSignature, TempoAccountsError> {
-    let TempoSignature::Primitive(signature) = signature else {
-        return Err(TempoAccountsError::InvalidAuthorization(
-            "the Accounts store does not support nonprimitive authorization signatures",
-        ));
+) -> Result<WritableAuthorizationSignature, TempoAccountsError> {
+    let signature = match signature {
+        TempoSignature::Primitive(signature) => signature,
+        TempoSignature::Multisig(signature) => {
+            return Ok(WritableAuthorizationSignature::Multisig(signature.clone()));
+        }
+        TempoSignature::Keychain(_) => {
+            return Err(TempoAccountsError::InvalidAuthorization(
+                "key authorization signatures cannot use keychain encoding",
+            ));
+        }
     };
-    Ok(match signature {
+    Ok(WritableAuthorizationSignature::Primitive(match signature {
         PrimitiveSignature::Secp256k1(signature) => WritablePrimitiveSignature::Secp256k1 {
             signature: WritableSecpSignature {
                 r: writable_bigint(signature.r()),
@@ -2559,7 +2608,7 @@ fn writable_signature(
                 },
             }
         }
-    })
+    }))
 }
 
 fn writable_scopes(authorization: &SignedKeyAuthorization) -> Option<Vec<WritableScope>> {
@@ -3017,7 +3066,10 @@ fn select_access_key(
             continue;
         }
         if key_authorization.as_ref().is_some_and(|authorization| {
-            authorization.account.is_none() && authorization.recover_signer().ok() != Some(account)
+            validate_authorization_for_account(account, authorization).is_err()
+                || (authorization.account.is_none()
+                    && matches!(authorization.signature, TempoSignature::Primitive(_))
+                    && authorization.recover_signer().ok() != Some(account))
         }) {
             continue;
         }
@@ -3266,7 +3318,10 @@ mod tests {
     use alloy_network::{NetworkWallet, TransactionBuilder};
     use alloy_provider::{ProviderBuilder, SendableTx, fillers::TxFiller, mock::Asserter};
     use alloy_rpc_types_eth::{TransactionInput, TransactionRequest};
-    use tempo_primitives::{TempoTxEnvelope, transaction::TempoSignature};
+    use tempo_primitives::{
+        TempoTxEnvelope,
+        transaction::{MultisigConfig, MultisigOwner, MultisigSignature, TempoSignature},
+    };
 
     use super::*;
 
@@ -4921,5 +4976,83 @@ mod tests {
             },
         });
         fs::write(path, serde_json::to_vec(&value).unwrap()).unwrap();
+    }
+
+    fn configurable_authorization(
+        account: Address,
+        signer: &PrivateKeySigner,
+    ) -> SignedKeyAuthorization {
+        let config = MultisigConfig {
+            salt: B256::ZERO,
+            version: 1,
+            threshold: 1,
+            owners: vec![MultisigOwner {
+                owner: Address::repeat_byte(1),
+                weight: 1,
+            }],
+        };
+        KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address())
+            .into_signed(TempoSignature::Multisig(
+                MultisigSignature::try_new(
+                    account,
+                    config,
+                    vec![PrimitiveSignature::Secp256k1(Signature::test_signature())],
+                )
+                .unwrap(),
+            ))
+    }
+
+    #[test]
+    fn configurable_parent_authorization_persists_complete_signature() {
+        let account = Address::repeat_byte(2);
+        let signer = PrivateKeySigner::random();
+        let authorization = configurable_authorization(account, &signer);
+        let writable = writable_access_key(account, &signer, &authorization).unwrap();
+        let value = serde_json::to_value(writable).unwrap();
+        assert!(value["keyAuthorization"]["signature"].is_string());
+        let persisted: PersistedSignedKeyAuthorization =
+            serde_json::from_value(value["keyAuthorization"].clone()).unwrap();
+        let decoded = SignedKeyAuthorization::try_from(persisted).unwrap();
+        assert_eq!(decoded, authorization);
+        assert!(validate_authorization_for_account(account, &decoded).is_ok());
+    }
+
+    #[test_case::test_case(false; "primitive")]
+    #[test_case::test_case(true; "multisig")]
+    fn explicit_wrong_account_metadata_is_rejected(multisig: bool) {
+        let account = Address::repeat_byte(2);
+        let signer = PrivateKeySigner::random();
+        let mut authorization = if multisig {
+            configurable_authorization(account, &signer)
+        } else {
+            KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address())
+                .into_signed(PrimitiveSignature::default())
+        };
+        authorization.authorization.account = Some(Address::repeat_byte(3));
+        let error = validate_authorization_for_account(account, &authorization).unwrap_err();
+        assert!(error.contains(&format!("expected {account}")));
+        assert!(error.contains(&format!("actual {}", Address::repeat_byte(3))));
+        assert!(validate_stored_authorization(account, &signer, &authorization).is_err());
+    }
+
+    #[test]
+    fn named_parent_mismatch_and_keychain_authorization_are_rejected() {
+        let account = Address::repeat_byte(2);
+        let signer = PrivateKeySigner::random();
+        assert!(
+            validate_authorization_for_account(
+                Address::repeat_byte(3),
+                &configurable_authorization(account, &signer)
+            )
+            .is_err()
+        );
+        let authorization =
+            KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address())
+                .into_signed(TempoSignature::Keychain(KeychainSignature::new(
+                    account,
+                    PrimitiveSignature::default(),
+                )));
+        assert!(validate_authorization_for_account(account, &authorization).is_err());
+        assert!(writable_signature(&authorization.signature).is_err());
     }
 }

--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -1987,8 +1987,13 @@ impl TryFrom<PersistedSignedKeyAuthorization> for SignedKeyAuthorization {
             // Ox 0.14 uses an empty RLP list as the positional limits
             // placeholder when scopes follow it. Preserve that exact signed
             // wire shape. Newer TIP-1053 fields switched skipped fields to the
-            // canonical optional null placeholder.
-            None if has_scopes && !has_tip1053_fields => Some(Vec::new()),
+            // canonical optional null placeholder. Native signatures never used this legacy form.
+            None if has_scopes
+                && !has_tip1053_fields
+                && matches!(&signature, PersistedAuthorizationSignature::Primitive(_)) =>
+            {
+                Some(Vec::new())
+            }
             None => None,
         };
         let allowed_calls = scopes.map(persisted_scopes_to_call_scopes).transpose()?;
@@ -5002,11 +5007,18 @@ mod tests {
             ))
     }
 
-    #[test]
-    fn configurable_parent_authorization_persists_complete_signature() {
+    #[test_case::test_case(false; "unscoped")]
+    #[test_case::test_case(true; "scoped_without_limits")]
+    fn configurable_parent_authorization_persists_complete_signature(scoped: bool) {
         let account = Address::repeat_byte(2);
         let signer = PrivateKeySigner::random();
-        let authorization = configurable_authorization(account, &signer);
+        let mut authorization = configurable_authorization(account, &signer);
+        if scoped {
+            authorization.authorization.allowed_calls = Some(vec![CallScope {
+                target: Address::repeat_byte(3),
+                selector_rules: Vec::new(),
+            }]);
+        }
         let writable = writable_access_key(account, &signer, &authorization).unwrap();
         let value = serde_json::to_value(writable).unwrap();
         assert!(value["keyAuthorization"]["signature"].is_string());
@@ -5014,6 +5026,8 @@ mod tests {
             serde_json::from_value(value["keyAuthorization"].clone()).unwrap();
         let decoded = SignedKeyAuthorization::try_from(persisted).unwrap();
         assert_eq!(decoded, authorization);
+        assert_eq!(decoded.signature_hash(), authorization.signature_hash());
+        assert_eq!(decoded.limits, None);
         assert!(validate_authorization_for_account(account, &decoded).is_ok());
     }
 

--- a/crates/alloy/src/accounts/store.rs
+++ b/crates/alloy/src/accounts/store.rs
@@ -5028,7 +5028,30 @@ mod tests {
             KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, signer.address())
                 .into_signed(PrimitiveSignature::default())
         };
-        authorization.authorization.account = Some(Address::repeat_byte(3));
+        let mut record =
+            serde_json::to_value(writable_access_key(account, &signer, &authorization).unwrap())
+                .unwrap();
+        let path = write_store(serde_json::json!([record]));
+        let store = TempoAccountsStore::open(&path).unwrap();
+        assert_eq!(
+            store.access_keys().unwrap()[0].key_authorization(),
+            Some(&authorization)
+        );
+        let wrong = Address::repeat_byte(3);
+        record["keyAuthorization"]["account"] = serde_json::json!(wrong);
+        overwrite_store(&path, serde_json::json!([record]));
+        let Err(TempoAccountsError::InvalidAccessKey { address, reason }) = store.access_keys()
+        else {
+            panic!("expected persisted account metadata rejection")
+        };
+        assert_eq!(address, signer.address());
+        assert_eq!(
+            reason,
+            format!("authorization account mismatch: expected {account}, actual {wrong}")
+        );
+        fs::remove_file(path).unwrap();
+
+        authorization.authorization.account = Some(wrong);
         let error = validate_authorization_for_account(account, &authorization).unwrap_err();
         assert!(error.contains(&format!("expected {account}")));
         assert!(error.contains(&format!("actual {}", Address::repeat_byte(3))));

--- a/crates/alloy/src/rpc/mod.rs
+++ b/crates/alloy/src/rpc/mod.rs
@@ -3,7 +3,11 @@
 mod header;
 pub use header::TempoHeaderResponse;
 
+mod native_multisig;
 mod request;
+#[cfg(feature = "revm")]
+pub use native_multisig::create_mock_native_multisig_signature;
+pub use native_multisig::{MultisigSimulationApproval, MultisigSimulationSpec};
 pub use request::{FeeToken, TempoCallBuilderExt, TempoTransactionRequest};
 
 mod receipt;

--- a/crates/alloy/src/rpc/native_multisig/mod.rs
+++ b/crates/alloy/src/rpc/native_multisig/mod.rs
@@ -12,7 +12,7 @@ use tempo_primitives::{
 
 /// One independently signed configurable role in a simulation.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct MultisigSimulationSpec {
     /// Full configuration at the requested state, encoded as RLP bytes.
     #[serde(with = "serde_multisig_config")]
@@ -36,6 +36,13 @@ impl MultisigSimulationSpec {
         let mut weight = MultisigWeightAccumulator::new(self.config.threshold)
             .map_err(|error| error.to_string())?;
         for approval in &self.approvals {
+            if approval
+                .key_data
+                .as_ref()
+                .is_some_and(|hint| !matches!(hint.len(), 1 | 2 | 4))
+            {
+                return Err("keyData must contain a 1-, 2-, or 4-byte length hint".into());
+            }
             if approval.key_type == Some(SignatureType::Multisig) {
                 return Err("multisig owners must use primitive signatures".into());
             }

--- a/crates/alloy/src/rpc/native_multisig/mod.rs
+++ b/crates/alloy/src/rpc/native_multisig/mod.rs
@@ -1,0 +1,165 @@
+use alloy_primitives::{Address, Bytes};
+use alloy_rlp::Decodable;
+use core::fmt;
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{Error as _, SeqAccess, Visitor},
+};
+use tempo_primitives::{
+    SignatureType,
+    transaction::{MAX_MULTISIG_SIGNATURES, MultisigConfig, MultisigWeightAccumulator},
+};
+
+/// One independently signed configurable role in a simulation.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MultisigSimulationSpec {
+    /// Full configuration at the requested state, encoded as RLP bytes.
+    #[serde(with = "serde_multisig_config")]
+    pub config: MultisigConfig,
+    /// Primitive owners in signing order.
+    #[serde(deserialize_with = "deserialize_approvals")]
+    pub approvals: Vec<MultisigSimulationApproval>,
+}
+
+impl MultisigSimulationSpec {
+    /// Checks the claimed primitive quorum before constructing simulation signatures.
+    pub fn validate_owners(&self, account: Address) -> Result<(), String> {
+        if self.approvals.len() > MAX_MULTISIG_SIGNATURES {
+            return Err(
+                tempo_primitives::transaction::MultisigQuorumError::TooManySignatures.to_string(),
+            );
+        }
+        self.config
+            .validate_for_account(account)
+            .map_err(|error| error.to_string())?;
+        let mut weight = MultisigWeightAccumulator::new(self.config.threshold)
+            .map_err(|error| error.to_string())?;
+        for approval in &self.approvals {
+            if approval.key_type == Some(SignatureType::Multisig) {
+                return Err("multisig owners must use primitive signatures".into());
+            }
+            let owner_weight = self
+                .config
+                .owner_weight(approval.owner)
+                .ok_or("multisig signer is not an owner")?;
+            weight
+                .record_owner(approval.owner, owner_weight)
+                .map_err(|error| error.to_string())?;
+        }
+        weight.finish().map_err(|error| error.to_string())
+    }
+}
+
+/// Primitive signature cost to model for one configured owner.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MultisigSimulationApproval {
+    pub owner: Address,
+    /// Omission conservatively models a maximum-size WebAuthn approval.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_type: Option<SignatureType>,
+    /// WebAuthn data-length hint; see [`TempoTransactionRequest::key_data`](super::TempoTransactionRequest::key_data).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_data: Option<Bytes>,
+}
+
+mod serde_multisig_config {
+    use super::*;
+    pub(super) fn serialize<S: Serializer>(
+        config: &MultisigConfig,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        Bytes::from(alloy_rlp::encode(config)).serialize(serializer)
+    }
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<MultisigConfig, D::Error> {
+        let encoded = Bytes::deserialize(deserializer)?;
+        let mut input = encoded.as_ref();
+        let config = MultisigConfig::decode(&mut input).map_err(D::Error::custom)?;
+        if !input.is_empty() {
+            return Err(D::Error::custom("trailing native multisig config bytes"));
+        }
+        config.validate().map_err(D::Error::custom)?;
+        Ok(config)
+    }
+}
+
+fn deserialize_approvals<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Vec<MultisigSimulationApproval>, D::Error> {
+    struct ApprovalsVisitor;
+    impl<'de> Visitor<'de> for ApprovalsVisitor {
+        type Value = Vec<MultisigSimulationApproval>;
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(
+                formatter,
+                "at most {MAX_MULTISIG_SIGNATURES} primitive approvals"
+            )
+        }
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            if seq
+                .size_hint()
+                .is_some_and(|size| size > MAX_MULTISIG_SIGNATURES)
+            {
+                return Err(A::Error::custom("too many multisig simulation approvals"));
+            }
+            let mut approvals = Vec::new();
+            while approvals.len() < MAX_MULTISIG_SIGNATURES {
+                let Some(approval) = seq.next_element()? else {
+                    return Ok(approvals);
+                };
+                approvals.push(approval);
+            }
+            if seq.next_element::<serde::de::IgnoredAny>()?.is_some() {
+                return Err(A::Error::custom("too many multisig simulation approvals"));
+            }
+            Ok(approvals)
+        }
+    }
+    deserializer.deserialize_seq(ApprovalsVisitor)
+}
+
+/// Constructs bounded dummy approvals only after checking the claimed owner quorum.
+#[cfg(feature = "revm")]
+pub fn create_mock_native_multisig_signature(
+    account: Address,
+    spec: &MultisigSimulationSpec,
+) -> Result<tempo_primitives::transaction::MultisigSignature, String> {
+    use alloy_primitives::B256;
+    use tempo_primitives::transaction::{
+        MAX_WEBAUTHN_SIGNATURE_LENGTH, MultisigSignature, PrimitiveSignature,
+        tt_signature::WebAuthnSignature,
+    };
+    spec.validate_owners(account)?;
+    let signatures = spec
+        .approvals
+        .iter()
+        .map(|approval| {
+            let signature = match approval.key_type {
+                None => PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                    webauthn_data: Bytes::from(vec![0xff; MAX_WEBAUTHN_SIGNATURE_LENGTH - 128]),
+                    r: B256::ZERO,
+                    s: B256::ZERO,
+                    pub_key_x: B256::ZERO,
+                    pub_key_y: B256::ZERO,
+                }),
+                Some(key_type) => {
+                    super::revm_compat::create_mock_primitive_signature_with_webauthn_limit(
+                        &key_type,
+                        approval.key_data.clone(),
+                        MAX_WEBAUTHN_SIGNATURE_LENGTH - 128,
+                    )
+                    .ok_or("multisig owners must use primitive signatures")?
+                }
+            };
+            Ok(signature)
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    MultisigSignature::try_new(account, spec.config.clone(), signatures)
+        .map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/alloy/src/rpc/native_multisig/tests.rs
+++ b/crates/alloy/src/rpc/native_multisig/tests.rs
@@ -1,0 +1,194 @@
+use super::*;
+use alloy_primitives::B256;
+use tempo_primitives::transaction::MultisigOwner;
+
+fn spec() -> MultisigSimulationSpec {
+    MultisigSimulationSpec {
+        config: MultisigConfig {
+            salt: B256::ZERO,
+            version: 1,
+            threshold: 2,
+            owners: vec![
+                MultisigOwner {
+                    owner: Address::repeat_byte(1),
+                    weight: 1,
+                },
+                MultisigOwner {
+                    owner: Address::repeat_byte(2),
+                    weight: 1,
+                },
+                MultisigOwner {
+                    owner: Address::repeat_byte(3),
+                    weight: 1,
+                },
+            ],
+        },
+        approvals: [1, 2]
+            .map(|owner| MultisigSimulationApproval {
+                owner: Address::repeat_byte(owner),
+                key_type: Some(SignatureType::Secp256k1),
+                key_data: None,
+            })
+            .to_vec(),
+    }
+}
+
+#[test]
+fn simulation_spec_roundtrips_config_as_rlp_bytes() {
+    let spec = spec();
+    let json = serde_json::to_value(&spec).unwrap();
+    assert!(json["config"].as_str().unwrap().starts_with("0x"));
+    assert_eq!(
+        serde_json::from_value::<MultisigSimulationSpec>(json).unwrap(),
+        spec
+    );
+}
+
+#[test_case::test_case(vec![]; "empty")]
+#[test_case::test_case(vec![1]; "insufficient")]
+#[test_case::test_case(vec![2,1]; "unsorted")]
+#[test_case::test_case(vec![1,1]; "duplicate")]
+#[test_case::test_case(vec![1,4]; "nonowner")]
+#[test_case::test_case(vec![1,2,3]; "after threshold")]
+#[test_case::test_case(vec![1;9]; "too many")]
+fn rejects_invalid_claimed_quorums(owners: Vec<u8>) {
+    let mut spec = spec();
+    spec.approvals = owners
+        .into_iter()
+        .map(|owner| MultisigSimulationApproval {
+            owner: Address::repeat_byte(owner),
+            key_type: None,
+            key_data: None,
+        })
+        .collect();
+    assert!(spec.validate_owners(Address::repeat_byte(9)).is_err());
+}
+
+#[test]
+fn rejects_nested_owner_and_oversized_json_list() {
+    let mut nested = spec();
+    nested.approvals[0].key_type = Some(SignatureType::Multisig);
+    assert!(nested.validate_owners(Address::repeat_byte(9)).is_err());
+    let mut json = serde_json::to_value(spec()).unwrap();
+    json["approvals"] = serde_json::json!([{"type":"multisig","spec":{}}]);
+    assert!(serde_json::from_value::<MultisigSimulationSpec>(json).is_err());
+    let mut value = spec();
+    value.approvals = vec![value.approvals[0].clone(); 9];
+    assert!(
+        serde_json::from_value::<MultisigSimulationSpec>(serde_json::to_value(value).unwrap())
+            .is_err()
+    );
+}
+
+#[cfg(feature = "revm")]
+#[test]
+fn mock_approvals_are_bounded_and_conservative() {
+    let mut spec = spec();
+    spec.approvals[0].key_type = None;
+    let signature = create_mock_native_multisig_signature(Address::repeat_byte(9), &spec).unwrap();
+    assert_eq!(signature.signatures()[0].encoded_length(), 2049);
+    assert_eq!(signature.signatures()[1].encoded_length(), 65);
+}
+
+#[cfg(feature = "reth")]
+#[test_case::test_case(0; "direct")]
+#[test_case::test_case(1; "delegate")]
+#[test_case::test_case(2; "inline grant")]
+fn native_roles_keep_transaction_context_with_empty_encoding(role: u8) {
+    use reth_evm::FromTxWithEncoded;
+    use tempo_primitives::{
+        TempoSignature, TempoTransaction,
+        transaction::{KeyAuthorization, KeychainSignature},
+    };
+    let account = Address::repeat_byte(9);
+    let multisig = create_mock_native_multisig_signature(account, &spec()).unwrap();
+    let mut tx = TempoTransaction::default();
+    let signature = match role {
+        0 => TempoSignature::Multisig(multisig),
+        1 => TempoSignature::Keychain(KeychainSignature::new(Address::repeat_byte(8), multisig)),
+        _ => {
+            tx.key_authorization = Some(
+                KeyAuthorization::unrestricted(
+                    4217,
+                    SignatureType::Secp256k1,
+                    Address::repeat_byte(8),
+                )
+                .into_signed(TempoSignature::Multisig(multisig)),
+            );
+            TempoSignature::default()
+        }
+    };
+    let tx = tx.into_signed(signature);
+    let env = tempo_revm::TempoTxEnv::from_encoded_tx(&tx, account, Bytes::new());
+    assert!(matches!(
+        env.execution_context,
+        tempo_revm::ExecutionContext::Transaction { .. }
+    ));
+}
+
+#[cfg(feature = "reth")]
+#[test_case::test_case(false; "direct")]
+#[test_case::test_case(true; "delegate")]
+fn block_simulation_rejects_configurable_roles(delegate: bool) {
+    use reth_rpc_convert::TryIntoSimTx;
+    let request = crate::rpc::TempoTransactionRequest {
+        multisig_simulation: Some(spec()),
+        key_id: delegate.then_some(Address::repeat_byte(9)),
+        ..Default::default()
+    };
+    let error =
+        TryIntoSimTx::<tempo_primitives::TempoTxEnvelope>::try_into_sim_tx(request).unwrap_err();
+    assert!(error.to_string().contains("evolving-position state"));
+}
+
+#[cfg(feature = "reth")]
+#[tokio::test]
+async fn signing_preserves_real_configurable_grant_without_simulation_hints() {
+    use alloy_signer::SignerSync;
+    use reth_rpc_convert::SignableTxRequest;
+    use tempo_primitives::{TempoSignature, TempoTxEnvelope, transaction::KeyAuthorization};
+    let signer = alloy_signer_local::PrivateKeySigner::random();
+    let parent = signer.address();
+    let authorization =
+        KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, Address::repeat_byte(8));
+    let config = MultisigConfig {
+        salt: B256::ZERO,
+        version: 1,
+        threshold: 1,
+        owners: vec![MultisigOwner {
+            owner: parent,
+            weight: 1,
+        }],
+    };
+    let digest =
+        tempo_primitives::transaction::multisig_digest(authorization.signature_hash(), parent, 1);
+    let signature = tempo_primitives::transaction::MultisigSignature::try_new(
+        parent,
+        config,
+        vec![
+            tempo_primitives::transaction::PrimitiveSignature::Secp256k1(
+                signer.sign_hash_sync(&digest).unwrap(),
+            ),
+        ],
+    )
+    .unwrap();
+    let authorization = authorization.into_signed(TempoSignature::Multisig(signature));
+    let request = crate::rpc::TempoTransactionRequest {
+        inner: alloy_rpc_types_eth::TransactionRequest {
+            from: Some(parent),
+            to: Some(Address::repeat_byte(7).into()),
+            chain_id: Some(4217),
+            nonce: Some(0),
+            gas: Some(100_000),
+            max_fee_per_gas: Some(1),
+            max_priority_fee_per_gas: Some(1),
+            ..Default::default()
+        },
+        key_authorization: Some(authorization.clone()),
+        ..Default::default()
+    };
+    let TempoTxEnvelope::AA(tx) = request.try_build_and_sign(signer).await.unwrap() else {
+        panic!("AA expected");
+    };
+    assert_eq!(tx.tx().key_authorization, Some(authorization));
+}

--- a/crates/alloy/src/rpc/native_multisig/tests.rs
+++ b/crates/alloy/src/rpc/native_multisig/tests.rs
@@ -44,6 +44,22 @@ fn simulation_spec_roundtrips_config_as_rlp_bytes() {
     );
 }
 
+#[test]
+fn simulation_spec_rejects_unknown_fields_and_malformed_hints() {
+    let mut json = serde_json::to_value(spec()).unwrap();
+    json["aprovals"] = serde_json::json!([]);
+    assert!(serde_json::from_value::<MultisigSimulationSpec>(json).is_err());
+    for len in [0, 1, 2, 3, 4, 5, 8192] {
+        let mut spec = spec();
+        spec.approvals[0].key_data = Some(Bytes::from(vec![0; len]));
+        assert_eq!(
+            spec.validate_owners(Address::repeat_byte(9)).is_ok(),
+            matches!(len, 1 | 2 | 4),
+            "hint length {len}"
+        );
+    }
+}
+
 #[test_case::test_case(vec![]; "empty")]
 #[test_case::test_case(vec![1]; "insufficient")]
 #[test_case::test_case(vec![2,1]; "unsorted")]

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -9,11 +9,12 @@ use serde::{Deserialize, Serialize};
 use tempo_primitives::{
     AASigned, SignatureType, TempoTransaction, TempoTxEnvelope,
     transaction::{
-        Call, SignedKeyAuthorization, TempoSignedAuthorization, TempoTypedTransaction,
-        key_authorization::serde_nonzero_quantity_opt,
+        Call, MultisigSignature, SignedKeyAuthorization, TempoSignedAuthorization,
+        TempoTypedTransaction, key_authorization::serde_nonzero_quantity_opt,
     },
 };
 
+use super::MultisigSimulationSpec;
 use crate::TempoNetwork;
 
 /// An Ethereum [`TransactionRequest`] extended with Tempo-specific fields.
@@ -54,8 +55,16 @@ pub struct TempoTransactionRequest {
     #[serde(default)]
     pub key_type: Option<SignatureType>,
 
-    /// Optional key-specific data for gas estimation (e.g., webauthn authenticator data).
-    /// Required when key_type is WebAuthn to calculate calldata gas costs.
+    /// Optional WebAuthn data-length hint for gas estimation, not authenticator bytes.
+    ///
+    /// For an explicit WebAuthn key type, 1-, 2-, or 4-byte big-endian unsigned integers
+    /// select the modeled data length, excluding the signature and public-key fields.
+    /// Omission or any other byte length defaults to 800. The length is clamped to the
+    /// generated authenticator/client-data template minimum and a maximum of 8192 bytes
+    /// for ordinary requests, or 1920 bytes for native multisig owner approvals.
+    /// Other algorithms ignore this hint. A native owner approval with an omitted
+    /// [`key_type`](super::MultisigSimulationApproval::key_type) also ignores it and
+    /// conservatively models maximum-size WebAuthn data instead.
     #[serde(default)]
     pub key_data: Option<Bytes>,
 
@@ -79,6 +88,24 @@ pub struct TempoTransactionRequest {
     /// Provide a signed KeyAuthorization when the transaction provisions an access key.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key_authorization: Option<SignedKeyAuthorization>,
+
+    /// Quorum for the outer sender, or the delegate named by keyId when using an access key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub multisig_simulation: Option<MultisigSimulationSpec>,
+
+    /// Independent parent quorum authorizing the attached keyAuthorization.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_authorization_simulation: Option<MultisigSimulationSpec>,
+
+    /// Dummy outer approval installed by state-aware RPC preprocessing.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub multisig_simulation_signature: Option<MultisigSignature>,
+
+    /// Configurable roles have been checked against the requested state.
+    #[doc(hidden)]
+    #[serde(skip)]
+    pub multisig_simulation_prepared: bool,
 
     /// Transaction valid before timestamp in seconds (for expiring nonces, [TIP-1009]).
     /// Transaction can only be included in a block before this timestamp.
@@ -109,6 +136,17 @@ pub struct TempoTransactionRequest {
 }
 
 impl TempoTransactionRequest {
+    /// Whether block simulation would need configurable authorization at each evolving position.
+    pub fn has_configurable_simulation(&self) -> bool {
+        self.key_type == Some(SignatureType::Multisig)
+            || self.multisig_simulation.is_some()
+            || self.key_authorization_simulation.is_some()
+            || self.multisig_simulation_signature.is_some()
+            || self
+                .key_authorization
+                .as_ref()
+                .is_some_and(|auth| auth.signature.is_multisig())
+    }
     /// Returns whether this request contains fields that require Tempo AA transaction semantics.
     pub(crate) fn has_aa_fields(&self) -> bool {
         !self.calls.is_empty()
@@ -119,6 +157,9 @@ impl TempoTransactionRequest {
             || self.key_id.is_some()
             || self.key_type.is_some()
             || self.key_data.is_some()
+            || self.multisig_simulation.is_some()
+            || self.key_authorization_simulation.is_some()
+            || self.multisig_simulation_signature.is_some()
             || self.valid_before.is_some()
             || self.valid_after.is_some()
             || self.fee_payer_signature.is_some()
@@ -461,6 +502,10 @@ impl From<TempoTransaction> for TempoTransactionRequest {
             key_id: None,
             nonce_key: Some(tx.nonce_key),
             key_authorization: tx.key_authorization,
+            multisig_simulation: None,
+            key_authorization_simulation: None,
+            multisig_simulation_signature: None,
+            multisig_simulation_prepared: false,
             valid_before: tx.valid_before,
             valid_after: tx.valid_after,
             fee_payer_signature: tx.fee_payer_signature,

--- a/crates/alloy/src/rpc/request.rs
+++ b/crates/alloy/src/rpc/request.rs
@@ -59,7 +59,8 @@ pub struct TempoTransactionRequest {
     ///
     /// For an explicit WebAuthn key type, 1-, 2-, or 4-byte big-endian unsigned integers
     /// select the modeled data length, excluding the signature and public-key fields.
-    /// Omission or any other byte length defaults to 800. The length is clamped to the
+    /// Omission defaults to 800. Ordinary requests also default unsupported byte lengths;
+    /// native owner approvals reject lengths other than 1, 2, or 4. The length is clamped to the
     /// generated authenticator/client-data template minimum and a maximum of 8192 bytes
     /// for ordinary requests, or 1920 bytes for native multisig owner approvals.
     /// Other algorithms ignore this hint. A native owner approval with an omitted
@@ -102,7 +103,7 @@ pub struct TempoTransactionRequest {
     #[serde(skip)]
     pub multisig_simulation_signature: Option<MultisigSignature>,
 
-    /// Configurable roles have been checked against the requested state.
+    /// Routing marker set after state-aware preprocessing; never authorizes skipping grant crypto.
     #[doc(hidden)]
     #[serde(skip)]
     pub multisig_simulation_prepared: bool,

--- a/crates/alloy/src/rpc/reth_compat.rs
+++ b/crates/alloy/src/rpc/reth_compat.rs
@@ -15,6 +15,12 @@ use tempo_revm::TempoTxEnv;
 
 impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
     fn try_into_sim_tx(self) -> Result<TempoTxEnvelope, ValueError<Self>> {
+        if self.has_configurable_simulation() {
+            return Err(ValueError::new(
+                self,
+                "configurable roles are unsupported in simulateV1 until evolving-position state validation is available",
+            ));
+        }
         match self.output_tx_type() {
             TempoTxType::AA => {
                 let tx = self.build_aa()?;
@@ -38,6 +44,10 @@ impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
                     key_id,
                     tempo_authorization_list,
                     key_authorization,
+                    multisig_simulation,
+                    key_authorization_simulation,
+                    multisig_simulation_signature,
+                    multisig_simulation_prepared,
                     valid_before,
                     valid_after,
                     fee_payer_signature,
@@ -57,6 +67,10 @@ impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
                             key_id,
                             tempo_authorization_list,
                             key_authorization,
+                            multisig_simulation,
+                            key_authorization_simulation,
+                            multisig_simulation_signature,
+                            multisig_simulation_prepared,
                             valid_before,
                             valid_after,
                             fee_payer_signature,
@@ -76,6 +90,10 @@ impl TryIntoSimTx<TempoTxEnvelope> for TempoTransactionRequest {
                             key_id,
                             tempo_authorization_list,
                             key_authorization,
+                            multisig_simulation,
+                            key_authorization_simulation,
+                            multisig_simulation_signature,
+                            multisig_simulation_prepared,
                             valid_before,
                             valid_after,
                             fee_payer_signature,
@@ -105,6 +123,14 @@ impl SignableTxRequest<TempoTxEnvelope> for TempoTransactionRequest {
         self,
         signer: impl TxSigner<Signature> + Send,
     ) -> Result<TempoTxEnvelope, SignTxRequestError> {
+        if self.multisig_simulation.is_some()
+            || self.key_authorization_simulation.is_some()
+            || self.multisig_simulation_signature.is_some()
+            || self.multisig_simulation_prepared
+            || self.key_type == Some(tempo_primitives::SignatureType::Multisig)
+        {
+            return Err(SignTxRequestError::InvalidTransactionRequest);
+        }
         if self.output_tx_type() == TempoTxType::AA {
             let mut tx = self
                 .build_aa()

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -30,11 +30,27 @@ impl TempoTransactionRequest {
         let caller_addr = self.inner.from.unwrap_or_default();
         let is_aa = self.has_aa_fields();
 
+        if self.has_configurable_simulation() && !self.multisig_simulation_prepared {
+            return Err(ValueError::new(
+                self,
+                "native multisig simulation requires a configuration witness and state-aware preprocessing",
+            ));
+        }
+
         if is_aa && self.calls.is_empty() && self.inner.to.is_none() {
             return Err(ValueError::new(self, "empty calls list"));
         }
 
-        let mock_signature = if is_aa {
+        let mock_signature = if let Some(signature) = self.multisig_simulation_signature.clone() {
+            Some(if self.key_id.is_some() {
+                TempoSignature::Keychain(tempo_primitives::transaction::KeychainSignature::new(
+                    caller_addr,
+                    signature,
+                ))
+            } else {
+                TempoSignature::Multisig(signature)
+            })
+        } else if is_aa {
             match create_mock_tempo_sig(
                 &self.key_type.unwrap_or(SignatureType::Secp256k1),
                 self.key_data.as_ref(),
@@ -77,6 +93,10 @@ impl TempoTransactionRequest {
             tempo_authorization_list,
             nonce_key,
             key_authorization,
+            multisig_simulation: _,
+            key_authorization_simulation: _,
+            multisig_simulation_signature: _,
+            multisig_simulation_prepared: _,
             valid_before,
             valid_after,
             fee_payer_signature: _,
@@ -151,6 +171,14 @@ pub(super) fn create_mock_primitive_signature(
     sig_type: &SignatureType,
     key_data: Option<Bytes>,
 ) -> Option<tempo_primitives::transaction::tt_signature::PrimitiveSignature> {
+    create_mock_primitive_signature_with_webauthn_limit(sig_type, key_data, 8192)
+}
+
+pub(super) fn create_mock_primitive_signature_with_webauthn_limit(
+    sig_type: &SignatureType,
+    key_data: Option<Bytes>,
+    max_webauthn_size: usize,
+) -> Option<tempo_primitives::transaction::tt_signature::PrimitiveSignature> {
     use tempo_primitives::transaction::tt_signature::{
         P256SignatureWithPreHash, PrimitiveSignature, WebAuthnSignature,
     };
@@ -175,7 +203,6 @@ pub(super) fn create_mock_primitive_signature(
             const AUTH_DATA_SIZE: usize = 37;
             const MIN_WEBAUTHN_SIZE: usize = AUTH_DATA_SIZE + BASE_CLIENT_JSON.len();
             const DEFAULT_WEBAUTHN_SIZE: usize = 800;
-            const MAX_WEBAUTHN_SIZE: usize = 8192;
 
             let size = if let Some(data) = key_data.as_ref() {
                 match data.len() {
@@ -187,7 +214,7 @@ pub(super) fn create_mock_primitive_signature(
             } else {
                 DEFAULT_WEBAUTHN_SIZE
             }
-            .clamp(MIN_WEBAUTHN_SIZE, MAX_WEBAUTHN_SIZE);
+            .clamp(MIN_WEBAUTHN_SIZE, max_webauthn_size);
 
             let mut webauthn_data = vec![0u8; AUTH_DATA_SIZE];
             webauthn_data[32] = 0x01;

--- a/crates/alloy/src/rpc/revm_compat.rs
+++ b/crates/alloy/src/rpc/revm_compat.rs
@@ -30,7 +30,16 @@ impl TempoTransactionRequest {
         let caller_addr = self.inner.from.unwrap_or_default();
         let is_aa = self.has_aa_fields();
 
-        if self.has_configurable_simulation() && !self.multisig_simulation_prepared {
+        if self.has_configurable_simulation()
+            && (!self.multisig_simulation_prepared
+                || (self.multisig_simulation.is_some()
+                    && self.multisig_simulation_signature.is_none())
+                || (self.key_authorization_simulation.is_some()
+                    && !self
+                        .key_authorization
+                        .as_ref()
+                        .is_some_and(|grant| grant.signature.is_multisig())))
+        {
             return Err(ValueError::new(
                 self,
                 "native multisig simulation requires a configuration witness and state-aware preprocessing",

--- a/crates/node/src/rpc/mod.rs
+++ b/crates/node/src/rpc/mod.rs
@@ -3,19 +3,23 @@ pub mod consensus;
 pub mod error;
 pub mod eth_ext;
 pub mod fork_schedule;
+mod native_multisig;
 pub mod operator;
 pub mod simulate;
 pub mod token;
 
 pub use admin::{TempoAdminApi, TempoAdminApiServer};
+use alloy_eips::{BlockId, eip2718::Encodable2718};
 use alloy_primitives::B256;
-use alloy_rpc_types_eth::{Log, ReceiptWithBloom};
+use alloy_rpc_types_eth::{Log, ReceiptWithBloom, state::EvmOverrides};
 pub use consensus::{TempoConsensusApiServer, TempoConsensusRpc};
 pub use eth_ext::{TempoEthExt, TempoEthExtApiServer};
 pub use fork_schedule::{TempoForkScheduleApiServer, TempoForkScheduleRpc};
 use futures::TryFutureExt;
 pub use operator::{TempoOperatorApiServer, TempoOperatorRpc};
-use reth_primitives_traits::{HeaderTy, SealedHeaderFor, TransactionMeta, WithEncoded};
+use reth_primitives_traits::{
+    HeaderTy, NodePrimitives, SealedHeaderFor, TransactionMeta, TxTy, WithEncoded,
+};
 use reth_rpc_eth_api::{FromEthApiError, IntoEthApiError, RpcTxReq};
 use reth_transaction_pool::{PoolTransaction, PoolTx, TransactionOrigin, TransactionPool};
 pub use simulate::{TempoSimulate, TempoSimulateApiServer, TempoSimulateV1Response};
@@ -48,7 +52,7 @@ use reth_node_builder::rpc::{EthApiBuilder, EthApiCtx};
 use reth_provider::{ChainSpecProvider, ProviderError};
 use reth_rpc::{DynRpcConverter, eth::EthApi};
 use reth_rpc_eth_api::{
-    EthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
+    EthApiTypes, FullEthApiTypes, RpcConverter, RpcNodeCore, RpcNodeCoreExt,
     helpers::{
         Call, EthApiSpec, EthBlocks, EthCall, EthFees, EthState, EthSubscriptions, EthTransactions,
         LoadBlock, LoadFee, LoadPendingBlock, LoadReceipt, LoadState, LoadTransaction,
@@ -61,8 +65,8 @@ use reth_rpc_eth_api::{
     transaction::{ConvertReceiptInput, ReceiptConverter},
 };
 use reth_rpc_eth_types::{
-    EthApiError, EthStateCache, FeeHistoryCache, GasPriceOracle, PendingBlock, SignError,
-    builder::config::PendingBlockKind, receipt::EthReceiptConverter,
+    EthApiError, EthStateCache, FeeHistoryCache, FillTransaction, GasPriceOracle, PendingBlock,
+    SignError, builder::config::PendingBlockKind, receipt::EthReceiptConverter,
 };
 use tempo_alloy::{TempoNetwork, rpc::TempoTransactionReceipt};
 use tempo_evm::{TempoBlockEnv, TempoInvalidTransaction};
@@ -414,6 +418,13 @@ where
         mut request: TempoTransactionRequest,
         mut db: impl Database<Error: Into<EthApiError>>,
     ) -> Result<TxEnvFor<Self::Evm>, Self::Error> {
+        native_multisig::prepare_native_multisig_simulation(
+            &mut request,
+            evm_env.cfg_env.spec,
+            &evm_env.block_env,
+            &mut db,
+        )
+        .map_err(Self::Error::from_eth_err)?;
         if let Some(nonce_key) = request.nonce_key
             && !nonce_key.is_zero()
             && request.nonce.is_none()
@@ -445,7 +456,67 @@ impl<N> LoadTransaction for TempoEthApi<N> where N: TempoEthApiBounds {}
 impl<N> EthTransactions for TempoEthApi<N>
 where
     N: TempoEthApiBounds,
+    Self: EthApiTypes<NetworkTypes = TempoNetwork> + FullEthApiTypes + RpcNodeCore<Pool = N::Pool>,
+    <Self as RpcNodeCore>::Primitives: NodePrimitives<SignedTx = TempoTxEnvelope>,
 {
+    fn fill_transaction(
+        &self,
+        mut request: RpcTxReq<Self::NetworkTypes>,
+    ) -> impl Future<Output = Result<FillTransaction<TxTy<Self::Primitives>>, Self::Error>> + Send
+    where
+        Self: EthApiSpec + LoadBlock + EstimateCall + LoadFee,
+    {
+        let this = self.clone();
+        async move {
+            let configurable = request.has_configurable_simulation();
+            if request.key_authorization_simulation.is_some() {
+                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                    "fillTransaction requires a real signed grant; use keyAuthorizationSimulation only for call and estimateGas".into()
+                )));
+            }
+            request.inner.value.get_or_insert_default();
+            if request.inner.nonce.is_none() {
+                request.inner.nonce = Some(this.next_available_nonce_for(&request).await?);
+            }
+            let chain_id = this.chain_id().to::<u64>();
+            if let Some(actual) = request.inner.chain_id
+                && actual != chain_id
+            {
+                return Err(Self::Error::from_eth_err(EthApiError::InvalidParams(
+                    format!("chain ID mismatch: expected {chain_id}, actual {actual}"),
+                )));
+            }
+            request.inner.chain_id = Some(chain_id);
+            // Preserve Tempo's nonce and fee-token allowance hooks before delegating
+            // fee defaults/encoding. Native hints need validation even with explicit gas.
+            if configurable || request.inner.gas.is_none() {
+                let estimated_gas = EstimateCall::estimate_gas_at(
+                    &this,
+                    request.clone(),
+                    BlockId::pending(),
+                    EvmOverrides::default(),
+                )
+                .await?;
+                request.inner.gas.get_or_insert(estimated_gas.to());
+            }
+            if !configurable {
+                return EthTransactions::fill_transaction(&this.inner, request)
+                    .await
+                    .map_err(Self::Error::from_eth_err);
+            }
+            let authorization = native_multisig::prepare_fill_output(&mut request)
+                .map_err(Self::Error::from_eth_err)?;
+            let filled = EthTransactions::fill_transaction(&this.inner, request)
+                .await
+                .map_err(Self::Error::from_eth_err)?;
+            let tx = native_multisig::restore_fill_authorization(filled.tx, authorization)
+                .map_err(Self::Error::from_eth_err)?;
+            Ok(FillTransaction {
+                raw: tx.encoded_2718().into(),
+                tx,
+            })
+        }
+    }
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {
         self.inner.signers()
     }

--- a/crates/node/src/rpc/native_multisig/mod.rs
+++ b/crates/node/src/rpc/native_multisig/mod.rs
@@ -16,6 +16,7 @@ pub(super) fn prepare_native_multisig_simulation(
     block: &TempoBlockEnv,
     db: &mut impl Database<Error: Into<EthApiError>>,
 ) -> Result<(), EthApiError> {
+    request.multisig_simulation_prepared = false;
     if !request.has_configurable_simulation() {
         return Ok(());
     }
@@ -35,29 +36,23 @@ pub(super) fn prepare_native_multisig_simulation(
         .inner
         .from
         .ok_or_else(|| invalid("native multisig simulation requires from"))?;
+    if request.key_id == Some(parent)
+        && (request.multisig_simulation.is_some()
+            || request.multisig_simulation_signature.is_some())
+    {
+        return Err(invalid("a configurable delegate cannot be its own parent"));
+    }
     if let Some(spec) = request.multisig_simulation.as_ref() {
         let account = request.key_id.unwrap_or(parent);
-        if request.key_id == Some(parent) {
-            return Err(invalid("a configurable delegate cannot be its own parent"));
-        }
         let signature = create_mock_native_multisig_signature(account, spec)
             .map_err(EthApiError::InvalidParams)?;
         validate_witness(&signature, factory, hardfork, db)?;
         request.multisig_simulation_signature = Some(signature);
-        request.multisig_simulation = None;
-    } else if let Some(signature) = &request.multisig_simulation_signature {
-        // Internal callers may preserve a prepared mock through repeated estimation passes.
-        if !request.multisig_simulation_prepared {
-            return Err(invalid("unprepared multisig simulation signature"));
-        }
-        if signature.account() != request.key_id.unwrap_or(parent) {
-            return Err(EthApiError::InvalidParams(format!(
-                "multisig simulation signature account mismatch: expected {}, actual {}",
-                request.key_id.unwrap_or(parent),
-                signature.account()
-            )));
-        }
-        validate_witness(signature, factory, hardfork, db)?;
+        // Retain the source witness so every estimation pass rebuilds and checks its mock.
+    } else if request.multisig_simulation_signature.is_some() {
+        return Err(invalid(
+            "multisig simulation signature requires its source witness",
+        ));
     }
     if let Some(spec) = request.key_authorization_simulation.as_ref() {
         let authorization = request
@@ -82,7 +77,6 @@ pub(super) fn prepare_native_multisig_simulation(
                 .clone()
                 .into_signed(TempoSignature::Multisig(signature)),
         );
-        request.key_authorization_simulation = None;
     } else if let Some(authorization) = &request.key_authorization
         && let TempoSignature::Multisig(signature) = &authorization.signature
     {
@@ -100,14 +94,12 @@ pub(super) fn prepare_native_multisig_simulation(
             )));
         }
         validate_witness(signature, factory, hardfork, db)?;
-        if !request.multisig_simulation_prepared {
-            NativeAuthorization {
-                signature,
-                inner_digest: authorization.signature_hash(),
-            }
-            .verify()
-            .map_err(|error| EthApiError::InvalidParams(error.to_string()))?;
+        NativeAuthorization {
+            signature,
+            inner_digest: authorization.signature_hash(),
         }
+        .verify()
+        .map_err(|error| EthApiError::InvalidParams(error.to_string()))?;
     }
     request.multisig_simulation_prepared = true;
     Ok(())

--- a/crates/node/src/rpc/native_multisig/mod.rs
+++ b/crates/node/src/rpc/native_multisig/mod.rs
@@ -1,0 +1,197 @@
+use alloy_primitives::Address;
+use reth_evm::revm::Database;
+use reth_rpc_eth_types::EthApiError;
+use tempo_alloy::rpc::{TempoTransactionRequest, create_mock_native_multisig_signature};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_primitives::{
+    TempoBlockEnv, TempoSignature, account::decode_config_commitment,
+    transaction::MultisigSignature,
+};
+use tempo_revm::native_multisig::{NativeAuthorization, NativeMultisigError};
+
+/// Checks independent role witnesses against the exact database selected for this call.
+pub(super) fn prepare_native_multisig_simulation(
+    request: &mut TempoTransactionRequest,
+    hardfork: TempoHardfork,
+    block: &TempoBlockEnv,
+    db: &mut impl Database<Error: Into<EthApiError>>,
+) -> Result<(), EthApiError> {
+    if !request.has_configurable_simulation() {
+        return Ok(());
+    }
+    let invalid = |message: &str| EthApiError::InvalidParams(message.into());
+    if !hardfork.is_t12() {
+        return Err(invalid(
+            "native multisig simulation requires T12 at the requested state",
+        ));
+    }
+    let factory = block
+        .multisig_recovery_factory
+        .filter(|address| !address.is_zero())
+        .ok_or_else(|| {
+            EthApiError::InvalidParams(NativeMultisigError::FactoryNotConfigured.to_string())
+        })?;
+    let parent = request
+        .inner
+        .from
+        .ok_or_else(|| invalid("native multisig simulation requires from"))?;
+    if let Some(spec) = request.multisig_simulation.as_ref() {
+        let account = request.key_id.unwrap_or(parent);
+        if request.key_id == Some(parent) {
+            return Err(invalid("a configurable delegate cannot be its own parent"));
+        }
+        let signature = create_mock_native_multisig_signature(account, spec)
+            .map_err(EthApiError::InvalidParams)?;
+        validate_witness(&signature, factory, hardfork, db)?;
+        request.multisig_simulation_signature = Some(signature);
+        request.multisig_simulation = None;
+    } else if let Some(signature) = &request.multisig_simulation_signature {
+        // Internal callers may preserve a prepared mock through repeated estimation passes.
+        if !request.multisig_simulation_prepared {
+            return Err(invalid("unprepared multisig simulation signature"));
+        }
+        if signature.account() != request.key_id.unwrap_or(parent) {
+            return Err(EthApiError::InvalidParams(format!(
+                "multisig simulation signature account mismatch: expected {}, actual {}",
+                request.key_id.unwrap_or(parent),
+                signature.account()
+            )));
+        }
+        validate_witness(signature, factory, hardfork, db)?;
+    }
+    if let Some(spec) = request.key_authorization_simulation.as_ref() {
+        let authorization = request
+            .key_authorization
+            .as_ref()
+            .ok_or_else(|| invalid("keyAuthorizationSimulation requires keyAuthorization"))?;
+        if authorization
+            .account
+            .is_some_and(|account| account != parent)
+        {
+            return Err(EthApiError::InvalidParams(format!(
+                "key authorization account mismatch: expected {parent}, actual {}",
+                authorization.account.unwrap()
+            )));
+        }
+        let signature = create_mock_native_multisig_signature(parent, spec)
+            .map_err(EthApiError::InvalidParams)?;
+        validate_witness(&signature, factory, hardfork, db)?;
+        request.key_authorization = Some(
+            authorization
+                .authorization
+                .clone()
+                .into_signed(TempoSignature::Multisig(signature)),
+        );
+        request.key_authorization_simulation = None;
+    } else if let Some(authorization) = &request.key_authorization
+        && let TempoSignature::Multisig(signature) = &authorization.signature
+    {
+        if let Some(actual) = authorization.account
+            && actual != parent
+        {
+            return Err(EthApiError::InvalidParams(format!(
+                "key authorization account mismatch: expected {parent}, actual {actual}"
+            )));
+        }
+        if signature.account() != parent {
+            return Err(EthApiError::InvalidParams(format!(
+                "multisig signature account mismatch: expected {parent}, actual {}",
+                signature.account()
+            )));
+        }
+        if !request.multisig_simulation_prepared {
+            NativeAuthorization {
+                signature,
+                inner_digest: authorization.signature_hash(),
+            }
+            .verify()
+            .map_err(|error| EthApiError::InvalidParams(error.to_string()))?;
+        }
+        validate_witness(signature, factory, hardfork, db)?;
+    }
+    request.multisig_simulation_prepared = true;
+    Ok(())
+}
+
+fn validate_witness(
+    signature: &MultisigSignature,
+    factory: Address,
+    hardfork: TempoHardfork,
+    db: &mut impl Database<Error: Into<EthApiError>>,
+) -> Result<(), EthApiError> {
+    let account = signature.account();
+    if !tempo_precompiles::native_multisig::valid_account(account, hardfork) {
+        return Err(EthApiError::InvalidParams(
+            NativeMultisigError::InvalidAccount { account }.to_string(),
+        ));
+    }
+    let info = db.basic(account).map_err(Into::into)?.unwrap_or_default();
+    if !info.is_empty_code_hash() {
+        return Err(EthApiError::InvalidParams(format!(
+            "configurable account {account} has code at the requested state"
+        )));
+    }
+    let stored = decode_config_commitment(&info.extension, hardfork.is_t12())
+        .map_err(|error| EthApiError::Internal(reth_errors::RethError::msg(error.to_string())))?;
+    let supplied = signature.config_commitment();
+    if supplied.is_zero() || (!stored.is_zero() && stored != supplied) {
+        return Err(EthApiError::InvalidParams(format!(
+            "{} for {account} at the requested state",
+            NativeMultisigError::ConfigurationCommitmentMismatch {
+                expected: stored,
+                actual: supplied
+            },
+        )));
+    }
+    if stored.is_zero() {
+        if signature.config().version != 0 {
+            return Err(EthApiError::InvalidParams(format!(
+                "unregistered configuration version mismatch: expected 0, actual {}",
+                signature.config().version
+            )));
+        }
+        let expected = signature
+            .config()
+            .derive_account(factory)
+            .map_err(|error| EthApiError::InvalidParams(error.to_string()))?;
+        if expected != account {
+            return Err(EthApiError::InvalidParams(format!(
+                "initial multisig account mismatch at the requested state: expected {expected}, actual {account}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Removes simulation hints while retaining the exact real grant for the unsigned response.
+pub(super) fn prepare_fill_output(
+    request: &mut TempoTransactionRequest,
+) -> Result<Option<tempo_primitives::transaction::SignedKeyAuthorization>, EthApiError> {
+    if request.key_authorization_simulation.is_some() {
+        return Err(EthApiError::InvalidParams("fillTransaction requires a real signed grant; keyAuthorizationSimulation is supported only by call and estimateGas".into()));
+    }
+    request.multisig_simulation = None;
+    request.multisig_simulation_signature = None;
+    request.multisig_simulation_prepared = false;
+    // Keep AA selection while passing the ordinary unsigned converter.
+    request.key_type = Some(tempo_primitives::SignatureType::Secp256k1);
+    request.key_data = None;
+    Ok(request.key_authorization.take())
+}
+
+pub(super) fn restore_fill_authorization(
+    tx: tempo_primitives::TempoTxEnvelope,
+    authorization: Option<tempo_primitives::transaction::SignedKeyAuthorization>,
+) -> Result<tempo_primitives::TempoTxEnvelope, EthApiError> {
+    let tempo_primitives::TempoTxEnvelope::AA(signed) = tx else {
+        return Err(EthApiError::InvalidParams(
+            "configurable fill requires an AA transaction".into(),
+        ));
+    };
+    let mut tx = signed.strip_signature();
+    tx.key_authorization = authorization;
+    Ok(tx.into_signed(TempoSignature::default()).into())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/node/src/rpc/native_multisig/mod.rs
+++ b/crates/node/src/rpc/native_multisig/mod.rs
@@ -99,6 +99,7 @@ pub(super) fn prepare_native_multisig_simulation(
                 signature.account()
             )));
         }
+        validate_witness(signature, factory, hardfork, db)?;
         if !request.multisig_simulation_prepared {
             NativeAuthorization {
                 signature,
@@ -107,7 +108,6 @@ pub(super) fn prepare_native_multisig_simulation(
             .verify()
             .map_err(|error| EthApiError::InvalidParams(error.to_string()))?;
         }
-        validate_witness(signature, factory, hardfork, db)?;
     }
     request.multisig_simulation_prepared = true;
     Ok(())

--- a/crates/node/src/rpc/native_multisig/tests.rs
+++ b/crates/node/src/rpc/native_multisig/tests.rs
@@ -216,7 +216,10 @@ fn prepares_independent_delegate_and_parent_roles(version: u64) {
     let tx = request
         .try_into_tempo_tx_env(tempo_revm::TempoTxEnv::default(), true)
         .unwrap();
-    let roles = tempo_revm::native_multisig::authorizations(&tx);
+    let roles = tempo_revm::native_multisig::authorizations(&tx)
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
     assert_eq!(roles.len(), 2);
     assert_eq!(roles[0].signature.account(), delegate);
     assert_eq!(roles[1].signature.account(), parent);

--- a/crates/node/src/rpc/native_multisig/tests.rs
+++ b/crates/node/src/rpc/native_multisig/tests.rs
@@ -121,7 +121,25 @@ fn real_grant_checks_state_before_cryptography() {
                 };
                 assert_eq!(message, expected);
             }
-            None => result.unwrap(),
+            None => {
+                result.unwrap();
+                request
+                    .key_authorization
+                    .as_mut()
+                    .unwrap()
+                    .authorization
+                    .chain_id += 1;
+                assert!(
+                    prepare_native_multisig_simulation(
+                        &mut request,
+                        TempoHardfork::T12,
+                        &block(),
+                        &mut db
+                    )
+                    .is_err(),
+                    "prepared real grant must be reverified after digest mutation"
+                );
+            }
         }
     }
 }
@@ -183,10 +201,13 @@ fn prepares_independent_delegate_and_parent_roles(version: u64) {
         .authorization
         .account = Some(wrong);
     let mut wrong_signer = request.clone();
+    wrong_signer.key_authorization_simulation = None;
     wrong_signer.key_authorization.as_mut().unwrap().signature =
         TempoSignature::Multisig(request.multisig_simulation_signature.clone().unwrap());
     let mut wrong_delegate = request.clone();
-    wrong_delegate.key_id = Some(wrong);
+    wrong_delegate.key_id = Some(parent);
+    let mut missing_witness = request.clone();
+    missing_witness.multisig_simulation = None;
     for (mut invalid, expected) in [
         (
             wrong_metadata,
@@ -198,9 +219,11 @@ fn prepares_independent_delegate_and_parent_roles(version: u64) {
         ),
         (
             wrong_delegate,
-            format!(
-                "multisig simulation signature account mismatch: expected {wrong}, actual {delegate}"
-            ),
+            "a configurable delegate cannot be its own parent".into(),
+        ),
+        (
+            missing_witness,
+            "multisig simulation signature requires its source witness".into(),
         ),
     ] {
         let Err(EthApiError::InvalidParams(message)) =
@@ -209,6 +232,7 @@ fn prepares_independent_delegate_and_parent_roles(version: u64) {
             panic!("expected {expected}")
         };
         assert_eq!(message, expected);
+        assert!(!invalid.multisig_simulation_prepared);
     }
     // Repeated preparation must retain both valid roles after the rejected alternatives.
     prepare_native_multisig_simulation(&mut request, TempoHardfork::T12, &block(), &mut db)

--- a/crates/node/src/rpc/native_multisig/tests.rs
+++ b/crates/node/src/rpc/native_multisig/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
-use alloy_primitives::{B256, U256};
+use alloy::signers::{SignerSync, local::PrivateKeySigner};
+use alloy_primitives::{B256, Signature, U256};
 use reth_evm::revm::{bytecode::Bytecode, state::AccountInfo};
 use std::collections::HashMap;
 use tempo_alloy::rpc::{MultisigSimulationApproval, MultisigSimulationSpec};
@@ -57,6 +58,71 @@ fn block() -> TempoBlockEnv {
     TempoBlockEnv {
         multisig_recovery_factory: Some(FACTORY),
         ..Default::default()
+    }
+}
+
+#[test]
+fn real_grant_checks_state_before_cryptography() {
+    let signer = PrivateKeySigner::from_slice(&[1; 32]).unwrap();
+    let (parent, mut spec) = spec(1, 1);
+    spec.config.owners[0].owner = signer.address();
+    let authorization =
+        KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, Address::repeat_byte(8));
+    let digest = tempo_primitives::transaction::multisig::multisig_digest(
+        authorization.signature_hash(),
+        parent,
+        spec.config.version,
+    );
+    let valid = signer.sign_hash_sync(&digest).unwrap();
+    let invalid = Signature::new(U256::ZERO, U256::ZERO, false);
+    let commitment = spec.config.commitment().unwrap();
+    let stale = B256::repeat_byte(7);
+    let state_error = format!(
+        "{} for {parent} at the requested state",
+        NativeMultisigError::ConfigurationCommitmentMismatch {
+            expected: stale,
+            actual: commitment,
+        }
+    );
+    let crypto_error =
+        NativeMultisigError::OwnerSignatureRecoveryFailed { approval_index: 0 }.to_string();
+    for (stored, approval, expected) in [
+        (stale, invalid, Some(state_error.clone())),
+        (stale, valid, Some(state_error)),
+        (commitment, invalid, Some(crypto_error)),
+        (commitment, valid, None),
+    ] {
+        let mut db = AccountDb::default();
+        db.insert_commitment(parent, stored);
+        let signature = MultisigSignature::try_new(
+            parent,
+            spec.config.clone(),
+            vec![PrimitiveSignature::Secp256k1(approval)],
+        )
+        .unwrap();
+        let mut request = TempoTransactionRequest {
+            inner: alloy_rpc_types_eth::TransactionRequest {
+                from: Some(parent),
+                ..Default::default()
+            },
+            key_authorization: Some(
+                authorization
+                    .clone()
+                    .into_signed(TempoSignature::Multisig(signature)),
+            ),
+            ..Default::default()
+        };
+        let result =
+            prepare_native_multisig_simulation(&mut request, TempoHardfork::T12, &block(), &mut db);
+        match expected {
+            Some(expected) => {
+                let Err(EthApiError::InvalidParams(message)) = result else {
+                    panic!("expected {expected}")
+                };
+                assert_eq!(message, expected);
+            }
+            None => result.unwrap(),
+        }
     }
 }
 

--- a/crates/node/src/rpc/native_multisig/tests.rs
+++ b/crates/node/src/rpc/native_multisig/tests.rs
@@ -1,0 +1,318 @@
+use super::*;
+use alloy_primitives::{B256, U256};
+use reth_evm::revm::{bytecode::Bytecode, state::AccountInfo};
+use std::collections::HashMap;
+use tempo_alloy::rpc::{MultisigSimulationApproval, MultisigSimulationSpec};
+use tempo_primitives::{
+    SignatureType,
+    account::encode_config_commitment,
+    transaction::{KeyAuthorization, MultisigConfig, MultisigOwner, PrimitiveSignature},
+};
+
+const FACTORY: Address = Address::repeat_byte(0x99);
+#[derive(Default)]
+struct AccountDb(HashMap<Address, AccountInfo>);
+impl AccountDb {
+    fn insert_commitment(&mut self, account: Address, hash: B256) {
+        self.0.entry(account).or_default().extension = encode_config_commitment(hash).into();
+    }
+}
+impl Database for AccountDb {
+    type Error = reth_errors::ProviderError;
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        Ok(self.0.get(&address).cloned())
+    }
+    fn code_by_hash(&mut self, _: B256) -> Result<Bytecode, Self::Error> {
+        panic!("metadata suffices")
+    }
+    fn storage(&mut self, _: Address, _: U256) -> Result<U256, Self::Error> {
+        panic!("no storage fallback")
+    }
+    fn block_hash(&mut self, _: u64) -> Result<B256, Self::Error> {
+        Ok(B256::ZERO)
+    }
+}
+fn spec(salt: u8, version: u64) -> (Address, MultisigSimulationSpec) {
+    let owner = Address::repeat_byte(1);
+    let config = MultisigConfig {
+        salt: B256::repeat_byte(salt),
+        version,
+        threshold: 1,
+        owners: vec![MultisigOwner { owner, weight: 1 }],
+    };
+    let account = config.derive_account(FACTORY).unwrap();
+    (
+        account,
+        MultisigSimulationSpec {
+            config,
+            approvals: vec![MultisigSimulationApproval {
+                owner,
+                key_type: Some(SignatureType::Secp256k1),
+                key_data: None,
+            }],
+        },
+    )
+}
+fn block() -> TempoBlockEnv {
+    TempoBlockEnv {
+        multisig_recovery_factory: Some(FACTORY),
+        ..Default::default()
+    }
+}
+
+#[test_case::test_case(0; "initial")]
+#[test_case::test_case(1; "registered")]
+fn prepares_independent_delegate_and_parent_roles(version: u64) {
+    let (parent, parent_spec) = spec(1, version);
+    let (delegate, delegate_spec) = spec(2, version);
+    let mut db = AccountDb::default();
+    if version != 0 {
+        db.insert_commitment(parent, parent_spec.config.commitment().unwrap());
+        db.insert_commitment(delegate, delegate_spec.config.commitment().unwrap());
+    }
+    let mut request = TempoTransactionRequest {
+        inner: alloy_rpc_types_eth::TransactionRequest {
+            from: Some(parent),
+            to: Some(Address::repeat_byte(8).into()),
+            ..Default::default()
+        },
+        key_id: Some(delegate),
+        key_type: Some(SignatureType::Multisig),
+        multisig_simulation: Some(delegate_spec),
+        key_authorization_simulation: Some(parent_spec),
+        key_authorization: Some(
+            KeyAuthorization::unrestricted(4217, SignatureType::Multisig, delegate)
+                .into_signed(PrimitiveSignature::default()),
+        ),
+        ..Default::default()
+    };
+    let wrong = Address::repeat_byte(9);
+    let mut wrong_metadata = request.clone();
+    wrong_metadata
+        .key_authorization
+        .as_mut()
+        .unwrap()
+        .authorization
+        .account = Some(wrong);
+    let Err(EthApiError::InvalidParams(message)) = prepare_native_multisig_simulation(
+        &mut wrong_metadata,
+        TempoHardfork::T12,
+        &block(),
+        &mut db,
+    ) else {
+        panic!("expected grant metadata rejection")
+    };
+    assert_eq!(
+        message,
+        format!("key authorization account mismatch: expected {parent}, actual {wrong}")
+    );
+    prepare_native_multisig_simulation(&mut request, TempoHardfork::T12, &block(), &mut db)
+        .unwrap();
+
+    let mut wrong_metadata = request.clone();
+    wrong_metadata
+        .key_authorization
+        .as_mut()
+        .unwrap()
+        .authorization
+        .account = Some(wrong);
+    let mut wrong_signer = request.clone();
+    wrong_signer.key_authorization.as_mut().unwrap().signature =
+        TempoSignature::Multisig(request.multisig_simulation_signature.clone().unwrap());
+    let mut wrong_delegate = request.clone();
+    wrong_delegate.key_id = Some(wrong);
+    for (mut invalid, expected) in [
+        (
+            wrong_metadata,
+            format!("key authorization account mismatch: expected {parent}, actual {wrong}"),
+        ),
+        (
+            wrong_signer,
+            format!("multisig signature account mismatch: expected {parent}, actual {delegate}"),
+        ),
+        (
+            wrong_delegate,
+            format!(
+                "multisig simulation signature account mismatch: expected {wrong}, actual {delegate}"
+            ),
+        ),
+    ] {
+        let Err(EthApiError::InvalidParams(message)) =
+            prepare_native_multisig_simulation(&mut invalid, TempoHardfork::T12, &block(), &mut db)
+        else {
+            panic!("expected {expected}")
+        };
+        assert_eq!(message, expected);
+    }
+    // Repeated preparation must retain both valid roles after the rejected alternatives.
+    prepare_native_multisig_simulation(&mut request, TempoHardfork::T12, &block(), &mut db)
+        .unwrap();
+    let tx = request
+        .try_into_tempo_tx_env(tempo_revm::TempoTxEnv::default(), true)
+        .unwrap();
+    let roles = tempo_revm::native_multisig::authorizations(&tx);
+    assert_eq!(roles.len(), 2);
+    assert_eq!(roles[0].signature.account(), delegate);
+    assert_eq!(roles[1].signature.account(), parent);
+    assert_eq!(
+        tx.execution_context,
+        tempo_revm::ExecutionContext::Simulation
+    );
+}
+
+#[derive(Clone, Copy)]
+enum WitnessRejection {
+    BeforeT12,
+    Code,
+    UnregisteredVersion,
+    WrongIdentity,
+}
+
+#[test_case::test_case(WitnessRejection::BeforeT12; "before_t12")]
+#[test_case::test_case(WitnessRejection::Code; "account_has_code")]
+#[test_case::test_case(WitnessRejection::UnregisteredVersion; "unregistered_positive_version")]
+#[test_case::test_case(WitnessRejection::WrongIdentity; "wrong_initial_identity")]
+fn rejects_invalid_witness_state(case: WitnessRejection) {
+    let version = u64::from(matches!(case, WitnessRejection::UnregisteredVersion));
+    let (account, spec) = spec(1, version);
+    let mut request = TempoTransactionRequest {
+        inner: alloy_rpc_types_eth::TransactionRequest {
+            from: Some(account),
+            ..Default::default()
+        },
+        multisig_simulation: Some(spec.clone()),
+        ..Default::default()
+    };
+    let mut db = AccountDb::default();
+    if version != 0 {
+        db.insert_commitment(account, spec.config.commitment().unwrap());
+    }
+    prepare_native_multisig_simulation(&mut request.clone(), TempoHardfork::T12, &block(), &mut db)
+        .unwrap();
+    let mut fork = TempoHardfork::T12;
+    let expected = match case {
+        WitnessRejection::BeforeT12 => {
+            fork = TempoHardfork::T11;
+            "native multisig simulation requires T12 at the requested state".to_owned()
+        }
+        WitnessRejection::Code => {
+            db.0.entry(account).or_default().code_hash =
+                Bytecode::new_legacy(vec![0x60, 0x00].into()).hash_slow();
+            format!("configurable account {account} has code at the requested state")
+        }
+        WitnessRejection::UnregisteredVersion => {
+            db.0.remove(&account);
+            "unregistered configuration version mismatch: expected 0, actual 1".to_owned()
+        }
+        WitnessRejection::WrongIdentity => {
+            let wrong = Address::repeat_byte(9);
+            request.inner.from = Some(wrong);
+            format!(
+                "initial multisig account mismatch at the requested state: expected {account}, actual {wrong}"
+            )
+        }
+    };
+    let Err(EthApiError::InvalidParams(message)) =
+        prepare_native_multisig_simulation(&mut request, fork, &block(), &mut db)
+    else {
+        panic!("expected {expected}")
+    };
+    assert_eq!(message, expected);
+}
+
+#[test]
+fn distinguishes_state_mismatch_from_corrupt_leaf() {
+    let (account, spec) = spec(1, 0);
+    let mut request = TempoTransactionRequest {
+        inner: alloy_rpc_types_eth::TransactionRequest {
+            from: Some(account),
+            ..Default::default()
+        },
+        multisig_simulation: Some(spec),
+        ..Default::default()
+    };
+    let mut db = AccountDb::default();
+    db.insert_commitment(account, B256::repeat_byte(7));
+    let error = prepare_native_multisig_simulation(
+        &mut request.clone(),
+        TempoHardfork::T12,
+        &block(),
+        &mut db,
+    )
+    .unwrap_err();
+    assert!(matches!(error, EthApiError::InvalidParams(_)));
+    assert!(error.to_string().contains("requested state"));
+    db.0.get_mut(&account).unwrap().extension = vec![1].into();
+    assert!(matches!(
+        prepare_native_multisig_simulation(&mut request, TempoHardfork::T12, &block(), &mut db),
+        Err(EthApiError::Internal(_))
+    ));
+}
+
+#[test]
+fn factory_is_required_and_registered_version_zero_is_valid() {
+    let (account, spec) = spec(1, 0);
+    let mut db = AccountDb::default();
+    db.insert_commitment(account, spec.config.commitment().unwrap());
+    let mut request = TempoTransactionRequest {
+        inner: alloy_rpc_types_eth::TransactionRequest {
+            from: Some(account),
+            ..Default::default()
+        },
+        multisig_simulation: Some(spec),
+        ..Default::default()
+    };
+    assert!(
+        prepare_native_multisig_simulation(
+            &mut request.clone(),
+            TempoHardfork::T12,
+            &TempoBlockEnv::default(),
+            &mut db
+        )
+        .is_err()
+    );
+    prepare_native_multisig_simulation(&mut request, TempoHardfork::T12, &block(), &mut db)
+        .unwrap();
+}
+
+#[test]
+fn fill_output_preserves_real_grant_and_removes_simulation_hints() {
+    let (account, spec) = spec(1, 0);
+    let real_grant =
+        KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, Address::repeat_byte(5))
+            .into_signed(PrimitiveSignature::Secp256k1(
+                alloy_primitives::Signature::test_signature(),
+            ));
+    let mut request = TempoTransactionRequest {
+        inner: alloy_rpc_types_eth::TransactionRequest {
+            from: Some(account),
+            to: Some(Address::repeat_byte(6).into()),
+            chain_id: Some(4217),
+            nonce: Some(0),
+            gas: Some(100_000),
+            max_fee_per_gas: Some(1),
+            max_priority_fee_per_gas: Some(1),
+            ..Default::default()
+        },
+        multisig_simulation: Some(spec.clone()),
+        key_authorization: Some(real_grant.clone()),
+        ..Default::default()
+    };
+    let mut mock_grant_request = request.clone();
+    mock_grant_request.key_authorization_simulation = Some(spec);
+    assert!(prepare_fill_output(&mut mock_grant_request).is_err());
+    let saved = prepare_fill_output(&mut request).unwrap();
+    assert!(!request.has_configurable_simulation());
+    let tx = request
+        .build_aa()
+        .unwrap()
+        .into_signed(TempoSignature::default())
+        .into();
+    let tempo_primitives::TempoTxEnvelope::AA(signed) =
+        restore_fill_authorization(tx, saved).unwrap()
+    else {
+        panic!("AA expected")
+    };
+    assert_eq!(signed.tx().key_authorization, Some(real_grant));
+    assert!(matches!(signed.signature(), TempoSignature::Primitive(_)));
+}

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -333,6 +333,67 @@ impl super::types::TestEnv for Localnet {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_fill_uses_fee_token_gas_allowance() -> eyre::Result<()> {
+    use super::types::TestEnv;
+    use reth_provider::{AccountReader, StateProviderFactory};
+
+    let mut env = Localnet::new().await?;
+    let signer = PrivateKeySigner::random();
+    env.fund_account(signer.address()).await?;
+    // eth_getBalance returns a wallet-compatibility placeholder; inspect real state.
+    let account = env
+        .setup
+        .node
+        .inner
+        .provider
+        .latest()?
+        .basic_account(&signer.address())?;
+    assert!(account.is_none_or(|account| account.balance.is_zero()));
+    assert!(
+        ITIP20::new(DEFAULT_FEE_TOKEN, &env.provider)
+            .balanceOf(signer.address())
+            .call()
+            .await?
+            > U256::ZERO
+    );
+
+    let request = tempo_node::rpc::TempoTransactionRequest {
+        inner: alloy::rpc::types::TransactionRequest {
+            from: Some(signer.address()),
+            max_fee_per_gas: Some(u128::from(TEMPO_T1_BASE_FEE) * 2),
+            max_priority_fee_per_gas: Some(u128::from(TEMPO_T1_BASE_FEE)),
+            ..Default::default()
+        },
+        calls: vec![create_transfer_call(
+            DEFAULT_FEE_TOKEN,
+            Address::random(),
+            U256::from(1),
+        )],
+        key_type: Some(tempo_primitives::SignatureType::Secp256k1),
+        fee_token: Some(DEFAULT_FEE_TOKEN),
+        ..Default::default()
+    };
+    let filled: serde_json::Value = env
+        .provider
+        .raw_request("eth_fillTransaction".into(), (&request,))
+        .await?;
+    let tx = parse_filled_tx(&filled)?;
+    assert!(tx.gas_limit > 21_000);
+    assert_eq!(tx.nonce, 0);
+    assert_eq!(tx.fee_token, Some(DEFAULT_FEE_TOKEN));
+
+    // Ordinary fill must retain explicitly supplied gas, even when it is too low to execute.
+    let mut explicit = request;
+    explicit.inner.gas = Some(1);
+    let filled: serde_json::Value = env
+        .provider
+        .raw_request("eth_fillTransaction".into(), (&explicit,))
+        .await?;
+    assert_eq!(parse_filled_tx(&filled)?.gas_limit, 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_aa_2d_nonce_pool_comprehensive() -> eyre::Result<()> {
     let localnet = Localnet::new().await?;
     let Localnet {


### PR DESCRIPTION
Adds state-aware simulation, safe transaction filling and wallet persistence for the configurable signer and grant roles in #7510. Validates witnesses before mock construction and rejects native simulateV1 requests until evolving-position state validation is supported.