### PR TITLE
refactor(consensus): employ commonware semantics when writing DKG state

### DIFF
--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -236,10 +236,6 @@ where
         TSender: Sender<PublicKey = PublicKey>,
         TReceiver: Receiver<PublicKey = PublicKey>,
     {
-        ensure!(
-            !storage.is_poisoned(),
-            "DKG storage must be reopened after a failed or cancelled mutation"
-        );
         let state = storage.current();
 
         self.metrics.reset();
@@ -253,10 +249,7 @@ where
             .set(state.players().len() as i64);
 
         if let Some(previous) = state.epoch.previous() {
-            // NOTE: State::prune emits an error event.
-            storage.prune(previous).await.wrap_err_with(|| {
-                format!("unable to prune storage before up until epoch `{previous}`",)
-            })?;
+            storage.prune(previous).await;
         }
 
         self.enter_epoch(&state)
@@ -319,7 +312,7 @@ where
                 }
 
                 Some((cause, block, ack)) = self.pending_finalized_blocks.next() => {
-                    let should_break = match self
+                    let new_state = self
                         .handle_finalized_header(
                             cause,
                             &state,
@@ -331,8 +324,8 @@ where
                             block.header().clone(),
                         )
                         .await
-                        .wrap_err("failed handling finalized block")?
-                    {
+                        .wrap_err("failed handling finalized block")?;
+                    let should_break = match new_state {
                         Some(new_state) => {
                             info_span!("run_dkg_loop", epoch = %state.epoch).in_scope(|| {
                                 info!(
@@ -341,13 +334,7 @@ where
                                 )
                             });
 
-                            if let Err(err) = storage
-                                .set_state(new_state)
-                                .await
-                                .wrap_err("failed appending new state to journal")
-                            {
-                                break Err(err);
-                            }
+                            storage.set_state(new_state).await;
                             // Emits an error event.
                             let _ = self.exit_epoch(&state);
 
@@ -364,8 +351,8 @@ where
                 network_msg = round_receiver.recv().fuse() => {
                     match network_msg {
                         Ok((sender, message)) => {
-                            // Produces an error event.
-                            let result = self.handle_network_msg(
+                            // Protocol errors are logged by the handler; write failures panic.
+                            let _ = self.handle_network_msg(
                                 &round,
                                 &mut round_sender,
                                 storage,
@@ -374,14 +361,6 @@ where
                                 sender,
                                 message,
                             ).await;
-                            // Malformed messages and send failures are recoverable,
-                            // but a failed storage mutation consumes its handle.
-                            // Exit with the original I/O error before another message
-                            // can access the poisoned storage.
-                            if storage.is_poisoned() {
-                                result.wrap_err("DKG storage invalidated while handling a network message")?;
-                                bail!("DKG storage invalidated without a reported error");
-                            }
                         }
                         Err(err) => {
                             break Err(err).wrap_err("network p2p subchannel closed")
@@ -541,10 +520,7 @@ where
                 share_candidate = state.share.clone();
             } else {
                 let state = state.clone();
-                return storage
-                    .init_verified(state)
-                    .await
-                    .wrap_err("failed writing initial state back to storage");
+                return Ok(storage.init_verified(state).await);
             }
         };
         let initial_state = self
@@ -552,10 +528,7 @@ where
             .await
             .wrap_err("failed constructing initial state")?;
 
-        storage
-            .init_verified(initial_state)
-            .await
-            .wrap_err("failed setting initial state")
+        Ok(storage.init_verified(initial_state).await)
     }
 
     #[instrument(skip_all, err)]
@@ -605,8 +578,7 @@ where
             ))?;
 
             self.record_finalized_header(storage, &round, header, None)
-                .await
-                .wrap_err("failed backfilling header to storage")?;
+                .await;
             height = height.next();
         }
         Ok(())
@@ -618,8 +590,7 @@ where
         round: &Round,
         header: TempoHeader,
         dealer_state: Option<&mut Dealer>,
-    ) -> eyre::Result<()>
-    where
+    ) where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
     {
         let height = Height::new(header.number());
@@ -638,8 +609,7 @@ where
                 };
                 storage
                     .append_dealer_log(round.epoch(), dealer.clone(), log)
-                    .await
-                    .wrap_err("failed to append dealer log from finalized header")?;
+                    .await;
                 if self.config.me.public_key() == dealer
                     && let Some(dealer_state) = dealer_state
                 {
@@ -652,10 +622,7 @@ where
             }
         }
 
-        storage
-            .append_finalized_header(round.epoch(), header)
-            .await
-            .wrap_err("failed to append finalized header")
+        storage.append_finalized_header(round.epoch(), header).await;
     }
 
     fn handle_verify_dealer_log(
@@ -791,8 +758,7 @@ where
                         player_state,
                         round_channel,
                     )
-                    .await
-                    .wrap_err("failed distributing shares")?;
+                    .await;
                 }
             }
             EpochPhase::Midpoint | EpochPhase::Late => {
@@ -804,8 +770,7 @@ where
 
         if height != epoch_info.last() {
             self.record_finalized_header(storage, round, header, dealer_state.as_mut())
-                .await
-                .wrap_err("failed to record finalized header")?;
+                .await;
 
             return Ok(None);
         }
@@ -925,8 +890,7 @@ where
         dealer_state: &mut Dealer,
         player_state: &mut Option<Player>,
         round_channel: &mut TSender,
-    ) -> eyre::Result<()>
-    where
+    ) where
         TStorageContext: BufferPooler + commonware_runtime::Metrics + Clock + Storage,
         TSender: Sender<PublicKey = PublicKey>,
     {
@@ -934,29 +898,28 @@ where
         for (player, pub_msg, priv_msg) in dealer_state.shares_to_distribute().collect::<Vec<_>>() {
             if player == me {
                 if let Some(player_state) = player_state {
-                    let result: eyre::Result<()> = async {
-                        let ack = player_state
-                            .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
-                            .await
-                            .wrap_err("failed to store our own dealing")?;
-                        self.metrics.shares_distributed.metric().inc();
-                        self.metrics.shares_received.metric().inc();
-                        dealer_state
-                            .receive_ack(storage, epoch, me.clone(), ack)
-                            .await
-                            .wrap_err("failed to store our own ACK")?;
-                        self.metrics.acks_received.metric().inc();
-                        self.metrics.acks_sent.metric().inc();
-                        info!("stored our own ACK and share");
-                        Ok(())
-                    }
-                    .await;
-                    if let Err(error) = result {
-                        if storage.is_poisoned() {
-                            return Err(error);
+                    let ack = match player_state
+                        .receive_dealing(storage, epoch, me.clone(), pub_msg, priv_msg)
+                        .await
+                    {
+                        Ok(ack) => ack,
+                        Err(error) => {
+                            warn!(%error, "failed to process our own dealing");
+                            continue;
                         }
-                        warn!(%error, "failed to process our own dealing or ACK");
+                    };
+                    self.metrics.shares_distributed.metric().inc();
+                    self.metrics.shares_received.metric().inc();
+                    if let Err(error) = dealer_state
+                        .receive_ack(storage, epoch, me.clone(), ack)
+                        .await
+                    {
+                        warn!(%error, "failed to process our own ACK");
+                        continue;
                     }
+                    self.metrics.acks_received.metric().inc();
+                    self.metrics.acks_sent.metric().inc();
+                    info!("stored our own ACK and share");
                 }
             } else {
                 // Send to remote player
@@ -968,7 +931,6 @@ where
                 }
             }
         }
-        Ok(())
     }
 
     #[instrument(
@@ -1007,7 +969,7 @@ where
                     let ack = player_state
                         .receive_dealing(storage, round.epoch(), from.clone(), pub_msg, priv_msg)
                         .await
-                        .wrap_err("failed storing dealing")?;
+                        .wrap_err("failed to process dealing")?;
 
                     let sent = round_channel.send(
                         Recipients::One(from.clone()),
@@ -1016,12 +978,14 @@ where
                     );
 
                     // Follows the doc on the return value of of Sender::send.
-                    ensure!(
-                        !sent.is_empty(),
-                        "failed returning ACK to dealer because it was rate \
-                        limited, the connection was closed, or the message \
-                        otherwise rejected",
-                    );
+                    if sent.is_empty() {
+                        warn!(
+                            "failed returning ACK to dealer because it was rate \
+                            limited, the connection was closed, or the message \
+                            otherwise rejected",
+                        );
+                        return Ok(());
+                    }
 
                     info!("returned ACK to dealer");
                     self.metrics.acks_sent.metric().inc();
@@ -1036,7 +1000,7 @@ where
                     dealer_state
                         .receive_ack(storage, round.epoch(), from, ack)
                         .await
-                        .wrap_err("failed storing ACK")?;
+                        .wrap_err("failed to process ACK")?;
                 } else {
                     info!("received an ACK, but we are not a dealer");
                 }

--- a/crates/consensus/src/dkg/manager/actor/state.rs
+++ b/crates/consensus/src/dkg/manager/actor/state.rs
@@ -28,7 +28,7 @@ use commonware_cryptography::{
 use commonware_parallel::Strategy;
 use commonware_runtime::{BufferPooler, Clock, Metrics, ReadOptions, buffer::paged::CacheRef};
 use commonware_storage::{journal::segmented, metadata};
-use commonware_utils::{N3f1, NZU16, NZU32, NZUsize, ordered};
+use commonware_utils::{N3f1, NZU16, NZU32, NZUsize, futures::rebind, ordered};
 use eyre::{OptionExt, WrapErr as _, bail};
 use tempo_primitives::TempoHeader;
 use tracing::{debug, info, instrument, warn};
@@ -55,9 +55,8 @@ pub(super) struct Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    // Commonware mutations consume their handles. These slots are empty while
-    // an operation is in flight, and stay empty after failure or cancellation.
-    // Such storage must be dropped and reopened, never reused by the actor.
+    // Rebind consuming commonware mutations through these slots. Write failures
+    // panic, so an invalidated handle is never reused by the actor.
     states: Option<metadata::Metadata<TContext, u64, State>>,
     events: Option<segmented::variable::Journal<TContext, Event>>,
 
@@ -85,19 +84,15 @@ where
         self.storage.current.as_ref()
     }
 
-    pub(super) async fn init_verified(self, state: State) -> eyre::Result<Storage<TContext>> {
+    pub(super) async fn init_verified(self, state: State) -> Storage<TContext> {
         let Self { mut storage } = self;
-        storage.states = Some(
-            storage
-                .states
-                .take()
-                .expect("DKG states storage is available")
-                .put_sync(state.epoch.get(), state.clone())
-                .await
-                .wrap_err("unable to write initial state to metadata")?,
-        );
+        rebind(&mut storage.states, |states| {
+            states.put_sync(state.epoch.get(), state.clone())
+        })
+        .await
+        .expect("failed to persist initial DKG state");
         storage.current = Some(state);
-        Ok(storage)
+        storage
     }
 }
 
@@ -105,10 +100,6 @@ impl<TContext> Storage<TContext>
 where
     TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
 {
-    pub(super) fn is_poisoned(&self) -> bool {
-        self.states.is_none() || self.events.is_none()
-    }
-
     /// Returns all player acknowledgments received during the given epoch.
     fn acks_for_epoch(
         &self,
@@ -147,25 +138,28 @@ where
         self.current.clone().expect("invariant: state must be set")
     }
 
-    /// Persists the outcome of a DKG ceremony to state
-    pub(super) async fn set_state(&mut self, state: State) -> eyre::Result<()> {
-        let states = self
-            .states
-            .as_mut()
-            .expect("DKG states storage is available");
-        if let Some(old) = states.put(state.epoch.get(), state.clone()) {
-            warn!(epoch = %old.epoch, "overwriting existing state");
-        }
-        self.states = Some(
-            self.states
-                .take()
-                .expect("DKG states storage is available")
-                .sync()
-                .await
-                .wrap_err("failed writing state")?,
-        );
+    /// Persists the outcome of a DKG ceremony, panicking on write failure.
+    pub(super) async fn set_state(&mut self, state: State) {
+        rebind(&mut self.states, |mut states| async {
+            if let Some(old) = states.put(state.epoch.get(), state.clone()) {
+                warn!(epoch = %old.epoch, "overwriting existing state");
+            }
+            states.sync().await
+        })
+        .await
+        .expect("failed to persist DKG state");
         self.current = Some(state);
-        Ok(())
+    }
+
+    /// Appends and durably syncs an event, panicking on write failure.
+    async fn append_event(&mut self, epoch: Epoch, event: Event) {
+        rebind(&mut self.events, |events| async move {
+            let section = epoch.get();
+            let (events, _, _) = events.append(section, &event).await?;
+            events.sync(section).await
+        })
+        .await
+        .expect("failed to persist DKG event");
     }
 
     /// Append a player ACK to the journal.
@@ -175,51 +169,31 @@ where
             %epoch,
             %player,
         ),
-        err,
     )]
-    async fn append_ack(
-        &mut self,
-        epoch: Epoch,
-        player: PublicKey,
-        ack: PlayerAck<PublicKey>,
-    ) -> eyre::Result<()> {
+    async fn append_ack(&mut self, epoch: Epoch, player: PublicKey, ack: PlayerAck<PublicKey>) {
         if self
             .cache
             .get(&epoch)
             .is_some_and(|events| events.acks.contains_key(&player))
         {
             info!(%player, %epoch, "ack for player already found in cache, dropping");
-            return Ok(());
+            return;
         }
 
-        let section = epoch.get();
-        let (events, _, _) = self
-            .events
-            .take()
-            .expect("DKG events storage is available")
-            .append(
-                section,
-                &Event::Ack {
-                    player: player.clone(),
-                    ack: ack.clone(),
-                },
-            )
-            .await
-            .wrap_err("unable to write event to storage")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync events journal")?,
-        );
+        self.append_event(
+            epoch,
+            Event::Ack {
+                player: player.clone(),
+                ack: ack.clone(),
+            },
+        )
+        .await;
 
         self.cache
             .entry(epoch)
             .or_default()
             .acks
             .insert(player, ack);
-
-        Ok(())
     }
 
     /// Append a dealer's dealing to the journal.
@@ -229,7 +203,6 @@ where
             %epoch,
             %dealer,
         ),
-        err,
     )]
     async fn append_dealing(
         &mut self,
@@ -237,45 +210,31 @@ where
         dealer: PublicKey,
         pub_msg: DealerPubMsg<MinSig>,
         priv_msg: DealerPrivMsg,
-    ) -> eyre::Result<()> {
+    ) {
         if self
             .cache
             .get(&epoch)
             .is_some_and(|events| events.dealings.contains_key(&dealer))
         {
             info!(%dealer, %epoch, "dealing of dealer already found in cache, dropping");
-            return Ok(());
+            return;
         }
 
-        let section = epoch.get();
-        let (events, _, _) = self
-            .events
-            .take()
-            .expect("DKG events storage is available")
-            .append(
-                section,
-                &Event::Dealing {
-                    dealer: dealer.clone(),
-                    public_msg: pub_msg.clone(),
-                    private_msg: priv_msg.clone(),
-                },
-            )
-            .await
-            .wrap_err("unable to write event to storage")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync events journal")?,
-        );
+        self.append_event(
+            epoch,
+            Event::Dealing {
+                dealer: dealer.clone(),
+                public_msg: pub_msg.clone(),
+                private_msg: priv_msg.clone(),
+            },
+        )
+        .await;
 
         self.cache
             .entry(epoch)
             .or_default()
             .dealings
             .insert(dealer, (pub_msg, priv_msg));
-
-        Ok(())
     }
 
     /// Appends a dealer log to the journal
@@ -284,7 +243,7 @@ where
         epoch: Epoch,
         dealer: PublicKey,
         log: dkg::DealerLog<MinSig, PublicKey>,
-    ) -> eyre::Result<()> {
+    ) {
         if self
             .cache
             .get(&epoch)
@@ -295,41 +254,24 @@ where
                 %epoch,
                 "dealer log already found in cache; dropping"
             );
-            return Ok(());
+            return;
         }
 
-        let section = epoch.get();
-        let (events, _, _) = self
-            .events
-            .take()
-            .expect("DKG events storage is available")
-            .append(
-                section,
-                &Event::Log {
-                    dealer: dealer.clone(),
-                    log: log.clone(),
-                },
-            )
-            .await
-            .wrap_err("failed to append log to journal")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync journal")?,
-        );
+        self.append_event(
+            epoch,
+            Event::Log {
+                dealer: dealer.clone(),
+                log: log.clone(),
+            },
+        )
+        .await;
 
         let cache = self.cache.entry(epoch).or_default();
         cache.logs.insert(dealer, log);
-        Ok(())
     }
 
     /// Appends the height, digest, and parent of the finalized header to the journal.
-    pub(super) async fn append_finalized_header(
-        &mut self,
-        epoch: Epoch,
-        header: TempoHeader,
-    ) -> eyre::Result<()> {
+    pub(super) async fn append_finalized_header(&mut self, epoch: Epoch, header: TempoHeader) {
         let height = Height::new(header.number());
         let digest = Digest(header.hash_slow());
         let parent = Digest(header.parent_hash());
@@ -344,30 +286,18 @@ where
                 %parent,
                 "finalized block was already found in cache; dropping",
             );
-            return Ok(());
+            return;
         }
 
-        let section = epoch.get();
-        let (events, _, _) = self
-            .events
-            .take()
-            .expect("DKG events storage is available")
-            .append(
-                section,
-                &Event::Finalized {
-                    digest,
-                    parent,
-                    height,
-                },
-            )
-            .await
-            .wrap_err("failed to append finalized block to journal")?;
-        self.events = Some(
-            events
-                .sync(section)
-                .await
-                .wrap_err("unable to sync journal")?,
-        );
+        self.append_event(
+            epoch,
+            Event::Finalized {
+                digest,
+                parent,
+                height,
+            },
+        )
+        .await;
 
         let cache = self.cache.entry(epoch).or_default();
         cache.finalized.insert(
@@ -378,7 +308,6 @@ where
                 parent,
             },
         );
-        Ok(())
     }
 
     pub(super) fn cache_dkg_outcome(
@@ -425,7 +354,7 @@ where
         err,
     )]
     pub(super) fn create_dealer_for_round(
-        &mut self,
+        &self,
         me: PrivateKey,
         round: Round,
         share: ShareState,
@@ -527,30 +456,18 @@ where
             .and_then(|cache| cache.notarized_blocks.get(digest))
     }
 
-    #[instrument(skip_all, fields(%up_to_epoch), err)]
-    pub(super) async fn prune(&mut self, up_to_epoch: Epoch) -> eyre::Result<()> {
-        let (events, _) = self
-            .events
-            .take()
-            .expect("DKG events storage is available")
-            .prune(up_to_epoch.get())
+    #[instrument(skip_all, fields(%up_to_epoch))]
+    pub(super) async fn prune(&mut self, up_to_epoch: Epoch) {
+        rebind(&mut self.events, |events| events.prune(up_to_epoch.get()))
             .await
-            .wrap_err("unable to prune events journal")?;
-        self.events = Some(events);
-        self.states
-            .as_mut()
-            .expect("DKG states storage is available")
-            .retain(|&key, _| key >= up_to_epoch.get());
-        self.states = Some(
-            self.states
-                .take()
-                .expect("DKG states storage is available")
-                .sync()
-                .await
-                .wrap_err("unable to prune events metadata")?,
-        );
+            .expect("failed to prune DKG events journal");
+        rebind(&mut self.states, |mut states| async move {
+            states.retain(|&key, _| key >= up_to_epoch.get());
+            states.sync().await
+        })
+        .await
+        .expect("failed to prune DKG state metadata");
         self.cache.retain(|&epoch, _| epoch >= up_to_epoch);
-        Ok(())
     }
 }
 
@@ -1002,10 +919,9 @@ impl Dealer {
         }
     }
 
-    /// Handle an incoming ack from a player.
+    /// Handle an incoming ack from a player, persisting it before returning success.
     ///
-    /// If the ack is valid and new, persists it to storage.
-    /// Returns true if the ack was successfully processed.
+    /// Returns protocol validation errors. Storage write failures panic.
     pub(super) async fn receive_ack<TContext>(
         &mut self,
         storage: &mut Storage<TContext>,
@@ -1019,21 +935,14 @@ impl Dealer {
         if !self.unsent.contains_key(&player) {
             bail!("already received an ack from `{player}`");
         }
-        match &mut self.dealer {
-            Some(dealer) => {
-                dealer
-                    .receive_player_ack(player.clone(), ack.clone())
-                    .wrap_err("unable to receive player ack")?;
-                self.unsent.remove(&player);
-                storage
-                    .append_ack(epoch, player.clone(), ack.clone())
-                    .await
-                    .wrap_err("unable to append ack to journal")?;
-            }
-            None => {
-                bail!("dealer was already finalized, dropping ack of player `{player}`");
-            }
-        }
+        let Some(dealer) = &mut self.dealer else {
+            bail!("dealer was already finalized, dropping ack of player `{player}`");
+        };
+        dealer
+            .receive_player_ack(player.clone(), ack.clone())
+            .wrap_err("unable to receive player ack")?;
+        storage.append_ack(epoch, player.clone(), ack).await;
+        self.unsent.remove(&player);
         Ok(())
     }
 
@@ -1155,9 +1064,9 @@ impl Player {
         }
     }
 
-    /// Handle an incoming dealer message.
+    /// Handle an incoming dealer message, persisting it before returning its ack.
     ///
-    /// If this is a new valid dealer message, persists it to storage before returning.
+    /// Returns protocol validation errors. Storage write failures panic.
     pub(super) async fn receive_dealing<TContext>(
         &mut self,
         storage: &mut Storage<TContext>,
@@ -1169,12 +1078,11 @@ impl Player {
     where
         TContext: BufferPooler + commonware_runtime::Storage + Clock + Metrics,
     {
-        // If we've already generated an ack, return the cached version
+        // Cached acks are backed by a persisted dealing.
         if let Some(ack) = self.acks.get(&dealer) {
             return Ok(ack.clone());
         }
 
-        // Otherwise generate a new ack
         let ack = self
             .player
             .dealer_message::<N3f1>(dealer.clone(), pub_msg.clone(), priv_msg.clone())
@@ -1182,8 +1090,7 @@ impl Player {
             .ok_or_eyre("dealer message was already processed without a cached acknowledgement")?;
         storage
             .append_dealing(epoch, dealer.clone(), pub_msg, priv_msg)
-            .await
-            .wrap_err("unable to append dealing to journal")?;
+            .await;
         self.acks.insert(dealer, ack.clone());
         Ok(ack)
     }
@@ -1393,7 +1300,7 @@ mod tests {
             );
 
             let state = make_test_state(&mut context, 0);
-            let storage = unverified.init_verified(state.clone()).await.unwrap();
+            let storage = unverified.init_verified(state.clone()).await;
             assert_eq!(storage.current(), state);
             drop(storage);
 
@@ -1406,6 +1313,143 @@ mod tests {
                 reopened.state(),
                 Some(&state),
                 "storage with an initial state must reopen with it"
+            );
+        });
+    }
+
+    #[test]
+    fn metadata_write_failures_panic() {
+        use commonware_utils::probability;
+        use futures::FutureExt as _;
+        use std::panic::AssertUnwindSafe;
+
+        for (operation, expected) in [
+            ("initialize", "failed to persist initial DKG state"),
+            ("set_state", "failed to persist DKG state"),
+            ("prune", "failed to prune DKG state metadata"),
+        ] {
+            deterministic::Runner::default().start(|mut context| async move {
+                let unverified = builder()
+                    .partition_prefix("metadata_write_failure")
+                    .init_unverified(context.child("storage"))
+                    .await
+                    .unwrap();
+                let state = make_test_state(&mut context, 1);
+                let faults = context.storage_fault_config();
+                let write = async {
+                    if operation == "initialize" {
+                        faults.write().sync_rate = Some(probability!(1.0));
+                        unverified.init_verified(state).await;
+                    } else {
+                        let mut storage = unverified.init_verified(state.clone()).await;
+                        faults.write().sync_rate = Some(probability!(1.0));
+                        if operation == "set_state" {
+                            storage
+                                .set_state(State {
+                                    epoch: state.epoch.next(),
+                                    ..state
+                                })
+                                .await;
+                        } else {
+                            storage.prune(state.epoch.next()).await;
+                        }
+                    }
+                };
+                let panic = AssertUnwindSafe(write)
+                    .catch_unwind()
+                    .await
+                    .expect_err("metadata write failures must panic");
+                let message = panic
+                    .downcast_ref::<String>()
+                    .map(String::as_str)
+                    .or_else(|| panic.downcast_ref::<&str>().copied())
+                    .expect("panic must have an error message");
+                assert!(message.starts_with(expected), "unexpected panic: {message}");
+            });
+        }
+    }
+
+    #[test]
+    fn receive_methods_persist_dealings_and_acks() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let mut state = make_test_state(&mut context, 1);
+            state.is_full_dkg = true;
+            let round = Round::from_state(&state, crate::config::NAMESPACE);
+            let dealer_key = PrivateKey::from_seed(100);
+            let player_key = PrivateKey::from_seed(101);
+            let mut storage = builder()
+                .partition_prefix("receive_methods_persist")
+                .init_unverified(context.child("initial"))
+                .await
+                .unwrap()
+                .init_verified(state.clone())
+                .await;
+            let mut dealer = storage
+                .create_dealer_for_round(
+                    dealer_key.clone(),
+                    round.clone(),
+                    state.share.clone(),
+                    state.seed,
+                )
+                .unwrap()
+                .unwrap();
+            let mut player = storage
+                .create_player_for_round(player_key.clone(), &round)
+                .unwrap()
+                .unwrap();
+            let (_, public, private) = dealer
+                .shares_to_distribute()
+                .find(|(recipient, _, _)| *recipient == player_key.public_key())
+                .unwrap();
+
+            let ack = player
+                .receive_dealing(
+                    &mut storage,
+                    state.epoch,
+                    dealer_key.public_key(),
+                    public,
+                    private,
+                )
+                .await
+                .unwrap();
+            drop(storage);
+            drop(player);
+
+            let mut storage = builder()
+                .partition_prefix("receive_methods_persist")
+                .init_unverified(context.child("after_dealing"))
+                .await
+                .unwrap()
+                .init_verified(state.clone())
+                .await;
+            let player = storage
+                .create_player_for_round(player_key.clone(), &round)
+                .unwrap()
+                .unwrap();
+            assert_eq!(player.acks.get(&dealer_key.public_key()), Some(&ack));
+
+            dealer
+                .receive_ack(&mut storage, state.epoch, player_key.public_key(), ack)
+                .await
+                .unwrap();
+            drop(storage);
+            drop(dealer);
+
+            let storage = builder()
+                .partition_prefix("receive_methods_persist")
+                .init_unverified(context.child("after_ack"))
+                .await
+                .unwrap()
+                .init_verified(state.clone())
+                .await;
+            let dealer = storage
+                .create_dealer_for_round(dealer_key, round, state.share, state.seed)
+                .unwrap()
+                .unwrap();
+            assert!(
+                dealer
+                    .shares_to_distribute()
+                    .all(|(recipient, _, _)| recipient != player_key.public_key())
             );
         });
     }
@@ -1424,22 +1468,17 @@ mod tests {
                 "new storage must not contain a state"
             );
 
-            let (events, _, _) = unverified
+            unverified
                 .storage
-                .events
-                .take()
-                .expect("DKG events storage is available")
-                .append(
-                    0,
-                    &Event::Finalized {
+                .append_event(
+                    Epoch::zero(),
+                    Event::Finalized {
                         digest: Digest(alloy_primitives::B256::with_last_byte(1)),
                         parent: Digest(alloy_primitives::B256::ZERO),
                         height: Height::zero(),
                     },
                 )
-                .await
-                .unwrap();
-            unverified.storage.events = Some(events.sync(0).await.unwrap());
+                .await;
             drop(unverified);
 
             let result = builder()

--- a/crates/consensus/src/dkg/manager/actor/tests/harness.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/harness.rs
@@ -143,8 +143,7 @@ impl HarnessBuilder {
                     .await
                     .unwrap()
                     .init_verified(state)
-                    .await
-                    .unwrap(),
+                    .await,
             )
         } else {
             None
@@ -280,6 +279,15 @@ impl Harness {
         self.mailbox.take();
     }
 
+    pub(super) async fn wait_for_actor_panic(&mut self) {
+        let handle = self.handle.take().expect("DKG actor is not running");
+        assert!(matches!(
+            handle.await,
+            Err(commonware_runtime::Error::Exited)
+        ));
+        self.mailbox.take();
+    }
+
     async fn reopen_storage(&mut self) {
         let unverified = state::builder()
             .partition_prefix(&self.partition_prefix)
@@ -287,7 +295,7 @@ impl Harness {
             .await
             .unwrap();
         self.storage = if let Some(state) = unverified.state().cloned() {
-            Some(unverified.init_verified(state).await.unwrap())
+            Some(unverified.init_verified(state).await)
         } else {
             None
         };

--- a/crates/consensus/src/dkg/manager/actor/tests/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/mod.rs
@@ -25,14 +25,17 @@ use harness::{
 };
 
 #[test]
-fn network_storage_failures_stop_actor_and_allow_recovery() {
+fn network_storage_failures_panic_and_allow_recovery() {
     use commonware_runtime::deterministic::FaultConfig;
     use commonware_utils::probability;
 
     // Exercise both failure while appending to a new journal section and
     // failure while syncing an appended dealing.
     for fail_open in [true, false] {
-        Runner::default().start(|mut context| async move {
+        let runner = Runner::new(
+            commonware_runtime::deterministic::Config::default().with_catch_panics(true),
+        );
+        runner.start(|mut context| async move {
             let (state, keys, _) = dkg_state(&mut context, Epoch::new(1), 2, true);
             let round = Round::from_state(&state, crate::config::NAMESPACE);
             let (_, public, private) = dkg::Dealer::start::<commonware_utils::N3f1>(
@@ -47,6 +50,29 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
                 .find(|(player, _)| player == &keys[0].public_key())
                 .unwrap()
                 .1;
+            let (_, other_public, _) = dkg::Dealer::start::<commonware_utils::N3f1>(
+                &mut context,
+                round.info().clone(),
+                keys[1].clone(),
+                None,
+            )
+            .unwrap();
+            let ack = dkg::Player::new(round.info().clone(), keys[0].clone())
+                .unwrap()
+                .dealer_message::<commonware_utils::N3f1>(
+                    keys[1].public_key(),
+                    public.clone(),
+                    private.clone(),
+                )
+                .unwrap()
+                .unwrap();
+            let invalid_messages = [
+                vec![u8::MAX].into(),
+                // The commitment belongs to a different polynomial.
+                Message::Dealer(other_public, private.clone()).encode(),
+                // This ACK was signed by keys[0], but arrives from keys[1].
+                Message::Ack(ack).encode(),
+            ];
             let message = Message::Dealer(public, private).encode();
             let network = TestNetwork::default();
             let (sender, mut receiver) = network.register(keys[1].public_key());
@@ -66,6 +92,23 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
             } else {
                 faults.write().sync_rate = Some(probability!(1.0));
             }
+            // Rejected protocol messages must not attempt a write or stop the
+            // actor, even when every storage operation would fail.
+            for invalid in invalid_messages {
+                assert!(
+                    sender
+                        .send(
+                            state.epoch.get(),
+                            Recipients::One(keys[0].public_key()),
+                            invalid,
+                            true,
+                        )
+                        .accepted()
+                );
+                context.sleep(Duration::from_millis(1)).await;
+                assert!(!harness.has_dealer_log(state.epoch).await);
+                assert!(receiver.recv().now_or_never().is_none());
+            }
             assert!(
                 sender
                     .send(
@@ -77,15 +120,18 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
                     .accepted()
             );
 
-            // No second message should be needed to discover the missing handle,
-            // and the actor must return normally rather than panic on an expect.
+            // The failed write must panic immediately without another message.
             let mut harness = context
                 .timeout(Duration::from_secs(1), async move {
-                    harness.wait_for_actor_exit().await;
+                    harness.wait_for_actor_panic().await;
                     harness
                 })
                 .await
-                .expect("a network storage failure must terminate the actor immediately");
+                .expect("a network storage failure must panic immediately");
+            assert!(
+                receiver.recv().now_or_never().is_none(),
+                "a dealing must be persisted before its ACK is sent",
+            );
 
             *faults.write() = FaultConfig::default();
             harness.stop().await;
@@ -136,7 +182,7 @@ fn network_storage_failures_stop_actor_and_allow_recovery() {
 }
 
 #[test]
-fn local_share_storage_failures_stop_actor_and_allow_recovery() {
+fn local_share_storage_failures_panic_and_allow_recovery() {
     use commonware_consensus::Reporter as _;
     use commonware_runtime::deterministic::FaultConfig;
     use commonware_utils::probability;
@@ -144,7 +190,10 @@ fn local_share_storage_failures_stop_actor_and_allow_recovery() {
     // Fail opening the dealing's journal section, syncing the dealing, or
     // syncing the ACK after the dealing has already been persisted.
     for (fail_open, seed_dealing) in [(true, false), (false, false), (false, true)] {
-        Runner::default().start(|mut context| async move {
+        let runner = Runner::new(
+            commonware_runtime::deterministic::Config::default().with_catch_panics(true),
+        );
+        runner.start(|mut context| async move {
             let (state, keys, _) = dkg_state(&mut context, Epoch::new(1), 2, true);
             let identity = keys[0].clone();
             let mut harness = Harness::builder(context.child("actor"), "local_storage_failure")
@@ -200,11 +249,11 @@ fn local_share_storage_failures_stop_actor_and_allow_recovery() {
             );
             let mut harness = context
                 .timeout(Duration::from_secs(1), async move {
-                    harness.wait_for_actor_exit().await;
+                    harness.wait_for_actor_panic().await;
                     harness
                 })
                 .await
-                .expect("a local storage failure must terminate the actor without panicking");
+                .expect("a local storage failure must panic immediately");
             assert!(
                 waiter.await.is_err(),
                 "the failed block must not be acknowledged"


### PR DESCRIPTION
Followup to the bump to commonware 2026.9.0 in https://github.com/tempoxyz/tempo/pull/7450: with this patch failed storage writes are treated as unrecoverable panics. This moves our semantics closer to commonware semantics that leans heavily on panics for unrecoverable errors.