### PR TITLE
docs(tip-1115): specify ordered fallback fee tokens

### DIFF
--- a/tips/tip-1115.md
+++ b/tips/tip-1115.md
@@ -1,0 +1,304 @@
+---
+id: TIP-1115
+title: Ordered Fallback Fee Tokens
+description: Replaces the single pathUSD fee-token fallback with a protocol-defined ordered list selected by the fee payer's ability to cover the maximum transaction fee.
+authors: Dan Robinson
+status: Draft
+related: TIP-1000, TIP-1033, TIP-1042
+protocolVersion: TBD
+---
+
+# TIP-1115: Ordered Fallback Fee Tokens
+
+## Abstract
+
+This TIP replaces the single pathUSD fallback for transaction fee payment with
+an ordered list of USD-denominated TIP-20 tokens defined by the protocol. When
+existing fee-token selection rules reach the default fallback, the protocol
+selects the first token whose balance can cover the transaction's maximum gas
+fee. This allows other stablecoins to serve as fallback fee tokens alongside
+pathUSD without requiring a transaction-level fee token or a stored preference.
+
+## Motivation
+
+Today, a transaction with no explicit, preferred, or inferred fee token falls
+back to pathUSD. A user who holds another supported stablecoin but insufficient
+pathUSD cannot pay for such a transaction automatically, even when that other
+token could cover the fee.
+
+An ordered protocol list extends this default behavior to additional
+stablecoins. Keeping pathUSD first preserves its selection whenever it can
+cover the maximum fee. Users who require a particular fee token can continue
+to choose one explicitly.
+
+Wallet-side selection can help individual clients, but does not change the
+default behavior for existing clients and Ethereum-compatible transactions.
+A user-configured list would require setup before use. Searching every TIP-20
+would make validation work unbounded. A small protocol-defined list supplies
+a common default with bounded work and deterministic priority.
+
+## Assumptions
+
+- Every configured candidate is a deployed USD-denominated TIP-20 with the
+  existing six-decimal fee denomination. An invalid candidate is a protocol
+  configuration error, not a reason for nodes to silently edit the list.
+- All nodes use the same list and order for a given chain and active protocol
+  version. Changing either requires a coordinated protocol upgrade.
+- A sufficient balance does not guarantee that fees can be collected. Existing
+  token validity, pause, TIP-403 authorization, access-key spending limits, and
+  FeeAMM liquidity requirements still apply to the selected token.
+- Candidate balances are read from the state immediately before fee collection.
+  Transfers or other balance changes during transaction execution cannot fund
+  that transaction's initial fee payment.
+
+## Threat Model
+
+- **Protocol upgrade participants** control list membership and ordering through
+  the existing upgrade process. This TIP introduces no administrative key or
+  transaction-callable list setter.
+- **Transaction senders and fee payers** can change their balances and signed
+  gas parameters to influence selection. They cannot supply additional default
+  candidates or override the protocol order. Sponsorship uses the recovered fee
+  payer's balances, not the sender's balances.
+- **Token issuers and liquidity providers** retain their existing powers over
+  token policies, pauses, and liquidity. List inclusion grants no exemption
+  from these controls and makes no new guarantee about a stablecoin's value.
+- **Block builders and other users** can change relevant balances through
+  transaction ordering or transfers, including unsolicited transfers. Selection
+  is therefore state-dependent; an explicit fee token remains the way to pin
+  the asset to be spent.
+
+---
+
+# Specification
+
+## Protocol List
+
+Define `FALLBACK_FEE_TOKENS` as an ordered sequence of token addresses in the
+chain's protocol configuration, selected by the active protocol version.
+
+- The list MUST contain between one and eight distinct addresses.
+- The first entry MUST be pathUSD,
+  `0x20c0000000000000000000000000000000000000`.
+- Every entry MUST be a deployed USD-denominated TIP-20. Zero addresses and
+  duplicates are invalid.
+- Membership and ordering MUST NOT depend on node-local preferences, token
+  enumeration, balances, a validator's preference, or AMM liquidity.
+- Additions, removals, and reordering require a protocol upgrade. The upgrade
+  configuration MUST publish the exact ordered addresses for each chain.
+
+The eight-entry limit bounds balance probes to eight per transaction. No
+precompile, mutable registry, storage migration, or list-update event is added.
+
+This draft specifies the mechanism without selecting additional issuers.
+The activating upgrade MUST specify its version and complete list, including
+at least one additional stablecoin to deliver the intended feature. Until that
+upgrade, the existing pathUSD-only fallback remains in effect.
+
+## Selection Precedence
+
+All existing rules before the final default fallback remain unchanged. In order,
+these are:
+
+1. An explicit transaction `feeToken`.
+2. The existing immediate preference rule for an eligible non-AA
+   `FeeManager.setUserToken(token)` transaction.
+3. The fee payer's stored `userTokens` preference.
+4. A token inferred from eligible TIP-20 calls.
+5. The input token inferred from an eligible Stablecoin DEX swap.
+6. The ordered fallback list defined here.
+
+Existing eligibility restrictions on these rules, including AA call shape and
+sponsorship restrictions, remain unchanged. If rules 1–5 select a token, a
+failure to pay with that token MUST NOT enter the fallback list. In particular,
+an explicitly selected pathUSD or a stored pathUSD preference does not opt in
+to balance-based fallback.
+
+This TIP changes only the fee payer's default token selection. The validator's
+default fee token remains pathUSD, and validator preferences continue to use
+the existing FeeManager rules.
+
+## Maximum Fee and Balance Comparison
+
+Let `payer` be the transaction's recovered fee payer, `G` its gas limit, and `P`
+its maximum fee per gas (`gasPrice` for a legacy transaction or
+`maxFeePerGas` for a transaction with a fee cap). Compute:
+
+```text
+maxFee = ceil(G * P / 10^12)
+```
+
+`maxFee` is in TIP-20 base units, using Tempo's existing conversion from
+attodollars to six-decimal token units. Multiplication MUST use sufficiently
+wide integer arithmetic and division MUST round up, as in
+`calc_gas_balance_spending`. The comparison uses the signed maximum fee, not
+the current effective gas price, an estimate of gas used, or the final fee.
+Existing validation of gas parameters and transaction value remains unchanged.
+
+For each candidate, read the same fee-payer token balance used by ordinary
+maximum-fee balance validation. Do not include allowances, another account's
+balance, future transfers, pending rewards that have not been credited, or
+balances in other tokens. One token must cover the entire maximum fee.
+
+## Ordered Search
+
+When the final fallback is reached:
+
+```text
+for token in FALLBACK_FEE_TOKENS:
+    if balance(token, payer) >= maxFee:
+        return token
+
+// Preserve the existing insufficient-funds validation path.
+return FALLBACK_FEE_TOKENS[0]
+```
+
+The first passing candidate MUST be selected; later candidates MUST NOT be
+probed. Exact equality is sufficient. If `maxFee == 0`, the first token is
+selected even when all balances are zero, and existing zero-fee behavior applies.
+
+If no candidate passes, returning the first entry is only a way to retain the
+existing error path: ordinary maximum-fee balance validation MUST reject the
+transaction as insufficiently funded. It MUST NOT collect a partial fee or
+combine balances. The existing error's balance field refers to pathUSD and its
+required amount is `maxFee`. Implementations MUST preserve the existing failure
+phase and nonce/replay-state handling.
+
+Insufficient balance is the only reason to advance to another candidate.
+After selecting a candidate, normal validation and fee collection run once for
+that token. A pause, policy rejection, access-key limit, invalid token, or
+insufficient FeeAMM liquidity MUST produce the existing failure; it MUST NOT
+restart selection. State-read errors MUST propagate, not be treated as zero
+balances.
+
+## Fee Collection and Execution
+
+Selection does not transfer tokens, reserve liquidity, consume access-key
+limits, or write a user preference. Balance probes MUST use the existing
+protocol storage-read machinery, with its ordinary account/storage warming and
+read-dependency recording, in list order. Unvisited candidates are not warmed
+or added as read dependencies by this search.
+
+The selected token is fixed for the transaction's fee collection and settlement.
+The existing upfront collection amount, based on the effective gas price,
+remains unchanged; `maxFee` is the affordability threshold, not a new debit
+amount. Unused fees are refunded to the fee payer in the selected token, and
+the existing FeeAMM routing converts fees to the validator's token as needed.
+A balance change or execution revert MUST NOT trigger another selection.
+
+This TIP adds no per-candidate gas surcharge and does not change intrinsic gas.
+The bounded additional protocol reads MUST be benchmarked before scheduling,
+including the worst case where all eight candidates are inspected.
+
+## Validation, Building, and Replay
+
+Pool validation, block building, canonical execution, simulation, and replay
+MUST use the same resolver for the same transaction, state, and protocol version.
+During block execution, selection uses the state produced by preceding
+transactions in canonical execution order.
+
+A cached token is not authoritative across balance changes. Pool maintenance
+MUST revalidate affected fallback transactions when the payer's balance changes
+in a previously inspected candidate, including an earlier candidate that was
+insufficient at admission. A pathUSD top-up can change a transaction from a
+later candidate back to pathUSD. Pool fee accounting and liquidity checks MUST
+follow the newly resolved token. An exhausted search depends on all entries.
+
+Parallel execution and action replay MUST retain the balance-read dependencies
+for skipped candidates as well as the selected candidate, so a preceding
+transaction that changes selection causes re-execution. Reorganizations and
+protocol-version changes MUST invalidate affected cached resolutions.
+
+## Activation and Compatibility
+
+Before activation, clients MUST retain the existing single-token fallback for
+historical execution. At activation, all selection paths MUST switch together
+to the versioned list. Transactions admitted before activation MUST be
+revalidated before inclusion under the new rules.
+
+Transaction encodings, signing payloads, FeeManager preference interfaces, and
+receipt formats remain unchanged. Previously failing fallback transactions can
+become payable with an additional listed token. Transactions with sufficient
+pathUSD continue to select pathUSD; transactions selected by an earlier rule
+retain their existing behavior.
+
+# Tooling
+
+SDKs and wallets that want protocol fallback MUST leave `feeToken` unset and
+account for any stored preference or call-based inference. A filler that
+inserts pathUSD creates an explicit choice and prevents list selection.
+Interfaces showing an estimated fee asset SHOULD identify that it can change
+with balances and transaction gas parameters before inclusion.
+
+RPC simulation and gas estimation MUST resolve against the requested block
+state and each simulated transaction's gas parameters, including state
+overrides where supported. Changing a trial gas limit can change the selected
+token; estimators MUST NOT reuse a resolution from a different trial. Existing
+simulation-only validation bypasses remain simulation-only and MUST NOT alter
+canonical validation. Callers requiring an estimate in a particular token
+should specify it explicitly.
+
+Estimators MUST validate their returned gas limit with the token selected at
+that limit. A fee-payment failure at a higher trial limit does not prove that
+every lower limit fails: a lower limit may select an earlier, usable token.
+
+Client chain configurations and SDK chain metadata SHOULD expose the active
+ordered list and activation boundary. No new RPC method is required. Test
+fixtures MUST support multiple fallback candidates and balance changes between
+admission and execution.
+
+# Observability
+
+N/A for new consensus events: the list changes only through protocol upgrades,
+and selection makes no persistent state change of its own. Existing fee
+transfer logs and receipt `feeToken` and `feePayer` fields identify the token
+and account used for a paid transaction. Zero-fee receipts retain their existing
+behavior, including omission of `feeToken` where applicable.
+
+Node diagnostics SHOULD distinguish list exhaustion from failure after a
+candidate was selected, and report the selected token and fallback index when
+debugging selection. Rollout monitoring SHOULD track fallback selection by
+token, insufficient-funds failures, and validation latency as the list grows.
+
+# Invariants
+
+The implementation test suite MUST cover:
+
+1. **Priority:** The selected fallback token is the earliest entry with
+   `balance >= maxFee`. Cover the first, middle, and last entries, and multiple
+   entries with sufficient funds.
+2. **Boundaries:** Cover exact equality, one base unit below the threshold,
+   upward rounding, zero fees, and maximum valid gas/price values. A balance
+   covering only the effective fee MUST NOT pass the maximum-fee comparison.
+3. **Exhaustion:** If every balance is insufficient, reject even when their sum
+   covers the fee. Preserve failure-phase, error-field, and rollback behavior.
+4. **Precedence:** Explicit choices, immediate and stored preferences, TIP-20
+   inference, and DEX inference retain their priority and eligibility rules.
+   Their fee failures MUST NOT fall through to the list.
+5. **Payer identity:** Sponsored transactions inspect the recovered payer's
+   balances. Sender funds cannot satisfy the payer's threshold.
+6. **No retry after selection:** A funded candidate's pause, policy rejection,
+   access-key limit, or liquidity failure does not select a later token. Cover
+   both existing and same-transaction access-key authorization.
+7. **Single-token settlement:** Only the selected token funds the fee and
+   receives any refund, including after an execution revert. Skipped tokens
+   incur no debits, reservations, spending-limit changes, or preference writes.
+8. **State consistency:** A prior transfer into or out of an inspected candidate
+   changes selection identically in pool revalidation, sequential execution,
+   parallel re-execution, simulation, and replay. Include an unsolicited top-up
+   to an earlier candidate and a reorganization undoing it. Cover gas-estimation
+   trials that cross a token-selection threshold.
+9. **Bounded reads:** Cover one- and eight-entry lists, early termination,
+   read errors, and invalid configuration. Record and warm exactly the probes
+   performed by the search; preserve skipped-candidate dependencies.
+10. **Compatibility:** Cover both sides of activation, historical replay,
+    pre-activation pending transactions, unchanged validator defaults, and
+    receipts for paid and zero-fee transactions.
+
+Success means an otherwise valid transaction that reaches the fallback can
+pay with a later listed stablecoin when earlier balances are insufficient,
+with deterministic selection and bounded validation work. Before scheduling,
+engineering, security, and tooling reviews MUST resolve the activation version
+and exact additional token addresses/order, validate their deployment and fee
+liquidity readiness, and assess worst-case validation benchmarks under the
+TIP-0000 process.

--- a/tips/tip-1115.md
+++ b/tips/tip-1115.md
@@ -1,7 +1,7 @@
 ---
 id: TIP-1115
 title: Ordered Fallback Fee Tokens
-description: Replaces the single pathUSD fee-token fallback with a protocol-defined ordered list selected by the fee payer's ability to cover the maximum transaction fee.
+description: Selects the first token in a protocol-defined fallback list with enough balance to cover the maximum transaction fee.
 authors: Dan Robinson
 status: Draft
 related: TIP-1000, TIP-1033, TIP-1042
@@ -12,293 +12,84 @@ protocolVersion: TBD
 
 ## Abstract
 
-This TIP replaces the single pathUSD fallback for transaction fee payment with
-an ordered list of USD-denominated TIP-20 tokens defined by the protocol. When
-existing fee-token selection rules reach the default fallback, the protocol
-selects the first token whose balance can cover the transaction's maximum gas
-fee. This allows other stablecoins to serve as fallback fee tokens alongside
-pathUSD without requiring a transaction-level fee token or a stored preference.
+Replace the pathUSD fee-token fallback with an ordered list of stablecoins.
+Select the first token whose balance covers the transaction's maximum gas fee.
 
 ## Motivation
 
-Today, a transaction with no explicit, preferred, or inferred fee token falls
-back to pathUSD. A user who holds another supported stablecoin but insufficient
-pathUSD cannot pay for such a transaction automatically, even when that other
-token could cover the fee.
-
-An ordered protocol list extends this default behavior to additional
-stablecoins. Keeping pathUSD first preserves its selection whenever it can
-cover the maximum fee. Users who require a particular fee token can continue
-to choose one explicitly.
-
-Wallet-side selection can help individual clients, but does not change the
-default behavior for existing clients and Ethereum-compatible transactions.
-A user-configured list would require setup before use. Searching every TIP-20
-would make validation work unbounded. A small protocol-defined list supplies
-a common default with bounded work and deterministic priority.
+Users holding other stablecoins should be able to pay fees by default without
+acquiring pathUSD or setting a fee-token preference.
 
 ## Assumptions
 
-- Every configured candidate is a deployed USD-denominated TIP-20 with the
-  existing six-decimal fee denomination. An invalid candidate is a protocol
-  configuration error, not a reason for nodes to silently edit the list.
-- All nodes use the same list and order for a given chain and active protocol
-  version. Changing either requires a coordinated protocol upgrade.
-- A sufficient balance does not guarantee that fees can be collected. Existing
-  token validity, pause, TIP-403 authorization, access-key spending limits, and
-  FeeAMM liquidity requirements still apply to the selected token.
-- Candidate balances are read from the state immediately before fee collection.
-  Transfers or other balance changes during transaction execution cannot fund
-  that transaction's initial fee payment.
+Listed tokens are deployed USD-denominated TIP-20s.
 
 ## Threat Model
 
-- **Protocol upgrade participants** control list membership and ordering through
-  the existing upgrade process. This TIP introduces no administrative key or
-  transaction-callable list setter.
-- **Transaction senders and fee payers** can change their balances and signed
-  gas parameters to influence selection. They cannot supply additional default
-  candidates or override the protocol order. Sponsorship uses the recovered fee
-  payer's balances, not the sender's balances.
-- **Token issuers and liquidity providers** retain their existing powers over
-  token policies, pauses, and liquidity. List inclusion grants no exemption
-  from these controls and makes no new guarantee about a stablecoin's value.
-- **Block builders and other users** can change relevant balances through
-  transaction ordering or transfers, including unsolicited transfers. Selection
-  is therefore state-dependent; an explicit fee token remains the way to pin
-  the asset to be spent.
+A transfer into an earlier token can change which token pays for a pending
+transaction. Users can specify a fee token explicitly to pin that choice.
 
 ---
 
 # Specification
 
-## Protocol List
+## Fallback List
 
-Define `FALLBACK_FEE_TOKENS` as an ordered sequence of token addresses in the
-chain's protocol configuration, selected by the active protocol version.
+Define `FALLBACK_FEE_TOKENS` as an ordered list of distinct token addresses in
+protocol configuration, with pathUSD first. Changes to the list take effect
+through protocol upgrades. Additional tokens and the activation version are TBD.
 
-- The list MUST contain between one and eight distinct addresses.
-- The first entry MUST be pathUSD,
-  `0x20c0000000000000000000000000000000000000`.
-- Every entry MUST be a deployed USD-denominated TIP-20. Zero addresses and
-  duplicates are invalid.
-- Membership and ordering MUST NOT depend on node-local preferences, token
-  enumeration, balances, a validator's preference, or AMM liquidity.
-- Additions, removals, and reordering require a protocol upgrade. The upgrade
-  configuration MUST publish the exact ordered addresses for each chain.
+## Selection
 
-The eight-entry limit bounds balance probes to eight per transaction. No
-precompile, mutable registry, storage migration, or list-update event is added.
+Replace only the final pathUSD fallback. Existing explicit fee-token choices,
+preferences, and inference rules retain their precedence; failures under those
+rules do not enter the fallback list.
 
-This draft specifies the mechanism without selecting additional issuers.
-The activating upgrade MUST specify its version and complete list, including
-at least one additional stablecoin to deliver the intended feature. Until that
-upgrade, the existing pathUSD-only fallback remains in effect.
-
-## Selection Precedence
-
-All existing rules before the final default fallback remain unchanged. In order,
-these are:
-
-1. An explicit transaction `feeToken`.
-2. The existing immediate preference rule for an eligible non-AA
-   `FeeManager.setUserToken(token)` transaction.
-3. The fee payer's stored `userTokens` preference.
-4. A token inferred from eligible TIP-20 calls.
-5. The input token inferred from an eligible Stablecoin DEX swap.
-6. The ordered fallback list defined here.
-
-Existing eligibility restrictions on these rules, including AA call shape and
-sponsorship restrictions, remain unchanged. If rules 1–5 select a token, a
-failure to pay with that token MUST NOT enter the fallback list. In particular,
-an explicitly selected pathUSD or a stored pathUSD preference does not opt in
-to balance-based fallback.
-
-This TIP changes only the fee payer's default token selection. The validator's
-default fee token remains pathUSD, and validator preferences continue to use
-the existing FeeManager rules.
-
-## Maximum Fee and Balance Comparison
-
-Let `payer` be the transaction's recovered fee payer, `G` its gas limit, and `P`
-its maximum fee per gas (`gasPrice` for a legacy transaction or
-`maxFeePerGas` for a transaction with a fee cap). Compute:
+When the fallback is reached, compute the maximum fee in TIP-20 base units:
 
 ```text
-maxFee = ceil(G * P / 10^12)
+maxFee = ceil(gasLimit * maxFeePerGas / 10^12)
 ```
 
-`maxFee` is in TIP-20 base units, using Tempo's existing conversion from
-attodollars to six-decimal token units. Multiplication MUST use sufficiently
-wide integer arithmetic and division MUST round up, as in
-`calc_gas_balance_spending`. The comparison uses the signed maximum fee, not
-the current effective gas price, an estimate of gas used, or the final fee.
-Existing validation of gas parameters and transaction value remains unchanged.
-
-For each candidate, read the same fee-payer token balance used by ordinary
-maximum-fee balance validation. Do not include allowances, another account's
-balance, future transfers, pending rewards that have not been credited, or
-balances in other tokens. One token must cover the entire maximum fee.
-
-## Ordered Search
-
-When the final fallback is reached:
+For legacy transactions, use `gasPrice` in place of `maxFeePerGas`.
+Using the fee payer's balances before execution:
 
 ```text
 for token in FALLBACK_FEE_TOKENS:
-    if balance(token, payer) >= maxFee:
+    if balance(token, feePayer) >= maxFee:
         return token
 
-// Preserve the existing insufficient-funds validation path.
-return FALLBACK_FEE_TOKENS[0]
+fail with insufficient funds
 ```
 
-The first passing candidate MUST be selected; later candidates MUST NOT be
-probed. Exact equality is sufficient. If `maxFee == 0`, the first token is
-selected even when all balances are zero, and existing zero-fee behavior applies.
+One token must cover the entire fee. A zero maximum fee selects pathUSD.
 
-If no candidate passes, returning the first entry is only a way to retain the
-existing error path: ordinary maximum-fee balance validation MUST reject the
-transaction as insufficiently funded. It MUST NOT collect a partial fee or
-combine balances. The existing error's balance field refers to pathUSD and its
-required amount is `maxFee`. Implementations MUST preserve the existing failure
-phase and nonce/replay-state handling.
+Only insufficient balance advances the search. Once a token is selected,
+existing pause, policy, access-key, and FeeAMM liquidity checks apply; a failure
+does not try another token. Fee collection and refunds use the selected token
+under the existing rules. The validator's default fee token remains pathUSD.
 
-Insufficient balance is the only reason to advance to another candidate.
-After selecting a candidate, normal validation and fee collection run once for
-that token. A pause, policy rejection, access-key limit, invalid token, or
-insufficient FeeAMM liquidity MUST produce the existing failure; it MUST NOT
-restart selection. State-read errors MUST propagate, not be treated as zero
-balances.
+## Validation
 
-## Fee Collection and Execution
-
-Selection does not transfer tokens, reserve liquidity, consume access-key
-limits, or write a user preference. Balance probes MUST use the existing
-protocol storage-read machinery, with its ordinary account/storage warming and
-read-dependency recording, in list order. Unvisited candidates are not warmed
-or added as read dependencies by this search.
-
-The selected token is fixed for the transaction's fee collection and settlement.
-The existing upfront collection amount, based on the effective gas price,
-remains unchanged; `maxFee` is the affordability threshold, not a new debit
-amount. Unused fees are refunded to the fee payer in the selected token, and
-the existing FeeAMM routing converts fees to the validator's token as needed.
-A balance change or execution revert MUST NOT trigger another selection.
-
-This TIP adds no per-candidate gas surcharge and does not change intrinsic gas.
-The bounded additional protocol reads MUST be benchmarked before scheduling,
-including the worst case where all eight candidates are inspected.
-
-## Validation, Building, and Replay
-
-Pool validation, block building, canonical execution, simulation, and replay
-MUST use the same resolver for the same transaction, state, and protocol version.
-During block execution, selection uses the state produced by preceding
-transactions in canonical execution order.
-
-A cached token is not authoritative across balance changes. Pool maintenance
-MUST revalidate affected fallback transactions when the payer's balance changes
-in a previously inspected candidate, including an earlier candidate that was
-insufficient at admission. A pathUSD top-up can change a transaction from a
-later candidate back to pathUSD. Pool fee accounting and liquidity checks MUST
-follow the newly resolved token. An exhausted search depends on all entries.
-
-Parallel execution and action replay MUST retain the balance-read dependencies
-for skipped candidates as well as the selected candidate, so a preceding
-transaction that changes selection causes re-execution. Reorganizations and
-protocol-version changes MUST invalidate affected cached resolutions.
-
-## Activation and Compatibility
-
-Before activation, clients MUST retain the existing single-token fallback for
-historical execution. At activation, all selection paths MUST switch together
-to the versioned list. Transactions admitted before activation MUST be
-revalidated before inclusion under the new rules.
-
-Transaction encodings, signing payloads, FeeManager preference interfaces, and
-receipt formats remain unchanged. Previously failing fallback transactions can
-become payable with an additional listed token. Transactions with sufficient
-pathUSD continue to select pathUSD; transactions selected by an earlier rule
-retain their existing behavior.
+Pool validation and execution use the same selection rule. Changes to the fee
+payer's balance in any examined token require revalidation, including tokens
+skipped for insufficient balance. Replay must track these read dependencies.
+Before activation, historical execution uses the existing pathUSD fallback.
 
 # Tooling
 
-SDKs and wallets that want protocol fallback MUST leave `feeToken` unset and
-account for any stored preference or call-based inference. A filler that
-inserts pathUSD creates an explicit choice and prevents list selection.
-Interfaces showing an estimated fee asset SHOULD identify that it can change
-with balances and transaction gas parameters before inclusion.
-
-RPC simulation and gas estimation MUST resolve against the requested block
-state and each simulated transaction's gas parameters, including state
-overrides where supported. Changing a trial gas limit can change the selected
-token; estimators MUST NOT reuse a resolution from a different trial. Existing
-simulation-only validation bypasses remain simulation-only and MUST NOT alter
-canonical validation. Callers requiring an estimate in a particular token
-should specify it explicitly.
-
-Estimators MUST validate their returned gas limit with the token selected at
-that limit. A fee-payment failure at a higher trial limit does not prove that
-every lower limit fails: a lower limit may select an earlier, usable token.
-
-Client chain configurations and SDK chain metadata SHOULD expose the active
-ordered list and activation boundary. No new RPC method is required. Test
-fixtures MUST support multiple fallback candidates and balance changes between
-admission and execution.
+Wallets using protocol fallback must leave `feeToken` unset. Gas estimation must
+resolve the token for each trial gas limit, since a different limit can change
+which token is selected.
 
 # Observability
 
-N/A for new consensus events: the list changes only through protocol upgrades,
-and selection makes no persistent state change of its own. Existing fee
-transfer logs and receipt `feeToken` and `feePayer` fields identify the token
-and account used for a paid transaction. Zero-fee receipts retain their existing
-behavior, including omission of `feeToken` where applicable.
-
-Node diagnostics SHOULD distinguish list exhaustion from failure after a
-candidate was selected, and report the selected token and fallback index when
-debugging selection. Rollout monitoring SHOULD track fallback selection by
-token, insufficient-funds failures, and validation latency as the list grows.
+Existing receipt `feeToken` and `feePayer` fields identify the payment. No new
+events are needed.
 
 # Invariants
 
-The implementation test suite MUST cover:
-
-1. **Priority:** The selected fallback token is the earliest entry with
-   `balance >= maxFee`. Cover the first, middle, and last entries, and multiple
-   entries with sufficient funds.
-2. **Boundaries:** Cover exact equality, one base unit below the threshold,
-   upward rounding, zero fees, and maximum valid gas/price values. A balance
-   covering only the effective fee MUST NOT pass the maximum-fee comparison.
-3. **Exhaustion:** If every balance is insufficient, reject even when their sum
-   covers the fee. Preserve failure-phase, error-field, and rollback behavior.
-4. **Precedence:** Explicit choices, immediate and stored preferences, TIP-20
-   inference, and DEX inference retain their priority and eligibility rules.
-   Their fee failures MUST NOT fall through to the list.
-5. **Payer identity:** Sponsored transactions inspect the recovered payer's
-   balances. Sender funds cannot satisfy the payer's threshold.
-6. **No retry after selection:** A funded candidate's pause, policy rejection,
-   access-key limit, or liquidity failure does not select a later token. Cover
-   both existing and same-transaction access-key authorization.
-7. **Single-token settlement:** Only the selected token funds the fee and
-   receives any refund, including after an execution revert. Skipped tokens
-   incur no debits, reservations, spending-limit changes, or preference writes.
-8. **State consistency:** A prior transfer into or out of an inspected candidate
-   changes selection identically in pool revalidation, sequential execution,
-   parallel re-execution, simulation, and replay. Include an unsolicited top-up
-   to an earlier candidate and a reorganization undoing it. Cover gas-estimation
-   trials that cross a token-selection threshold.
-9. **Bounded reads:** Cover one- and eight-entry lists, early termination,
-   read errors, and invalid configuration. Record and warm exactly the probes
-   performed by the search; preserve skipped-candidate dependencies.
-10. **Compatibility:** Cover both sides of activation, historical replay,
-    pre-activation pending transactions, unchanged validator defaults, and
-    receipts for paid and zero-fee transactions.
-
-Success means an otherwise valid transaction that reaches the fallback can
-pay with a later listed stablecoin when earlier balances are insufficient,
-with deterministic selection and bounded validation work. Before scheduling,
-engineering, security, and tooling reviews MUST resolve the activation version
-and exact additional token addresses/order, validate their deployment and fee
-liquidity readiness, and assess worst-case validation benchmarks under the
-TIP-0000 process.
+Tests should cover first and later candidates, exact balances, upward rounding,
+zero fees, insufficient funds across all candidates, sponsored fee payers,
+unchanged selection precedence, failure after selection, and balance changes
+between pool admission and execution.

--- a/tips/tip-1115.md
+++ b/tips/tip-1115.md
@@ -76,6 +76,8 @@ payer's balance in any examined token require revalidation, including tokens
 skipped for insufficient balance. Replay must track these read dependencies.
 Before activation, historical execution uses the existing pathUSD fallback.
 
+## Gas Overhead
+
 For a list of `N` tokens, transactions rejected because every candidate has
 insufficient balance require `N - 1` additional storage reads. The worst-case
 number of storage reads per transaction also increases by `N - 1`, since even a

--- a/tips/tip-1115.md
+++ b/tips/tip-1115.md
@@ -76,6 +76,11 @@ payer's balance in any examined token require revalidation, including tokens
 skipped for insufficient balance. Replay must track these read dependencies.
 Before activation, historical execution uses the existing pathUSD fallback.
 
+For a list of `N` tokens, transactions rejected because every candidate has
+insufficient balance require `N - 1` additional storage reads. The worst-case
+number of storage reads per transaction also increases by `N - 1`, since even a
+valid transaction may need to check the entire list.
+
 # Tooling
 
 This change applies only to transactions that omit `feeToken` and whose fee-payer

--- a/tips/tip-1115.md
+++ b/tips/tip-1115.md
@@ -4,7 +4,7 @@ title: Ordered Fallback Fee Tokens
 description: Selects the first token in a protocol-defined fallback list with enough balance to cover the maximum transaction fee.
 authors: Dan Robinson
 status: Draft
-related: TIP-1000, TIP-1033, TIP-1042
+related: N/A
 protocolVersion: TBD
 ---
 
@@ -82,6 +82,9 @@ For a list of `N` tokens, transactions rejected because every candidate has
 insufficient balance require `N - 1` additional storage reads. The worst-case
 number of storage reads per transaction also increases by `N - 1`, since even a
 valid transaction may need to check the entire list.
+
+The gas charged for fee-token selection remains constant regardless of the
+number of tokens checked.
 
 # Tooling
 

--- a/tips/tip-1115.md
+++ b/tips/tip-1115.md
@@ -78,9 +78,9 @@ Before activation, historical execution uses the existing pathUSD fallback.
 
 # Tooling
 
-Wallets using protocol fallback must leave `feeToken` unset. Gas estimation must
-resolve the token for each trial gas limit, since a different limit can change
-which token is selected.
+This change applies only to transactions that omit `feeToken` and whose fee-payer
+address has no stored fee-token preference. Existing fee-token inference rules
+still take precedence.
 
 # Observability
 


### PR DESCRIPTION
Replaces the pathUSD-only fallback with an ordered protocol list, selecting the first token whose balance covers the maximum transaction fee. This lets other stablecoins pay fees by default while preserving existing fee-token preferences and inference.

The list starts with pathUSD; additional tokens and activation timing are TBD.
