### PR TITLE
feat(precompiles): allow trailing ABI bytes from T12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,8 +445,7 @@ dependencies = [
 [[package]]
 name = "alloy-json-abi"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dba4e59c3581a39e03e0b0b4a46ee9c41315b5d843b1e903271952b32bedb7c"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -511,8 +510,7 @@ dependencies = [
 [[package]]
 name = "alloy-primitives"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce7b00f0cb42c66ec353076ded1dff1fbf818f6e0e26c40c8a8456c04483fca4"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -950,8 +948,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64558980fb038cd34b4285ec2b36a2a8bd8d4ddd13b3f6e42d97cb5ee29938e"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -964,8 +961,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-expander"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffb0e793abdbaea9d01259493c8272c3af295d03389e70a2acdf53b57ad1edf"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -983,8 +979,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-macro-input"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2c0ec8425d9663dac939ba75750f17d2933d2f020814b4f8fde4a60da6d26"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -1001,8 +996,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-type-parser"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b37db6a7ad8170596345f864522f789cc7af093f516d6cdf34bbdcfba8adab"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1011,8 +1005,7 @@ dependencies = [
 [[package]]
 name = "alloy-sol-types"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f40e33a0f588dde548c3b6767a71e61b593421a8c1b253b9cf1441dc7cf7ab5"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -13180,8 +13173,7 @@ dependencies = [
 [[package]]
 name = "syn-solidity"
 version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6415502cd1e9ed58b3ceb415164b812d5572757b1a6f0e280ae806723c1fab"
+source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
+checksum = "c6a70852055d66af821d28497e690c95950020ed1ee4c7a0ab9b02a01ac75ee3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1a3f2206f2ba4206fdeeddce6640eed3e26b8a13ac41444adb66b76d8e650"
+checksum = "14b3b9990889736af898bd4e51f7d0c0228d6a9b9c3a5fecb3e6b25a7abc791c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -463,8 +463,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858acd7fdad1e4a7057fd9c1b39c1f2cd6bcd57ebf3c56e2853c02ead049e816"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -528,8 +529,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5e9dbd49258ac3ab893a481d46be29b58be7f734dcac46cd80b6b13ee36566c"
 dependencies = [
  "alloy-rlp",
  "arbitrary",
@@ -966,8 +968,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60dd79f578c3912f1fc2a150dbeb8110b8cfb976c60f98ebf6de9d5da5965a2b"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -979,8 +982,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edb8520f2f94275e1caa73c85207dcc78ec402a9a4c429240f9a0783a8f16c0"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -997,8 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66af2d9344882172993be5f5cbfd349fdfa52cb548f7af8715b446fb35ef6001"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -1014,8 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c2a8abc3334044013b23d5e438cc5dc802e5544cc42b713d0840d5185967cc"
 dependencies = [
  "serde",
  "winnow 1.0.3",
@@ -1023,8 +1029,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6f87cf007caa54e95455875fbd25879b008d0d9c7c340a2c258b3a3400a28c"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -4042,7 +4049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -13279,8 +13286,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.7.2"
-source = "git+https://github.com/decofe/core?rev=abef344e72089ac7e1ed1bfeb557483acbfca895#abef344e72089ac7e1ed1bfeb557483acbfca895"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6a2e3c7f7a3e4e83d1752cec5d1e357ced0cf96e85419b6a07f227db3def3a"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -413,6 +413,16 @@ vergen-git2 = "10.0.1"
 
 [patch.crates-io]
 
+# Alloy strict decoding with trailing bytes: https://github.com/alloy-rs/core/pull/1186.
+alloy-json-abi = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+alloy-primitives = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+alloy-sol-types = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+alloy-sol-macro = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+alloy-sol-macro-expander = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+alloy-sol-macro-input = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+alloy-sol-type-parser = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+syn-solidity = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
+
 # Commonware v2026.7.0
 # commonware-actor = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }
 # commonware-broadcast = { git = "https://github.com/commonwarexyz/monorepo", rev = "5950bf7179bb0650a57ed58b9e0478822944b335" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,9 +216,9 @@ reth-revm = { git = "https://github.com/paradigmxyz/reth", rev = "8e55cc5", feat
 revm = { version = "43.0.2", features = ["optional_fee_charge"], default-features = false }
 revm-inspectors = "0.43.0"
 
-alloy-json-abi = { version = "1.7.2", default-features = false }
-alloy-primitives = { version = "1.7.2", default-features = false }
-alloy-sol-types = { version = "1.7.2", default-features = false }
+alloy-json-abi = { version = "1.7.3", default-features = false }
+alloy-primitives = { version = "1.7.3", default-features = false }
+alloy-sol-types = { version = "1.7.3", default-features = false }
 
 alloy = { version = "2.4.2", default-features = false }
 alloy-consensus = { version = "2.4.2", default-features = false }
@@ -410,15 +410,3 @@ vergen-git2 = "10.0.1"
 # reth-trie-db = { path = "../reth/crates/trie/db" }
 # reth-trie-parallel = { path = "../reth/crates/trie/parallel" }
 # reth-trie-sparse = { path = "../reth/crates/trie/sparse" }
-
-[patch.crates-io]
-
-# Alloy strict decoding with trailing bytes: https://github.com/alloy-rs/core/pull/1186.
-alloy-json-abi = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-alloy-primitives = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-alloy-sol-types = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-alloy-sol-macro = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-alloy-sol-macro-expander = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-alloy-sol-macro-input = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-alloy-sol-type-parser = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }
-syn-solidity = { git = "https://github.com/decofe/core", rev = "abef344e72089ac7e1ed1bfeb557483acbfca895" }

--- a/crates/precompiles/src/dispatch.rs
+++ b/crates/precompiles/src/dispatch.rs
@@ -20,6 +20,7 @@ sol! {
 pub const ABI_DECODER_MEMORY_LIMIT: usize = 16 * 1024 * 1024;
 
 /// Returns the hardfork-aware ABI decoder configuration used to dispatch precompile calls.
+/// Strict decoding starts at T11; T12 additionally permits trailing bytes.
 #[inline]
 pub const fn abi_decoder_config_for_spec(
     spec: TempoHardfork,
@@ -27,6 +28,7 @@ pub const fn abi_decoder_config_for_spec(
     alloy::sol_types::abi::AbiDecoderConfig::new()
         .memory_limit(ABI_DECODER_MEMORY_LIMIT)
         .strict(spec.is_t11())
+        .validate_allow_trailing_bytes(spec.is_t12())
 }
 
 pub mod typed {
@@ -365,6 +367,69 @@ mod tests {
                 Self::Tempo(error) => error.into_precompile_result(gas, reservoir),
             }
         }
+    }
+
+    #[test]
+    fn trailing_bytes_are_allowed_from_t12() -> eyre::Result<()> {
+        let canonical = ITestMemoryDispatch::setValuesCall {
+            values: vec![U256::from(1), U256::from(2)],
+        }
+        .abi_encode();
+
+        for spec in [
+            TempoHardfork::Genesis,
+            TempoHardfork::T10,
+            TempoHardfork::T11,
+            TempoHardfork::T12,
+            TempoHardfork::T13,
+        ] {
+            let config = abi_decoder_config_for_spec(spec);
+            assert_eq!(config.get_strict(), spec.is_t11());
+            assert_eq!(config.get_validate(), spec.is_t11());
+            assert_eq!(config.get_validate_allow_trailing_bytes(), spec.is_t12());
+            assert_eq!(config.get_memory_limit(), ABI_DECODER_MEMORY_LIMIT);
+
+            let mut storage = HashMapStorageProvider::new_with_spec(1, spec);
+            for suffix_len in [0, 1, 32, 33] {
+                let mut calldata = canonical.clone();
+                calldata.extend(vec![0xff; suffix_len]);
+                let output = StorageCtx::enter(&mut storage, || {
+                    dispatch!(
+                        &calldata,
+                        |call| match call {
+                            ITestMemoryDispatch::ITestMemoryDispatchCalls {
+                                setValues(_) => Ok(PrecompileOutput::new(0, Bytes::new(), 0)),
+                            }
+                        }
+                    )
+                })?;
+                let expected_success = suffix_len == 0 || !spec.is_t11() || spec.is_t12();
+                assert_eq!(
+                    output.is_success(),
+                    expected_success,
+                    "{spec:?}, {suffix_len}"
+                );
+            }
+
+            // Allowing a suffix must not permit gaps inside the encoding.
+            let mut gapped = canonical.clone();
+            gapped[4..36].copy_from_slice(&U256::from(64).to_be_bytes::<32>());
+            gapped.splice(36..36, [0u8; 32]);
+            assert_eq!(
+                ITestMemoryDispatch::setValuesCall::abi_decode_with_config(&gapped, config).is_ok(),
+                !spec.is_t11(),
+                "{spec:?}"
+            );
+            assert!(
+                ITestMemoryDispatch::setValuesCall::abi_decode_with_config(
+                    &canonical[..canonical.len() - 1],
+                    config,
+                )
+                .is_err(),
+                "{spec:?}"
+            );
+        }
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Enables `validate_allow_trailing_bytes` from T12 while retaining strict decoding from T11 and the existing 16 MiB decoder memory limit. Pre-T12 behavior is unchanged; regression coverage checks suffix acceptance across Genesis/T10/T11/T12/T13 and continued rejection of gaps and truncation under strict decoding.

Temporarily pins Alloy core crates to [alloy-rs/core#1186](https://github.com/alloy-rs/core/pull/1186); replace the pin with an upstream release before merging.

Validation: 115 dispatch tests pass; nightly formatting and library Clippy pass (existing warnings only).

Prompted by: @klkvr
