### PR TITLE
feat(bench): default GCP multi-region runs to C4D

### DIFF
--- a/.github/workflows/bench-e2e-multi-region.yml
+++ b/.github/workflows/bench-e2e-multi-region.yml
@@ -280,8 +280,8 @@ jobs:
       BENCH_INPUT_BLOAT: ${{ inputs.bloat || '100' }}
       BENCH_INPUT_VALIDATOR_COUNT: ${{ inputs['validator-count'] || (github.event_name == 'pull_request' && '1') || '10' }}
       BENCH_INPUT_REGIONS: ${{ inputs.regions || '' }}
-      BENCH_INPUT_INSTANCE_TYPE: ${{ (inputs.cloud || 'aws') == 'gcp' && 'n2-standard-8' || 'c6id.8xlarge' }}
-      BENCH_INPUT_LOCAL_SSD_COUNT: ${{ (inputs.cloud || 'aws') == 'gcp' && ((inputs.bloat || '100') == '100' && '4' || '1') || '4' }}
+      BENCH_INPUT_INSTANCE_TYPE: ${{ (inputs.cloud || 'aws') == 'gcp' && 'c4d-standard-48-lssd' || 'c6id.8xlarge' }}
+      BENCH_INPUT_LOCAL_SSD_COUNT: '4'
       BENCH_INPUT_TPS: ${{ inputs.tps || (github.event_name == 'pull_request' && '100') || '50000' }}
       BENCH_INPUT_ACCOUNTS: ${{ inputs.accounts || '1000' }}
       BENCH_INPUT_MAX_CONCURRENT_REQUESTS: ${{ inputs['max-concurrent-requests'] || (github.event_name == 'pull_request' && '10') || '5000' }}


### PR DESCRIPTION
Default GCP multi-region benchmarks to `c4d-standard-48-lssd` with four Local SSDs at every state tier, keeping AWS unchanged and matching [benchmark PR #404](https://github.com/tempoxyz/tempo-multi-region-benchmark/pull/404), which should merge first. [GCP foundation PR #18](https://github.com/tempoxyz/gcp/pull/18) is merged and applied; workflow actionlint passes, and the [five-region 1 GiB benchmark](https://github.com/tempoxyz/tempo-multi-region-benchmark/actions/runs/34487279306) passed on the benchmark PR head at 8,933 / 9,195 on-chain TPS, with teardown of all 11 test VMs confirmed.

Prompted by: @shekhirin
