### PR TITLE
chore(deps): use Reth transaction fetcher refactor branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8986,7 +8986,7 @@ checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 [[package]]
 name = "reth-basic-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9013,7 +9013,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9044,7 +9044,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9064,7 +9064,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -9077,7 +9077,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9162,7 +9162,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -9172,7 +9172,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9225,7 +9225,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -9242,7 +9242,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9269,7 +9269,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9294,7 +9294,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -9323,10 +9323,9 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
- "alloy-eips",
  "alloy-primitives",
  "arbitrary",
  "arrayvec",
@@ -9350,7 +9349,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -9380,7 +9379,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9395,7 +9394,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9420,7 +9419,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9444,7 +9443,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "dashmap",
@@ -9468,7 +9467,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9505,7 +9504,7 @@ dependencies = [
 [[package]]
 name = "reth-e2e-test-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9564,7 +9563,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -9591,7 +9590,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9614,7 +9613,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9641,7 +9640,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -9697,7 +9696,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9727,7 +9726,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9745,7 +9744,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -9761,7 +9760,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9785,7 +9784,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -9796,7 +9795,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -9824,7 +9823,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -9847,7 +9846,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -9888,7 +9887,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "clap",
  "eyre",
@@ -9911,7 +9910,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9927,7 +9926,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9943,7 +9942,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -9956,7 +9955,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9986,7 +9985,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10000,7 +9999,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -10010,7 +10009,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10036,7 +10035,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10056,7 +10055,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-cache"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "fixed-cache",
@@ -10074,7 +10073,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -10087,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10106,7 +10105,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10144,7 +10143,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -10158,7 +10157,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "serde",
  "serde_json",
@@ -10168,7 +10167,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10194,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "bytes",
  "futures",
@@ -10214,7 +10213,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "bitflags 2.11.1",
  "byteorder",
@@ -10231,7 +10230,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "bindgen",
  "cc",
@@ -10240,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "futures",
  "libc",
@@ -10254,7 +10253,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "ipnet",
@@ -10263,7 +10262,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -10277,7 +10276,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10336,7 +10335,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10361,7 +10360,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10385,7 +10384,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10400,7 +10399,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -10414,7 +10413,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "anyhow",
  "bincode",
@@ -10432,7 +10431,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -10456,7 +10455,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10524,7 +10523,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10579,19 +10578,17 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network",
  "alloy-primitives",
- "alloy-rlp",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "ethereum_ssz",
  "ethereum_ssz_derive",
  "eyre",
- "futures",
  "http-body-util",
  "jsonrpsee",
  "reth-chainspec",
@@ -10618,10 +10615,8 @@ dependencies = [
  "reth-rpc-eth-api",
  "reth-rpc-eth-types",
  "reth-rpc-server-types",
- "reth-tasks",
  "reth-tracing",
  "reth-transaction-pool",
- "reth-trie-common",
  "revm",
  "serde",
  "serde_json",
@@ -10632,7 +10627,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10656,7 +10651,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10680,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "bytes",
  "eyre",
@@ -10710,7 +10705,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -10722,7 +10717,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10746,7 +10741,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -10758,7 +10753,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -10781,7 +10776,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -10824,7 +10819,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -10874,7 +10869,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -10901,7 +10896,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -10917,7 +10912,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -10932,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11008,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -11038,7 +11033,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -11081,7 +11076,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-evm",
@@ -11101,7 +11096,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11132,7 +11127,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -11179,7 +11174,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -11229,7 +11224,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.4.0",
@@ -11245,7 +11240,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11276,7 +11271,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11328,7 +11323,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11356,7 +11351,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -11370,7 +11365,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -11390,7 +11385,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -11405,7 +11400,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eip7928",
@@ -11431,7 +11426,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11448,7 +11443,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-overlay"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -11476,7 +11471,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "crossbeam-utils",
  "dashmap",
@@ -11497,7 +11492,7 @@ dependencies = [
 [[package]]
 name = "reth-testing-utils"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11513,7 +11508,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -11523,7 +11518,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "clap",
  "eyre",
@@ -11543,7 +11538,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing-otlp"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -11562,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11605,7 +11600,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -11631,7 +11626,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -11659,7 +11654,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -11675,7 +11670,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -11699,7 +11694,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "2.5.2"
-source = "git+https://github.com/paradigmxyz/reth?rev=8e55cc5#8e55cc50c95cfd1675149aab7281fd87d751b3c8"
+source = "git+https://github.com/paradigmxyz/reth?branch=matt%2Ftx-fetcher-rewrite#d1c9cf0ed977994b4d12f31f31a190bc3f51ab78"
 dependencies = [
  "alloy-primitives",
  "alloy-trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,70 +146,70 @@ tempo-telemetry-util = { path = "crates/telemetry-util", default-features = fals
 tempo-transaction-pool = { path = "crates/transaction-pool", default-features = false }
 tempo-validator-config = { path = "crates/validator-config", default-features = false }
 
-reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
-reth-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-cli-util = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite", default-features = false }
+reth-cli = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-cli-commands = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-cli-runner = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-cli-util = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
 reth-codecs = { version = "0.7.0", default-features = false }
-reth-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-db = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-discv5 = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-engine-local = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-errors = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-etl = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
-reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-execution-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-evm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-network-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-network-peers = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", default-features = false }
-reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-core = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-consensus-common = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-db = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-discv5 = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-e2e-test-utils = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-engine-local = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-engine-tree = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-errors = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-eth-wire-types = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-etl = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-ethereum-cli = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-ethereum-consensus = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-ethereum-engine-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-ethereum-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite", default-features = false }
+reth-execution-cache = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-execution-types = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-evm = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-evm-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-network-api = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-network-p2p = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite", default-features = false }
+reth-nippy-jar = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-node-api = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-node-builder = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-node-core = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-node-ethereum = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-node-metrics = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-payload-primitives = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
 reth-primitives-traits = { version = "0.7.0", default-features = false }
-reth-config = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-downloaders = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-prune-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-stages = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-static-file = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-tasks = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-tracing = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-trie = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
-reth-trie-db = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5" }
+reth-config = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-downloaders = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-prune-types = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc-builder = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc-convert = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc-eth-api = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc-eth-types = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-rpc-server-types = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-stages = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-static-file = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-static-file-types = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-tasks = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-tracing = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-trie = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
+reth-trie-db = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite" }
 
-reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", features = [
+reth-revm = { git = "https://github.com/paradigmxyz/reth", branch = "matt/tx-fetcher-rewrite", features = [
   "std",
   "optional-checks",
 ] }

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -1259,7 +1259,7 @@ where
     fn get_blobs_for_versioned_hashes_v4(
         &self,
         versioned_hashes: &[B256],
-        cell_mask: alloy_eips::eip7594::BlobCellMask,
+        cell_mask: alloy_primitives::B128,
     ) -> Result<
         Vec<Option<alloy_eips::eip4844::BlobCellsAndProofsV1>>,
         reth_transaction_pool::blobstore::BlobStoreError,

--- a/crates/transaction-pool/src/tempo_pool.rs
+++ b/crates/transaction-pool/src/tempo_pool.rs
@@ -99,6 +99,21 @@ where
         self.protocol_pool.validator().validator().client()
     }
 
+    /// Returns all transactions from `sender`, grouped by pending and queued status.
+    // The transaction fetcher branch does not expose this method on `TransactionPool` yet.
+    pub fn all_transactions_by_sender(
+        &self,
+        sender: Address,
+    ) -> AllPoolTransactions<TempoPooledTransaction> {
+        let mut transactions = self.protocol_pool.all_transactions();
+        transactions.pending.retain(|tx| tx.sender() == sender);
+        transactions.queued.retain(|tx| tx.sender() == sender);
+        self.aa_2d_pool
+            .read()
+            .append_all_transactions_by_sender(sender, &mut transactions);
+        transactions
+    }
+
     /// Updates the 2d nonce pool with the given state changes.
     ///
     /// Returns mined AA transactions.
@@ -958,17 +973,6 @@ where
         self.aa_2d_pool
             .read()
             .append_all_transactions(&mut transactions);
-        transactions
-    }
-
-    fn all_transactions_by_sender(
-        &self,
-        sender: Address,
-    ) -> AllPoolTransactions<Self::Transaction> {
-        let mut transactions = self.protocol_pool.all_transactions_by_sender(sender);
-        self.aa_2d_pool
-            .read()
-            .append_all_transactions_by_sender(sender, &mut transactions);
         transactions
     }
 

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -109,13 +109,11 @@ impl TempoPooledTransaction {
             calc_gas_balance_spending(transaction.gas_limit(), transaction.max_fee_per_gas())
                 .saturating_add(value);
         let fee_token_cost = cost - value;
-        let in_memory_size = transaction.size();
         Self {
             inner: EthPooledTransaction {
                 transaction,
                 cost,
                 encoded_length,
-                in_memory_size,
                 blob_sidecar: EthBlobTransactionSidecar::None,
                 blob_cell_availability: None,
             },


### PR DESCRIPTION
Use Matt's `matt/tx-fetcher-rewrite` branch from [reth#26924](https://github.com/paradigmxyz/reth/pull/26924) for all Reth Git dependencies, with `Cargo.lock` pinned to [d1c9cf0](https://github.com/paradigmxyz/reth/commit/d1c9cf0ed977994b4d12f31f31a190bc3f51ab78). Tempo's existing network builder picks up the rewritten transaction fetcher.

This is an experimental draft: the upstream branch is [21 commits ahead and 62 behind Tempo's current Reth pin](https://github.com/paradigmxyz/reth/compare/8e55cc50c95cfd1675149aab7281fd87d751b3c8...d1c9cf0ed977994b4d12f31f31a190bc3f51ab78), so it also drops upstream changes until the branch is rebased.

Validation: formatting, locked dependency resolution, and `git diff --check` pass; all 104 Reth Git packages resolve to the same commit. Full workspace compilation with all targets and features is in progress; runtime tests have not run.

Prompted by: @shekhirin
