### PR TITLE
chore(bench): set scheduled multi-region duration to 300s

### DIFF
--- a/.github/workflows/bench-e2e-multi-region-scheduled.yml
+++ b/.github/workflows/bench-e2e-multi-region-scheduled.yml
@@ -28,7 +28,7 @@ on:
         description: Benchmark duration in seconds.
         type: string
         required: true
-        default: "90"
+        default: "300"
       bloat:
         description: State bloat size in GB.
         type: choice
@@ -162,7 +162,7 @@ jobs:
       feature: ${{ needs.resolve-refs.outputs.feature-ref }}
       feature-name: ${{ needs.resolve-refs.outputs.feature-name }}
       preset: public-mix
-      duration: ${{ inputs.duration || '90' }}
+      duration: ${{ inputs.duration || '300' }}
       bloat: ${{ inputs.bloat || '100' }}
       validator-count: ${{ inputs['validator-count'] || '10' }}
       regions: ${{ inputs.regions || '' }}


### PR DESCRIPTION
Increase the scheduled multi-region benchmark duration from 90 to 300 seconds. Update both the manual dispatch default on the scheduled workflow and the fallback used by cron runs; explicit duration overrides still apply.

Validation: parsed the workflow YAML, checked both duration settings, and ran `git diff --check`.

Prompted by: @shekhirin
