### PR TITLE
docs(tip-1012): specify encrypted forced withdrawals for Zones

### DIFF
--- a/tips/tip-1012.md
+++ b/tips/tip-1012.md
@@ -1,0 +1,391 @@
+---
+id: TIP-1012
+title: Encrypted Forced Withdrawals for Zones
+description: Root-authorized full-balance withdrawals through the encrypted L1 inbox, with upfront compensation and proven Zone execution.
+authors: "@adityapk00, Dankrad Feist (@dankrad)"
+status: Draft
+related: https://github.com/tempoxyz/zones/pull/1425
+protocolVersion: TBD
+---
+
+# TIP-1012: Encrypted Forced Withdrawals for Zones
+
+## Abstract
+
+This TIP introduces an encrypted L1 request for withdrawing the full liquid balance of one token from a Zone account. The account's root key authorizes the withdrawal, the fee payer pays a fixed 0.1-token compensation to the portal admin at admission, and the shared Zone state transition function validates and executes the request under the proof pipeline. Successful requests create ordinary withdrawals, including the existing return-to-account path when L1 delivery fails. The mechanism requires a live sequencer and enforced inclusion; it does not provide exits after operator failure or a bounded-time inclusion guarantee.
+
+## Motivation
+
+A Zone account holder needs a way to initiate a withdrawal through the L1 portal without first obtaining inclusion of an ordinary Zone withdrawal transaction or establishing an allowance. An authenticated L1 inbox request provides that entry point: once imported, its validation and outcome become part of the transition that the sequencer must prove.
+
+The proposal reuses the encrypted deposit envelope and authenticated inbox to keep the account, recipient, and signed authorization private at admission. It reuses the ordinary withdrawal queue and bounce-back accounting for delivery and recovery. Withdrawing one token's full liquid balance limits the authorized action and avoids introducing arbitrary forced transaction execution.
+
+This proposal formalizes the design in [Zones PR #1425](https://github.com/tempoxyz/zones/pull/1425), using [source revision b7873d1](https://github.com/tempoxyz/zones/blob/b7873d15431b780e31ff04cb8456f0557eb62fe1/crates/exithatch/README.md). It follows the [TIP template](https://github.com/tempoxyz/tempo/blob/main/tips/tip_template.md) and [TIP process](https://github.com/tempoxyz/tempo/blob/main/tips/tip-0000.md). The source draft was submitted by @adityapk00. The TIP owner is Dankrad Feist (@dankrad); the target protocol version remains to be assigned.
+
+### Design choices and alternatives
+
+| Choice | Rationale and tradeoff |
+| --- | --- |
+| Encrypted L1 authorization | Reuses deposit encryption and hides the exiting account and recipient at admission. Signature, deadline, and replay validation must run after decryption on Zone. |
+| Full liquid balance at processing time | Gives the signed request a narrow action without adding arbitrary calldata. The eventual amount can include later credits; admission does not reserve or freeze funds. |
+| Root-key authorization | Requires the account's own authority for this exit path. Access keys, delegated keychain signatures, arbitrary ERC-1271 callbacks, and counterfactual accounts are outside V1. |
+| Dedicated consumed-nonce map | Makes each account authorization single-use without exposing a plaintext authorization digest on L1. Ciphertext deduplication alone cannot establish single-use authorization. |
+| Fixed compensation paid at admission | Pays for processing independently of the eventual outcome and avoids a Zone compensation ledger. An admitted request pays even if it is rejected, empty, delayed, or never processed. |
+| Existing plain withdrawal and bounce-back path | Reuses the established delivery and recovery accounting. A failed L1 payment returns principal to the account that was debited, subject to current token policy. |
+| Live-sequencer scope | Uses the current decryption, inbox, and proof infrastructure. Operator-failure exits and independent inclusion deadlines require a separate design. |
+
+## Assumptions
+
+| Assumption | Consequence if it does not hold |
+| --- | --- |
+| A live sequencer imports L1 checkpoints, processes the inbox, submits accepted proofs, and services withdrawals. Inclusion is enforced by the surrounding system. | The request can remain pending indefinitely. Queue correctness alone does not establish liveness or an exit deadline. |
+| L1 queue commitments, admission metadata, and the imported L1 anchor are authenticated under the existing finality and witness rules. | Unauthenticated or malformed protocol data cannot support an accepted transition; missing witnesses abort execution. |
+| The shared STF is used for both Zone execution and proving, and settlement runs an enforcing verifier for the activated version. | An execution result is not an authenticated withdrawal unless the matching transition is verified and settled. |
+| Historical encryption keys and valid decryption material remain available for admitted requests. | Rotation must not strand an admitted request. Missing or invalid decryption proofs abort processing instead of rejecting the user request. |
+| Existing TIP-20 supply, reward, and policy hooks, token backing, and withdrawal recovery accounting are preserved. | A raw balance mutation or partial debit would violate the accounting model and is not a conforming implementation. |
+| Shared inbox and outbox limits are sized for the admitted mixed workload, including proof and settlement costs. | Resource exhaustion aborts execution; it must not become a terminal rejection or a reason to skip a queue suffix. |
+| Activation coordinates portal, node, prover, verifier, and tooling versions while preserving legacy encodings and storage. | A deployment that cannot process an already-admitted version must not activate. |
+
+## Threat Model
+
+| Actor or boundary | Trust assumptions and required behavior |
+| --- | --- |
+| Account holder and signing client | The account's root key authorizes the exact account, Zone, token, recipient, nonce, and admission deadline. Compromise of that key is outside this mechanism's protection. Clients use the correct domain, canonical encoding, and fresh encryption material. |
+| Fee payer or relayer | The payer may differ from the account holder and must satisfy admission access and fee-transfer rules. Paying or relaying does not grant authority over the hidden account. Encryption binds the request to the payer through the existing HKDF sender context. |
+| Sequencer and execution host | The host is not trusted to choose decryption results, skip imported forced entries, alter recipients or balances, or select rejection reasons. Authenticated inputs and shared execution rules determine these results. Continued production and checkpoint import remain liveness assumptions. |
+| Prover and settlement verifier | Settlement accepts only the activated proof or attestation scheme with the complete execution commitments. For Nitro, trust includes the approved image, AWS attestation checks, and the bound execution digest. |
+| Portal admin and token policy authorities | Existing pause, role, enabled-token, and native token policies remain authoritative at the specified stages. The admin receives admission compensation; payment does not itself guarantee timely execution or delivery. |
+| Public L1 observers and request submitters | Admission reveals public request metadata but not the encrypted authorization. Malformed requests and repeated authorizations must follow deterministic validation and replay rules without consuming another account's authorization nonce. |
+| L1 recipient and token-transfer boundary | Delivery can fail because of current policy or transfer behavior. Existing reentrancy protection and atomic payment/bounce-back accounting must preserve principal and prevent duplicate delivery or recovery. |
+
+Public settlement reveals the recipient and withdrawn amount. The sequencer and authorized readers of decryption material can read requests; settlement balance privacy and unlinkability are outside scope.
+
+---
+
+# Specification
+
+The requirements below define V1 behavior. MUST and MUST NOT indicate conformance requirements; imperative statements also specify required behavior. Items in **Open decisions before scheduling** remain explicit draft parameters and must be fixed before this TIP is implementation-ready.
+
+## Scope and lifecycle
+
+Each request authorizes the full liquid balance of one token from one Zone account. Partial withdrawals, arbitrary forced transactions, and exits after operator failure are out of scope. The signed deadline governs admission, not execution or delivery.
+
+1. **Request on L1:** The user signs and encrypts an exit authorization, and the portal collects and pays the fixed 0.1-token fee to its L1 admin and queues the request.
+2. **Process on Zone:** The sequencer decrypts and validates the request through the STF, which burns the account's full liquid token balance at processing time and creates a withdrawal, or records an empty or rejected outcome.
+3. **Prove and settle:** The prover replays the same STF, and L1 settlement verifies the proof and authenticates the outcomes and resulting withdrawals.
+4. **Deliver on L1:** The sequencer processes the withdrawal through the normal queue, paying the recipient or bouncing the principal back to the Zone account if payment fails.
+
+The STF executes Step 2 and is replayed by the prover in Step 3. They use the same transition rules.
+
+## State ownership and identifiers
+
+| State or identifier | Location and purpose |
+| --- | --- |
+| Signed authorization | Carried inside the encrypted request queued on L1 and decoded within Zone execution. Includes the account, Zone chain ID, token, recipient, authorization nonce, and admission deadline. |
+| Consumed authorization nonces | Dedicated authenticated Zone storage keyed by `(account, nonce)`. The STF reads and updates this replay map; the prover verifies the same changes. It is separate from ordinary account transaction nonces. |
+| `requestId` | Nonzero monotonic portal-local identifier for the admitted forced request and its public processing outcome. |
+| `depositNumber` | Global inbox identifier that places the request among deposits and bounce-backs. It is distinct from `requestId`. |
+| Admission metadata and outcomes | Portal storage holds the feature/config version, request counter, encrypted-entry identity/token/deposit metadata, and settled outcomes. Zone storage holds pending outcomes. |
+| `DepositPayload.nonce` | Encryption-envelope GCM nonce. It serves encryption security and is independent of the signed authorization nonce. |
+| `fallbackNonce` | Allocated from the existing outbox counter and mapped in Zone state to the debited account. Used once by the existing failed-delivery recovery path. |
+| Pending bounce-back credits | Existing Zone recovery ledger for principal that cannot yet be reminted under token policy. |
+
+The authorization replay key is `(account, nonce)`, without a token component: two authorizations for the same account and nonce compete for the same single-use entry even if they name different tokens. This TIP does not require a sequential authorization counter. The consumed map remains private to Zone state; L1 admission does not publish or check a plaintext authorization digest.
+
+A fresh authorization consumes its nonce only after successful authorization, including when processing yields an empty balance, balance overflow, or deterministic policy rejection. An invalid authorization does not consume it. Fatal transition failure rolls back the replay map with all other Zone effects. Exact storage slots are an activation deliverable, not assigned by this draft.
+
+## Step 1: Request on L1
+
+The client signs the authorization, encrypts it together with the signature using the Zone's published encryption key, and submits the encrypted request to the portal.
+
+```solidity
+uint128 constant FORCED_EXIT_COMPENSATION = 100_000;
+
+struct ForcedExitAuthorization {
+    address account;
+    uint256 zoneChainId;
+    address token;
+    address recipient;
+    uint256 nonce;
+    uint64 admitBefore;      // Exclusive L1 admission deadline; not an execution deadline
+}
+
+/// @notice Queue an encrypted authorization to withdraw one account's full liquid token balance.
+/// @dev Requires an unpaused portal, an eligible fee payer, a supported enabled token,
+///      a valid bounded encryption envelope/key, and shared inbox capacity.
+///      Collects FORCED_EXIT_COMPENSATION from msg.sender and immediately pays admin.
+///      All admission effects revert together if validation or either fee transfer fails.
+///      Authorization, nonce, signed deadline, and recipient checks occur after decryption on Zone.
+/// @param token Public token used for compensation and matched against the signed token on Zone.
+/// @param keyIndex Zone encryption-key index, subject to the existing deposit key-validity rules.
+/// @param encrypted DepositPayload containing the versioned authorization and root signature.
+/// @return requestId Nonzero, monotonically allocated identifier local to this portal.
+/// @return depositNumber Global inbox deposit number assigned to the queued request.
+function requestForcedExit(
+    address token,
+    uint256 keyIndex,
+    DepositPayload calldata encrypted
+) external returns (uint64 requestId, uint64 depositNumber);
+
+struct ForcedExit {
+    uint64 requestId;
+    address token;
+    uint256 keyIndex;
+    DepositPayload encrypted;
+    address feePayer;
+    uint64 requestedAtBlock;
+    uint64 requestedAtTime;
+}
+```
+
+EIP-712 domain: name `TempoZoneForcedExit`, version `1`, L1 chain ID, verifying contract equal to the portal. The canonical signed type is `ForcedExitAuthorization(address account,uint256 zoneChainId,address token,address recipient,uint256 nonce,uint64 admitBefore)`.
+
+### Encryption
+
+Use the existing `DepositPayload` ABI unchanged: `ephemeralPubkeyX`, `ephemeralPubkeyYParity`, `ciphertext`, `nonce`, and `tag`. As with `Deposit`, `keyIndex` belongs to the outer queued struct, not the encryption envelope.
+
+Client plaintext is `abi.encode(uint8(1), authorization, signature)`, with strict canonical decoding and a bounded signature envelope. Use a fresh ephemeral key and GCM nonce for every encryption. Reuse secp256k1 ECDH, the existing HKDF salt and context `(portal, keyIndex, ephemeralPubkeyX, sender)`, AES-256-GCM, and empty AAD. Here `sender` is the fee payer (`msg.sender`), captured by the portal; a client using a relayer must encrypt for that relayer address. The forced-exit EIP-712 domain and versioned plaintext distinguish this operation from deposits; the forced plaintext cannot pass the existing 64-byte deposit decoder.
+
+The deposit plaintext is fixed at 64 bytes. Forced authorization plus signature is larger: share the envelope and cryptographic helpers, but add a separate bounded forced-exit codec and ciphertext-length validation. Do not change the existing deposit encoding or its 64-byte rule. Pin maximum ciphertext/signature sizes for the enabled signature schemes before activation; arbitrary unbounded ciphertext is not admissible. The minimum encodable plaintext length and ABI alignment are checked at admission, and exact canonical encoding is checked after decryption.
+
+### L1 admission
+
+`requestId` is portal-local, monotonic, nonzero and distinct from the global deposit number. Append `DepositType.ForcedExit = 2`, preserving existing discriminants and encodings.
+
+The portal validates the public enabled token, ciphertext envelope/size, ephemeral-point validity, encryption key using the existing deposit key-validity and rotation-grace rules, and queue capacity. It collects exactly `FORCED_EXIT_COMPENSATION` from `msg.sender` and immediately transfers it to the portal’s `admin` on L1, assigns request/deposit IDs and admission block/time, and commits the entire entry with `keccak256(abi.encode(DepositType.ForcedExit, entry, previousHash))`. Emit the complete reconstructible encrypted entry using the existing L1 event ingestion/backfill pattern. Fee collection, payment to `admin` and all admission changes are atomic.
+
+Compensation is a protocol constant, not a user-selected amount or a configurable sequencer fee. Follow the existing deposit fee-payment pattern: call `transferFrom(msg.sender, portal, FORCED_EXIT_COMPENSATION)`, then `transfer(admin, FORCED_EXIT_COMPENSATION)` in the request token under native token-transfer policies. Either transfer failing reverts the entire admission, including both transfers, ID allocation and queue changes. The recipient is the portal’s current `admin`, exactly as for deposit fees; it need not be the sequencer leader. Payment is complete at admission, so no compensation recipient or amount is stored in the queued entry or signed authorization. Only supported six-decimal tokens are admissible: `100_000` base units is 0.1 token, not a guaranteed USD amount.
+
+The portal implementation of `requestForcedExit` uses the same `whenNotPaused` gate as ordinary encrypted deposits. Admission while paused reverts before collecting compensation, allocating IDs or changing the queue. L1 delivery follows the existing `processWithdrawals` pause gate, leaving withdrawals queued until delivery is unpaused.
+
+Apply the existing depositor-access check to the fee payer (`msg.sender`), including its existing callback-gateway exception when gateway enforcement is enabled. The token must be enabled and supported, and both fee transfers must satisfy native token pause and TIP-403 rules. The token's `depositsActive` flag does not gate forced requests: it controls incoming principal deposits, whereas a forced request collects only compensation. The hidden exiting account need not be a portal member. Recipient membership and gateway eligibility are checked after decryption as specified in Step 2, then checked again at L1 delivery.
+
+Keep token public because compensation is collected in the selected token, just as deposit token accounting is public. There is no public withdrawal amount at admission: execution determines the full balance. Account, recipient, authorization nonce, admission deadline, and signature remain encrypted. L1 cannot check recipient policy, the signed admission deadline, or authorization-digest deduplication at admission. Check these inside Zone execution. Do not publish the plaintext authorization digest merely for deduplication; use the Zone-local consumed authorization nonce map. Ciphertext duplication does not replace authorization replay protection.
+
+A forced withdrawal request has no deposit-refund recipient or admission-principal refund path. A withdrawal created by successful Zone execution has the normal withdrawal bounce-back path described below. If admission reverts, fee collection, payment and queue changes revert atomically. Once admitted, the fee has already been paid to `admin`, even if the request is later rejected, empty, delayed or never processed. Zone execution failure does not undo this L1 payment, and a later withdrawal bounce-back does not refund it.
+
+### Capacity
+
+Forced requests share the same public admission capacity and outstanding-entry accounting as ordinary encrypted deposits; each consumes one queue entry. Preserve the existing reserve for withdrawal-generated entries, including bounce-backs. Size the shared admission limit using worst-case signature verification, authenticated balance/policy reads, ciphertext decryption, outcome storage and settlement calldata/gas, accounting for token initialization within the same execution budget. The entire imported queue head must fit the execution budget; a lower processing cap must not silently skip a suffix.
+
+## Step 2: Process on Zone
+
+Process this variant in canonical inbox order and read the historical encryption key from authenticated L1 storage using `keyIndex`, just as deposits do. Key rotation after admission must not prevent processing an accepted request using its historical key. Reuse `DecryptionData` and Chaum-Pedersen verification to establish the correct ECDH shared secret, then derive the key and decrypt inside the shared STF used by Zone execution and the prover.
+
+A portal pause after admission does not prevent inbox processing or produce a terminal rejection; token-level restrictions still apply. The forced-exit inbox helper must not inherit the portal-pause check from the ordinary outbox request helper. The admitted request may create a withdrawal while paused, but its L1 delivery waits for the portal to be unpaused.
+
+An absent or invalid Chaum-Pedersen proof invalidates processing; it must never produce a terminal rejected exit. Only after verifying the correct shared secret may an invalid GCM tag or malformed plaintext produce a deterministic invalid-request outcome. A validly decrypted but unauthorized request also produces a deterministic rejection. Never trust `QueuedDeposit.rejected` for this variant. Malformed authenticated outer protocol data and missing witnesses remain fatal execution errors.
+
+After decryption, verify the signed domain/Zone, public token equality, admission deadline, root-key authorization and nonce. Evaluate token and recipient policy failures separately from authorization, using the failure semantics below. Require nonzero account/recipient. The account’s own root key must sign the authorization: verify the signature over the canonical EIP-712 digest and require the recovered or derived signer address to equal `account`. Access keys and delegated keychain signatures cannot authorize a forced exit, even if active or otherwise permitted to spend from the account. Require authenticated L1 `requestedAtTime < admitBefore`; equality is expired and zero grants no unlimited-deadline exception. This is an admission deadline, not an execution deadline: a request admitted in time may execute later, subject to the processing-time authorization and policy checks above, and withdraw the full liquid balance then present, including funds received after admission. Passing `admitBefore` does not cancel an admitted request. Invalid requests still pay the fixed admission processing fee.
+
+Signature envelopes must use explicitly supported Tempo-compatible schemes with strict canonical decoding, including rejection of trailing data and unsupported versions. V1 excludes arbitrary ERC-1271 callbacks and counterfactual accounts. Accept only supported primitive root-signature envelopes and reject access-key/keychain envelopes. There is no signing-key selector in the authorization; derive the signer identity from the verified signature. The outer `keyIndex` still selects the Zone encryption key and does not select the account signing key. Pin cross-language type-hash and signature vectors.
+
+For a fresh authorized nonzero-balance request, evaluate execution policies against authenticated state at the imported L1 anchor: require the token to be enabled, require the signed recipient to hold `Role.Account` when portal access enforcement is enabled, and reject a recipient with `Role.CallbackGateway` when gateway enforcement is enabled because this is a plain withdrawal. Require the native token pause and TIP-403 checks used by the debit path, including the debited account's sender eligibility; do not bypass them when bypassing the allowance requirement. The exiting account's portal membership and the token's `depositsActive` flag are not execution requirements. Apply the recipient checks to the L1 destination; do not require it to hold a Zone balance or have a Zone signing key. L1 delivery independently rechecks its current recipient resolution, portal membership/gateway rules and TIP-403 receive policy for `portal → recipient`, and performs the native token transfer. A later delivery failure follows the ordinary bounce-back path.
+
+The sequencer must supply valid decryption material and execute every imported forced entry to produce a valid accepted transition. Reuse the existing authenticated queue and proof pipeline. This does not itself force checkpoint import or continued block production: the guarantee is conditional on live execution and enforced inclusion. Do not describe queue correctness alone as a deadline or operator-failure guarantee.
+
+Each forced exit consumes exactly one `DecryptionData` in the mixed inbox stream, just like an encrypted deposit; bounce-backs consume none. Missing or extra entries invalidate processing.
+
+For a successfully authenticated request, the shared STF derives its outcome as follows; requests rejected during decryption or authorization skip this sequence and go directly to the common terminal finalization below:
+
+1. Checks the dedicated Zone-local `(account, nonce)` replay map. After successful authorization, consumes the nonce even for an empty balance or deterministic policy failure; invalid authorization cannot consume another account's nonce.
+2. Reads the liquid balance `B` through authenticated state witnesses.
+3. Rejects unsupported `uint128` overflow without truncation, otherwise produces `Empty` for zero balance, otherwise checks applicable token and recipient policies. An applicable policy failure produces a deterministic `Rejected(reason)`. These outcomes do not debit principal.
+4. Otherwise burns exactly `B` using an inbox-only outbox helper, without a preexisting user allowance or ordinary withdrawal fee. Token accounting/reward/policy hooks remain atomic with the debit.
+5. Enqueues a normal plain withdrawal to the signed recipient and derives `Exited(B)` and the exact withdrawal hash for terminal finalization. Allocate a nonzero fallback nonce from the existing outbox counter and map it to the signed `account` in Zone state, so failed L1 delivery returns principal to the account that was debited. Principal debit, reward hooks, fallback registration and withdrawal enqueue are one atomic attempt. Record `Exited(B)` only when that attempt succeeds; the failure table below defines rejection and fatal rollback boundaries. Use request-ID-based public attribution, not the plaintext authorization digest.
+
+All terminal paths converge on a common finalization step: record exactly one outcome and consume the inbox entry. This includes invalid ciphertext after a valid decryption proof, invalid authorization, replay, policy rejection, empty balance and successful withdrawal creation. No terminal rejection may return before this finalization. Fatal errors bypass terminal finalization and abort the enclosing transition, rolling back all Zone effects, including any earlier requests' effects in that transition.
+
+The debit helper must reuse upstream TIP-20 supply, rewards and policy hooks, not raw balance-slot writes or an unrestricted arbitrary-account burn API. Reuse the existing `Withdrawal` encoding: set plain withdrawal callback data empty, gas limit zero, memo zero and encrypted sender empty. Set `senderTag` to `keccak256(abi.encode("TempoZoneForcedExit", portal, requestId))` for public request attribution without revealing the account. Bind the exact withdrawal, including its fallback nonce, to the outcome; no `forcedExitId` field or new withdrawal encoding is required.
+
+L1 admission enforces collection and immediate payment of the fixed fee. Authenticated inclusion in the portal queue establishes that these admission rules succeeded; the STF does not pay, mint, credit or refund compensation. There is no Zone compensation ledger or claim function. No user transaction interleaves within inbox processing. Later requests see the resulting balance. Requests do not freeze funds at admission.
+
+### Processing outcomes and failure semantics
+
+The table describes committed Zone effects for one admitted request. Every terminal outcome consumes that inbox entry. In every row, the fee was already paid on L1 at admission and is unchanged by Zone execution, including an aborted transition. Consuming an inbox entry is distinct from consuming the signed `(account, nonce)`: an invalid request must not reserve another account's authorization nonce. “No change” below means no change attributable to this request.
+
+| Condition | Processing result | Authorization nonce | Principal and withdrawal |
+| --- | --- | --- | --- |
+| Missing/extra decryption data, invalid Chaum-Pedersen proof, missing state witness, or malformed authenticated outer entry | Abort transition; no terminal outcome | Roll back | Roll back all effects |
+| Correctly proven shared secret, but invalid GCM tag or noncanonical/malformed plaintext | Terminal `Rejected(reason)` | No change | No change; no withdrawal |
+| Invalid/unsupported signature, wrong domain/Zone or public token, zero account/recipient, or admission deadline not met | Terminal `Rejected(reason)` | No change | No change; no withdrawal |
+| Signature is valid for a different account, or uses an access-key/keychain envelope | Terminal `Rejected(reason)` | No change | No change; no withdrawal |
+| Otherwise authorized request reuses a consumed nonce | Terminal `Rejected(reason)` | Already consumed; no change | No change; no withdrawal |
+| Fresh authorized request has a balance exceeding the supported `uint128` range | Terminal `Rejected(reason)` | Consume | No change; no withdrawal |
+| Fresh authorized request has zero balance | Terminal `Empty` | Consume | No change; no withdrawal |
+| Fresh authorized request has a deterministic token/recipient policy failure, including a classified policy revert during the debit attempt | Terminal `Rejected(reason)` | Consume | Roll back the entire debit attempt, including reward hooks, fallback registration and withdrawal enqueue |
+| Fresh authorized request successfully debits the full balance and enqueues its withdrawal | Terminal `Exited(B)` | Consume | Debit exactly `B` and enqueue one withdrawal atomically |
+| Out of gas, execution-capacity exhaustion, internal invariant failure, or an unclassified execution error, including after debit | Abort transition; no terminal outcome | Roll back | Roll back all effects |
+
+Apply checks in canonical order: decryption proof, ciphertext/codec, signed fields and authorization, replay, balance overflow, zero balance, applicable token/recipient policies, then the debit attempt. A valid zero-balance request produces `Empty` before token/recipient policy evaluation. Pin the order of checks within each category and the versioned public reason codes so the host cannot choose among rejection reasons. Fatal witness or execution errors encountered at any stage take precedence over a terminal outcome.
+
+Use a nested storage checkpoint for the debit attempt. Catch only explicitly classified deterministic policy errors: roll back that checkpoint, then record `Rejected(reason)` and nonce consumption outside it through common terminal finalization. On success, commit the attempt and record `Exited(B)`. The enclosing transition still commits or rolls back the attempt, nonce, outcome and inbox cursor together. Never turn an arbitrary error into a user rejection, and never preserve a successful outcome from an aborted transition. The L1 admission transaction is separate: its completed fee payment to `admin` is unaffected when Zone execution aborts.
+
+Temporary outbox limits must not cause terminal rejection or nonce consumption. Ensure the outbox limits can accommodate withdrawals produced by the admitted inbox workload within the shared execution budget; exhaustion is an execution failure to resolve before producing an accepted transition, not grounds to skip a queue suffix.
+
+### Request rejection and withdrawal bounce-back
+
+Reuse deposit encryption and queue infrastructure, but do not route forced requests through the ordinary deposit refund handler. A rejected or empty forced request creates no principal withdrawal, refund, or `WithdrawalBounceBack` entry; the account principal remains unchanged. A request whose debit attempt fails must roll back the attempt and follow the rejection or fatal-error rules above; it must not create a bounce-back to compensate for partially applied Zone execution. Missing witnesses or invalid decryption proofs still invalidate processing rather than consuming the request as a rejection.
+
+After successful execution and settlement, the resulting withdrawal follows ordinary L1 delivery and withdrawal bounce-back behavior. Failed L1 delivery enqueues a `WithdrawalBounceBack` entry returning the principal to the signed Zone account through its fallback nonce. This is distinct from rejecting a request before a withdrawal exists.
+
+Existing deposit refunds and withdrawal bounce-backs, including those from forced withdrawals, may coexist in the same inbox. A forced exit processes after any preceding entries, so funds credited by an earlier bounce-back contribute to its processing-time balance. Funds credited by a later bounce-back are not included in an already processed exit. The original authorization nonce remains consumed; a later forced withdrawal requires a new authorized request and processing compensation, or the user may request an ordinary withdrawal under its normal rules.
+
+## Step 3: Prover and the STF
+
+The prover replays the same STF used in Step 2 against authenticated Zone and L1 witnesses. It verifies the queue commitment/order, historical encryption key and decryption proof, the account’s root signature, signed authorization fields and nonce, exact full-balance debit, fallback-nonce registration to the debited account, and resulting withdrawal/outcome. Fee payment is enforced by authenticated L1 admission, not replayed as a Zone state change. Missing witnesses or a forged decryption proof invalidate the transition; the host cannot choose a rejection reason.
+
+The batch includes an ordered public outcome array:
+
+```solidity
+struct ForcedExitOutcome {
+    uint64 requestId;
+    uint64 depositNumber;
+    address token;
+    address recipient;       // Zero unless Exited
+    uint8 status;            // Exited, Empty, Rejected
+    uint16 reason;           // Versioned code; zero on success
+    uint128 amount;          // Zero unless Exited
+    bytes32 withdrawalHash;  // Zero unless Exited
+}
+```
+
+For an `Exited` outcome, define `withdrawalHash = keccak256(abi.encode(withdrawal))`, using the complete existing Solidity `Withdrawal` struct in its declared field order, including `senderTag`, `fallbackNonce` and the empty dynamic fields. Use standard ABI encoding, not packed encoding. This hashes the individual withdrawal without a queue suffix. The existing queue link remains `keccak256(abi.encode(withdrawal, remainingQueue))`; the proof must bind the exact same withdrawal to both its outcome hash and that batch's withdrawal queue commitment. `Empty` and `Rejected` outcomes have `withdrawalHash = bytes32(0)`. Pin Solidity/Rust vectors for both encodings.
+
+Bound the outcome array by the measured execution and settlement budget. Commit `keccak256(abi.encode(outcomes))`, including the canonical empty array, in batch output, proof/attestation inputs, settlement quorum digest and verifier inputs, together with the existing chain/portal, L1 anchor, parent/next Zone transition, deposit queue, token transition and withdrawal commitments. Every consumed forced request must have exactly one outcome; a successful exit must enter that batch's withdrawal commitment. Checkpoint-only blocks cannot count as processing an exit.
+
+The sequencer submits the batch and matching proof to L1. An enforcing verifier must reject forged, empty, wrong-image/version, stale-parent or mismatched-input proofs. For Nitro, the attestation must bind the approved image, AWS attestation trust checks and exact execution digest.
+
+After verification, the portal checks request/deposit identity and token against admission metadata, rejects unknown requests, omitted/duplicate/reordered outcomes and status regressions, and authenticates each successful withdrawal once for normal queue delivery. The proof binds the recipient to the decrypted authorization; L1 cannot read that recipient at admission. Failed outcomes have zero recipient, amount and withdrawal hash.
+
+`Exited` records successful Zone debit and withdrawal creation, not successful L1 payment. Later delivery or bounce-back does not rewrite that processing outcome. Status tooling reports delivery and bounce-back progress separately using the existing withdrawal and inbox events.
+
+This proves correct processing of imported requests. It does not independently compel checkpoint import or continued production, so this version makes no bounded-time inclusion or operator-failure guarantee.
+
+## Step 4: Withdrawal on L1
+
+After the proven batch settles, the sequencer calls the existing `processWithdrawals` to deliver the forced withdrawal in normal FIFO order. Funds go to the authenticated recipient.
+
+Use the existing withdrawal encoding, queue hashes and fallback-nonce semantics. The authenticated outcome binds the request to its exact withdrawal. Delivery uses the existing sequencer authorization, portal pause gate, token/recipient policy checks, deposit-capacity preflight and reentrancy protection.
+
+Process the withdrawal exactly like a normal plain withdrawal. On successful transfer, consume it through normal queue accounting so it cannot be paid again. If delivery fails, consume the withdrawal and enqueue one `WithdrawalBounceBack` entry with the same token, full principal amount and fallback nonce. Continue processing later withdrawals under the existing rules; a blocked recipient does not retain the failed withdrawal at the queue head. A transaction-level revert, including a pause or capacity failure, rolls back these effects under the existing behavior.
+
+The Zone processes the bounce-back through the existing inbox handler: consume the fallback mapping once and attempt to mint the principal back to the signed account under current token policy. If minting is blocked, record the amount in the existing pending withdrawal-bounce-back credit ledger for later claim through its policy-aware claim path. No new recovery ledger or delivery path is needed. Neither the bounce-back nor claiming its pending credit re-executes the original forced request or charges its processing compensation again. The original nonce remains consumed and compensation remains earned; another forced withdrawal requires a new authorization and fee.
+
+### Privacy
+
+Encryption hides account, recipient and authorization at request time from public L1 observers. The public request still exposes fee payer, token, compensation, key index, timing and ciphertext length. Successful settlement reveals recipient and withdrawn amount; no account or plaintext authorization/digest is required for delivery. This is deposit-style request privacy, not settlement balance privacy or unlinkability, and the sequencer and authorized readers of execution/decryption material can decrypt the request. Public failure reasons must be bounded protocol codes, never decrypted payloads.
+
+## Activation requirements
+
+V1 fixes `FORCED_EXIT_COMPENSATION` at `100_000` base units. Changing it requires a versioned portal admission change and an updated signed authorization domain version so existing signatures cannot authorize requests at the new fee. Already-admitted requests have paid their fee and are neither charged again nor refunded when processing crosses an upgrade boundary. Keep the STF and proof verifier compatible with each admitted authorization version; there is no processing-time compensation amount to migrate.
+
+Portal storage includes feature/config version, request counter, encrypted-entry identity/token/deposit metadata and outcomes. Zone storage includes authorization nonces and pending outcomes, and reuses the existing fallback-recipient mapping and pending withdrawal-bounce-back credits. Append storage without reordering existing slots; update Solidity layouts and Rust witness/storage views together and regenerate ABI/layout/runtime artifacts through repository tooling.
+
+Keep pure codecs, authorization digests and validation helpers in `exithatch`; stateful execution remains in existing inbox/outbox precompiles. Propagate the typed entry through L1 event ingestion, canonical reconstruction and restart/backfill; propagate outcomes through builder, executor, SPF, proof/quorum inputs and settlement. Checker and CLI tooling must support backing/outcome inspection and sign/encrypt/request/status operations.
+
+### Backward compatibility and rollout
+
+The feature MUST activate through a coordinated protocol/config version. Before activation, the new admission method and queue variant must not produce entries that the active node, prover, or verifier cannot process. Preserve existing deposit discriminants and encoding, the 64-byte deposit plaintext rule, the `DepositPayload` ABI, ordinary `Withdrawal` encoding, and the existing deposit-refund and withdrawal-bounce-back semantics.
+
+Admission, imported-request execution, proof/attestation generation, quorum signing, settlement verification, and event ingestion MUST agree on the new entry and outcome commitments. Storage additions MUST preserve existing slots and regenerate Solidity/Rust layouts, ABI bindings, and runtime artifacts together. Upgrade handling MUST be exercised with pending legacy entries and already-admitted forced requests; changing the fee does not reopen payment or refund an earlier admission.
+
+### Open decisions before scheduling
+
+The following draft parameters MUST be fixed and reviewed before this TIP is scheduled for activation.
+
+| Decision | Required output |
+| --- | --- |
+| Activation scheduling | Target protocol version and coordinated rollout plan. |
+| Primitive root-signature support | Exact enabled signature schemes, versioned envelopes, signer-identity rules, maximum signature lengths, and Solidity/Rust vectors. |
+| Forced-exit codec bounds | Exact minimum and maximum ciphertext lengths, canonical ABI constraints, and maximum encoded plaintext for the enabled signatures. |
+| Admission and execution capacity | Measured shared inbox admission limit, outbox headroom/reserve, worst-case execution/proving cost, and maximum outcome/settlement size and gas. |
+| Wire-level outcomes and errors | Numeric `status` discriminants, versioned `reason` codes, classification of deterministic policy reverts, canonical order within validation categories, and admission error ABI. |
+| Event and inspection interfaces | New event names, signatures, indexed fields, and how settled outcomes are exposed to indexers, as specified in Observability. Preserve existing delivery/recovery events. |
+| Persistent storage and proofs | Exact new slots/layouts, authenticated witness views, outcome commitment integration, and activated verifier/image/version identifiers. |
+| Interoperability fixtures | Pinned type hashes, encryption/signature codecs, queue/withdrawal/outcome hashes, cross-language fixtures, and activation-boundary vectors. |
+
+# Tooling
+
+| Consumer | Required changes |
+| --- | --- |
+| Wallets, SDKs, and signing clients | Build the canonical authorization and EIP-712 domain; choose an unused account authorization nonce; sign with a supported primitive root scheme; encode and encrypt with fresh ephemeral key/GCM nonce; bind the HKDF sender to the actual fee payer; submit `requestForcedExit`. |
+| User-facing request flow | Explain the fixed fee and upfront payment, selected token, recipient, exclusive admission deadline, processing-time full-balance semantics, and live-sequencer dependency. Show admission, processing, and delivery as separate stages. |
+| CLI and libraries | Support sign, encrypt, request, and status operations, plus backing/outcome inspection. Surface `requestId`, `depositNumber`, and the verified withdrawal hash for correlation. Exact command and API names remain an implementation deliverable. |
+| Node, builder, executor, and prover | Decode the appended inbox variant, preserve mixed-entry ordering and decryption-data counts, authenticate the replay map, execute the shared rules, and propagate pending outcomes and commitments through the full proof/quorum/settlement pipeline. |
+| Indexers and support tooling | Reconstruct admissions from L1 events, backfill across restarts and finality changes, correlate proven outcomes with ordinary delivery and bounce-back progress, and inspect pending credits through existing recovery tooling. |
+| Test and integration tooling | Provide cross-language codecs and hashing vectors, authenticated state fixtures, mixed inbox/outbox scenarios, failure-table coverage, and backing reconciliation. |
+
+Status output MUST distinguish `Exited` from successful L1 payment. A bounced-back withdrawal keeps its original processing outcome and consumed authorization nonce; another forced withdrawal requires a new authorization and fee. Recovery of the existing principal through bounce-back or pending-credit claim does not charge the forced-exit fee again.
+
+Clients MUST NOT imply that `admitBefore` cancels an admitted request, that the amount is fixed at admission, that the admission fee is refunded on rejection, or that this path guarantees an exit after operator failure. Public logs and diagnostics MUST NOT expose the decrypted authorization or its signature/digest. The recipient and amount may be displayed from the authenticated public settlement outcome.
+
+# Observability
+
+## Required event coverage and public data
+
+The exact new event ABI is an open decision. The following information is required; existing withdrawal and recovery event names and semantics are preserved.
+
+| Record | Required fields or data | Emission/publication requirement and operational question |
+| --- | --- | --- |
+| Forced-request admission | `depositNumber` and the complete `ForcedExit` entry: `requestId`, `token`, `keyIndex`, every `DepositPayload` field, `feePayer`, `requestedAtBlock`, and `requestedAtTime`. | The portal MUST emit the complete reconstructible encrypted admission using the existing ingestion/backfill pattern. Establishes which request was admitted, where it sits in the inbox, and when it began waiting. The protocol version fixes the paid compensation; the successful admission transaction establishes payment. |
+| Proven processing outcomes | The ordered `ForcedExitOutcome[]`: `requestId`, `depositNumber`, `token`, `recipient`, `status`, `reason`, `amount`, and `withdrawalHash`, bound to the settled batch. | The array MUST be public as part of the matching settlement data. The draft does not yet assign a separate outcome event; the finalized event/inspection ABI must let indexers discover the settled batch and retrieve its outcomes. Establishes whether processing rejected, found an empty balance, or created an authenticated withdrawal. |
+| Ordinary withdrawal delivery | Existing queue/withdrawal identity and payment or bounce-back result, correlated with the complete withdrawal and its hash. | Implementations MUST retain the existing withdrawal events used to observe delivery. Distinguishes creation of a withdrawal from payment to the recipient. No new withdrawal encoding is introduced. |
+| Bounce-back admission and processing | Existing bounce-back identity, token, principal amount, fallback nonce, and recovery result or pending-credit state. | Implementations MUST retain the existing inbox/recovery events and inspection paths. Shows whether failed delivery has returned funds or left a policy-blocked pending credit. |
+| Pending-credit claim | Existing claim record and resulting pending-credit state. | Implementations MUST retain the existing policy-aware claim observability. Shows completion of recovery without implying that the original forced request was re-executed. |
+
+Public failures MUST use bounded, versioned reason codes. Non-success outcomes expose zero recipient, amount, and withdrawal hash. The exiting account, signed nonce, admission deadline, signature, and plaintext authorization digest MUST NOT be added to L1 admission events or public diagnostics. Existing recovery observability must not be extended with decrypted authorization data.
+
+## Operational measurements and success criteria
+
+Operators should monitor admitted and processed request counts, terminal outcomes by reason, the oldest outstanding admission, checkpoint/import lag, proof/settlement lag, withdrawal delivery and recovery lag, shared queue occupancy, and witness/decryption/capacity failures. These measurements diagnose liveness; they do not create a protocol deadline.
+
+Before testnet rollout, dashboards and alerts should make missing progress, unprocessable mixed workloads, settlement mismatches, unexpected terminal policy failures, and unresolved recovery credits visible. Initial acceptance criteria are:
+
+1. Every imported forced request in an accepted transition has exactly one authenticated outcome, in canonical order.
+2. A successful outcome creates exactly one matching withdrawal and can be followed through payment or principal recovery.
+3. Missing or invalid decryption proofs, missing witnesses, and malformed authenticated outer entries cannot be committed as terminal user rejections; fatal failures roll back the enclosing Zone transition.
+4. Backing reconciliation and single-use authorization/recovery invariants hold across restarts, upgrades, and all classified failures.
+5. The measured maximum admitted mixed workload fits execution, proving, outbox, and settlement budgets.
+
+# Invariants
+
+## Authorization, ordering, and atomicity
+
+1. Only a supported signature from the account's own root key can authorize its forced withdrawal. Paying compensation is not authorization.
+2. Each `(account, nonce)` can authorize at most one terminal processing attempt that passes authorization and freshness checks. Empty, overflow, and deterministic policy outcomes consume it; invalid authorization does not; fatal transition failure rolls consumption back.
+3. Every terminal outcome consumes exactly one inbox entry and records exactly one processing outcome. All imported forced entries execute in canonical mixed-inbox order, with exactly one decryption-data item per encrypted entry.
+4. `Exited(B)` commits the full authenticated processing-time liquid balance debit, token hooks, fallback mapping, and matching withdrawal together. An incomplete attempt cannot leave principal debited or create a recovery entry.
+5. The proven outcome, individual withdrawal hash, and withdrawal queue commitment bind the same complete withdrawal, including its recipient and fallback nonce.
+6. Admission compensation is paid once on L1 and creates no Zone compensation balance or claim. Zone rejection, rollback, delay, and recovery do not reverse or repeat it.
+7. An admitted request may execute after its admission deadline; its balance includes earlier credits in inbox order. Later credits require a later authorized withdrawal.
+8. A settled processing outcome is stable. L1 delivery, bounce-back, and pending-credit recovery are subsequent stages and cannot rewrite it or restore its authorization nonce.
+
+## Principal backing and recovery
+
+For each token, admission collects the fixed fee and transfers the same amount to `admin` on L1, leaving portal principal backing and Zone account balances unchanged. The fee creates no pending liability or Zone credit. Processing converts the Zone principal into a pending withdrawal. Settlement authenticates that withdrawal without changing escrow balance. Successful delivery reduces backing and the single withdrawal liability by the same amount. Failed delivery leaves backing unchanged and replaces the withdrawal liability with one queued bounce-back liability. Zone bounce-back processing replaces that liability with either reminted principal or an existing pending bounce-back credit; claiming a credit replaces it with minted principal. These are alternative states of one backed liability, never simultaneous claims to the same principal. The outcome is a processing record, not an additional liability. Preserve ordinary deposit, refund and withdrawal backing throughout, including token supply/reward hooks.
+
+## Required test coverage
+
+- Round-trip vectors using the existing envelope, HKDF context, historical keys, and `DecryptionData`; wrong portal/sender/key and tampered ciphertext cases.
+- Mixed deposits, forced exits, and bounce-backs preserve queue hashes and exact decryption ordering; existing deposit vectors remain unchanged.
+- Missing or forged decryption proof cannot consume a forced request; correctly proven invalid ciphertext produces a deterministic failure.
+- Authorization replay, signed/public token mismatch, admission deadline boundaries (before/equal/after, including zero), execution after the admission deadline with later-received funds, wrong-account signatures, rejection of access-key/keychain envelopes, and atomic full-balance processing.
+- Public settlement recipient/token/amount cannot be substituted; plaintext authorization is absent from L1 admission calldata/events.
+- Enforcing settlement rejects forged/empty/mismatched proofs and omitted outcomes; checkpoint-only blocks cannot satisfy requests.
+- Sequencer `processWithdrawals` uses the existing plain-withdrawal encoding and behavior: each withdrawal is consumed once by payment or bounce-back enqueue, failed transfers do not block the suffix, and transaction-level reverts preserve atomic payment/bounce-back/cursor accounting.
+- Rejected/empty forced requests create no principal refund or bounce-back. Failed L1 delivery creates exactly one normal bounce-back for the full principal, with the authenticated fallback nonce resolving only to the debited Zone account; replay cannot pay or remint twice.
+- Bounce-back processing remints to the debited account or records an existing pending bounce-back credit when policy blocks minting. Later claims remain policy-aware and cannot duplicate principal. The original authorization nonce remains consumed, compensation is not refunded or charged again for recovery, and a new forced request requires a new authorization and fee.
+- Bounce-backs before and after a forced request affect only the appropriate processing-time balance; existing deposit refunds and ordinary withdrawal bounce-backs remain unchanged. Processing outcomes remain stable while tooling tracks payment, bounce-back and pending-credit progress separately.
+
+- Exercise every row of the failure-semantics table, including replay versus inbox consumption, canonical failure precedence, policy failure after burn, and fatal failure after an earlier request in the same transition. Verify the specified nonce, principal, reward, fallback, outcome and cursor effects or rollback; completed L1 admission payments remain unaffected.
+- Full-balance zero/dust/max/overflow, admin address equal to the exiting account (fee payment changes only its L1 balance), withdrawal-capacity exhaustion, and supply/backing reconciliation.
+- Admission collects exactly `FORCED_EXIT_COMPENSATION` and immediately pays the same amount to the current portal `admin` on L1, matching deposit fee handling. Failure of either transfer, including a blocked admin or paused token, rolls back the entire admission. Later admin/leader changes do not trigger another payment.
+- Paused admission matches encrypted deposits: no fee collection, ID allocation or queue mutation. Requests admitted before a portal pause can still process through the inbox without a pause-induced rejection; L1 delivery remains queued while paused and resumes under the normal rules after unpausing.
+- Deposits and forced requests consume the same public admission capacity, reject when that shared capacity is full, and cannot consume the existing withdrawal-processing reserve; there is no separate forced-request allowance.
+- Admission applies the existing fee-payer depositor-access rules; an enabled token with `depositsActive = false` still admits a forced request if both fee transfers are permitted. A nonmember exiting account may withdraw to an eligible recipient, but native token restrictions remain enforced. Check recipient membership/gateway changes at execution and delivery separately.
+- Every terminal path, including invalid ciphertext and invalid signatures, reaches common outcome/cursor finalization; fatal errors roll back all Zone effects of the enclosing transition without undoing the earlier L1 fee payment.
+- Processing, rejection, empty outcomes, execution retries and bounce-back recovery neither pay nor mint compensation; no Zone compensation ledger or claim API is introduced.
+- Individual withdrawal hashes match standard Solidity/Rust ABI vectors, exclude the queue suffix and bind every withdrawal field; substituting a field or a suffix-dependent queue hash cannot satisfy the outcome commitment.
+- Admission fee-transfer failure, membership/token policy behavior, no recharging of admitted requests across upgrades and signed-domain version separation, and maximum mixed execution/settlement budgets.
+- Restart/backfill and finality handling, coordinated activation with pending legacy deposits/withdrawals, storage/ABI compatibility, and reentrancy attempts during delivery.

--- a/tips/tip-1012.md
+++ b/tips/tip-1012.md
@@ -2,7 +2,7 @@
 id: TIP-1012
 title: Encrypted Forced Withdrawals for Zones
 description: Root-authorized full-balance withdrawals through the encrypted L1 inbox, with upfront compensation and proven Zone execution.
-authors: "@adityapk00, Dankrad Feist (@dankrad)"
+authors: "Aditya Kulkarni (@adityapk00), Dankrad Feist (@dankrad)"
 status: Draft
 related: https://github.com/tempoxyz/zones/pull/1425
 protocolVersion: TBD
@@ -12,91 +12,64 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP introduces an encrypted L1 request for withdrawing the full liquid balance of one token from a Zone account. The account's root key authorizes the withdrawal, the fee payer pays a fixed 0.1-token compensation to the portal admin at admission, and the shared Zone state transition function validates and executes the request under the proof pipeline. Successful requests create ordinary withdrawals, including the existing return-to-account path when L1 delivery fails. The mechanism requires a live sequencer and enforced inclusion; it does not provide exits after operator failure or a bounded-time inclusion guarantee.
+This TIP adds an encrypted L1 request to withdraw one token's full liquid balance from a Zone account. The account's root key authorizes the request, the fee payer pays a fixed 0.1-token fee to the portal admin at admission, and the shared Zone state transition function (STF) validates and executes it under the proof pipeline. Successful requests create ordinary withdrawals with the existing failed-delivery recovery path. This mechanism requires a live sequencer and enforced inclusion; it provides neither operator-failure exits nor a bounded-time inclusion guarantee.
 
 ## Motivation
 
-A Zone account holder needs a way to initiate a withdrawal through the L1 portal without first obtaining inclusion of an ordinary Zone withdrawal transaction or establishing an allowance. An authenticated L1 inbox request provides that entry point: once imported, its validation and outcome become part of the transition that the sequencer must prove.
+A Zone account holder needs to initiate a withdrawal through L1 without first obtaining inclusion of an ordinary Zone transaction or establishing an allowance. This proposal formalizes the design in [Zones PR #1425](https://github.com/tempoxyz/zones/pull/1425).
 
-The proposal reuses the encrypted deposit envelope and authenticated inbox to keep the account, recipient, and signed authorization private at admission. It reuses the ordinary withdrawal queue and bounce-back accounting for delivery and recovery. Withdrawing one token's full liquid balance limits the authorized action and avoids introducing arbitrary forced transaction execution.
+Using the encrypted deposit envelope hides the account, recipient, and authorization at admission, but moves signature and replay checks to the Zone. A dedicated consumed-nonce map makes authorizations single-use without publishing a plaintext digest. Full-balance withdrawals limit the authorized action, while upfront compensation pays for processing independently of its outcome. General forced transactions and partial withdrawals are outside scope.
 
-This proposal formalizes the design in [Zones PR #1425](https://github.com/tempoxyz/zones/pull/1425), using [source revision b7873d1](https://github.com/tempoxyz/zones/blob/b7873d15431b780e31ff04cb8456f0557eb62fe1/crates/exithatch/README.md). It follows the [TIP template](https://github.com/tempoxyz/tempo/blob/main/tips/tip_template.md) and [TIP process](https://github.com/tempoxyz/tempo/blob/main/tips/tip-0000.md). The source draft was submitted by @adityapk00. The TIP owner is Dankrad Feist (@dankrad); the target protocol version remains to be assigned.
-
-### Design choices and alternatives
-
-| Choice | Rationale and tradeoff |
-| --- | --- |
-| Encrypted L1 authorization | Reuses deposit encryption and hides the exiting account and recipient at admission. Signature, deadline, and replay validation must run after decryption on Zone. |
-| Full liquid balance at processing time | Gives the signed request a narrow action without adding arbitrary calldata. The eventual amount can include later credits; admission does not reserve or freeze funds. |
-| Root-key authorization | Requires the account's own authority for this exit path. Access keys, delegated keychain signatures, arbitrary ERC-1271 callbacks, and counterfactual accounts are outside V1. |
-| Dedicated consumed-nonce map | Makes each account authorization single-use without exposing a plaintext authorization digest on L1. Ciphertext deduplication alone cannot establish single-use authorization. |
-| Fixed compensation paid at admission | Pays for processing independently of the eventual outcome and avoids a Zone compensation ledger. An admitted request pays even if it is rejected, empty, delayed, or never processed. |
-| Existing plain withdrawal and bounce-back path | Reuses the established delivery and recovery accounting. A failed L1 payment returns principal to the account that was debited, subject to current token policy. |
-| Live-sequencer scope | Uses the current decryption, inbox, and proof infrastructure. Operator-failure exits and independent inclusion deadlines require a separate design. |
+The proposal builds on the existing [deposit encryption](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#encrypted-deposit-cryptography), [withdrawal processing](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#withdrawal-processing), and [withdrawal recovery](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#withdrawal-failures-and-bounce-back) rules. This TIP specifies the forced-request behavior and its integration with those paths.
 
 ## Assumptions
 
-| Assumption | Consequence if it does not hold |
+| Assumption | Consequence if violated |
 | --- | --- |
-| A live sequencer imports L1 checkpoints, processes the inbox, submits accepted proofs, and services withdrawals. Inclusion is enforced by the surrounding system. | The request can remain pending indefinitely. Queue correctness alone does not establish liveness or an exit deadline. |
-| L1 queue commitments, admission metadata, and the imported L1 anchor are authenticated under the existing finality and witness rules. | Unauthenticated or malformed protocol data cannot support an accepted transition; missing witnesses abort execution. |
-| The shared STF is used for both Zone execution and proving, and settlement runs an enforcing verifier for the activated version. | An execution result is not an authenticated withdrawal unless the matching transition is verified and settled. |
-| Historical encryption keys and valid decryption material remain available for admitted requests. | Rotation must not strand an admitted request. Missing or invalid decryption proofs abort processing instead of rejecting the user request. |
-| Existing TIP-20 supply, reward, and policy hooks, token backing, and withdrawal recovery accounting are preserved. | A raw balance mutation or partial debit would violate the accounting model and is not a conforming implementation. |
-| Shared inbox and outbox limits are sized for the admitted mixed workload, including proof and settlement costs. | Resource exhaustion aborts execution; it must not become a terminal rejection or a reason to skip a queue suffix. |
-| Activation coordinates portal, node, prover, verifier, and tooling versions while preserving legacy encodings and storage. | A deployment that cannot process an already-admitted version must not activate. |
+| A live sequencer imports checkpoints, processes the inbox, submits accepted proofs, and services withdrawals; the surrounding system enforces inclusion. | Requests may remain pending indefinitely. |
+| L1 queue commitments, admission metadata, and state witnesses follow the existing finality and authentication rules. | Missing witnesses or malformed authenticated protocol data invalidate execution. |
+| Zone execution and proving use the same STF, and settlement enforces the activated verifier. | Unverified execution cannot authorize L1 payment. |
+| Historical encryption keys and valid decryption material remain available. | Admitted requests cannot be processed; key rotation must not strand them. |
+| The complete admitted workload fits execution, proving, and settlement limits, including token initialization and resulting withdrawals. | Resource exhaustion aborts the transition rather than rejecting or skipping requests. |
 
 ## Threat Model
 
-| Actor or boundary | Trust assumptions and required behavior |
+| Actor | Authority and trust boundary |
 | --- | --- |
-| Account holder and signing client | The account's root key authorizes the exact account, Zone, token, recipient, nonce, and admission deadline. Compromise of that key is outside this mechanism's protection. Clients use the correct domain, canonical encoding, and fresh encryption material. |
-| Fee payer or relayer | The payer may differ from the account holder and must satisfy admission access and fee-transfer rules. Paying or relaying does not grant authority over the hidden account. Encryption binds the request to the payer through the existing HKDF sender context. |
-| Sequencer and execution host | The host is not trusted to choose decryption results, skip imported forced entries, alter recipients or balances, or select rejection reasons. Authenticated inputs and shared execution rules determine these results. Continued production and checkpoint import remain liveness assumptions. |
-| Prover and settlement verifier | Settlement accepts only the activated proof or attestation scheme with the complete execution commitments. For Nitro, trust includes the approved image, AWS attestation checks, and the bound execution digest. |
-| Portal admin and token policy authorities | Existing pause, role, enabled-token, and native token policies remain authoritative at the specified stages. The admin receives admission compensation; payment does not itself guarantee timely execution or delivery. |
-| Public L1 observers and request submitters | Admission reveals public request metadata but not the encrypted authorization. Malformed requests and repeated authorizations must follow deterministic validation and replay rules without consuming another account's authorization nonce. |
-| L1 recipient and token-transfer boundary | Delivery can fail because of current policy or transfer behavior. Existing reentrancy protection and atomic payment/bounce-back accounting must preserve principal and prevent duplicate delivery or recovery. |
+| Account holder | The root key authorizes the signed withdrawal. Root-key compromise is outside scope. |
+| Fee payer or relayer | May differ from the account holder. Payment grants no withdrawal authority; the encryption context binds the payload to this payer. |
+| Sequencer and execution host | Cannot choose decryption results, skip imported entries, substitute recipients or balances, or choose rejection reasons. Continued operation remains a liveness assumption. |
+| Prover and verifier | Must authenticate the complete transition. Nitro additionally relies on the approved image, AWS attestation checks, and bound execution digest. |
+| Portal admin and token authorities | Retain existing pause, role, and token-policy authority. The admin receives admission fees. |
+| Public submitters | May submit malformed or repeated requests. Admission access checks, fees, and shared capacity constrain submissions, but do not guarantee fair access to the queue. |
+| L1 recipient | Delivery may fail; ordinary atomic payment and bounce-back accounting must prevent duplicate payment or recovery. |
 
-Public settlement reveals the recipient and withdrawn amount. The sequencer and authorized readers of decryption material can read requests; settlement balance privacy and unlinkability are outside scope.
+Encryption protects admission from public observers. The sequencer and authorized readers of decryption material can read requests, and successful settlement reveals the recipient and amount. Settlement balance privacy and unlinkability are outside scope.
 
 ---
 
 # Specification
 
-The requirements below define V1 behavior. MUST and MUST NOT indicate conformance requirements; imperative statements also specify required behavior. Items in **Open decisions before scheduling** remain explicit draft parameters and must be fixed before this TIP is implementation-ready.
+## Lifecycle and state
 
-## Scope and lifecycle
+1. **Request on L1:** Sign and encrypt an authorization; the portal collects the fee and queues the request.
+2. **Process on Zone:** The STF authenticates the request and creates a withdrawal, or records an empty or rejected outcome.
+3. **Prove and settle:** The prover executes the same rules and L1 settlement authenticates the outcomes and withdrawals.
+4. **Deliver on L1:** The existing withdrawal queue pays the recipient or returns principal through bounce-back recovery.
 
-Each request authorizes the full liquid balance of one token from one Zone account. Partial withdrawals, arbitrary forced transactions, and exits after operator failure are out of scope. The signed deadline governs admission, not execution or delivery.
-
-1. **Request on L1:** The user signs and encrypts an exit authorization, and the portal collects and pays the fixed 0.1-token fee to its L1 admin and queues the request.
-2. **Process on Zone:** The sequencer decrypts and validates the request through the STF, which burns the account's full liquid token balance at processing time and creates a withdrawal, or records an empty or rejected outcome.
-3. **Prove and settle:** The prover replays the same STF, and L1 settlement verifies the proof and authenticates the outcomes and resulting withdrawals.
-4. **Deliver on L1:** The sequencer processes the withdrawal through the normal queue, paying the recipient or bouncing the principal back to the Zone account if payment fails.
-
-The STF executes Step 2 and is replayed by the prover in Step 3. They use the same transition rules.
-
-## State ownership and identifiers
-
-| State or identifier | Location and purpose |
+| State or identifier | Meaning |
 | --- | --- |
-| Signed authorization | Carried inside the encrypted request queued on L1 and decoded within Zone execution. Includes the account, Zone chain ID, token, recipient, authorization nonce, and admission deadline. |
-| Consumed authorization nonces | Dedicated authenticated Zone storage keyed by `(account, nonce)`. The STF reads and updates this replay map; the prover verifies the same changes. It is separate from ordinary account transaction nonces. |
-| `requestId` | Nonzero monotonic portal-local identifier for the admitted forced request and its public processing outcome. |
-| `depositNumber` | Global inbox identifier that places the request among deposits and bounce-backs. It is distinct from `requestId`. |
-| Admission metadata and outcomes | Portal storage holds the feature/config version, request counter, encrypted-entry identity/token/deposit metadata, and settled outcomes. Zone storage holds pending outcomes. |
-| `DepositPayload.nonce` | Encryption-envelope GCM nonce. It serves encryption security and is independent of the signed authorization nonce. |
-| `fallbackNonce` | Allocated from the existing outbox counter and mapped in Zone state to the debited account. Used once by the existing failed-delivery recovery path. |
-| Pending bounce-back credits | Existing Zone recovery ledger for principal that cannot yet be reminted under token policy. |
+| `(account, nonce)` | Dedicated authenticated Zone replay key, separate from ordinary transaction nonces. It has no token component and need not be sequential. Authorizations for different tokens using the same key compete for one use. |
+| `requestId` | Nonzero, monotonically allocated portal-local forced-request ID. |
+| `depositNumber` | Global inbox position shared with deposits and bounce-backs; distinct from `requestId`. |
+| `DepositPayload.nonce` | GCM encryption nonce, independent of the signed authorization nonce. |
+| `fallbackNonce` | Nonzero existing outbox counter value mapped in Zone state to the debited account for one-time recovery. |
 
-The authorization replay key is `(account, nonce)`, without a token component: two authorizations for the same account and nonce compete for the same single-use entry even if they name different tokens. This TIP does not require a sequential authorization counter. The consumed map remains private to Zone state; L1 admission does not publish or check a plaintext authorization digest.
-
-A fresh authorization consumes its nonce only after successful authorization, including when processing yields an empty balance, balance overflow, or deterministic policy rejection. An invalid authorization does not consume it. Fatal transition failure rolls back the replay map with all other Zone effects. Exact storage slots are an activation deliverable, not assigned by this draft.
+The portal stores admission metadata, feature/config version, request counter, and settled outcomes. Zone state stores consumed authorization nonces and pending outcomes, and reuses the existing fallback mappings and pending recovery credits. The replay map remains private to Zone state.
 
 ## Step 1: Request on L1
 
-The client signs the authorization, encrypts it together with the signature using the Zone's published encryption key, and submits the encrypted request to the portal.
+The client signs the authorization and encrypts it with the signature using the Zone's published encryption key.
 
 ```solidity
 uint128 constant FORCED_EXIT_COMPENSATION = 100_000;
@@ -118,7 +91,7 @@ struct ForcedExitAuthorization {
 ///      Authorization, nonce, signed deadline, and recipient checks occur after decryption on Zone.
 /// @param token Public token used for compensation and matched against the signed token on Zone.
 /// @param keyIndex Zone encryption-key index, subject to the existing deposit key-validity rules.
-/// @param encrypted DepositPayload containing the versioned authorization and root signature.
+/// @param encrypted DepositPayload containing the encoded authorization and root signature.
 /// @return requestId Nonzero, monotonically allocated identifier local to this portal.
 /// @return depositNumber Global inbox deposit number assigned to the queued request.
 function requestForcedExit(
@@ -136,256 +109,190 @@ struct ForcedExit {
     uint64 requestedAtBlock;
     uint64 requestedAtTime;
 }
+
+event ForcedExitRequested(uint64 indexed depositNumber, ForcedExit entry);
+
+error InvalidForcedExitCiphertextLength(uint256 actual);
 ```
 
-EIP-712 domain: name `TempoZoneForcedExit`, version `1`, L1 chain ID, verifying contract equal to the portal. The canonical signed type is `ForcedExitAuthorization(address account,uint256 zoneChainId,address token,address recipient,uint256 nonce,uint64 admitBefore)`.
+The EIP-712 domain is name `TempoZoneForcedExit`, `version = "1"`, L1 chain ID, and verifying contract equal to the portal. The canonical signed type is `ForcedExitAuthorization(address account,uint256 zoneChainId,address token,address recipient,uint256 nonce,uint64 admitBefore)`.
+
+`signature` is a `bytes` value containing the raw primitive signature encoding defined in [TIP-0001](./tip-0001.md#signature-types). Inherit its decoding, verification, and address-derivation rules, using the forced-exit EIP-712 digest as the signing hash. Keychain/access-key envelopes are rejected.
 
 ### Encryption
 
-Use the existing `DepositPayload` ABI unchanged: `ephemeralPubkeyX`, `ephemeralPubkeyYParity`, `ciphertext`, `nonce`, and `tag`. As with `Deposit`, `keyIndex` belongs to the outer queued struct, not the encryption envelope.
+Use the existing `DepositPayload` ABI and [encrypted-deposit cryptography](https://github.com/tempoxyz/zones/blob/main/specs/spec.md#onchain-decryption-verification), including key derivation and empty AAD. The encryption context's `sender` is the actual fee payer (`msg.sender`), captured by the portal; relayed requests must be encrypted for that relayer. Each encryption uses a fresh ephemeral key and GCM nonce.
 
-Client plaintext is `abi.encode(uint8(1), authorization, signature)`, with strict canonical decoding and a bounded signature envelope. Use a fresh ephemeral key and GCM nonce for every encryption. Reuse secp256k1 ECDH, the existing HKDF salt and context `(portal, keyIndex, ephemeralPubkeyX, sender)`, AES-256-GCM, and empty AAD. Here `sender` is the fee payer (`msg.sender`), captured by the portal; a client using a relayer must encrypt for that relayer address. The forced-exit EIP-712 domain and versioned plaintext distinguish this operation from deposits; the forced plaintext cannot pass the existing 64-byte deposit decoder.
+The forced-request plaintext is `abi.encode(uint8(1), authorization, signature)`, using the primitive signature bytes specified above. L1 admission requires `384 <= encrypted.ciphertext.length <= 2368` and a length divisible by 32. These bounds accommodate the inherited signature formats; signature validity remains a Zone check. Ordinary deposits retain their existing 64-byte plaintext and decoder.
 
-The deposit plaintext is fixed at 64 bytes. Forced authorization plus signature is larger: share the envelope and cryptographic helpers, but add a separate bounded forced-exit codec and ciphertext-length validation. Do not change the existing deposit encoding or its 64-byte rule. Pin maximum ciphertext/signature sizes for the enabled signature schemes before activation; arbitrary unbounded ciphertext is not admissible. The minimum encodable plaintext length and ABI alignment are checked at admission, and exact canonical encoding is checked after decryption.
+After decryption, require the leading `uint8` value to equal `1`, the inherited primitive signature format and bounds, and canonical ABI encoding: re-encoding the decoded values must reproduce the complete plaintext, including padding and offsets. Reject trailing data and any other prefix value.
 
-### L1 admission
+### Admission and compensation
 
-`requestId` is portal-local, monotonic, nonzero and distinct from the global deposit number. Append `DepositType.ForcedExit = 2`, preserving existing discriminants and encodings.
+`requestForcedExit` requires:
 
-The portal validates the public enabled token, ciphertext envelope/size, ephemeral-point validity, encryption key using the existing deposit key-validity and rotation-grace rules, and queue capacity. It collects exactly `FORCED_EXIT_COMPENSATION` from `msg.sender` and immediately transfers it to the portal’s `admin` on L1, assigns request/deposit IDs and admission block/time, and commits the entire entry with `keccak256(abi.encode(DepositType.ForcedExit, entry, previousHash))`. Emit the complete reconstructible encrypted entry using the existing L1 event ingestion/backfill pattern. Fee collection, payment to `admin` and all admission changes are atomic.
+- An unpaused portal, using the ordinary deposit pause gate.
+- The existing depositor-access check on `msg.sender`, including its callback-gateway exception when gateway enforcement is enabled.
+- An enabled, supported six-decimal token. Its `depositsActive` flag does not gate forced requests.
+- A valid ephemeral curve point, bounded encryption envelope, valid key under existing rotation/grace rules, and available public inbox capacity.
 
-Compensation is a protocol constant, not a user-selected amount or a configurable sequencer fee. Follow the existing deposit fee-payment pattern: call `transferFrom(msg.sender, portal, FORCED_EXIT_COMPENSATION)`, then `transfer(admin, FORCED_EXIT_COMPENSATION)` in the request token under native token-transfer policies. Either transfer failing reverts the entire admission, including both transfers, ID allocation and queue changes. The recipient is the portal’s current `admin`, exactly as for deposit fees; it need not be the sequencer leader. Payment is complete at admission, so no compensation recipient or amount is stored in the queued entry or signed authorization. Only supported six-decimal tokens are admissible: `100_000` base units is 0.1 token, not a guaranteed USD amount.
+Reuse the existing portal errors for pause, depositor access, token enablement, ephemeral-point, key-validity, and shared-capacity failures. A ciphertext length outside the forced-request bounds or not divisible by 32 reverts with `InvalidForcedExitCiphertextLength(actual)`. Fee transfers propagate native TIP-20 reverts, as ordinary deposits do.
 
-The portal implementation of `requestForcedExit` uses the same `whenNotPaused` gate as ordinary encrypted deposits. Admission while paused reverts before collecting compensation, allocating IDs or changing the queue. L1 delivery follows the existing `processWithdrawals` pause gate, leaving withdrawals queued until delivery is unpaused.
+The portal calls `transferFrom(msg.sender, portal, FORCED_EXIT_COMPENSATION)`, then `transfer(admin, FORCED_EXIT_COMPENSATION)` in the public request token. Both transfers obey native token pause and TIP-403 policies. `100_000` base units is 0.1 token, not a guaranteed USD amount. The recipient is the current portal admin, which need not be the sequencer leader; the amount is a protocol constant.
 
-Apply the existing depositor-access check to the fee payer (`msg.sender`), including its existing callback-gateway exception when gateway enforcement is enabled. The token must be enabled and supported, and both fee transfers must satisfy native token pause and TIP-403 rules. The token's `depositsActive` flag does not gate forced requests: it controls incoming principal deposits, whereas a forced request collects only compensation. The hidden exiting account need not be a portal member. Recipient membership and gateway eligibility are checked after decryption as specified in Step 2, then checked again at L1 delivery.
+Append `DepositType.ForcedExit = 2`, preserving existing discriminants. Assign request/deposit IDs and admission block/time, and commit the complete entry as `keccak256(abi.encode(DepositType.ForcedExit, entry, previousHash))`. Emit `ForcedExitRequested(depositNumber, entry)` with the complete queued entry. Fee collection, payment, ID allocation, queue changes, and the event are atomic: any admission failure reverts them all.
 
-Keep token public because compensation is collected in the selected token, just as deposit token accounting is public. There is no public withdrawal amount at admission: execution determines the full balance. Account, recipient, authorization nonce, admission deadline, and signature remain encrypted. L1 cannot check recipient policy, the signed admission deadline, or authorization-digest deduplication at admission. Check these inside Zone execution. Do not publish the plaintext authorization digest merely for deduplication; use the Zone-local consumed authorization nonce map. Ciphertext duplication does not replace authorization replay protection.
+Once admitted, the fee is final even if processing rejects, finds an empty balance, aborts, is delayed, or never occurs. Execution and recovery do not pay or refund it. There is no Zone compensation ledger, compensation claim, or admission-principal refund path; compensation recipient and amount are not stored in the authorization or queued entry.
 
-A forced withdrawal request has no deposit-refund recipient or admission-principal refund path. A withdrawal created by successful Zone execution has the normal withdrawal bounce-back path described below. If admission reverts, fee collection, payment and queue changes revert atomically. Once admitted, the fee has already been paid to `admin`, even if the request is later rejected, empty, delayed or never processed. Zone execution failure does not undo this L1 payment, and a later withdrawal bounce-back does not refund it.
+Account, recipient, signed nonce, deadline, and signature remain encrypted. L1 admission cannot check authorization, recipient policy, the signed deadline, or authorization replay. These checks occur in Step 2; ciphertext deduplication cannot replace them. Admission must not publish a plaintext authorization digest. The hidden account need not be a portal member.
 
 ### Capacity
 
-Forced requests share the same public admission capacity and outstanding-entry accounting as ordinary encrypted deposits; each consumes one queue entry. Preserve the existing reserve for withdrawal-generated entries, including bounce-backs. Size the shared admission limit using worst-case signature verification, authenticated balance/policy reads, ciphertext decryption, outcome storage and settlement calldata/gas, accounting for token initialization within the same execution budget. The entire imported queue head must fit the execution budget; a lower processing cap must not silently skip a suffix.
+Forced requests inherit ordinary deposits' public admission limit, outstanding-entry accounting, and reserve for withdrawal-generated entries, including bounce-backs. Each request occupies one shared public slot and cannot consume the reserve. There is no separate forced-request allowance.
+
+Consequently, a payer satisfying admission rules can fill the shared capacity with requests that later reject, blocking both deposits and other forced requests until capacity reopens. Fees deter such submissions but do not guarantee availability or fair admission.
 
 ## Step 2: Process on Zone
 
-Process this variant in canonical inbox order and read the historical encryption key from authenticated L1 storage using `keyIndex`, just as deposits do. Key rotation after admission must not prevent processing an accepted request using its historical key. Reuse `DecryptionData` and Chaum-Pedersen verification to establish the correct ECDH shared secret, then derive the key and decrypt inside the shared STF used by Zone execution and the prover.
+Process every imported entry in canonical mixed-inbox order, with no interleaved user transactions. Each forced request consumes exactly one `DecryptionData`, as encrypted deposits do; bounce-backs consume none. Read the historical key from authenticated L1 state using `keyIndex`, verify the Chaum-Pedersen proof of the ECDH shared secret, then derive the key and decrypt within the shared STF. Do not trust a host-supplied `QueuedDeposit.rejected` value.
 
-A portal pause after admission does not prevent inbox processing or produce a terminal rejection; token-level restrictions still apply. The forced-exit inbox helper must not inherit the portal-pause check from the ordinary outbox request helper. The admitted request may create a withdrawal while paused, but its L1 delivery waits for the portal to be unpaused.
+### Authorization and balance
 
-An absent or invalid Chaum-Pedersen proof invalidates processing; it must never produce a terminal rejected exit. Only after verifying the correct shared secret may an invalid GCM tag or malformed plaintext produce a deterministic invalid-request outcome. A validly decrypted but unauthorized request also produces a deterministic rejection. Never trust `QueuedDeposit.rejected` for this variant. Malformed authenticated outer protocol data and missing witnesses remain fatal execution errors.
+Require nonzero account and recipient, the correct signed domain and Zone chain ID, and equality between signed and public tokens. Verify the primitive signature as specified in Step 1 and require its recovered or derived address to equal `account`. Arbitrary ERC-1271 callbacks and counterfactual accounts are unsupported. There is no account signing-key selector.
 
-After decryption, verify the signed domain/Zone, public token equality, admission deadline, root-key authorization and nonce. Evaluate token and recipient policy failures separately from authorization, using the failure semantics below. Require nonzero account/recipient. The account’s own root key must sign the authorization: verify the signature over the canonical EIP-712 digest and require the recovered or derived signer address to equal `account`. Access keys and delegated keychain signatures cannot authorize a forced exit, even if active or otherwise permitted to spend from the account. Require authenticated L1 `requestedAtTime < admitBefore`; equality is expired and zero grants no unlimited-deadline exception. This is an admission deadline, not an execution deadline: a request admitted in time may execute later, subject to the processing-time authorization and policy checks above, and withdraw the full liquid balance then present, including funds received after admission. Passing `admitBefore` does not cancel an admitted request. Invalid requests still pay the fixed admission processing fee.
+Require authenticated L1 `requestedAtTime < admitBefore`; equality is expired and zero is not an unlimited deadline. This governs admission only. Passing the deadline does not cancel an admitted request or prevent later execution.
 
-Signature envelopes must use explicitly supported Tempo-compatible schemes with strict canonical decoding, including rejection of trailing data and unsupported versions. V1 excludes arbitrary ERC-1271 callbacks and counterfactual accounts. Accept only supported primitive root-signature envelopes and reject access-key/keychain envelopes. There is no signing-key selector in the authorization; derive the signer identity from the verified signature. The outer `keyIndex` still selects the Zone encryption key and does not select the account signing key. Pin cross-language type-hash and signature vectors.
+After authorization and replay checks, read the full liquid balance `B` from authenticated state. Admission does not freeze funds: `B` includes earlier credits in inbox order, including deposits or bounce-backs received after admission. Credits after this request is processed are excluded. Reject balances exceeding `uint128` without truncation; a zero balance produces `Empty` before policy evaluation.
 
-For a fresh authorized nonzero-balance request, evaluate execution policies against authenticated state at the imported L1 anchor: require the token to be enabled, require the signed recipient to hold `Role.Account` when portal access enforcement is enabled, and reject a recipient with `Role.CallbackGateway` when gateway enforcement is enabled because this is a plain withdrawal. Require the native token pause and TIP-403 checks used by the debit path, including the debited account's sender eligibility; do not bypass them when bypassing the allowance requirement. The exiting account's portal membership and the token's `depositsActive` flag are not execution requirements. Apply the recipient checks to the L1 destination; do not require it to hold a Zone balance or have a Zone signing key. L1 delivery independently rechecks its current recipient resolution, portal membership/gateway rules and TIP-403 receive policy for `portal → recipient`, and performs the native token transfer. A later delivery failure follows the ordinary bounce-back path.
+### Execution policies and withdrawal creation
 
-The sequencer must supply valid decryption material and execute every imported forced entry to produce a valid accepted transition. Reuse the existing authenticated queue and proof pipeline. This does not itself force checkpoint import or continued block production: the guarantee is conditional on live execution and enforced inclusion. Do not describe queue correctness alone as a deadline or operator-failure guarantee.
+For a fresh authorized nonzero balance, evaluate the following against authenticated state at the imported L1 anchor:
 
-Each forced exit consumes exactly one `DecryptionData` in the mixed inbox stream, just like an encrypted deposit; bounce-backs consume none. Missing or extra entries invalidate processing.
+- The token is enabled, and native token pause, TIP-403 sender eligibility, and other debit policies permit the operation.
+- The signed L1 recipient holds `Role.Account` if portal access enforcement is enabled, and is not `Role.CallbackGateway` if gateway enforcement is enabled.
 
-For a successfully authenticated request, the shared STF derives its outcome as follows; requests rejected during decryption or authorization skip this sequence and go directly to the common terminal finalization below:
+The exiting account's portal membership and the token's `depositsActive` flag are not required. The L1 recipient needs neither a Zone balance nor a Zone signing key. A portal pause after admission does not block inbox execution; the pause gate still applies to L1 delivery.
 
-1. Checks the dedicated Zone-local `(account, nonce)` replay map. After successful authorization, consumes the nonce even for an empty balance or deterministic policy failure; invalid authorization cannot consume another account's nonce.
-2. Reads the liquid balance `B` through authenticated state witnesses.
-3. Rejects unsupported `uint128` overflow without truncation, otherwise produces `Empty` for zero balance, otherwise checks applicable token and recipient policies. An applicable policy failure produces a deterministic `Rejected(reason)`. These outcomes do not debit principal.
-4. Otherwise burns exactly `B` using an inbox-only outbox helper, without a preexisting user allowance or ordinary withdrawal fee. Token accounting/reward/policy hooks remain atomic with the debit.
-5. Enqueues a normal plain withdrawal to the signed recipient and derives `Exited(B)` and the exact withdrawal hash for terminal finalization. Allocate a nonzero fallback nonce from the existing outbox counter and map it to the signed `account` in Zone state, so failed L1 delivery returns principal to the account that was debited. Principal debit, reward hooks, fallback registration and withdrawal enqueue are one atomic attempt. Record `Exited(B)` only when that attempt succeeds; the failure table below defines rejection and fatal rollback boundaries. Use request-ID-based public attribution, not the plaintext authorization digest.
+Burn exactly `B` through a forced-inbox-only path that preserves TIP-20 supply, reward, and policy hooks. No allowance or ordinary withdrawal fee is required; this must not expose an unrestricted arbitrary-account burn API. Debit, reward effects, fallback registration, and withdrawal enqueue form one atomic attempt.
 
-All terminal paths converge on a common finalization step: record exactly one outcome and consume the inbox entry. This includes invalid ciphertext after a valid decryption proof, invalid authorization, replay, policy rejection, empty balance and successful withdrawal creation. No terminal rejection may return before this finalization. Fatal errors bypass terminal finalization and abort the enclosing transition, rolling back all Zone effects, including any earlier requests' effects in that transition.
-
-The debit helper must reuse upstream TIP-20 supply, rewards and policy hooks, not raw balance-slot writes or an unrestricted arbitrary-account burn API. Reuse the existing `Withdrawal` encoding: set plain withdrawal callback data empty, gas limit zero, memo zero and encrypted sender empty. Set `senderTag` to `keccak256(abi.encode("TempoZoneForcedExit", portal, requestId))` for public request attribution without revealing the account. Bind the exact withdrawal, including its fallback nonce, to the outcome; no `forcedExitId` field or new withdrawal encoding is required.
-
-L1 admission enforces collection and immediate payment of the fixed fee. Authenticated inclusion in the portal queue establishes that these admission rules succeeded; the STF does not pay, mint, credit or refund compensation. There is no Zone compensation ledger or claim function. No user transaction interleaves within inbox processing. Later requests see the resulting balance. Requests do not freeze funds at admission.
+Use the existing `Withdrawal` encoding with empty callback data, zero gas limit, zero memo, and empty encrypted sender. Set `senderTag = keccak256(abi.encode("TempoZoneForcedExit", portal, requestId))`. Allocate a nonzero fallback nonce from the existing outbox counter and map it to the signed account. A successful attempt records `Exited(B)` and binds this complete withdrawal to the outcome.
 
 ### Processing outcomes and failure semantics
 
-The table describes committed Zone effects for one admitted request. Every terminal outcome consumes that inbox entry. In every row, the fee was already paid on L1 at admission and is unchanged by Zone execution, including an aborted transition. Consuming an inbox entry is distinct from consuming the signed `(account, nonce)`: an invalid request must not reserve another account's authorization nonce. “No change” below means no change attributable to this request.
+Apply checks in this order: decryption proof, ciphertext/codec, signed fields and authorization, replay, balance overflow, zero balance, execution policies, then debit. The first failing category determines the rejection reason; checks within a category share one code. Fatal witness or execution errors at any stage take precedence over terminal outcomes.
+
+The reason codes are:
+
+| Code | Name | Meaning |
+| --- | --- | --- |
+| 0 | `None` | Required for `Exited` and `Empty`; invalid for `Rejected`. |
+| 1 | `InvalidPayload` | Invalid GCM tag, malformed/noncanonical plaintext ABI, or invalid plaintext prefix. |
+| 2 | `InvalidAuthorization` | Invalid signed fields, expired admission deadline, malformed/unsupported primitive signature, failed signature verification, account mismatch, or keychain/access-key envelope. |
+| 3 | `NonceAlreadyConsumed` | Otherwise authorized request reuses a consumed `(account, nonce)`. |
+| 4 | `BalanceOverflow` | Full liquid balance exceeds `uint128`. |
+| 5 | `PolicyRejected` | Token enablement, native pause/TIP-403, or recipient access/gateway policy rejects the operation. |
+
+`PolicyRejected` reuses the conditions represented by portal `TokenNotEnabled()`, `AccountNotAllowed(address)`, and `InvalidCallbackTarget()`, and TIP-20 `ContractPaused()` and `PolicyForbids()`. Only these policy failures, including the two TIP-20 errors during debit, produce this terminal rejection. Other execution errors abort the transition; portal pause after admission is not a processing rejection.
+
+The following table defines nonce consumption and committed Zone effects. Every terminal outcome records exactly one result and consumes its inbox entry. Consuming an inbox entry is separate from consuming an authorization nonce.
 
 | Condition | Processing result | Authorization nonce | Principal and withdrawal |
 | --- | --- | --- | --- |
 | Missing/extra decryption data, invalid Chaum-Pedersen proof, missing state witness, or malformed authenticated outer entry | Abort transition; no terminal outcome | Roll back | Roll back all effects |
-| Correctly proven shared secret, but invalid GCM tag or noncanonical/malformed plaintext | Terminal `Rejected(reason)` | No change | No change; no withdrawal |
-| Invalid/unsupported signature, wrong domain/Zone or public token, zero account/recipient, or admission deadline not met | Terminal `Rejected(reason)` | No change | No change; no withdrawal |
-| Signature is valid for a different account, or uses an access-key/keychain envelope | Terminal `Rejected(reason)` | No change | No change; no withdrawal |
-| Otherwise authorized request reuses a consumed nonce | Terminal `Rejected(reason)` | Already consumed; no change | No change; no withdrawal |
-| Fresh authorized request has a balance exceeding the supported `uint128` range | Terminal `Rejected(reason)` | Consume | No change; no withdrawal |
+| Correctly proven shared secret, but invalid GCM tag or noncanonical/malformed plaintext | `Rejected(InvalidPayload)` | No change | No change; no withdrawal |
+| Invalid/unsupported signature, wrong domain/Zone or public token, zero account/recipient, or admission deadline not met | `Rejected(InvalidAuthorization)` | No change | No change; no withdrawal |
+| Signature is valid for a different account, or uses an access-key/keychain envelope | `Rejected(InvalidAuthorization)` | No change | No change; no withdrawal |
+| Otherwise authorized request reuses a consumed nonce | `Rejected(NonceAlreadyConsumed)` | Already consumed; no change | No change; no withdrawal |
+| Fresh authorized request has a balance exceeding the supported `uint128` range | `Rejected(BalanceOverflow)` | Consume | No change; no withdrawal |
 | Fresh authorized request has zero balance | Terminal `Empty` | Consume | No change; no withdrawal |
-| Fresh authorized request has a deterministic token/recipient policy failure, including a classified policy revert during the debit attempt | Terminal `Rejected(reason)` | Consume | Roll back the entire debit attempt, including reward hooks, fallback registration and withdrawal enqueue |
+| Fresh authorized request has a classified token/recipient policy failure, including during the debit attempt | `Rejected(PolicyRejected)` | Consume | Roll back the entire debit attempt, including reward hooks, fallback registration and withdrawal enqueue |
 | Fresh authorized request successfully debits the full balance and enqueues its withdrawal | Terminal `Exited(B)` | Consume | Debit exactly `B` and enqueue one withdrawal atomically |
 | Out of gas, execution-capacity exhaustion, internal invariant failure, or an unclassified execution error, including after debit | Abort transition; no terminal outcome | Roll back | Roll back all effects |
 
-Apply checks in canonical order: decryption proof, ciphertext/codec, signed fields and authorization, replay, balance overflow, zero balance, applicable token/recipient policies, then the debit attempt. A valid zero-balance request produces `Empty` before token/recipient policy evaluation. Pin the order of checks within each category and the versioned public reason codes so the host cannot choose among rejection reasons. Fatal witness or execution errors encountered at any stage take precedence over a terminal outcome.
+A deterministic policy failure during debit rolls back the entire debit attempt while retaining nonce consumption and the rejected outcome. Fatal errors abort the enclosing transition and roll back all Zone effects, including earlier requests in that transition. Nonce, outcome, inbox cursor, and successful debit effects commit together. Capacity exhaustion is fatal, including temporary outbox exhaustion; it cannot be converted into a terminal rejection or used to skip entries.
 
-Use a nested storage checkpoint for the debit attempt. Catch only explicitly classified deterministic policy errors: roll back that checkpoint, then record `Rejected(reason)` and nonce consumption outside it through common terminal finalization. On success, commit the attempt and record `Exited(B)`. The enclosing transition still commits or rolls back the attempt, nonce, outcome and inbox cursor together. Never turn an arbitrary error into a user rejection, and never preserve a successful outcome from an aborted transition. The L1 admission transaction is separate: its completed fee payment to `admin` is unaffected when Zone execution aborts.
+Rejected and empty requests leave principal unchanged and create no withdrawal, principal refund, or bounce-back. Only failed delivery of a successfully created withdrawal uses the recovery path in Step 4.
 
-Temporary outbox limits must not cause terminal rejection or nonce consumption. Ensure the outbox limits can accommodate withdrawals produced by the admitted inbox workload within the shared execution budget; exhaustion is an execution failure to resolve before producing an accepted transition, not grounds to skip a queue suffix.
+Portal or token authorities can cause an admitted request to fail policy checks. Such rejection consumes its authorization nonce without refunding the admission fee; retrying requires a new authorization and another fee.
 
-### Request rejection and withdrawal bounce-back
+## Step 3: Prove and settle
 
-Reuse deposit encryption and queue infrastructure, but do not route forced requests through the ordinary deposit refund handler. A rejected or empty forced request creates no principal withdrawal, refund, or `WithdrawalBounceBack` entry; the account principal remains unchanged. A request whose debit attempt fails must roll back the attempt and follow the rejection or fatal-error rules above; it must not create a bounce-back to compensate for partially applied Zone execution. Missing witnesses or invalid decryption proofs still invalidate processing rather than consuming the request as a rejection.
+The prover executes the same STF against authenticated Zone and L1 witnesses, verifying queue order, decryption, authorization, replay state, balance/policy effects, fallback registration, and outcomes. Authenticated L1 admission establishes the fee payment.
 
-After successful execution and settlement, the resulting withdrawal follows ordinary L1 delivery and withdrawal bounce-back behavior. Failed L1 delivery enqueues a `WithdrawalBounceBack` entry returning the principal to the signed Zone account through its fallback nonce. This is distinct from rejecting a request before a withdrawal exists.
-
-Existing deposit refunds and withdrawal bounce-backs, including those from forced withdrawals, may coexist in the same inbox. A forced exit processes after any preceding entries, so funds credited by an earlier bounce-back contribute to its processing-time balance. Funds credited by a later bounce-back are not included in an already processed exit. The original authorization nonce remains consumed; a later forced withdrawal requires a new authorized request and processing compensation, or the user may request an ordinary withdrawal under its normal rules.
-
-## Step 3: Prover and the STF
-
-The prover replays the same STF used in Step 2 against authenticated Zone and L1 witnesses. It verifies the queue commitment/order, historical encryption key and decryption proof, the account’s root signature, signed authorization fields and nonce, exact full-balance debit, fallback-nonce registration to the debited account, and resulting withdrawal/outcome. Fee payment is enforced by authenticated L1 admission, not replayed as a Zone state change. Missing witnesses or a forged decryption proof invalidate the transition; the host cannot choose a rejection reason.
-
-The batch includes an ordered public outcome array:
+Append `ForcedExitOutcome[] calldata outcomes` to `submitBatch`. The array follows consumed forced-request order and uses the following ABI:
 
 ```solidity
+enum ForcedExitStatus {
+    Exited,   // 0
+    Empty,    // 1
+    Rejected  // 2
+}
+
 struct ForcedExitOutcome {
     uint64 requestId;
     uint64 depositNumber;
     address token;
     address recipient;       // Zero unless Exited
-    uint8 status;            // Exited, Empty, Rejected
-    uint16 reason;           // Versioned code; zero on success
+    ForcedExitStatus status; // ABI uint8
+    uint16 reason;           // Reason code from the table above; zero unless Rejected
     uint128 amount;          // Zero unless Exited
     bytes32 withdrawalHash;  // Zero unless Exited
 }
+
+event ForcedExitOutcomes(uint64 indexed withdrawalBatchIndex, ForcedExitOutcome[] outcomes);
 ```
 
-For an `Exited` outcome, define `withdrawalHash = keccak256(abi.encode(withdrawal))`, using the complete existing Solidity `Withdrawal` struct in its declared field order, including `senderTag`, `fallbackNonce` and the empty dynamic fields. Use standard ABI encoding, not packed encoding. This hashes the individual withdrawal without a queue suffix. The existing queue link remains `keccak256(abi.encode(withdrawal, remainingQueue))`; the proof must bind the exact same withdrawal to both its outcome hash and that batch's withdrawal queue commitment. `Empty` and `Rejected` outcomes have `withdrawalHash = bytes32(0)`. Pin Solidity/Rust vectors for both encodings.
+For `Exited`, define `withdrawalHash = keccak256(abi.encode(withdrawal))` over the complete existing Solidity struct in declared field order, including `senderTag`, `fallbackNonce`, and empty dynamic fields. This uses standard ABI encoding and excludes the queue suffix. The queue link remains `keccak256(abi.encode(withdrawal, remainingQueue))`; both commitments must bind the same withdrawal. `Empty` and `Rejected` expose zero recipient, amount, and withdrawal hash. Settlement rejects unknown status/reason values or invalid combinations; this TIP fixes the code assignments.
 
-Bound the outcome array by the measured execution and settlement budget. Commit `keccak256(abi.encode(outcomes))`, including the canonical empty array, in batch output, proof/attestation inputs, settlement quorum digest and verifier inputs, together with the existing chain/portal, L1 anchor, parent/next Zone transition, deposit queue, token transition and withdrawal commitments. Every consumed forced request must have exactly one outcome; a successful exit must enter that batch's withdrawal commitment. Checkpoint-only blocks cannot count as processing an exit.
+Commit `keccak256(abi.encode(outcomes))`, including the canonical empty array, in batch output, proof/attestation inputs, settlement quorum digest, and verifier inputs. Include the existing chain/portal, L1 anchor, parent/next Zone transition, deposit queue, token transition, and withdrawal commitments. Each consumed request has exactly one outcome, and each successful outcome enters that batch's withdrawal commitment. Checkpoint-only blocks cannot process requests.
 
-The sequencer submits the batch and matching proof to L1. An enforcing verifier must reject forged, empty, wrong-image/version, stale-parent or mismatched-input proofs. For Nitro, the attestation must bind the approved image, AWS attestation trust checks and exact execution digest.
+Settlement must enforce the activated verifier and reject forged, empty, wrong-image/version, stale-parent, or mismatched-input proofs. Nitro attestations must bind the approved image, AWS attestation checks, and exact execution digest.
 
-After verification, the portal checks request/deposit identity and token against admission metadata, rejects unknown requests, omitted/duplicate/reordered outcomes and status regressions, and authenticates each successful withdrawal once for normal queue delivery. The proof binds the recipient to the decrypted authorization; L1 cannot read that recipient at admission. Failed outcomes have zero recipient, amount and withdrawal hash.
+After verification, the portal checks request/deposit identity and token against admission metadata. It rejects unknown requests, omitted/duplicate/reordered outcomes, and status regressions, and authenticates each successful withdrawal once. The proof binds the recipient to the decrypted authorization. `Exited` records debit and withdrawal creation; subsequent payment or recovery cannot rewrite that settled outcome.
 
-`Exited` records successful Zone debit and withdrawal creation, not successful L1 payment. Later delivery or bounce-back does not rewrite that processing outcome. Status tooling reports delivery and bounce-back progress separately using the existing withdrawal and inbox events.
+After each accepted batch, emit `ForcedExitOutcomes` immediately after the existing `BatchSubmitted`, using the same `withdrawalBatchIndex` and the exact authenticated array, including an empty array when no forced requests were consumed. This publishes settled outcomes without requiring indexers to depend on storage layout or transaction traces.
 
-This proves correct processing of imported requests. It does not independently compel checkpoint import or continued production, so this version makes no bounded-time inclusion or operator-failure guarantee.
+## Step 4: Deliver on L1
 
-## Step 4: Withdrawal on L1
+After settlement, the sequencer uses existing `processWithdrawals` in FIFO order. Ordinary sequencer authorization, portal pause, deposit-capacity preflight, and reentrancy rules apply. Delivery rechecks current recipient resolution, portal membership/gateway restrictions, and native token transfer/receive policies for `portal → recipient`.
 
-After the proven batch settles, the sequencer calls the existing `processWithdrawals` to deliver the forced withdrawal in normal FIFO order. Funds go to the authenticated recipient.
+Successful payment consumes the withdrawal. Failed delivery consumes it and enqueues one ordinary `WithdrawalBounceBack` for the full principal and authenticated fallback nonce; it does not block the remaining queue. Transaction-level reverts preserve atomic queue/payment accounting.
 
-Use the existing withdrawal encoding, queue hashes and fallback-nonce semantics. The authenticated outcome binds the request to its exact withdrawal. Delivery uses the existing sequencer authorization, portal pause gate, token/recipient policy checks, deposit-capacity preflight and reentrancy protection.
+The existing recovery handler consumes the fallback mapping once and remints to the debited account under current policy, or records a pending withdrawal-bounce-back credit for later policy-aware claim. Existing deposit refunds and other withdrawals retain their normal behavior.
 
-Process the withdrawal exactly like a normal plain withdrawal. On successful transfer, consume it through normal queue accounting so it cannot be paid again. If delivery fails, consume the withdrawal and enqueue one `WithdrawalBounceBack` entry with the same token, full principal amount and fallback nonce. Continue processing later withdrawals under the existing rules; a blocked recipient does not retain the failed withdrawal at the queue head. A transaction-level revert, including a pause or capacity failure, rolls back these effects under the existing behavior.
+Bounce-back and pending-credit claims do not restore the authorization nonce or re-execute the request. A later forced withdrawal requires a new authorization and admission fee; the account may also use ordinary withdrawal rules.
 
-The Zone processes the bounce-back through the existing inbox handler: consume the fallback mapping once and attempt to mint the principal back to the signed account under current token policy. If minting is blocked, record the amount in the existing pending withdrawal-bounce-back credit ledger for later claim through its policy-aware claim path. No new recovery ledger or delivery path is needed. Neither the bounce-back nor claiming its pending credit re-executes the original forced request or charges its processing compensation again. The original nonce remains consumed and compensation remains earned; another forced withdrawal requires a new authorization and fee.
+## Activation and compatibility
 
-### Privacy
+Activation must coordinate portal, node, prover, verifier, and tooling versions. The new admission method must not queue entries until all components can process the variant and agree on entry, outcome, and proof commitments. Preserve legacy deposit discriminants, the 64-byte deposit encoding, `DepositPayload`, ordinary `Withdrawal`, and existing recovery behavior. Append storage without moving existing slots and keep Solidity/Rust layouts, ABI bindings, and runtime artifacts consistent.
 
-Encryption hides account, recipient and authorization at request time from public L1 observers. The public request still exposes fee payer, token, compensation, key index, timing and ciphertext length. Successful settlement reveals recipient and withdrawn amount; no account or plaintext authorization/digest is required for delivery. This is deposit-style request privacy, not settlement balance privacy or unlinkability, and the sequencer and authorized readers of execution/decryption material can decrypt the request. Public failure reasons must be bounded protocol codes, never decrypted payloads.
-
-## Activation requirements
-
-V1 fixes `FORCED_EXIT_COMPENSATION` at `100_000` base units. Changing it requires a versioned portal admission change and an updated signed authorization domain version so existing signatures cannot authorize requests at the new fee. Already-admitted requests have paid their fee and are neither charged again nor refunded when processing crosses an upgrade boundary. Keep the STF and proof verifier compatible with each admitted authorization version; there is no processing-time compensation amount to migrate.
-
-Portal storage includes feature/config version, request counter, encrypted-entry identity/token/deposit metadata and outcomes. Zone storage includes authorization nonces and pending outcomes, and reuses the existing fallback-recipient mapping and pending withdrawal-bounce-back credits. Append storage without reordering existing slots; update Solidity layouts and Rust witness/storage views together and regenerate ABI/layout/runtime artifacts through repository tooling.
-
-Keep pure codecs, authorization digests and validation helpers in `exithatch`; stateful execution remains in existing inbox/outbox precompiles. Propagate the typed entry through L1 event ingestion, canonical reconstruction and restart/backfill; propagate outcomes through builder, executor, SPF, proof/quorum inputs and settlement. Checker and CLI tooling must support backing/outcome inspection and sign/encrypt/request/status operations.
-
-### Backward compatibility and rollout
-
-The feature MUST activate through a coordinated protocol/config version. Before activation, the new admission method and queue variant must not produce entries that the active node, prover, or verifier cannot process. Preserve existing deposit discriminants and encoding, the 64-byte deposit plaintext rule, the `DepositPayload` ABI, ordinary `Withdrawal` encoding, and the existing deposit-refund and withdrawal-bounce-back semantics.
-
-Admission, imported-request execution, proof/attestation generation, quorum signing, settlement verification, and event ingestion MUST agree on the new entry and outcome commitments. Storage additions MUST preserve existing slots and regenerate Solidity/Rust layouts, ABI bindings, and runtime artifacts together. Upgrade handling MUST be exercised with pending legacy entries and already-admitted forced requests; changing the fee does not reopen payment or refund an earlier admission.
-
-### Open decisions before scheduling
-
-The following draft parameters MUST be fixed and reviewed before this TIP is scheduled for activation.
-
-| Decision | Required output |
-| --- | --- |
-| Activation scheduling | Target protocol version and coordinated rollout plan. |
-| Primitive root-signature support | Exact enabled signature schemes, versioned envelopes, signer-identity rules, maximum signature lengths, and Solidity/Rust vectors. |
-| Forced-exit codec bounds | Exact minimum and maximum ciphertext lengths, canonical ABI constraints, and maximum encoded plaintext for the enabled signatures. |
-| Admission and execution capacity | Measured shared inbox admission limit, outbox headroom/reserve, worst-case execution/proving cost, and maximum outcome/settlement size and gas. |
-| Wire-level outcomes and errors | Numeric `status` discriminants, versioned `reason` codes, classification of deterministic policy reverts, canonical order within validation categories, and admission error ABI. |
-| Event and inspection interfaces | New event names, signatures, indexed fields, and how settled outcomes are exposed to indexers, as specified in Observability. Preserve existing delivery/recovery events. |
-| Persistent storage and proofs | Exact new slots/layouts, authenticated witness views, outcome commitment integration, and activated verifier/image/version identifiers. |
-| Interoperability fixtures | Pinned type hashes, encryption/signature codecs, queue/withdrawal/outcome hashes, cross-language fixtures, and activation-boundary vectors. |
+Changes to these protocol rules require a new TIP. Changing the fixed compensation also requires a coordinated portal admission change and a new signed-domain version. Already-admitted requests retain their original payment and authorization semantics across upgrades; historical encodings and decryption material must remain processable.
 
 # Tooling
 
-| Consumer | Required changes |
-| --- | --- |
-| Wallets, SDKs, and signing clients | Build the canonical authorization and EIP-712 domain; choose an unused account authorization nonce; sign with a supported primitive root scheme; encode and encrypt with fresh ephemeral key/GCM nonce; bind the HKDF sender to the actual fee payer; submit `requestForcedExit`. |
-| User-facing request flow | Explain the fixed fee and upfront payment, selected token, recipient, exclusive admission deadline, processing-time full-balance semantics, and live-sequencer dependency. Show admission, processing, and delivery as separate stages. |
-| CLI and libraries | Support sign, encrypt, request, and status operations, plus backing/outcome inspection. Surface `requestId`, `depositNumber`, and the verified withdrawal hash for correlation. Exact command and API names remain an implementation deliverable. |
-| Node, builder, executor, and prover | Decode the appended inbox variant, preserve mixed-entry ordering and decryption-data counts, authenticate the replay map, execute the shared rules, and propagate pending outcomes and commitments through the full proof/quorum/settlement pipeline. |
-| Indexers and support tooling | Reconstruct admissions from L1 events, backfill across restarts and finality changes, correlate proven outcomes with ordinary delivery and bounce-back progress, and inspect pending credits through existing recovery tooling. |
-| Test and integration tooling | Provide cross-language codecs and hashing vectors, authenticated state fixtures, mixed inbox/outbox scenarios, failure-table coverage, and backing reconciliation. |
+Wallets, SDKs, and CLI tools must support signing, encryption for the actual payer, submission, and status lookup by `requestId`/`depositNumber`. User flows must explain the fee, processing-time balance, admission deadline, and liveness assumptions, and distinguish admission, processing, delivery, and recovery.
 
-Status output MUST distinguish `Exited` from successful L1 payment. A bounced-back withdrawal keeps its original processing outcome and consumed authorization nonce; another forced withdrawal requires a new authorization and fee. Recovery of the existing principal through bounce-back or pending-credit claim does not charge the forced-exit fee again.
-
-Clients MUST NOT imply that `admitBefore` cancels an admitted request, that the amount is fixed at admission, that the admission fee is refunded on rejection, or that this path guarantees an exit after operator failure. Public logs and diagnostics MUST NOT expose the decrypted authorization or its signature/digest. The recipient and amount may be displayed from the authenticated public settlement outcome.
+Nodes and provers must carry the new inbox variant and outcomes through ingestion, reconstruction, execution, and settlement. Indexers must support restart/backfill, correlate outcomes with withdrawals by their complete hash, and expose recovery credits and backing reconciliation.
 
 # Observability
 
-## Required event coverage and public data
+| Record | Required public information and purpose |
+| --- | --- |
+| Admission | `ForcedExitRequested` publishes the inbox position and complete entry for queue reconstruction and waiting-time tracking. |
+| Settled processing | `ForcedExitOutcomes` publishes the authenticated ordered outcomes, linked to the existing `BatchSubmitted` by `withdrawalBatchIndex`. |
+| Delivery and recovery | Retain existing withdrawal, bounce-back, and pending-credit claim events and inspection paths, correlated with the authenticated withdrawal. |
 
-The exact new event ABI is an open decision. The following information is required; existing withdrawal and recovery event names and semantics are preserved.
+Public admission reveals the fee payer, token, key index, timing, ciphertext length, and fixed compensation. L1 admission events and public diagnostics must not expose the decrypted account, signed nonce/deadline, signature, or plaintext authorization digest. Recovery observability must not add those fields; recipient and amount are public through successful settlement.
 
-| Record | Required fields or data | Emission/publication requirement and operational question |
-| --- | --- | --- |
-| Forced-request admission | `depositNumber` and the complete `ForcedExit` entry: `requestId`, `token`, `keyIndex`, every `DepositPayload` field, `feePayer`, `requestedAtBlock`, and `requestedAtTime`. | The portal MUST emit the complete reconstructible encrypted admission using the existing ingestion/backfill pattern. Establishes which request was admitted, where it sits in the inbox, and when it began waiting. The protocol version fixes the paid compensation; the successful admission transaction establishes payment. |
-| Proven processing outcomes | The ordered `ForcedExitOutcome[]`: `requestId`, `depositNumber`, `token`, `recipient`, `status`, `reason`, `amount`, and `withdrawalHash`, bound to the settled batch. | The array MUST be public as part of the matching settlement data. The draft does not yet assign a separate outcome event; the finalized event/inspection ABI must let indexers discover the settled batch and retrieve its outcomes. Establishes whether processing rejected, found an empty balance, or created an authenticated withdrawal. |
-| Ordinary withdrawal delivery | Existing queue/withdrawal identity and payment or bounce-back result, correlated with the complete withdrawal and its hash. | Implementations MUST retain the existing withdrawal events used to observe delivery. Distinguishes creation of a withdrawal from payment to the recipient. No new withdrawal encoding is introduced. |
-| Bounce-back admission and processing | Existing bounce-back identity, token, principal amount, fallback nonce, and recovery result or pending-credit state. | Implementations MUST retain the existing inbox/recovery events and inspection paths. Shows whether failed delivery has returned funds or left a policy-blocked pending credit. |
-| Pending-credit claim | Existing claim record and resulting pending-credit state. | Implementations MUST retain the existing policy-aware claim observability. Shows completion of recovery without implying that the original forced request was re-executed. |
-
-Public failures MUST use bounded, versioned reason codes. Non-success outcomes expose zero recipient, amount, and withdrawal hash. The exiting account, signed nonce, admission deadline, signature, and plaintext authorization digest MUST NOT be added to L1 admission events or public diagnostics. Existing recovery observability must not be extended with decrypted authorization data.
-
-## Operational measurements and success criteria
-
-Operators should monitor admitted and processed request counts, terminal outcomes by reason, the oldest outstanding admission, checkpoint/import lag, proof/settlement lag, withdrawal delivery and recovery lag, shared queue occupancy, and witness/decryption/capacity failures. These measurements diagnose liveness; they do not create a protocol deadline.
-
-Before testnet rollout, dashboards and alerts should make missing progress, unprocessable mixed workloads, settlement mismatches, unexpected terminal policy failures, and unresolved recovery credits visible. Initial acceptance criteria are:
-
-1. Every imported forced request in an accepted transition has exactly one authenticated outcome, in canonical order.
-2. A successful outcome creates exactly one matching withdrawal and can be followed through payment or principal recovery.
-3. Missing or invalid decryption proofs, missing witnesses, and malformed authenticated outer entries cannot be committed as terminal user rejections; fatal failures roll back the enclosing Zone transition.
-4. Backing reconciliation and single-use authorization/recovery invariants hold across restarts, upgrades, and all classified failures.
-5. The measured maximum admitted mixed workload fits execution, proving, outbox, and settlement budgets.
+Operators should monitor request counts and outcomes by reason, oldest outstanding admission, shared queue occupancy, checkpoint/import and proof/settlement lag, delivery/recovery lag, and witness/decryption/capacity failures. Before testnet rollout, dashboards and alerts should expose stalled progress, unprocessable workloads, commitment mismatches, unexpected policy rejections, and unresolved credits.
 
 # Invariants
 
-## Authorization, ordering, and atomicity
+1. Only the account's root authority can authorize a request, and each `(account, nonce)` permits at most one fresh authorized terminal attempt under the failure table.
+2. Every consumed forced entry has exactly one authenticated outcome in inbox order. Successful outcomes bind the same complete withdrawal in execution, settlement, and delivery.
+3. A committed debit includes its token hooks, fallback mapping, and withdrawal. Failed attempts cannot leave partial principal effects.
+4. Principal remains backed through withdrawal, payment, bounce-back, and pending credit. These are successive states of one liability; a processing outcome creates no additional claim, and payment or recovery cannot occur twice.
+5. Admission compensation leaves no Zone liability. Settled outcomes and consumed authorizations remain stable through delivery and recovery.
+6. The maximum admitted mixed workload fits execution, proving, and settlement budgets without skipping a queue suffix.
 
-1. Only a supported signature from the account's own root key can authorize its forced withdrawal. Paying compensation is not authorization.
-2. Each `(account, nonce)` can authorize at most one terminal processing attempt that passes authorization and freshness checks. Empty, overflow, and deterministic policy outcomes consume it; invalid authorization does not; fatal transition failure rolls consumption back.
-3. Every terminal outcome consumes exactly one inbox entry and records exactly one processing outcome. All imported forced entries execute in canonical mixed-inbox order, with exactly one decryption-data item per encrypted entry.
-4. `Exited(B)` commits the full authenticated processing-time liquid balance debit, token hooks, fallback mapping, and matching withdrawal together. An incomplete attempt cannot leave principal debited or create a recovery entry.
-5. The proven outcome, individual withdrawal hash, and withdrawal queue commitment bind the same complete withdrawal, including its recipient and fallback nonce.
-6. Admission compensation is paid once on L1 and creates no Zone compensation balance or claim. Zone rejection, rollback, delay, and recovery do not reverse or repeat it.
-7. An admitted request may execute after its admission deadline; its balance includes earlier credits in inbox order. Later credits require a later authorized withdrawal.
-8. A settled processing outcome is stable. L1 delivery, bounce-back, and pending-credit recovery are subsequent stages and cannot rewrite it or restore its authorization nonce.
-
-## Principal backing and recovery
-
-For each token, admission collects the fixed fee and transfers the same amount to `admin` on L1, leaving portal principal backing and Zone account balances unchanged. The fee creates no pending liability or Zone credit. Processing converts the Zone principal into a pending withdrawal. Settlement authenticates that withdrawal without changing escrow balance. Successful delivery reduces backing and the single withdrawal liability by the same amount. Failed delivery leaves backing unchanged and replaces the withdrawal liability with one queued bounce-back liability. Zone bounce-back processing replaces that liability with either reminted principal or an existing pending bounce-back credit; claiming a credit replaces it with minted principal. These are alternative states of one backed liability, never simultaneous claims to the same principal. The outcome is a processing record, not an additional liability. Preserve ordinary deposit, refund and withdrawal backing throughout, including token supply/reward hooks.
-
-## Required test coverage
-
-- Round-trip vectors using the existing envelope, HKDF context, historical keys, and `DecryptionData`; wrong portal/sender/key and tampered ciphertext cases.
-- Mixed deposits, forced exits, and bounce-backs preserve queue hashes and exact decryption ordering; existing deposit vectors remain unchanged.
-- Missing or forged decryption proof cannot consume a forced request; correctly proven invalid ciphertext produces a deterministic failure.
-- Authorization replay, signed/public token mismatch, admission deadline boundaries (before/equal/after, including zero), execution after the admission deadline with later-received funds, wrong-account signatures, rejection of access-key/keychain envelopes, and atomic full-balance processing.
-- Public settlement recipient/token/amount cannot be substituted; plaintext authorization is absent from L1 admission calldata/events.
-- Enforcing settlement rejects forged/empty/mismatched proofs and omitted outcomes; checkpoint-only blocks cannot satisfy requests.
-- Sequencer `processWithdrawals` uses the existing plain-withdrawal encoding and behavior: each withdrawal is consumed once by payment or bounce-back enqueue, failed transfers do not block the suffix, and transaction-level reverts preserve atomic payment/bounce-back/cursor accounting.
-- Rejected/empty forced requests create no principal refund or bounce-back. Failed L1 delivery creates exactly one normal bounce-back for the full principal, with the authenticated fallback nonce resolving only to the debited Zone account; replay cannot pay or remint twice.
-- Bounce-back processing remints to the debited account or records an existing pending bounce-back credit when policy blocks minting. Later claims remain policy-aware and cannot duplicate principal. The original authorization nonce remains consumed, compensation is not refunded or charged again for recovery, and a new forced request requires a new authorization and fee.
-- Bounce-backs before and after a forced request affect only the appropriate processing-time balance; existing deposit refunds and ordinary withdrawal bounce-backs remain unchanged. Processing outcomes remain stable while tooling tracks payment, bounce-back and pending-credit progress separately.
-
-- Exercise every row of the failure-semantics table, including replay versus inbox consumption, canonical failure precedence, policy failure after burn, and fatal failure after an earlier request in the same transition. Verify the specified nonce, principal, reward, fallback, outcome and cursor effects or rollback; completed L1 admission payments remain unaffected.
-- Full-balance zero/dust/max/overflow, admin address equal to the exiting account (fee payment changes only its L1 balance), withdrawal-capacity exhaustion, and supply/backing reconciliation.
-- Admission collects exactly `FORCED_EXIT_COMPENSATION` and immediately pays the same amount to the current portal `admin` on L1, matching deposit fee handling. Failure of either transfer, including a blocked admin or paused token, rolls back the entire admission. Later admin/leader changes do not trigger another payment.
-- Paused admission matches encrypted deposits: no fee collection, ID allocation or queue mutation. Requests admitted before a portal pause can still process through the inbox without a pause-induced rejection; L1 delivery remains queued while paused and resumes under the normal rules after unpausing.
-- Deposits and forced requests consume the same public admission capacity, reject when that shared capacity is full, and cannot consume the existing withdrawal-processing reserve; there is no separate forced-request allowance.
-- Admission applies the existing fee-payer depositor-access rules; an enabled token with `depositsActive = false` still admits a forced request if both fee transfers are permitted. A nonmember exiting account may withdraw to an eligible recipient, but native token restrictions remain enforced. Check recipient membership/gateway changes at execution and delivery separately.
-- Every terminal path, including invalid ciphertext and invalid signatures, reaches common outcome/cursor finalization; fatal errors roll back all Zone effects of the enclosing transition without undoing the earlier L1 fee payment.
-- Processing, rejection, empty outcomes, execution retries and bounce-back recovery neither pay nor mint compensation; no Zone compensation ledger or claim API is introduced.
-- Individual withdrawal hashes match standard Solidity/Rust ABI vectors, exclude the queue suffix and bind every withdrawal field; substituting a field or a suffix-dependent queue hash cannot satisfy the outcome commitment.
-- Admission fee-transfer failure, membership/token policy behavior, no recharging of admitted requests across upgrades and signed-domain version separation, and maximum mixed execution/settlement budgets.
-- Restart/backfill and finality handling, coordinated activation with pending legacy deposits/withdrawals, storage/ABI compatibility, and reentrancy attempts during delivery.
+Critical validation cases are the failure-table branches and precedence; replay and domain/account/token binding; admission-deadline boundaries and later credits; atomic fee/debit failures; shared-capacity exhaustion; and single-use delivery/recovery across policy changes, restarts, and upgrades. Interoperability vectors must cover canonical encodings and commitments, including tampering and field substitution.


### PR DESCRIPTION
Specifies root-authorized, encrypted full-balance Zone withdrawals initiated on L1, with upfront compensation, shared STF/prover validation, and ordinary withdrawal delivery and bounce-back. Converts the design in https://github.com/tempoxyz/zones/pull/1425 into TIP-1012 with explicit assumptions, threat model, state ownership, tooling, observability, and invariants; the proposal remains Draft with activation parameters open.

Validation: repository TIP naming hook, Markdown/front-matter checks, and `git diff --check`; the original interfaces, failure table, and all 21 test requirements are preserved.
