### PR TITLE
docs(tip-1108): clarify account extension execution semantics

### DIFF
--- a/tips/tip-1108.md
+++ b/tips/tip-1108.md
@@ -79,13 +79,15 @@ config_hash != 0: rlp([nonce, balance, storageRoot, codeHash, config_hash])
 - Once stored, the hash must never be cleared.
 - An account with a nonzero hash must not be deleted as empty, even if its other fields would allow deletion.
 
+An account with a nonzero hash also counts as nonempty for EVM execution. If it has no code, `EXTCODEHASH` returns `keccak256("")` rather than zero. `CALL` and `SELFDESTRUCT` do not charge for creating a new account when such an account is the recipient.
+
 **Where the hash must be preserved**
 
 The hash is part of the account's authenticated state. Every representation of that state must carry the same value:
 
 - State roots and account proofs.
-- Execution witnesses and block access lists used for execution.
-- Snapshots and state synchronization.
+- Execution witnesses.
+- Snapshots.
 - Historical reexecution, rollback, and reorgs.
 
 ## Access and updates
@@ -142,4 +144,4 @@ Initial registration is recorded by the included transaction and its configurati
 - Accounts without a commitment keep byte-identical legacy encodings and state roots.
 - After an included configurable-account transaction, the hash is nonzero, including at version zero and after execution failure.
 - Emptying an account never clears its commitment.
-- Test commitment preservation through synchronization, historical replay, rollback, and reorgs.
+- Test commitment preservation through snapshots, historical replay, rollback, and reorgs.


### PR DESCRIPTION
Clarifies that configured accounts count as nonempty for EVM execution, including EXTCODEHASH and recipient account-creation charges. Removes BAL and state-synchronization preservation requirements to match the current account-extension support.

Targets the TIP branch in #7510.
