### PR TITLE
fix(bench): use plain TIP-20 transfers in public-mix

### DIFF
--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -1,5 +1,5 @@
 # Forward-looking public workload, weighted by submitted transactions (not gas).
-# Transaction shares: plain transfer 80%, mint 2%, MPP 18%.
+# Transaction shares: plain transfer 80%, mint 5%, MPP 15%.
 # These are benchmark assumptions, not a replay of mainnet activity.
 # Uses the native MPP open-only preset with txgen main.
 # Transfers and mints target prepopulated state-bloat accounts; requires nonzero bloat.
@@ -53,6 +53,6 @@ mix:
   - template: public_transfer
     weight: 80
   - template: public_mint
-    weight: 2
+    weight: 5
   - sequence: mpp_open_only
-    weight: 18
+    weight: 15

--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -1,6 +1,6 @@
 # Forward-looking public workload, weighted by submitted transactions (not gas).
-# Relative transaction shares: plain transfer 25, memo transfer 40, mint 1, MPP 15.
-# Normalized: approximately 30.86%, 49.38%, 1.23%, and 18.52%, respectively.
+# Relative transaction shares: plain transfer 65, mint 1, MPP 15.
+# Normalized: approximately 80.25%, 1.23%, and 18.52%, respectively.
 # These are benchmark assumptions, not a replay of mainnet activity.
 # Uses the native MPP open-only preset with txgen main.
 # Transfers and mints target prepopulated state-bloat accounts; requires nonzero bloat.
@@ -33,22 +33,6 @@ templates:
       args:
         - {address_pool: {pool: existing_recipients, select: random}}
         - 1
-  public_transfer_memo:
-    type: tempo
-    from: {pool: users, select: random}
-    gas_limit: 300000
-    fee_token: "0x20c0000000000000000000000000000000000000"
-    expiring_nonce: true
-    valid_for_secs: 25
-    call:
-      to:
-        choice: ${TXGEN_TIP20_TOKENS}
-      abi: ERC20
-      function: transferWithMemo
-      args:
-        - {address_pool: {pool: existing_recipients, select: random}}
-        - 1
-        - {random_bytes: 32}
   public_mint:
     type: tempo
     # Dev genesis grants the pathUSD issuer role to users[0].
@@ -66,12 +50,9 @@ templates:
         - 1
 
 # Each selection emits one transaction, including MPP.
-# Preserve the relative allocations of the four retained workloads.
 mix:
   - template: public_transfer
-    weight: 25
-  - template: public_transfer_memo
-    weight: 40
+    weight: 65
   - template: public_mint
     weight: 1
   - sequence: mpp_open_only

--- a/contrib/bench/txgen/presets/public-mix.yml
+++ b/contrib/bench/txgen/presets/public-mix.yml
@@ -1,6 +1,5 @@
 # Forward-looking public workload, weighted by submitted transactions (not gas).
-# Relative transaction shares: plain transfer 65, mint 1, MPP 15.
-# Normalized: approximately 80.25%, 1.23%, and 18.52%, respectively.
+# Transaction shares: plain transfer 80%, mint 2%, MPP 18%.
 # These are benchmark assumptions, not a replay of mainnet activity.
 # Uses the native MPP open-only preset with txgen main.
 # Transfers and mints target prepopulated state-bloat accounts; requires nonzero bloat.
@@ -52,8 +51,8 @@ templates:
 # Each selection emits one transaction, including MPP.
 mix:
   - template: public_transfer
-    weight: 65
+    weight: 80
   - template: public_mint
-    weight: 1
+    weight: 2
   - sequence: mpp_open_only
-    weight: 15
+    weight: 18


### PR DESCRIPTION
Replace TIP-20 transfers with memo in `public-mix` with plain transfers. Set the transaction mix to 80% plain TIP-20 transfers, 5% mint, and 15% MPP, and update the documented shares.

Validation: YAML parsing and workload assertions passed; `git diff --check` passed. The txgen executable is unavailable locally, so no runtime benchmark was run.

Prompted by: @shekhirin
