### PR TITLE
docs(tip-1116): add T12 hardfork meta TIP

### DIFF
--- a/tips/tip-1116.md
+++ b/tips/tip-1116.md
@@ -1,0 +1,78 @@
+---
+id: TIP-1116
+title: T12 Hardfork Meta TIP
+description: Meta TIP collecting changes proposed for the T12 hardfork.
+authors: Jennifer (@jenpaff)
+status: Draft
+related: TIP-1105
+protocolVersion: T12
+---
+
+# TIP-1116: T12 Hardfork Meta TIP
+
+## Abstract
+
+This meta TIP collects changes proposed for the T12 hardfork and links their
+implementations. Its initial entry relaxes trailing-byte validation in precompile
+ABI decoding while retaining the other strict decoding checks introduced at T11.
+
+## Motivation
+
+A shared T12 tracking document makes the proposed upgrade scope and implementation
+dependencies reviewable. Allowing trailing ABI bytes restores compatibility for
+otherwise valid precompile calls that include a suffix, without removing the
+remaining decoding checks described in [TIP-1105](./tip-1105.md).
+
+## Assumptions
+
+All validators must apply the same decoding rules at the T12 activation boundary.
+This draft tracks proposed scope; activation timing and final inclusion remain
+subject to the [TIP process](./tip-0000.md).
+
+## Threat Model
+
+Callers can supply arbitrary calldata. Accepting a trailing suffix must not bypass
+validation of the decoded arguments, canonical dynamic-data layout, or the decoder
+memory limit. Validators rely on consistent hardfork gating to avoid divergent
+execution results.
+
+---
+
+# Specification
+
+## 1. Allow trailing ABI bytes in precompile calls
+
+**PR**: [#7598](https://github.com/tempoxyz/tempo/pull/7598)
+
+From T12, Tempo precompile dispatchers enable Alloy's
+`validate_allow_trailing_bytes` option alongside the strict ABI validation enabled
+at T11. Otherwise valid ABI arguments may be followed by unused trailing bytes;
+strict validation of the decoded arguments remains enabled, including rejection
+of gaps and truncation. The existing 16 MiB decoder memory limit remains in place.
+
+Pre-T12 behavior is unchanged: T11 retains strict decoding without trailing-byte
+acceptance, and earlier hardforks retain their historical decoding behavior.
+
+The implementation currently depends on
+[alloy-rs/core#1186](https://github.com/alloy-rs/core/pull/1186); its temporary
+dependency pin must be replaced with an upstream release before merging the
+implementation PR.
+
+# Tooling
+
+No new RPC methods, ABI interfaces, or SDK commands are introduced by this entry.
+Existing tooling can continue producing canonical ABI calldata; callers that
+append a suffix become compatible with precompile dispatch from T12.
+
+# Observability
+
+No new events are required for this entry. Existing transaction receipts and
+execution traces can be used to inspect precompile call outcomes around activation.
+
+# Invariants
+
+- Historical execution before T12 remains unchanged.
+- T12 accepts otherwise valid ABI calldata with a trailing suffix.
+- Strict decoding continues to reject gaps and truncated arguments at T12.
+- The 16 MiB decoder memory limit remains enforced.
+- Regression coverage distinguishes Genesis/T10, T11, and T12/T13 decoding behavior.

--- a/tips/tip-1116.md
+++ b/tips/tip-1116.md
@@ -23,26 +23,13 @@ dependencies reviewable. Allowing trailing ABI bytes restores compatibility for
 otherwise valid precompile calls that include a suffix, without removing the
 remaining decoding checks described in [TIP-1105](./tip-1105.md).
 
-## Assumptions
-
-All validators must apply the same decoding rules at the T12 activation boundary.
-This draft tracks proposed scope; activation timing and final inclusion remain
-subject to the [TIP process](./tip-0000.md).
-
-## Threat Model
-
-Callers can supply arbitrary calldata. Accepting a trailing suffix must not bypass
-validation of the decoded arguments, canonical dynamic-data layout, or the decoder
-memory limit. Validators rely on consistent hardfork gating to avoid divergent
-execution results.
-
 ---
 
-# Specification
+# Changes
 
 ## 1. Allow trailing ABI bytes in precompile calls
 
-**PR**: [#7598](https://github.com/tempoxyz/tempo/pull/7598)
+**PRs**: [#7598](https://github.com/tempoxyz/tempo/pull/7598) · **Author**: @klkvr
 
 From T12, Tempo precompile dispatchers enable Alloy's
 `validate_allow_trailing_bytes` option alongside the strict ABI validation enabled
@@ -52,27 +39,3 @@ of gaps and truncation. The existing 16 MiB decoder memory limit remains in plac
 
 Pre-T12 behavior is unchanged: T11 retains strict decoding without trailing-byte
 acceptance, and earlier hardforks retain their historical decoding behavior.
-
-The implementation currently depends on
-[alloy-rs/core#1186](https://github.com/alloy-rs/core/pull/1186); its temporary
-dependency pin must be replaced with an upstream release before merging the
-implementation PR.
-
-# Tooling
-
-No new RPC methods, ABI interfaces, or SDK commands are introduced by this entry.
-Existing tooling can continue producing canonical ABI calldata; callers that
-append a suffix become compatible with precompile dispatch from T12.
-
-# Observability
-
-No new events are required for this entry. Existing transaction receipts and
-execution traces can be used to inspect precompile call outcomes around activation.
-
-# Invariants
-
-- Historical execution before T12 remains unchanged.
-- T12 accepts otherwise valid ABI calldata with a trailing suffix.
-- Strict decoding continues to reject gaps and truncated arguments at T12.
-- The 16 MiB decoder memory limit remains enforced.
-- Regression coverage distinguishes Genesis/T10, T11, and T12/T13 decoding behavior.


### PR DESCRIPTION
Adds a draft T12 hardfork meta TIP with [#7598](https://github.com/tempoxyz/tempo/pull/7598) as its first entry, covering trailing ABI byte acceptance while preserving pre-T12 behavior. Uses the same Abstract, Motivation, and numbered Changes format as [TIP-1105](https://github.com/tempoxyz/tempo/blob/main/tips/tip-1105.md), including PR and author references.

Prompted by: @jenpaff
