### PR TITLE
feat(bench): summarize non-INFO/DEBUG logs by message

### DIFF
--- a/.github/scripts/bench-log-summary.js
+++ b/.github/scripts/bench-log-summary.js
@@ -6,7 +6,7 @@ const readline = require('node:readline');
 const { stripVTControlCharacters } = require('node:util');
 
 // Node file logs use tracing's JSON formatter. Support terminal output as well
-// for txgen, profiling tools, and results collected before JSON logging.
+// for node console fallback and results collected before JSON logging.
 function parseLine(raw) {
   const line = stripVTControlCharacters(raw).trim();
   if (line.startsWith('{')) {
@@ -59,11 +59,6 @@ async function scanLogs(resultsDir, mode) {
       const consoleLog = path.join(resultsDir, label, 'node.log');
       if (fs.existsSync(consoleLog)) files.push(consoleLog);
     }
-    files.push(...filesUnder(mode === 'e2e'
-      ? path.join(resultsDir, `txgen-logs-${label}`)
-      : path.join(resultsDir, label, 'txgen-logs')));
-    const captureLog = path.join(resultsDir, `tracy-capture-${label}.log`);
-    if (mode === 'e2e' && fs.existsSync(captureLog)) files.push(captureLog);
     const run = { label, side, total: 0, files: files.map(f => path.relative(resultsDir, f)),
       missing_node_logs: missing.map(f => path.relative(resultsDir, f)) };
     for (const filename of files) {
@@ -98,7 +93,7 @@ function buildMarkdown(report) {
   const total = side => report.runs.some(r => r.side === side)
     ? report.runs.filter(r => r.side === side).reduce((sum, r) => sum + r.total, 0) : '—';
   const lines = ['', '## Non-INFO/DEBUG logs', '',
-    'Counts include all collected run logs, including setup, warmup, and shutdown. Annotated key/value fields are excluded; repeated messages are counted, not deduplicated. Unlevelled output is ignored.', '',
+    'Counts include only Tempo node logs across each run, including startup, warmup, and shutdown. Annotated key/value fields are excluded; repeated messages are counted, not deduplicated. Unlevelled output is ignored.', '',
     '| Run type | Total lines |', '|----------|------------:|',
     `| Baseline | ${total('baseline')} |`, `| Feature | ${total('feature')} |`, ''];
   if (report.runs.some(r => r.missing_node_logs.length)) {

--- a/.github/scripts/bench-log-summary.js
+++ b/.github/scripts/bench-log-summary.js
@@ -92,8 +92,7 @@ function escapeCell(value) {
 function buildMarkdown(report) {
   const total = side => report.runs.some(r => r.side === side)
     ? report.runs.filter(r => r.side === side).reduce((sum, r) => sum + r.total, 0) : '—';
-  const lines = ['', '## Non-INFO/DEBUG logs', '',
-    'Counts include only Tempo node logs across each run, including startup, warmup, and shutdown. Annotated key/value fields are excluded, except that JSON logs without a message use the error field. Repeated messages are counted, not deduplicated. Unlevelled output is ignored.', '',
+  const lines = ['', '### Warn/Error Logs', '',
     '| Run type | Total lines |', '|----------|------------:|',
     `| Baseline | ${total('baseline')} |`, `| Feature | ${total('feature')} |`, ''];
   if (report.runs.some(r => r.missing_node_logs.length)) {
@@ -124,7 +123,7 @@ function buildMarkdown(report) {
 async function main(resultsDir, mode, markdownName) {
   const report = await scanLogs(resultsDir, mode);
   fs.writeFileSync(path.join(resultsDir, 'log-summary.json'), `${JSON.stringify(report, null, 2)}\n`);
-  fs.appendFileSync(path.join(resultsDir, markdownName), buildMarkdown(report));
+  fs.appendFileSync(path.join(resultsDir, markdownName), `\n## Observability\n${buildMarkdown(report)}`);
 }
 
 if (require.main === module) {

--- a/.github/scripts/bench-log-summary.js
+++ b/.github/scripts/bench-log-summary.js
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+const path = require('node:path');
+const readline = require('node:readline');
+const { stripVTControlCharacters } = require('node:util');
+
+// Node file logs use tracing's JSON formatter. Support terminal output as well
+// for txgen, profiling tools, and results collected before JSON logging.
+function parseLine(raw) {
+  const line = stripVTControlCharacters(raw).trim();
+  if (line.startsWith('{')) {
+    try {
+      const entry = JSON.parse(line);
+      if (!entry.level) return null;
+      const level = entry.level.toUpperCase();
+      if (level === 'INFO' || level === 'DEBUG') return null;
+      return String(entry.fields?.message ?? entry.message ?? '(no message)');
+    } catch {
+      return null;
+    }
+  }
+  const match = line.match(/^(?:\d{4}-\d\d-\d\dT\S+\s+)?(TRACE|DEBUG|INFO|WARN|ERROR)\s+(.*)$/);
+  if (!match || match[1] === 'INFO' || match[1] === 'DEBUG') return null;
+  // The terminal formatter puts the target before the message and annotated
+  // fields after it. Keep formatted values in the message itself unchanged.
+  return match[2]
+    .replace(/^[\w]+(?:::[\w]+)*:\s+/, '')
+    .split(/(?:^|\s)[\w.]+=/, 1)[0].trim() || '(no message)';
+}
+
+function filesUnder(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const filename = path.join(dir, entry.name);
+    if (entry.isDirectory()) return filesUnder(filename);
+    return entry.isFile() ? [filename] : [];
+  }).sort();
+}
+
+async function scanLogs(resultsDir, mode) {
+  if (!['e2e', 'replay'].includes(mode)) throw new Error(`Unknown benchmark mode: ${mode}`);
+  const labels = fs.readFileSync(path.join(resultsDir, 'run-order.txt'), 'utf8')
+    .split(/\r?\n/).filter(Boolean);
+  if (labels.length === 0) throw new Error('No benchmark runs found in run-order.txt');
+  const counts = new Map();
+  const runs = [];
+  for (const label of labels) {
+    if (!/^(baseline|feature)-\d+$/.test(label)) throw new Error(`Invalid run label: ${label}`);
+    const side = label.split('-')[0];
+    const nodeDirs = mode === 'e2e'
+      ? ['a', 'b'].map(role => path.join(resultsDir, `logs-${label}-${role}`))
+      : [path.join(resultsDir, label, 'tempo-logs')];
+    const missing = nodeDirs.filter(dir => filesUnder(dir).length === 0);
+    const files = nodeDirs.flatMap(filesUnder);
+    // Console output duplicates node file logs. Only fall back to it when the
+    // replay node produced no file logs (e.g. file logging was disabled).
+    if (mode === 'replay' && files.length === 0) {
+      const consoleLog = path.join(resultsDir, label, 'node.log');
+      if (fs.existsSync(consoleLog)) files.push(consoleLog);
+    }
+    files.push(...filesUnder(mode === 'e2e'
+      ? path.join(resultsDir, `txgen-logs-${label}`)
+      : path.join(resultsDir, label, 'txgen-logs')));
+    const captureLog = path.join(resultsDir, `tracy-capture-${label}.log`);
+    if (mode === 'e2e' && fs.existsSync(captureLog)) files.push(captureLog);
+    const run = { label, side, total: 0, files: files.map(f => path.relative(resultsDir, f)),
+      missing_node_logs: missing.map(f => path.relative(resultsDir, f)) };
+    for (const filename of files) {
+      const input = fs.createReadStream(filename);
+      const lines = readline.createInterface({ input, crlfDelay: Infinity });
+      // Forward stream errors to the iterator instead of leaving an unhandled
+      // error event or silently reporting an incomplete scan as zero.
+      input.on('error', () => lines.close());
+      for await (const line of lines) {
+        const message = parseLine(line);
+        if (message === null) continue;
+        const row = counts.get(message) || { message, baseline: 0, feature: 0, per_run: {} };
+        row[side] += 1;
+        row.per_run[label] = (row.per_run[label] || 0) + 1;
+        counts.set(message, row);
+        run.total += 1;
+      }
+      if (input.errored) throw input.errored;
+    }
+    runs.push(run);
+  }
+  return { runs, messages: [...counts.values()].sort((a, b) =>
+    (b.baseline + b.feature) - (a.baseline + a.feature) || a.message.localeCompare(b.message)) };
+}
+
+function escapeCell(value) {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/\|/g, '&#124;').replace(/`/g, '&#96;').replace(/[\r\n]+/g, ' ');
+}
+
+function buildMarkdown(report) {
+  const total = side => report.runs.some(r => r.side === side)
+    ? report.runs.filter(r => r.side === side).reduce((sum, r) => sum + r.total, 0) : '—';
+  const lines = ['', '## Non-INFO/DEBUG logs', '',
+    'Counts include all collected run logs, including setup, warmup, and shutdown. Annotated key/value fields are excluded; repeated messages are counted, not deduplicated. Unlevelled output is ignored.', '',
+    '| Run type | Total lines |', '|----------|------------:|',
+    `| Baseline | ${total('baseline')} |`, `| Feature | ${total('feature')} |`, ''];
+  if (report.runs.some(r => r.missing_node_logs.length)) {
+    lines.push('⚠️ Some node file logs are missing; counts may be incomplete. See `log-summary.json` for source coverage.', '');
+  }
+  if (report.messages.length) {
+    lines.push('<details><summary>Counts by message</summary>', '',
+      '| Message | Baseline | Feature |', '|---------|---------:|--------:|');
+    // Leave room for metrics and observability links within GitHub's comment
+    // limit. The artifact always retains the complete breakdown, including runs.
+    let bytes = 0;
+    for (const [index, row] of report.messages.entries()) {
+      const line = `| ${escapeCell(row.message)} | ${total('baseline') === '—' ? '—' : row.baseline} | ${total('feature') === '—' ? '—' : row.feature} |`;
+      bytes += Buffer.byteLength(line);
+      if (bytes > 24000) {
+        lines.push('', `Showing ${index} of ${report.messages.length} messages; the complete breakdown is in \`log-summary.json\` in the results artifact.`);
+        break;
+      }
+      lines.push(line);
+    }
+    lines.push('', '</details>');
+  } else {
+    lines.push('No non-INFO/DEBUG messages found in the collected logs.');
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+async function main(resultsDir, mode, markdownName) {
+  const report = await scanLogs(resultsDir, mode);
+  fs.writeFileSync(path.join(resultsDir, 'log-summary.json'), `${JSON.stringify(report, null, 2)}\n`);
+  fs.appendFileSync(path.join(resultsDir, markdownName), buildMarkdown(report));
+}
+
+if (require.main === module) {
+  const [resultsDir, mode, markdownName] = process.argv.slice(2);
+  if (!resultsDir || !mode || !markdownName) {
+    console.error('usage: bench-log-summary.js <results-dir> <e2e|replay> <markdown-file>');
+    process.exit(2);
+  }
+  main(resultsDir, mode, markdownName).catch(error => { console.error(error); process.exitCode = 1; });
+}
+
+module.exports = { parseLine, scanLogs, buildMarkdown, main };

--- a/.github/scripts/bench-log-summary.js
+++ b/.github/scripts/bench-log-summary.js
@@ -15,7 +15,7 @@ function parseLine(raw) {
       if (!entry.level) return null;
       const level = entry.level.toUpperCase();
       if (level === 'INFO' || level === 'DEBUG') return null;
-      return String(entry.fields?.message ?? entry.message ?? '(no message)');
+      return String(entry.fields?.message ?? entry.message ?? entry.fields?.error ?? entry.error ?? '(no message)');
     } catch {
       return null;
     }
@@ -93,7 +93,7 @@ function buildMarkdown(report) {
   const total = side => report.runs.some(r => r.side === side)
     ? report.runs.filter(r => r.side === side).reduce((sum, r) => sum + r.total, 0) : '—';
   const lines = ['', '## Non-INFO/DEBUG logs', '',
-    'Counts include only Tempo node logs across each run, including startup, warmup, and shutdown. Annotated key/value fields are excluded; repeated messages are counted, not deduplicated. Unlevelled output is ignored.', '',
+    'Counts include only Tempo node logs across each run, including startup, warmup, and shutdown. Annotated key/value fields are excluded, except that JSON logs without a message use the error field. Repeated messages are counted, not deduplicated. Unlevelled output is ignored.', '',
     '| Run type | Total lines |', '|----------|------------:|',
     `| Baseline | ${total('baseline')} |`, `| Feature | ${total('feature')} |`, ''];
   if (report.runs.some(r => r.missing_node_logs.length)) {

--- a/.github/scripts/bench-log-summary.test.js
+++ b/.github/scripts/bench-log-summary.test.js
@@ -1,0 +1,112 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+const { parseLine, scanLogs, buildMarkdown, main } = require('./bench-log-summary');
+
+function fixture(t, files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bench-logs-'));
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }));
+  for (const [name, content] of Object.entries(files)) {
+    const filename = path.join(dir, name);
+    fs.mkdirSync(path.dirname(filename), { recursive: true });
+    fs.writeFileSync(filename, content);
+  }
+  return dir;
+}
+
+const json = (level, message, fields = {}) =>
+  JSON.stringify({ level, fields: { message, ...fields }, target: 'tempo::node' }) + '\n';
+
+test('JSON excludes annotations but preserves key=value inside the actual message', () => {
+  assert.equal(parseLine(json('WARN', 'failed with status=503', { peer: 42, error: 'many words' })),
+    'failed with status=503');
+  assert.equal(parseLine(json('TRACE', 'trace event')), 'trace event');
+  for (const level of ['INFO', 'DEBUG']) assert.equal(parseLine(json(level, 'ignored')), null);
+  assert.equal(parseLine('{"level":"ERROR","fields":{"error":"boom"}}'), '(no message)');
+});
+
+test('terminal output strips ANSI, target and structured fields', () => {
+  assert.equal(parseLine('2026-09-10T01:02:03.123Z \x1b[33m WARN\x1b[0m tempo::node: Peer failed peer=1 error="connection refused"'), 'Peer failed');
+  assert.equal(parseLine('ERROR Failed to submit batch=2 error.sources=[many words]'), 'Failed to submit');
+  assert.equal(parseLine('WARN error="connection refused"'), '(no message)');
+  assert.equal(parseLine('INFO normal message with WARN in it'), null);
+  assert.equal(parseLine('DEBUG ignored'), null);
+  assert.equal(parseLine('compiling crate; WARN is not a log level here'), null);
+});
+
+test('E2E scans every node and rotated file plus sender/setup/capture logs across runs', async t => {
+  const dir = fixture(t, {
+    'run-order.txt': 'feature-1\nbaseline-1\nbaseline-2\n',
+    'logs-feature-1-a/tempo.log': json('ERROR', 'Peer failed', { peer: 1 }),
+    'logs-feature-1-b/tempo.log': json('INFO', 'ignored'),
+    'logs-baseline-1-a/tempo.log.1': json('WARN', 'Peer failed', { peer: 2 }),
+    'logs-baseline-1-a/tempo.log': json('WARN', 'Peer failed', { peer: 3 }),
+    'logs-baseline-1-b/tempo.log': json('DEBUG', 'ignored'),
+    'logs-baseline-2-a/tempo.log': json('TRACE', 'Trace event'),
+    'logs-baseline-2-b/tempo.log': json('WARN', 'Peer failed', { peer: 4 }),
+    'txgen-logs-feature-1/setup-stderr.log': 'WARN Setup retry attempt=1\n',
+    'txgen-logs-feature-1/sender-stderr.log': 'ERROR Submit failed batch=1\nERROR Submit failed batch=2\n',
+    'tracy-capture-feature-1.log': 'WARN Capture warning\n',
+    'logs-feature-99-a/tempo.log': json('ERROR', 'stale run'),
+    'summary.md': '# Existing metrics\n',
+  });
+  await main(dir, 'e2e', 'summary.md');
+  const report = JSON.parse(fs.readFileSync(path.join(dir, 'log-summary.json')));
+  assert.deepEqual(report.runs.map(r => r.total), [5, 2, 2]);
+  assert.deepEqual(report.messages.find(r => r.message === 'Peer failed'), {
+    message: 'Peer failed', baseline: 3, feature: 1,
+    per_run: { 'feature-1': 1, 'baseline-1': 2, 'baseline-2': 1 },
+  });
+  const markdown = fs.readFileSync(path.join(dir, 'summary.md'), 'utf8');
+  assert.match(markdown, /^# Existing metrics/);
+  assert.match(markdown, /\| Baseline \| 4 \|/);
+  assert.match(markdown, /\| Feature \| 5 \|/);
+  assert.match(markdown, /\| Peer failed \| 3 \| 1 \|/);
+  assert.doesNotMatch(markdown, /peer=|stale run|incomplete/);
+});
+
+test('replay avoids duplicate node console logs and includes warmup and sender output', async t => {
+  const dir = fixture(t, {
+    'run-order.txt': 'baseline-1\nfeature-1',
+    'baseline-1/tempo-logs/tempo.log': json('WARN', 'Repeated'),
+    'baseline-1/node.log': 'WARN Repeated\n',
+    'baseline-1/txgen-logs/warmup.log': 'WARN Repeated\n',
+    'feature-1/tempo-logs/tempo.log': json('INFO', 'normal'),
+    'feature-1/txgen-logs/sender.log': 'ERROR Failed\n',
+    'comment.md': '# Replay metrics\n',
+  });
+  await main(dir, 'replay', 'comment.md');
+  const markdown = fs.readFileSync(path.join(dir, 'comment.md'), 'utf8');
+  assert.match(markdown, /\| Repeated \| 2 \| 0 \|/);
+  assert.match(markdown, /\| Failed \| 0 \| 1 \|/);
+  assert.match(markdown, /^# Replay metrics/);
+});
+
+test('missing file logs use replay console fallback and are visibly marked incomplete', async t => {
+  const dir = fixture(t, { 'run-order.txt': 'feature-1\n', 'feature-1/node.log': 'ERROR Failed\n' });
+  const report = await scanLogs(dir, 'replay');
+  const markdown = buildMarkdown(report);
+  assert.match(markdown, /incomplete/);
+  assert.match(markdown, /\| Failed \| — \| 1 \|/);
+});
+
+test('zero counts, safe Markdown and bounded comment size', () => {
+  const report = { runs: [{ side: 'feature', total: 0, missing_node_logs: [] }], messages: [] };
+  assert.match(buildMarkdown(report), /\| Feature \| 0 \|/);
+  assert.match(buildMarkdown(report), /No non-INFO\/DEBUG messages/);
+  report.messages = [{ message: '<tag>|`code`\nnext', baseline: 0, feature: 1 }];
+  assert.match(buildMarkdown(report), /&lt;tag&gt;&#124;&#96;code&#96; next/);
+  report.messages = Array.from({ length: 1000 }, (_, i) => ({
+    message: `Message ${i} ${'x'.repeat(100)}`, baseline: 0, feature: 1,
+  }));
+  const markdown = buildMarkdown(report);
+  assert.ok(Buffer.byteLength(markdown) < 26000);
+  assert.match(markdown, /Showing \d+ of 1000 messages/);
+});
+
+test('invalid run labels cannot read outside results', async t => {
+  const dir = fixture(t, { 'run-order.txt': '../baseline-1' });
+  await assert.rejects(scanLogs(dir, 'e2e'), /Invalid run label/);
+});

--- a/.github/scripts/bench-log-summary.test.js
+++ b/.github/scripts/bench-log-summary.test.js
@@ -24,7 +24,37 @@ test('JSON excludes annotations but preserves key=value inside the actual messag
     'failed with status=503');
   assert.equal(parseLine(json('TRACE', 'trace event')), 'trace event');
   for (const level of ['INFO', 'DEBUG']) assert.equal(parseLine(json(level, 'ignored')), null);
-  assert.equal(parseLine('{"level":"ERROR","fields":{"error":"boom"}}'), '(no message)');
+  assert.equal(parseLine('{"level":"ERROR","fields":{"peer":42}}'), '(no message)');
+});
+
+test('JSON falls back to error only when message is absent', () => {
+  assert.equal(parseLine(json('WARN', undefined, { error: 'proposal aborted', peer: 42 })), 'proposal aborted');
+  assert.equal(parseLine('{"level":"ERROR","error":"top-level error"}'), 'top-level error');
+  assert.equal(parseLine('{"level":"WARN","message":"explicit message","fields":{"error":"ignored"}}'), 'explicit message');
+  assert.equal(parseLine(json('WARN', 'explicit message', { error: 'ignored' })), 'explicit message');
+  for (const level of ['INFO', 'DEBUG']) {
+    assert.equal(parseLine(json(level, undefined, { error: 'ignored' })), null);
+  }
+});
+
+test('message-less proposal warnings group by error with baseline and feature counts', async t => {
+  const error = 'proposal return channel was closed by consensus engine before block could be proposed; aborting';
+  const dir = fixture(t, {
+    'run-order.txt': 'baseline-1\nfeature-1\n',
+    'logs-baseline-1-a/tempo.log': json('WARN', undefined, { error, view: 162 }),
+    'logs-baseline-1-b/tempo.log': [121, 138, 161].map(view => json('WARN', undefined, { error, view })).join(''),
+    'logs-feature-1-a/tempo.log': json('INFO', 'normal'),
+    'logs-feature-1-b/tempo.log': [45, 167].map(view => json('WARN', undefined, { error, view })).join(''),
+    'summary.md': '# Metrics\n',
+  });
+  await main(dir, 'e2e', 'summary.md');
+  const report = JSON.parse(fs.readFileSync(path.join(dir, 'log-summary.json')));
+  assert.deepEqual(report.messages, [{
+    message: error, baseline: 4, feature: 2, per_run: { 'baseline-1': 4, 'feature-1': 2 },
+  }]);
+  const markdown = fs.readFileSync(path.join(dir, 'summary.md'), 'utf8');
+  assert.ok(markdown.includes(`| ${error} | 4 | 2 |`));
+  assert.doesNotMatch(markdown, /\(no message\)|view=/);
 });
 
 test('terminal output strips ANSI, target and structured fields', () => {

--- a/.github/scripts/bench-log-summary.test.js
+++ b/.github/scripts/bench-log-summary.test.js
@@ -36,7 +36,7 @@ test('terminal output strips ANSI, target and structured fields', () => {
   assert.equal(parseLine('compiling crate; WARN is not a log level here'), null);
 });
 
-test('E2E scans every node and rotated file plus sender/setup/capture logs across runs', async t => {
+test('E2E scans every node and rotated file across runs, ignoring txgen and profiler logs', async t => {
   const dir = fixture(t, {
     'run-order.txt': 'feature-1\nbaseline-1\nbaseline-2\n',
     'logs-feature-1-a/tempo.log': json('ERROR', 'Peer failed', { peer: 1 }),
@@ -54,7 +54,9 @@ test('E2E scans every node and rotated file plus sender/setup/capture logs acros
   });
   await main(dir, 'e2e', 'summary.md');
   const report = JSON.parse(fs.readFileSync(path.join(dir, 'log-summary.json')));
-  assert.deepEqual(report.runs.map(r => r.total), [5, 2, 2]);
+  assert.deepEqual(report.runs.map(r => r.total), [1, 2, 2]);
+  assert.ok(report.runs.flatMap(r => r.files).every(file => file.startsWith('logs-')));
+  assert.deepEqual(report.messages.map(r => r.message), ['Peer failed', 'Trace event']);
   assert.deepEqual(report.messages.find(r => r.message === 'Peer failed'), {
     message: 'Peer failed', baseline: 3, feature: 1,
     per_run: { 'feature-1': 1, 'baseline-1': 2, 'baseline-2': 1 },
@@ -62,12 +64,12 @@ test('E2E scans every node and rotated file plus sender/setup/capture logs acros
   const markdown = fs.readFileSync(path.join(dir, 'summary.md'), 'utf8');
   assert.match(markdown, /^# Existing metrics/);
   assert.match(markdown, /\| Baseline \| 4 \|/);
-  assert.match(markdown, /\| Feature \| 5 \|/);
+  assert.match(markdown, /\| Feature \| 1 \|/);
   assert.match(markdown, /\| Peer failed \| 3 \| 1 \|/);
   assert.doesNotMatch(markdown, /peer=|stale run|incomplete/);
 });
 
-test('replay avoids duplicate node console logs and includes warmup and sender output', async t => {
+test('replay scans only node logs, avoiding console duplicates and txgen output', async t => {
   const dir = fixture(t, {
     'run-order.txt': 'baseline-1\nfeature-1',
     'baseline-1/tempo-logs/tempo.log': json('WARN', 'Repeated'),
@@ -79,8 +81,13 @@ test('replay avoids duplicate node console logs and includes warmup and sender o
   });
   await main(dir, 'replay', 'comment.md');
   const markdown = fs.readFileSync(path.join(dir, 'comment.md'), 'utf8');
-  assert.match(markdown, /\| Repeated \| 2 \| 0 \|/);
-  assert.match(markdown, /\| Failed \| 0 \| 1 \|/);
+  assert.match(markdown, /\| Repeated \| 1 \| 0 \|/);
+  assert.doesNotMatch(markdown, /Failed/);
+  assert.match(markdown, /\| Feature \| 0 \|/);
+  const report = JSON.parse(fs.readFileSync(path.join(dir, 'log-summary.json')));
+  assert.deepEqual(report.runs.flatMap(r => r.files), [
+    'baseline-1/tempo-logs/tempo.log', 'feature-1/tempo-logs/tempo.log',
+  ]);
   assert.match(markdown, /^# Replay metrics/);
 });
 

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -239,7 +239,6 @@ run_single() {
 
   echo "=== Starting run: $label ==="
   mkdir -p "$output_dir"
-  mkdir -p "$output_dir/txgen-logs"
   local log="$output_dir/node.log"
 
   # Recover snapshot
@@ -415,11 +414,10 @@ run_single() {
   if [ "$WARMUP" -gt 0 ]; then
     local warmup_to=$(( from_block + WARMUP - 1 ))
     echo "Running warmup ($WARMUP blocks: $from_block..$warmup_to)..."
-    { "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$warmup_to" \
+    "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$warmup_to" \
       | "$TXGEN_BENCH_BIN" send-blocks \
         --engine http://127.0.0.1:8551 \
-        --jwt-secret "$DATADIR/jwt.hex";
-    } 2>&1 | tee "$output_dir/txgen-logs/warmup.log" | sed -u "s/^/[bench] /"
+        --jwt-secret "$DATADIR/jwt.hex" 2>&1 | sed -u "s/^/[bench] /"
     from_block=$(( warmup_to + 1 ))
   fi
 
@@ -435,7 +433,7 @@ run_single() {
     victoriametrics_report=(--report "victoriametrics:$BENCH_VICTORIAMETRICS_URL")
   fi
 
-  { "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$bench_to" \
+  "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$bench_to" \
     | "$TXGEN_BENCH_BIN" send-blocks \
       --engine http://127.0.0.1:8551 \
       --jwt-secret "$DATADIR/jwt.hex" \
@@ -451,8 +449,7 @@ run_single() {
       -m "benchmark_id=$BENCHMARK_ID" \
       -m "benchmark_run=$label" \
       -m "run_type=$run_type" \
-      -m "blocks=$BLOCKS";
-  } 2>&1 | tee "$output_dir/txgen-logs/sender.log" | sed -u "s/^/[bench] /"
+      -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
 
   # Cleanup (runs via EXIT trap; call explicitly for the success log line)
   cleanup_run

--- a/.github/scripts/bench-tempo-replay.sh
+++ b/.github/scripts/bench-tempo-replay.sh
@@ -239,6 +239,7 @@ run_single() {
 
   echo "=== Starting run: $label ==="
   mkdir -p "$output_dir"
+  mkdir -p "$output_dir/txgen-logs"
   local log="$output_dir/node.log"
 
   # Recover snapshot
@@ -258,6 +259,7 @@ run_single() {
     --chain "$CHAIN_NAME"
     --datadir "$DATADIR"
     --log.file.directory "$output_dir/tempo-logs"
+    --log.file.format json
     --http
     --http.port 8545
     --http.api all
@@ -413,10 +415,11 @@ run_single() {
   if [ "$WARMUP" -gt 0 ]; then
     local warmup_to=$(( from_block + WARMUP - 1 ))
     echo "Running warmup ($WARMUP blocks: $from_block..$warmup_to)..."
-    "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$warmup_to" \
+    { "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$warmup_to" \
       | "$TXGEN_BENCH_BIN" send-blocks \
         --engine http://127.0.0.1:8551 \
-        --jwt-secret "$DATADIR/jwt.hex" 2>&1 | sed -u "s/^/[bench] /"
+        --jwt-secret "$DATADIR/jwt.hex";
+    } 2>&1 | tee "$output_dir/txgen-logs/warmup.log" | sed -u "s/^/[bench] /"
     from_block=$(( warmup_to + 1 ))
   fi
 
@@ -432,7 +435,7 @@ run_single() {
     victoriametrics_report=(--report "victoriametrics:$BENCH_VICTORIAMETRICS_URL")
   fi
 
-  "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$bench_to" \
+  { "$TXGEN_TEMPO_BIN" extract --rpc "$REPLAY_RPC_URL" --from "$from_block" --to "$bench_to" \
     | "$TXGEN_BENCH_BIN" send-blocks \
       --engine http://127.0.0.1:8551 \
       --jwt-secret "$DATADIR/jwt.hex" \
@@ -448,7 +451,8 @@ run_single() {
       -m "benchmark_id=$BENCHMARK_ID" \
       -m "benchmark_run=$label" \
       -m "run_type=$run_type" \
-      -m "blocks=$BLOCKS" 2>&1 | sed -u "s/^/[bench] /"
+      -m "blocks=$BLOCKS";
+  } 2>&1 | tee "$output_dir/txgen-logs/sender.log" | sed -u "s/^/[bench] /"
 
   # Cleanup (runs via EXIT trap; call explicitly for the success log line)
   cleanup_run

--- a/.github/workflows/bench-e2e.yml
+++ b/.github/workflows/bench-e2e.yml
@@ -1142,7 +1142,7 @@ jobs:
                 const tracesUrl = `https://tempoxyz.grafana.net/explore?schemaVersion=1&panes=${encodeURIComponent(tracesPane)}&orgId=1`;
                 const internalPerfLine = internalPerfUrl ? `- [Internal dashboard](${internalPerfUrl})\n` : '';
                 const grafanaLine = process.env.BENCH_METRICS === 'true' ? `- [Grafana](${grafanaUrl})\n` : '';
-                grafanaSection = `\n\n### Observability\n\n${internalPerfLine}${grafanaLine}- [Logs](${logsUrl})\n- [Traces](${tracesUrl})\n${valscopeLine}`;
+                grafanaSection = `\n${internalPerfLine}${grafanaLine}- [Logs](${logsUrl})\n- [Traces](${tracesUrl})\n${valscopeLine}`;
               }
             } catch (e) {}
 
@@ -1201,7 +1201,13 @@ jobs:
             }
 
             const jobUrl = process.env.BENCH_JOB_URL || `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${grafanaSection}${samplySection}${tracySection}`;
+            const observabilityHeading = '\n## Observability\n';
+            if (summary.includes(observabilityHeading)) {
+              summary = summary.replace(observabilityHeading, () => observabilityHeading + grafanaSection);
+            } else if (grafanaSection) {
+              summary += observabilityHeading + grafanaSection;
+            }
+            const body = `cc @${process.env.BENCH_ACTOR}\n\n${resultHeadline} [View job](${jobUrl})\n\n${summary}${samplySection}${tracySection}`;
             const ackCommentId = process.env.BENCH_COMMENT_ID;
 
             if (ackCommentId) {

--- a/.github/workflows/bench-replay.yml
+++ b/.github/workflows/bench-replay.yml
@@ -484,6 +484,11 @@ jobs:
           BENCH_REPLAY_RPC_URL: ${{ env.BENCH_CHAIN == 'mainnet' && secrets.BENCH_MAINNET_RPC_URL || env.BENCH_CHAIN == 'testnet' && secrets.BENCH_TESTNET_RPC_URL || '' }}
         run: bash .github/scripts/bench-tempo-replay.sh
 
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24
+
       - name: Parse results
         id: results
         if: success()
@@ -515,6 +520,7 @@ jobs:
             --feature-ref "$FEATURE_REF" \
             --baseline-json "${BASELINE_JSONS[@]}" \
             --feature-json "${FEATURE_JSONS[@]}"
+          node .github/scripts/bench-log-summary.js "$BENCH_WORK_DIR" replay comment.md
 
       - name: Generate charts
         id: charts

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1047,6 +1047,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
         $"($ctx.results_dir)/tracy-capture-($phase).log"
         $"($ctx.results_dir)/logs-($phase)-a"
         $"($ctx.results_dir)/logs-($phase)-b"
+        $"($ctx.results_dir)/txgen-logs-($phase)"
     ] {
         if ($stale | path exists) { rm -rf $stale }
     }
@@ -1056,6 +1057,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
     let a_rpc = "http://127.0.0.1:8545"
     let b_rpc = "http://127.0.0.1:8645"
     let a_base_args = (build-base-args $genesis $ctx.a.datadir $a_log_dir "0.0.0.0" 8545 9001)
+        | append ["--log.file.format" "json"]
         | append (build-e2e-consensus-args $ctx.a.node_dir $ctx.trusted_peers $ctx.a.consensus_port $ctx.a.ip)
         | append $local_reth_args
         | append (log-filter-args $ctx.loud)
@@ -1064,6 +1066,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
         | append (if $ctx.tracy != "off" { ["--log.tracy" "--log.tracy.filter" $ctx.tracy_filter] } else { [] })
         | append (benchmark-otlp-args $ctx.tracing_otlp)
     let b_base_args = (build-base-args $genesis $ctx.b.datadir $b_log_dir "0.0.0.0" 8645 9101)
+        | append ["--log.file.format" "json"]
         | append (build-e2e-consensus-args $ctx.b.node_dir $ctx.trusted_peers $ctx.b.consensus_port $ctx.b.ip)
         | append $local_reth_args
         | append (log-filter-args $ctx.loud)
@@ -1150,6 +1153,7 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --submit-rpc-url $submit_rpc_url
                 --metrics-url $metrics_urls
                 --report-path $"($ctx.results_dir)/report-($phase).json"
+                --log-dir $"($ctx.results_dir)/txgen-logs-($phase)"
                 --tps $ctx.tps
                 --duration $ctx.duration
                 --accounts $ctx.accounts
@@ -1331,6 +1335,7 @@ def e2e-generate-summary [results_dir: string] {
         SLACK_BENCH_CHANNEL: ""
     } {
         ^node .github/scripts/bench-e2e-classify.js $results_dir
+        ^node .github/scripts/bench-log-summary.js $results_dir e2e summary.md
     }
 }
 

--- a/bench-e2e.nu
+++ b/bench-e2e.nu
@@ -1047,7 +1047,6 @@ def run-local-e2e-phase [run: record, ctx: record] {
         $"($ctx.results_dir)/tracy-capture-($phase).log"
         $"($ctx.results_dir)/logs-($phase)-a"
         $"($ctx.results_dir)/logs-($phase)-b"
-        $"($ctx.results_dir)/txgen-logs-($phase)"
     ] {
         if ($stale | path exists) { rm -rf $stale }
     }
@@ -1153,7 +1152,6 @@ def run-local-e2e-phase [run: record, ctx: record] {
                 --submit-rpc-url $submit_rpc_url
                 --metrics-url $metrics_urls
                 --report-path $"($ctx.results_dir)/report-($phase).json"
-                --log-dir $"($ctx.results_dir)/txgen-logs-($phase)"
                 --tps $ctx.tps
                 --duration $ctx.duration
                 --accounts $ctx.accounts

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -606,7 +606,6 @@ def txgen-run-preset-pipeline [
     --submit-rpc-url: string
     --metrics-url: list<string>
     --report-path: string
-    --log-dir: string = ""                          # Retain setup and sender output for benchmark summaries
     --tps: int
     --duration: int
     --accounts: int
@@ -740,11 +739,6 @@ def txgen-run-preset-pipeline [
 
         print "  Streaming keychain setup transactions into bench send..."
         let setup_result = (bash -lc $setup_pipeline | complete)
-        if $log_dir != "" {
-            mkdir $log_dir
-            $setup_result.stdout | save -f ($log_dir | path join "setup-stdout.log")
-            $setup_result.stderr | save -f ($log_dir | path join "setup-stderr.log")
-        }
         if $setup_result.stdout != "" { print $setup_result.stdout }
         if $setup_result.stderr != "" { print $setup_result.stderr }
 
@@ -755,11 +749,6 @@ def txgen-run-preset-pipeline [
 
     print $"  Streaming up to ($tx_count) txgen transaction\(s\) over ($txgen_duration) into bench send..."
     let result = (bash -lc $pipeline | complete)
-    if $log_dir != "" {
-        mkdir $log_dir
-        $result.stdout | save -f ($log_dir | path join "sender-stdout.log")
-        $result.stderr | save -f ($log_dir | path join "sender-stderr.log")
-    }
     if $result.stdout != "" { print $result.stdout }
     if $result.stderr != "" { print $result.stderr }
 

--- a/contrib/bench/txgen/helpers.nu
+++ b/contrib/bench/txgen/helpers.nu
@@ -606,6 +606,7 @@ def txgen-run-preset-pipeline [
     --submit-rpc-url: string
     --metrics-url: list<string>
     --report-path: string
+    --log-dir: string = ""                          # Retain setup and sender output for benchmark summaries
     --tps: int
     --duration: int
     --accounts: int
@@ -739,6 +740,11 @@ def txgen-run-preset-pipeline [
 
         print "  Streaming keychain setup transactions into bench send..."
         let setup_result = (bash -lc $setup_pipeline | complete)
+        if $log_dir != "" {
+            mkdir $log_dir
+            $setup_result.stdout | save -f ($log_dir | path join "setup-stdout.log")
+            $setup_result.stderr | save -f ($log_dir | path join "setup-stderr.log")
+        }
         if $setup_result.stdout != "" { print $setup_result.stdout }
         if $setup_result.stderr != "" { print $setup_result.stderr }
 
@@ -749,6 +755,11 @@ def txgen-run-preset-pipeline [
 
     print $"  Streaming up to ($tx_count) txgen transaction\(s\) over ($txgen_duration) into bench send..."
     let result = (bash -lc $pipeline | complete)
+    if $log_dir != "" {
+        mkdir $log_dir
+        $result.stdout | save -f ($log_dir | path join "sender-stdout.log")
+        $result.stderr | save -f ($log_dir | path join "sender-stderr.log")
+    }
     if $result.stdout != "" { print $result.stdout }
     if $result.stderr != "" { print $result.stderr }
 


### PR DESCRIPTION
Adds baseline/feature totals and per-message counts for non-INFO/DEBUG Tempo node logs under Observability → Warn/Error Logs in Derek's E2E and replay comments and Actions summaries, excluding annotated key/value fields except for an `error` fallback when a JSON log has no `message`. Scans all retained node logs (including rotations and both E2E validators) and saves the full breakdown with per-run counts in `log-summary.json`; node file logs use JSON for reliable message extraction.

Validation: nine Node tests pass, including message precedence, error fallback, and grouping proposal-return warnings as 4 baseline / 2 feature occurrences, plus `git diff --check`. The workflow's comment and run-summary formatting was checked with stubbed GitHub calls, both with and without observability links. Bash/Nushell syntax checks and workflow YAML parsing passed for the workflow changes; the dedicated benchmark has not been rerun with these updates. Missing node logs are flagged, and large comment tables point to the complete results artifact.

Prompted by: @mediocregopher
