### PR TITLE
refactor: compute fixed Keccak hashes at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6525,6 +6525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d8d8ce877200136358e0bbff3a77965875db3af755a11e1fa6b1b3e2df13ea"
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13881,6 +13887,7 @@ dependencies = [
  "derive_more",
  "eyre",
  "itertools 0.14.0",
+ "keccak-const",
  "p256 0.13.2",
  "paste",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,6 +287,7 @@ insta = { version = "1", features = ["yaml"] }
 itertools = "0.14.0"
 jiff = { version = "0.2.18", default-features = false }
 jsonrpsee = { version = "0.26.0", features = ["server", "client", "macros"] }
+keccak-const = "0.2.0"
 metrics = "0.24.3"
 minisign = "0.8"
 minisign-verify = "0.2"

--- a/crates/e2e/src/tests/blocked_transfers.rs
+++ b/crates/e2e/src/tests/blocked_transfers.rs
@@ -317,7 +317,7 @@ where
 
     let roles = IRolesAuth::new(token, provider);
     let grant = roles
-        .grantRole(*ISSUER_ROLE, admin)
+        .grantRole(ISSUER_ROLE, admin)
         .gas(GAS)
         .gas_price(GAS_PRICE)
         .send()

--- a/crates/evm/benches/dex_execution.rs
+++ b/crates/evm/benches/dex_execution.rs
@@ -88,7 +88,7 @@ fn seed_dex_cache_db(
             )?;
 
             let mut quote = TIP20Token::from_address(PATH_USD_ADDRESS)?;
-            quote.grant_role_internal(admin, *ISSUER_ROLE)?;
+            quote.grant_role_internal(admin, ISSUER_ROLE)?;
 
             let base_token = TIP20Factory::new().create_token(
                 admin,
@@ -102,7 +102,7 @@ fn seed_dex_cache_db(
                 },
             )?;
             let mut base = TIP20Token::from_address(base_token)?;
-            base.grant_role_internal(admin, *ISSUER_ROLE)?;
+            base.grant_role_internal(admin, ISSUER_ROLE)?;
 
             for participant in participants {
                 let mint = ITIP20::mintCall {

--- a/crates/evm/benches/tip20_execution.rs
+++ b/crates/evm/benches/tip20_execution.rs
@@ -121,7 +121,7 @@ fn seed_in_memory_cache_db(
             )?;
 
             let mut token = TIP20Token::from_address(PATH_USD_ADDRESS)?;
-            token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            token.grant_role_internal(admin, ISSUER_ROLE)?;
             for participant in participants {
                 token.mint(
                     admin,

--- a/crates/node/tests/it/block_building.rs
+++ b/crates/node/tests/it/block_building.rs
@@ -103,7 +103,7 @@ where
 
     // Grant issuer role
     let roles = IRolesAuth::new(token_addr, provider.clone());
-    let grant_tx = roles.grantRole(*ISSUER_ROLE, sender_address);
+    let grant_tx = roles.grantRole(ISSUER_ROLE, sender_address);
     let grant_bytes = sign_and_encode(grant_tx.into_transaction_request(), nonce_start + 1).await?;
     node.rpc.inject_tx(grant_bytes).await?;
     node.advance_block().await?;

--- a/crates/node/tests/it/gas/receive_policy_guard.rs
+++ b/crates/node/tests/it/gas/receive_policy_guard.rs
@@ -55,7 +55,7 @@ where
 
     let roles = IRolesAuth::new(token, provider);
     let grant = roles
-        .grantRole(*ISSUER_ROLE, admin)
+        .grantRole(ISSUER_ROLE, admin)
         .gas(GAS_LIMIT)
         .send()
         .await?

--- a/crates/node/tests/it/gas/stablecoin_dex.rs
+++ b/crates/node/tests/it/gas/stablecoin_dex.rs
@@ -102,7 +102,7 @@ where
 
     let roles = IRolesAuth::new(*token.address(), provider);
     let receipt = roles
-        .grantRole(*ISSUER_ROLE, caller)
+        .grantRole(ISSUER_ROLE, caller)
         .gas(1_000_000)
         .send()
         .await?

--- a/crates/node/tests/it/tip20.rs
+++ b/crates/node/tests/it/tip20.rs
@@ -848,7 +848,7 @@ async fn test_tip20_pause_blocks_fee_collection() -> eyre::Result<()> {
 
     // Grant PAUSE_ROLE to admin and user
     roles
-        .grantRole(*PAUSE_ROLE, admin)
+        .grantRole(PAUSE_ROLE, admin)
         .gas(gas)
         .gas_price(gas_price)
         .send()
@@ -856,7 +856,7 @@ async fn test_tip20_pause_blocks_fee_collection() -> eyre::Result<()> {
         .get_receipt()
         .await?;
     roles
-        .grantRole(*PAUSE_ROLE, user)
+        .grantRole(PAUSE_ROLE, user)
         .gas(gas)
         .gas_price(gas_price)
         .send()

--- a/crates/node/tests/it/tip_fee_amm.rs
+++ b/crates/node/tests/it/tip_fee_amm.rs
@@ -48,7 +48,7 @@ where
     let token = ITIP20::new(event.token, provider.clone());
 
     IRolesAuth::new(*token.address(), provider)
-        .grantRole(*ISSUER_ROLE, caller)
+        .grantRole(ISSUER_ROLE, caller)
         .gas(1_000_000)
         .send()
         .await?

--- a/crates/node/tests/it/utils.rs
+++ b/crates/node/tests/it/utils.rs
@@ -334,7 +334,7 @@ where
     let roles = IRolesAuth::new(*token.address(), provider);
 
     roles
-        .grantRole(*ISSUER_ROLE, caller)
+        .grantRole(ISSUER_ROLE, caller)
         .from(caller)
         .gas(1_000_000)
         .send()

--- a/crates/precompiles/Cargo.toml
+++ b/crates/precompiles/Cargo.toml
@@ -26,6 +26,7 @@ alloy-json-abi = { workspace = true, optional = true }
 itertools = { workspace = true, optional = true }
 alloy-evm = { workspace = true, features = ["std"] }
 alloy-primitives = { workspace = true, features = ["map-foldhash"] }
+keccak-const.workspace = true
 revm.workspace = true
 paste.workspace = true
 bitflags.workspace = true

--- a/crates/precompiles/benches/tempo_precompiles.rs
+++ b/crates/precompiles/benches/tempo_precompiles.rs
@@ -81,7 +81,7 @@ fn tip20_metadata(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
             token
                 .mint(
                     admin,
@@ -110,7 +110,7 @@ fn tip20_view(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
             token
                 .mint(
                     admin,
@@ -216,7 +216,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
 
             let amount = U256::from(100);
             b.iter(|| {
@@ -235,7 +235,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
             // Pre-mint tokens for burning
             token
                 .mint(
@@ -287,7 +287,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
             // Pre-mint tokens for transfers
             token
                 .mint(
@@ -320,7 +320,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
             // Pre-mint tokens and set allowance
             token
                 .mint(
@@ -367,7 +367,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *ISSUER_ROLE);
+            let _ = token.grant_role_internal(admin, ISSUER_ROLE);
             // Pre-mint tokens for transfers
             token
                 .mint(
@@ -396,7 +396,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *PAUSE_ROLE);
+            let _ = token.grant_role_internal(admin, PAUSE_ROLE);
 
             b.iter(|| {
                 let token = black_box(&mut token);
@@ -414,7 +414,7 @@ fn tip20_mutate(c: &mut Criterion) {
             let mut token = TIP20Setup::create("TestToken", "TEST", admin)
                 .apply()
                 .unwrap();
-            let _ = token.grant_role_internal(admin, *UNPAUSE_ROLE);
+            let _ = token.grant_role_internal(admin, UNPAUSE_ROLE);
 
             b.iter(|| {
                 let token = black_box(&mut token);

--- a/crates/precompiles/src/receive_policy_guard/mod.rs
+++ b/crates/precompiles/src/receive_policy_guard/mod.rs
@@ -460,7 +460,7 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("T", "T", admin)
                 .with_issuer(admin)
-                .with_role(burner, *BURN_BLOCKED_ROLE)
+                .with_role(burner, BURN_BLOCKED_ROLE)
                 .with_mint(originator, amount)
                 .apply()?;
             block_all_senders(receiver, receiver)?;

--- a/crates/precompiles/src/stablecoin_dex/mod.rs
+++ b/crates/precompiles/src/stablecoin_dex/mod.rs
@@ -6153,7 +6153,7 @@ mod tests {
 
                 // Pause the base token
                 let mut base_tip20 = TIP20Token::from_address(base_token)?;
-                base_tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
+                base_tip20.grant_role_internal(admin, PAUSE_ROLE)?;
                 base_tip20.pause(admin, ITIP20::pauseCall {})?;
 
                 let res_in =
@@ -6215,7 +6215,7 @@ mod tests {
                     non_escrow_token
                 };
                 let mut tip20 = TIP20Token::from_address(token_to_pause)?;
-                tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
+                tip20.grant_role_internal(admin, PAUSE_ROLE)?;
                 tip20.pause(admin, ITIP20::pauseCall {})?;
 
                 let next_order_id_before = exchange.next_order_id()?;
@@ -6399,7 +6399,7 @@ mod tests {
 
                 // Pause pathUSD (the intermediate token)
                 let mut path_usd_tip20 = TIP20Token::from_address(path_usd.address())?;
-                path_usd_tip20.grant_role_internal(admin, *PAUSE_ROLE)?;
+                path_usd_tip20.grant_role_internal(admin, PAUSE_ROLE)?;
                 path_usd_tip20.pause(admin, ITIP20::pauseCall {})?;
 
                 // Bob tries multi-hop swap: USDC -> pathUSD -> EURC

--- a/crates/precompiles/src/test_util.rs
+++ b/crates/precompiles/src/test_util.rs
@@ -233,7 +233,7 @@ impl TIP20Setup {
 
     /// Grant ISSUER_ROLE to an account.
     pub fn with_issuer(self, account: Address) -> Self {
-        self.with_role(account, *tip20::ISSUER_ROLE)
+        self.with_role(account, tip20::ISSUER_ROLE)
     }
 
     /// Grant an arbitrary role to an account.

--- a/crates/precompiles/src/tip20/dispatch.rs
+++ b/crates/precompiles/src/tip20/dispatch.rs
@@ -330,8 +330,8 @@ mod tests {
 
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Test", "TST", admin)
-                .with_role(pauser, *PAUSE_ROLE)
-                .with_role(unpauser, *UNPAUSE_ROLE)
+                .with_role(pauser, PAUSE_ROLE)
+                .with_role(unpauser, UNPAUSE_ROLE)
                 .apply()?;
             assert!(!token.paused()?);
 
@@ -363,7 +363,7 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Test", "TST", admin)
                 .with_issuer(admin)
-                .with_role(burner, *ISSUER_ROLE)
+                .with_role(burner, ISSUER_ROLE)
                 .with_mint(burner, initial_balance)
                 .apply()?;
 
@@ -489,11 +489,11 @@ mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Test", "TST", admin)
                 .with_issuer(admin)
-                .with_role(user1, *ISSUER_ROLE)
+                .with_role(user1, ISSUER_ROLE)
                 .apply()?;
 
             let has_role_call = IRolesAuth::hasRoleCall {
-                role: *ISSUER_ROLE,
+                role: ISSUER_ROLE,
                 account: user1,
             };
             let calldata = has_role_call.abi_encode();
@@ -503,7 +503,7 @@ mod tests {
             assert!(has_role);
 
             let has_role_call = IRolesAuth::hasRoleCall {
-                role: *ISSUER_ROLE,
+                role: ISSUER_ROLE,
                 account: user2,
             };
             let calldata = has_role_call.abi_encode();

--- a/crates/precompiles/src/tip20/mod.rs
+++ b/crates/precompiles/src/tip20/mod.rs
@@ -32,10 +32,10 @@ use crate::{
     tip403_registry::{ALLOW_ALL_POLICY_ID, AuthRole, ITIP403Registry, TIP403Registry},
 };
 use alloy::{
-    primitives::{Address, B256, U256, keccak256, uint},
+    primitives::{Address, B256, U256, uint},
     sol_types::SolValue,
 };
-use std::sync::LazyLock;
+use keccak_const::Keccak256;
 use tempo_chainspec::hardfork::TempoHardfork;
 use tempo_contracts::precompiles::{
     DECIMALS as TIP20_DECIMALS, ReceivePolicyGuardError, STABLECOIN_DEX_ADDRESS,
@@ -110,26 +110,35 @@ pub struct TIP20Token {
 }
 
 /// EIP-712 Permit typehash: keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
-pub static PERMIT_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
-    keccak256(b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
-});
+pub const PERMIT_TYPEHASH: B256 = B256::new(
+    Keccak256::new()
+        .update(
+            b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)",
+        )
+        .finalize(),
+);
 
 /// EIP-712 domain separator typehash
-pub static EIP712_DOMAIN_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
-    keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
-});
+pub const EIP712_DOMAIN_TYPEHASH: B256 = B256::new(
+    Keccak256::new()
+        .update(
+            b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+        )
+        .finalize(),
+);
 
 /// EIP-712 version hash: keccak256("1")
-pub static VERSION_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"1"));
+pub const VERSION_HASH: B256 = B256::new(Keccak256::new().update(b"1").finalize());
 
 /// Role hash for pausing token transfers.
-pub static PAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"PAUSE_ROLE"));
+pub const PAUSE_ROLE: B256 = B256::new(Keccak256::new().update(b"PAUSE_ROLE").finalize());
 /// Role hash for unpausing token transfers.
-pub static UNPAUSE_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"UNPAUSE_ROLE"));
+pub const UNPAUSE_ROLE: B256 = B256::new(Keccak256::new().update(b"UNPAUSE_ROLE").finalize());
 /// Role hash for minting new tokens.
-pub static ISSUER_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"ISSUER_ROLE"));
+pub const ISSUER_ROLE: B256 = B256::new(Keccak256::new().update(b"ISSUER_ROLE").finalize());
 /// Role hash that authorizes burning tokens from blocked accounts.
-pub static BURN_BLOCKED_ROLE: LazyLock<B256> = LazyLock::new(|| keccak256(b"BURN_BLOCKED_ROLE"));
+pub const BURN_BLOCKED_ROLE: B256 =
+    B256::new(Keccak256::new().update(b"BURN_BLOCKED_ROLE").finalize());
 
 #[rustfmt::skip]
 /// System custody addresses added to burn-blocked protection at each hardfork.
@@ -219,7 +228,7 @@ impl TIP20Token {
     /// This role identifier grants permission to pause the token contract.
     /// The role is computed as `keccak256("PAUSE_ROLE")`.
     pub fn pause_role() -> B256 {
-        *PAUSE_ROLE
+        PAUSE_ROLE
     }
 
     /// Returns the UNPAUSE_ROLE constant
@@ -227,7 +236,7 @@ impl TIP20Token {
     /// This role identifier grants permission to unpause the token contract.
     /// The role is computed as `keccak256("UNPAUSE_ROLE")`.
     pub fn unpause_role() -> B256 {
-        *UNPAUSE_ROLE
+        UNPAUSE_ROLE
     }
 
     /// Returns the ISSUER_ROLE constant
@@ -235,7 +244,7 @@ impl TIP20Token {
     /// This role identifier grants permission to mint and burn tokens.
     /// The role is computed as `keccak256("ISSUER_ROLE")`.
     pub fn issuer_role() -> B256 {
-        *ISSUER_ROLE
+        ISSUER_ROLE
     }
 
     /// Returns the BURN_BLOCKED_ROLE constant
@@ -243,7 +252,7 @@ impl TIP20Token {
     /// This role identifier grants permission to burn tokens from blocked accounts.
     /// The role is computed as `keccak256("BURN_BLOCKED_ROLE")`.
     pub fn burn_blocked_role() -> B256 {
-        *BURN_BLOCKED_ROLE
+        BURN_BLOCKED_ROLE
     }
 
     /// Returns the token balance of `account`.
@@ -401,7 +410,7 @@ impl TIP20Token {
     /// # Errors
     /// - `Unauthorized` — caller does not hold `PAUSE_ROLE`
     pub fn pause(&mut self, msg_sender: Address, _call: ITIP20::pauseCall) -> Result<()> {
-        self.check_role(msg_sender, *PAUSE_ROLE)?;
+        self.check_role(msg_sender, PAUSE_ROLE)?;
         self.paused.write(true)?;
 
         self.emit_event(TIP20Event::pause_state_update(msg_sender, true))
@@ -412,7 +421,7 @@ impl TIP20Token {
     /// # Errors
     /// - `Unauthorized` — caller does not hold `UNPAUSE_ROLE`
     pub fn unpause(&mut self, msg_sender: Address, _call: ITIP20::unpauseCall) -> Result<()> {
-        self.check_role(msg_sender, *UNPAUSE_ROLE)?;
+        self.check_role(msg_sender, UNPAUSE_ROLE)?;
         self.paused.write(false)?;
 
         self.emit_event(TIP20Event::pause_state_update(msg_sender, false))
@@ -615,7 +624,7 @@ impl TIP20Token {
         if hardfork.is_t3() {
             self.check_not_paused()?;
         }
-        self.check_role(msg_sender, *BURN_BLOCKED_ROLE)?;
+        self.check_role(msg_sender, BURN_BLOCKED_ROLE)?;
 
         if check_protected {
             // Prevent burning from system custody addresses to protect accounting invariants.
@@ -661,7 +670,7 @@ impl TIP20Token {
         if self.storage.spec().is_t3() {
             self.check_not_paused()?;
         }
-        self.check_role(msg_sender, *ISSUER_ROLE)?;
+        self.check_role(msg_sender, ISSUER_ROLE)?;
 
         self._transfer(msg_sender, &Recipient::direct(Address::ZERO), amount)?;
 
@@ -714,9 +723,9 @@ impl TIP20Token {
         let chain_id = U256::from(self.storage.chain_id());
 
         let encoded = (
-            *EIP712_DOMAIN_TYPEHASH,
+            EIP712_DOMAIN_TYPEHASH,
             name_hash,
-            *VERSION_HASH,
+            VERSION_HASH,
             chain_id,
             self.address,
         )
@@ -743,7 +752,7 @@ impl TIP20Token {
         let nonce = self.permit_nonces[call.owner].read()?;
         let struct_hash = self.storage.keccak256(
             &(
-                *PERMIT_TYPEHASH,
+                PERMIT_TYPEHASH,
                 call.owner,
                 call.spender,
                 call.value,
@@ -1112,7 +1121,7 @@ impl TIP20Token {
         memo: B256,
     ) -> Result<Option<(U256, Recipient)>> {
         let to = Recipient::resolve(to)?;
-        self.check_role(msg_sender, *ISSUER_ROLE)?;
+        self.check_role(msg_sender, ISSUER_ROLE)?;
         let total_supply = self.total_supply()?;
 
         if self.storage.spec().is_t3() {
@@ -1592,7 +1601,7 @@ pub(crate) mod tests {
         test_util::{TIP20Setup, VIRTUAL_MASTER, register_virtual_master, setup_storage},
         tip403_registry::{ALLOW_ALL_POLICY_ID, REJECT_ALL_POLICY_ID},
     };
-    use alloy::primitives::{Address, FixedBytes, IntoLogData, U256, hex};
+    use alloy::primitives::{Address, FixedBytes, IntoLogData, U256, hex, keccak256};
     use rand_08::{Rng, distributions::Alphanumeric, thread_rng};
     use tempo_chainspec::hardfork::TempoHardfork;
     use tempo_contracts::precompiles::{
@@ -2369,7 +2378,7 @@ pub(crate) mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Test", "TST", admin)
                 .with_issuer(admin)
-                .with_role(admin, *PAUSE_ROLE)
+                .with_role(admin, PAUSE_ROLE)
                 .with_mint(user, amount)
                 .apply()?;
 
@@ -3344,7 +3353,7 @@ pub(crate) mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Token", "TKN", admin)
                 .with_issuer(admin)
-                .with_role(burner, *BURN_BLOCKED_ROLE)
+                .with_role(burner, BURN_BLOCKED_ROLE)
                 .with_mint(TIP_FEE_MANAGER_ADDRESS, amount)
                 .with_mint(STABLECOIN_DEX_ADDRESS, amount)
                 .with_mint(TIP20_CHANNEL_RESERVE_ADDRESS, amount)
@@ -3375,7 +3384,7 @@ pub(crate) mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Token", "TKN", admin)
                 .with_issuer(admin)
-                .with_role(burner, *BURN_BLOCKED_ROLE)
+                .with_role(burner, BURN_BLOCKED_ROLE)
                 .apply()?;
 
             for protected in [
@@ -3413,7 +3422,7 @@ pub(crate) mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Token", "TKN", admin)
                 .with_issuer(admin)
-                .with_role(burner, *BURN_BLOCKED_ROLE)
+                .with_role(burner, BURN_BLOCKED_ROLE)
                 .with_mint(TIP20_CHANNEL_RESERVE_ADDRESS, amount)
                 .apply()?;
 
@@ -4170,7 +4179,7 @@ pub(crate) mod tests {
             let domain_separator = compute_domain_separator(token_name, token_address);
             let struct_hash = keccak256(
                 (
-                    *PERMIT_TYPEHASH,
+                    PERMIT_TYPEHASH,
                     signer.address(),
                     spender,
                     value,
@@ -4198,9 +4207,9 @@ pub(crate) mod tests {
         fn compute_domain_separator(token_name: &str, token_address: Address) -> B256 {
             keccak256(
                 (
-                    *EIP712_DOMAIN_TYPEHASH,
+                    EIP712_DOMAIN_TYPEHASH,
                     keccak256(token_name.as_bytes()),
-                    *VERSION_HASH,
+                    VERSION_HASH,
                     U256::from(CHAIN_ID),
                     token_address,
                 )
@@ -4465,7 +4474,7 @@ pub(crate) mod tests {
 
             StorageCtx::enter(&mut storage, || {
                 let mut token = TIP20Setup::create("Test", "TST", admin)
-                    .with_role(admin, *PAUSE_ROLE)
+                    .with_role(admin, PAUSE_ROLE)
                     .apply()?;
 
                 // Pause the token
@@ -4686,7 +4695,7 @@ pub(crate) mod tests {
         StorageCtx::enter(&mut storage, || {
             let mut token = TIP20Setup::create("Test", "TST", admin)
                 .with_issuer(admin)
-                .with_role(admin, *PAUSE_ROLE)
+                .with_role(admin, PAUSE_ROLE)
                 .apply()?;
             token.pause(admin, ITIP20::pauseCall {})?;
 
@@ -4719,7 +4728,7 @@ pub(crate) mod tests {
             StorageCtx::enter(&mut storage, || {
                 let mut token = TIP20Setup::create("Test", "TST", admin)
                     .with_issuer(admin)
-                    .with_role(admin, *PAUSE_ROLE)
+                    .with_role(admin, PAUSE_ROLE)
                     .apply()?;
 
                 token.pause(admin, ITIP20::pauseCall {})?;
@@ -4755,7 +4764,7 @@ pub(crate) mod tests {
             StorageCtx::enter(&mut storage, || {
                 let mut token = TIP20Setup::create("Test", "TST", admin)
                     .with_issuer(admin)
-                    .with_role(admin, *PAUSE_ROLE)
+                    .with_role(admin, PAUSE_ROLE)
                     .with_mint(admin, amount * U256::from(2))
                     .apply()?;
 
@@ -4811,8 +4820,8 @@ pub(crate) mod tests {
 
                 let mut token = TIP20Setup::create("Test", "TST", admin)
                     .with_issuer(admin)
-                    .with_role(admin, *PAUSE_ROLE)
-                    .with_role(admin, *BURN_BLOCKED_ROLE)
+                    .with_role(admin, PAUSE_ROLE)
+                    .with_role(admin, BURN_BLOCKED_ROLE)
                     .with_mint(blocked, amount)
                     .apply()?;
 

--- a/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/dispatch.rs
@@ -21,7 +21,7 @@ impl Precompile for TIP20ChannelReserve {
                     CLOSE_GRACE_PERIOD(_) => metadata::<ITIP20ChannelReserve::CLOSE_GRACE_PERIODCall>(|| {
                         Ok(CLOSE_GRACE_PERIOD)
                     }),
-                    VOUCHER_TYPEHASH(_) => metadata::<ITIP20ChannelReserve::VOUCHER_TYPEHASHCall>(|| Ok(*VOUCHER_TYPEHASH)),
+                    VOUCHER_TYPEHASH(_) => metadata::<ITIP20ChannelReserve::VOUCHER_TYPEHASHCall>(|| Ok(VOUCHER_TYPEHASH)),
                     open(call) => mutate(call, msg_sender, |sender, c| {
                         preserve_storage_credits(self.address)?;
                         self.open(sender, c)

--- a/crates/precompiles/src/tip20_channel_reserve/mod.rs
+++ b/crates/precompiles/src/tip20_channel_reserve/mod.rs
@@ -19,7 +19,7 @@ use alloy::{
     primitives::{Address, B256, U256, aliases::U96, keccak256},
     sol_types::SolValue,
 };
-use std::sync::LazyLock;
+use keccak_const::Keccak256;
 use tempo_chainspec::constants::{mainnet::MAINNET_CHAIN_ID, moderato::MODERATO_CHAIN_ID};
 pub use tempo_contracts::precompiles::{
     ITIP20ChannelReserve, TIP20_CHANNEL_RESERVE_ADDRESS, TIP20ChannelReserveError,
@@ -32,23 +32,28 @@ use tempo_primitives::TempoAddressExt;
 pub const CLOSE_GRACE_PERIOD: u64 = 15 * 60;
 
 /// EIP-712 type hash for signed cumulative payment vouchers.
-static VOUCHER_TYPEHASH: LazyLock<B256> =
-    LazyLock::new(|| keccak256(b"Voucher(bytes32 channelId,uint96 cumulativeAmount)"));
+const VOUCHER_TYPEHASH: B256 = B256::new(
+    Keccak256::new()
+        .update(b"Voucher(bytes32 channelId,uint96 cumulativeAmount)")
+        .finalize(),
+);
 /// EIP-712 domain type hash used by [`TIP20ChannelReserve::domain_separator`].
-static EIP712_DOMAIN_TYPEHASH: LazyLock<B256> = LazyLock::new(|| {
-    keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)")
-});
+const EIP712_DOMAIN_TYPEHASH: B256 = B256::new(
+    Keccak256::new()
+        .update(
+            b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)",
+        )
+        .finalize(),
+);
 /// EIP-712 domain name hash for the reserve voucher domain.
-static NAME_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"TIP20 Channel Reserve"));
+const NAME_HASH: B256 = B256::new(Keccak256::new().update(b"TIP20 Channel Reserve").finalize());
 /// EIP-712 domain version hash for the reserve voucher domain.
-static VERSION_HASH: LazyLock<B256> = LazyLock::new(|| keccak256(b"1"));
+const VERSION_HASH: B256 = B256::new(Keccak256::new().update(b"1").finalize());
 
 /// EIP-712 domain separator for the reserve voucher domain on mainnet.
-static DOMAIN_SEPARATOR_MAINNET: LazyLock<B256> =
-    LazyLock::new(|| domain_separator_inner(MAINNET_CHAIN_ID));
+const DOMAIN_SEPARATOR_MAINNET: B256 = const_domain_separator(MAINNET_CHAIN_ID);
 /// EIP-712 domain separator for the reserve voucher domain on testnet.
-static DOMAIN_SEPARATOR_TESTNET: LazyLock<B256> =
-    LazyLock::new(|| domain_separator_inner(MODERATO_CHAIN_ID));
+const DOMAIN_SEPARATOR_TESTNET: B256 = const_domain_separator(MODERATO_CHAIN_ID);
 
 /// Packed persistent state for one channel.
 ///
@@ -546,8 +551,8 @@ impl TIP20ChannelReserve {
     /// Returns the EIP-712 domain separator for this chain and precompile address.
     pub fn domain_separator(&self) -> Result<B256> {
         let hash = match self.storage.chain_id() {
-            MAINNET_CHAIN_ID => *DOMAIN_SEPARATOR_MAINNET,
-            MODERATO_CHAIN_ID => *DOMAIN_SEPARATOR_TESTNET,
+            MAINNET_CHAIN_ID => DOMAIN_SEPARATOR_MAINNET,
+            MODERATO_CHAIN_ID => DOMAIN_SEPARATOR_TESTNET,
             chain_id => domain_separator_inner(chain_id),
         };
 
@@ -739,7 +744,7 @@ impl TIP20ChannelReserve {
     fn get_voucher_digest_inner(&self, channel_id: B256, cumulative_amount: U96) -> Result<B256> {
         let struct_hash = self
             .storage
-            .keccak256(&(*VOUCHER_TYPEHASH, channel_id, cumulative_amount).abi_encode())?;
+            .keccak256(&(VOUCHER_TYPEHASH, channel_id, cumulative_amount).abi_encode())?;
         let domain_separator = self.domain_separator()?;
 
         let mut digest_input = [0u8; 66];
@@ -751,15 +756,29 @@ impl TIP20ChannelReserve {
     }
 }
 
+/// Computes a fixed-chain domain separator at compile time using ABI-padded fields.
+const fn const_domain_separator(chain_id: u64) -> B256 {
+    B256::new(
+        Keccak256::new()
+            .update(EIP712_DOMAIN_TYPEHASH.as_slice())
+            .update(NAME_HASH.as_slice())
+            .update(VERSION_HASH.as_slice())
+            .update(&U256::from_limbs([chain_id, 0, 0, 0]).to_be_bytes::<32>())
+            .update(&[0; 12])
+            .update(&TIP20_CHANNEL_RESERVE_ADDRESS.into_array())
+            .finalize(),
+    )
+}
+
 /// Computes the EIP-712 domain separator.
 ///
 /// NOTE: This keccak is unmetered because it is not computed at tx runtime.
 fn domain_separator_inner(chain_id: u64) -> B256 {
     keccak256(
         (
-            *EIP712_DOMAIN_TYPEHASH,
-            *NAME_HASH,
-            *VERSION_HASH,
+            EIP712_DOMAIN_TYPEHASH,
+            NAME_HASH,
+            VERSION_HASH,
             U256::from(chain_id),
             TIP20_CHANNEL_RESERVE_ADDRESS,
         )
@@ -790,6 +809,24 @@ mod tests {
     use tempo_contracts::precompiles::{
         ITIP20ChannelReserve::ITIP20ChannelReserveCalls, TIP20Error,
     };
+
+    #[test]
+    fn const_domain_separators_match_abi_encoding() {
+        assert_eq!(
+            DOMAIN_SEPARATOR_MAINNET,
+            domain_separator_inner(MAINNET_CHAIN_ID)
+        );
+        assert_eq!(
+            DOMAIN_SEPARATOR_TESTNET,
+            domain_separator_inner(MODERATO_CHAIN_ID)
+        );
+        for chain_id in [0, 1, 1337, u64::MAX] {
+            assert_eq!(
+                const_domain_separator(chain_id),
+                domain_separator_inner(chain_id)
+            );
+        }
+    }
 
     fn descriptor(
         payer: Address,

--- a/crates/revm/src/handler/tests.rs
+++ b/crates/revm/src/handler/tests.rs
@@ -266,7 +266,7 @@ fn test_paused_fee_token_rejected() {
         StorageCtx::enter_ctx(&mut test.evm.inner.ctx, StorageActions::disabled(), || {
             let mut token = TIP20Setup::create("Paused USD", "PUSD", admin)
                 .with_issuer(admin)
-                .with_role(admin, *tempo_precompiles::tip20::PAUSE_ROLE)
+                .with_role(admin, tempo_precompiles::tip20::PAUSE_ROLE)
                 .with_mint(fee_payer, fee)
                 .apply()?;
             token.pause(admin, tempo_precompiles::tip20::ITIP20::pauseCall {})?;

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -819,7 +819,7 @@ fn create_path_usd_token(
             // Initialize pathUSD directly (not via factory) since it's at a reserved address.
             let mut token = TIP20Token::from_address(PATH_USD_ADDRESS)
                 .expect("Could not create pathUSD token instance");
-            token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            token.grant_role_internal(admin, ISSUER_ROLE)?;
 
             // Mint to all recipients
             for recipient in recipients.iter().progress() {
@@ -901,7 +901,7 @@ fn create_and_mint_token(
 
             let mut token =
                 TIP20Token::from_address(token_address).expect("Could not create token instance");
-            token.grant_role_internal(admin, *ISSUER_ROLE)?;
+            token.grant_role_internal(admin, ISSUER_ROLE)?;
 
             let result = token.set_supply_cap(
                 admin,


### PR DESCRIPTION
Replaces fixed-hash `LazyLock`s with `keccak-const` expressions, including TIP-20 role/type hashes and channel-reserve domain separators. Keeps the hash inputs in source while removing runtime initialization.

This avoids an atomic read every time we access the value.