### PR TITLE
deps: update reth from main (2026-09-14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9088,7 +9088,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9115,7 +9115,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9166,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9546,7 +9546,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9666,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9926,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "clap",
  "eyre",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10111,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10188,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10259,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "serde",
  "serde_json",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10295,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "bytes",
  "futures",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "bindgen",
  "cc",
@@ -10341,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "futures",
  "libc",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10364,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10462,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10486,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10557,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10757,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "bytes",
  "eyre",
@@ -10811,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10847,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10859,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10882,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10925,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11002,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11033,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11139,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11182,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11202,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11280,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11330,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11346,7 +11346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11456,7 +11456,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11470,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11548,7 +11548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11613,7 +11613,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "clap",
  "eyre",
@@ -11643,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11662,7 +11662,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11705,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11731,7 +11731,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11759,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11775,7 +11775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11799,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
+source = "git+https://github.com/paradigmxyz/reth?rev=9582336#95823365b9f0787a676de38c044b54830e3fb29d"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9088,7 +9088,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9115,7 +9115,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9166,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9546,7 +9546,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9666,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9926,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "clap",
  "eyre",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10088,11 +10088,10 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
  "alloy-rpc-types-eth",
  "reth-codecs",
  "reth-primitives-traits",
@@ -10102,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10112,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10138,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10158,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10176,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10189,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10208,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10246,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10260,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "serde",
  "serde_json",
@@ -10270,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10296,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "bytes",
  "futures",
@@ -10316,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10333,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "bindgen",
  "cc",
@@ -10342,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "futures",
  "libc",
@@ -10356,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10365,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10379,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10438,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10463,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10487,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10502,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10516,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10534,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10558,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10626,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10681,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10734,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10758,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10782,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "bytes",
  "eyre",
@@ -10812,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10824,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10848,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10860,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10883,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10926,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10976,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11003,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11019,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11034,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11110,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11140,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11183,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11203,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11234,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11281,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11331,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11347,9 +11346,8 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
- "alloy-eips",
  "alloy-primitives",
  "alloy-rpc-types-engine",
  "jsonrpsee-core",
@@ -11378,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11430,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11458,7 +11456,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11472,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11492,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11507,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11533,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11550,7 +11548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11578,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11599,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11615,7 +11613,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11625,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "clap",
  "eyre",
@@ -11645,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11664,7 +11662,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11707,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11733,7 +11731,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11761,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11777,7 +11775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11801,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9088,7 +9088,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9115,7 +9115,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9166,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9546,7 +9546,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9666,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9926,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "clap",
  "eyre",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10111,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10188,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10259,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "serde",
  "serde_json",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10295,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "bytes",
  "futures",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "bindgen",
  "cc",
@@ -10341,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "futures",
  "libc",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10364,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10462,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10486,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10557,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10757,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "bytes",
  "eyre",
@@ -10811,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10847,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10859,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10882,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10925,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11002,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11033,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11139,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11182,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11202,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11280,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11330,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11346,7 +11346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11456,7 +11456,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11470,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11548,7 +11548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11613,7 +11613,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "clap",
  "eyre",
@@ -11643,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11662,7 +11662,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11705,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11731,7 +11731,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11759,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11775,7 +11775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11799,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=4bf2ff2#4bf2ff217a0a80912424d7cdf19a2efe32b47039"
+source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9088,7 +9088,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9115,7 +9115,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9146,7 +9146,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9166,7 +9166,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9179,7 +9179,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9264,7 +9264,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9274,7 +9274,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9327,7 +9327,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9344,7 +9344,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9358,7 +9358,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9371,7 +9371,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9396,7 +9396,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9425,7 +9425,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9452,7 +9452,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9482,7 +9482,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9497,7 +9497,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9522,7 +9522,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9546,7 +9546,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9570,7 +9570,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9607,7 +9607,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9666,7 +9666,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9693,7 +9693,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9716,7 +9716,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9743,7 +9743,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9799,7 +9799,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9829,7 +9829,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9847,7 +9847,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9863,7 +9863,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9887,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9898,7 +9898,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9926,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9949,7 +9949,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9990,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "clap",
  "eyre",
@@ -10013,7 +10013,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10029,7 +10029,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10045,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -10058,7 +10058,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10088,7 +10088,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10101,7 +10101,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10111,7 +10111,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10137,7 +10137,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10157,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10175,7 +10175,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10188,7 +10188,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10207,7 +10207,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10245,7 +10245,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10259,7 +10259,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "serde",
  "serde_json",
@@ -10269,7 +10269,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10295,7 +10295,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "bytes",
  "futures",
@@ -10315,7 +10315,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10332,7 +10332,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "bindgen",
  "cc",
@@ -10341,7 +10341,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "futures",
  "libc",
@@ -10355,7 +10355,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10364,7 +10364,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10378,7 +10378,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10437,7 +10437,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10462,7 +10462,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10486,7 +10486,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10501,7 +10501,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10515,7 +10515,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10533,7 +10533,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10557,7 +10557,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10625,7 +10625,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10680,7 +10680,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10733,7 +10733,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10757,7 +10757,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10781,7 +10781,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "bytes",
  "eyre",
@@ -10811,7 +10811,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10823,7 +10823,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10847,7 +10847,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10859,7 +10859,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10882,7 +10882,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10925,7 +10925,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10975,7 +10975,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11002,7 +11002,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11018,7 +11018,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -11033,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11109,7 +11109,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11139,7 +11139,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11182,7 +11182,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11202,7 +11202,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11233,7 +11233,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11280,7 +11280,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11330,7 +11330,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11346,7 +11346,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -11376,7 +11376,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11428,7 +11428,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11456,7 +11456,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11470,7 +11470,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11490,7 +11490,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11505,7 +11505,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11531,7 +11531,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11548,7 +11548,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11576,7 +11576,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11597,7 +11597,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11613,7 +11613,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11623,7 +11623,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "clap",
  "eyre",
@@ -11643,7 +11643,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11662,7 +11662,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11705,7 +11705,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11731,7 +11731,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11759,7 +11759,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11775,7 +11775,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11799,7 +11799,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=040bef7#040bef7b319c7ec145689e03fe78710e11986db6"
+source = "git+https://github.com/paradigmxyz/reth?rev=d779aae#d779aae046271b62357ef1bbf3c619b9c31eb97c"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "4bf2ff2", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "040bef7", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", features = [
   "std",
   "optional-checks",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "9582336", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9582336", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "9582336", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "9582336" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "d779aae", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "9582336", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -275,12 +275,10 @@ impl AA2dPool {
         let replaced = match self.by_id.entry(tx_id) {
             Entry::Occupied(mut entry) => {
                 // Ensure the replacement transaction is not underpriced
-                if entry
-                    .get()
-                    .inner
-                    .transaction
-                    .is_underpriced(&tx.inner.transaction, &self.config.price_bump_config)
-                {
+                if entry.get().inner.transaction.is_replacement_underpriced(
+                    &tx.inner.transaction,
+                    &self.config.price_bump_config,
+                ) {
                     return Err(PoolError::new(
                         *transaction.hash(),
                         PoolErrorKind::ReplacementUnderpriced,


### PR DESCRIPTION
Automated nightly update of reth dependencies from `paradigmxyz/reth` main branch.

## Upstream reth changes

[`8e55cc5...9582336`](https://github.com/paradigmxyz/reth/compare/8e55cc5...9582336)

🔗 Amp thread: https://ampcode.com/threads/T-01a09de6-8040-76dd-b257-91edc630aa4f
- **RPC**
  - Adopt Alloy helpers for block ID display and message signing ([#27120](https://github.com/paradigmxyz/reth/pull/27120), [#27132](https://github.com/paradigmxyz/reth/pull/27132)).
  - Hold resource permits for proof and blocking call tasks ([#27107](https://github.com/paradigmxyz/reth/pull/27107), [#27106](https://github.com/paradigmxyz/reth/pull/27106)).
  - Increase the default transaction hash cache to 100k entries ([#27137](https://github.com/paradigmxyz/reth/pull/27137)).

- **Primitives**
  - Delegate receipt-root and fee calculations to Alloy ([#27119](https://github.com/paradigmxyz/reth/pull/27119), [#27123](https://github.com/paradigmxyz/reth/pull/27123)).

- **Engine / Payload**
  - Start trie proofs with an early update batch ([#27093](https://github.com/paradigmxyz/reth/pull/27093)).
  - Validate Amsterdam payload fields ([#27173](https://github.com/paradigmxyz/reth/pull/27173)).

- **Transaction Pool**
  - Add a nonce-bound check hook and make replacement policy extensible ([#27185](https://github.com/paradigmxyz/reth/pull/27185), [#27201](https://github.com/paradigmxyz/reth/pull/27201)).

- **Networking**
  - Preserve cell masks when coalescing ETH/72 announcements and extend RLP fuzz coverage ([#27090](https://github.com/paradigmxyz/reth/pull/27090), [#27180](https://github.com/paradigmxyz/reth/pull/27180)).
  - Replace EF bootnodes with the NodeOps fleet ([#27130](https://github.com/paradigmxyz/reth/pull/27130)).

- **Storage**
  - Preserve refreshed static-file cache entries ([#27131](https://github.com/paradigmxyz/reth/pull/27131)).

- **Build**
  - Fix the Nix build process ([#27202](https://github.com/paradigmxyz/reth/pull/27202)).

## Migrations

🔗 Amp thread: https://ampcode.com/threads/T-01a09de6-b6ed-701a-8e92-aeede44bb90b
- Upgraded all Reth Git dependencies from revision `8e55cc5` to `9582336`.
- Migrated replacement-price validation from `is_underpriced` to the renamed `is_replacement_underpriced` API; parameters and behavior remain unchanged.

[GitHub Workflow](https://github.com/tempoxyz/tempo/actions/runs/34801463791)
