### PR TITLE
chore(bench): increase RPC transaction hash cache to 3 million

### DIFF
--- a/tempo.nu
+++ b/tempo.nu
@@ -1988,6 +1988,7 @@ def build-base-args [genesis_path: string, datadir: string, log_dir: string, bin
         "--ws.addr" $bind_ip
         "--ws.port" $"($http_port)"
         "--ws.api" "all"
+        "--rpc-cache.max-cached-tx-hashes" "3000000"
         "--metrics" $"($bind_ip):($reth_metrics_port)"
         "--ipcpath" $ipc_path
         "--log.file.directory" $log_dir


### PR DESCRIPTION
Sets `--rpc-cache.max-cached-tx-hashes` to 3,000,000 in the shared node arguments used by localnet and all in-repo txgen benchmark presets, including both e2e comparison nodes. This gives transaction lookups capacity for roughly 100 blocks of 25,000 transactions with headroom instead of inheriting Reth's 30,000-entry default.
