### PR TITLE
feat(tempo-replay): mirror live traffic to shadow forks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4855,6 +4855,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14062,6 +14072,41 @@ dependencies = [
  "sha2 0.10.9",
  "tempo-contracts",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "tempo-replay"
+version = "1.14.0"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "clap",
+ "fs4",
+ "futures-util",
+ "hex",
+ "httpdate",
+ "k256",
+ "p256 0.13.2",
+ "reqwest 0.13.3",
+ "rocksdb",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "tempo-primitives",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "toml 1.1.5+spec-1.1.0",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ publish = false
 [workspace]
 members = [
   "bin/tempo",
+  "bin/tempo-replay",
   "bin/tempo-sidecar",
   "crates/alloy",
   "crates/chainspec",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ We provide three different installation paths: installing a pre-built binary, bu
 
 See the [Tempo documentation](https://docs.tempo.xyz/guide/node) for instructions on how to install and run Tempo.
 
+For live transaction traffic on an independent shadow fork, use [Tempo Replay](bin/tempo-replay/README.md).
+
 ### As a developer
 
 Tempo has several SDKs to help you get started building on Tempo:

--- a/bin/tempo-replay/.gitignore
+++ b/bin/tempo-replay/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/data/
+*.log
+.env

--- a/bin/tempo-replay/Cargo.toml
+++ b/bin/tempo-replay/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "tempo-replay"
+description = "Durable finalized transaction traffic mirroring for Tempo shadow forks"
+
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+keywords.workspace = true
+publish.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+tempo-primitives = { workspace = true, features = ["std", "serde"] }
+alloy-consensus = { workspace = true, features = ["std", "serde", "k256"] }
+alloy-eips = { workspace = true, features = ["std"] }
+alloy-primitives = { workspace = true, features = ["std", "serde", "rlp"] }
+alloy-rlp.workspace = true
+
+anyhow = "1"
+clap.workspace = true
+fs4 = "0.13"
+futures-util = "0.3"
+hex = "0.4"
+httpdate = "1"
+reqwest = { workspace = true, features = ["json"] }
+rocksdb = { version = "0.24", default-features = false, features = ["bindgen-runtime", "lz4"] }
+rustls.workspace = true
+serde = { workspace = true, features = ["std"] }
+serde_json = { workspace = true, features = ["std"] }
+sha2.workspace = true
+tokio.workspace = true
+tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
+tokio-util.workspace = true
+toml = "1"
+tracing.workspace = true
+tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
+url.workspace = true
+
+[dev-dependencies]
+axum.workspace = true
+base64.workspace = true
+k256 = { version = "0.13", features = ["ecdsa"] }
+p256 = { workspace = true, features = ["ecdsa"] }
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }

--- a/bin/tempo-replay/IMPLEMENTATION.md
+++ b/bin/tempo-replay/IMPLEMENTATION.md
@@ -1,0 +1,56 @@
+# Implementation notes
+
+Tempo Replay is a workspace package with a library and the `tempo-replay` CLI. Live operation starts with configured source/target identities and pool bounds using `run --from-block N`; exhaustive workload qualification is a separate `verify` command.
+
+| Code | Responsibility |
+| --- | --- |
+| `src/config.rs` | Strict schema, bounds and policy validation; deployment evidence schema. |
+| `src/model.rs` | Local native Tempo envelopes, signer recovery, canonical encoding, root/hash checks and occurrence states. |
+| `src/rpc.rs` | Bounded authenticated HTTP transport and native source WebSocket notifications. |
+| `src/capture.rs` | Finalized capture, certified-history repair, staged execution fallback and compatibility incidents. |
+| `src/journal.rs` | Single RocksDB writer, synchronous atomic batches, indexes, independent cursors and secondary readers. |
+| `src/profile.rs` | Captured workload, types, nonce distribution, deadlines and sender/block peaks. |
+| `src/verify.rs` | Live identity/adapter/pool checks and separate exhaustive workload/history qualification. |
+| `src/timing.rs` | Monotonic catch-up/live anchors, retained slip and separate release-rate constraint. |
+| `src/engine.rs` | Pipelined dispatch, sender/network credits, gap isolation, finality/receipt reconciliation and bounded recovery. |
+| `src/metrics.rs` | Prometheus counters/gauges and health endpoint. |
+| `src/main.rs` | CLI, task supervision, signals and shutdown. |
+
+## Concrete choices
+
+- `run --from-block N` mirrors N inclusively and follows finalized traffic continuously. N must equal the native snapshot height plus one. The live path accepts no prior workload profile, probes execution retrieval at the trusted current tip, and waits if N has not finalized yet. Actual backlog ancestry is verified by concurrent capture. `verify` still requires a profile, measured throughput/latency and the complete retention-horizon probe. Live startup logs missing throughput/latency qualification without claiming an SLO.
+- A supplied replay height is validated independently of an earlier capture journal's start. Repeating it on restart does not reset capture, attempt or inclusion cursors.
+- RocksDB namespaces use ordered key prefixes within one column family. This retains atomic batches across metadata/occurrences/cursors with a smaller operational footprint. Source height/index entries also store the source block hash; hash indexes preserve repeated system occurrences. A canonical cursor gates staged history.
+- Attempt intents for each dispatch batch share an fsync. Remaining updates commit immediately, with no deliberate group delay; this is within `group_commit_max_ms`. Retention is fail-closed disk backpressure, with no automatic pruning.
+- Source WS events coalesce into a bounded latest-event slot. Every polling pass repairs from the durable cursor, and HTTP polling continues without WS traffic. The full event block supplies the trusted upper anchor. Target finality uses 250 ms polling and verified gap repair; configured target WS URLs are validated deployment metadata and are not used as a second target transport in this version.
+- The crate inherits workspace dependencies and uses local Tempo primitives with minimal features. HTTP JSON is decoded directly into native Tempo headers/envelopes; no generic Ethereum-only transaction reconstruction or full node dependency is used.
+- The owned consensus RPC is the finality trust boundary. Certificate/digest evidence is retained; independent BLS certificate validation with changing DKG contexts is not claimed.
+- `bootstrap_artifact_digest` binds the exact native generated manifest bytes. The deployment manifest separately records node binary/chainspec digests. Its validator public-key set must equal the native manifest's set. Standard RPC verifies chain ID, patched checkpoint and finalized ancestry; effective node configuration remains operator evidence.
+- Accepted/unknown pool entries retain credits until positive finalized inclusion or a rejection that has no preceding uncertain/accepted attempt. Null lookups never imply removal. An unresolved reservation pauses recovery rather than leaking credits. Automatic eviction detection and provisional-head credit release are not used, so finalized-history conflicts pause instead of rolling back provisional inclusions.
+- An ambiguous attempt stays on its previous verified ingress. New work can route to another available verified ingress after reconciliation. This conservative failover avoids an unobserved cross-validator resend.
+- Permanent sequential gaps block later occurrences, including those not submitted. Already accepted/in-flight successors retain credits and are reconciled. Authority nonce changes are preserved in original EIP-7702/Tempo envelopes; nonce jumps do not generate fillers. A conflicting finalized transaction or authoritative consumed nonce without the required hash pauses replay.
+- Coverage counts all user occurrences after the fork boundary. `offered` means a durable initial attempt intent, which remains uncertain across a crash-before-write window. Receipt-proven finalized coverage is separate. Source receipts compare status and gas; raw logs are retained without semantic log normalization.
+
+## Deployment qualification checklist
+
+Run these against isolated real Tempo nodes at the pinned revision before claiming production traffic fidelity:
+
+1. Native bootstrap, patched boundary, TLS/credentials and correct validator/chainspec deployment.
+2. Full source and target retained-history recovery across the intended outage horizon; socket disconnect and node restart.
+3. Future-nonce admission for legacy/key-zero/2D families, expiry and keychain rules, policy/fee-token/AMM parity, access-key and authorization dependencies.
+4. Peak-block/hot-sender throughput, journal fsync cost, actual pool-accounted memory, catch-up surplus and live lag over sustained traffic. A mean source profile and operator capacity attestations are necessary, not proof of peak-rate fidelity.
+5. Conservative reservation progress under eviction, restart and long inclusion delay. If this policy cannot sustain the deployment, add and qualify a positive pool-removal adapter before increasing claims of coverage or throughput.
+6. Full user-denominator offered/finalized coverage and status/gas drift, including expected expiry and descendants affected by missing state transitions.
+
+The deterministic and mock-RPC suite validates the daemon's bookkeeping, cryptographic encodings and transport/recovery decisions. It does not emulate Tempo consensus, EVM execution or mempool admission, and does not establish mainnet-rate throughput.
+
+## Local validation
+
+The suite covers the following checks from the Tempo workspace root:
+
+- `cargo test --locked -p tempo-replay -j 4`: 28 tests, including continuous following, waiting for the first block, and restart recovery in `tests/live.rs`.
+- `cargo clippy --locked -p tempo-replay --all-targets -- -D warnings`.
+- `cargo +nightly fmt --all --check`.
+- CLI help/version, example parsing, documentation links and Markdown fences.
+
+The signature corpus includes legacy, EIP-2930/1559/7702, AA 2D and expiring nonces, sponsored batches, P256, WebAuthn, keychain V2, expiring key authorization and Tempo authorization lists. Loopback RPC tests cover capture fallback, conflicting ancestry, missing end certificates, response-loss reconciliation, restart, crash-before-write, expiry/dependency gaps, capacity deferral and cancellation. All test servers terminate with their tests.

--- a/bin/tempo-replay/README.md
+++ b/bin/tempo-replay/README.md
@@ -1,0 +1,123 @@
+# Tempo Replay
+
+A Rust daemon that captures finalized Tempo transactions and submits their original signed bytes to an isolated shadow fork with independent validators. It preserves source block bursts, uses bounded catch-up, and switches to 1× pacing when the dispatch frontier reaches the configured lag.
+
+Independent ordering, stock validator clocks and state divergence can cause rejection. Tempo Replay records those gaps against **every captured user occurrence**. It does not promise identical execution, replay system transactions, rewrite nonces, re-sign transactions, or change node validation.
+
+## Live mirroring from a height
+
+Configure the source RPC, shadow validators and snapshot identity once in [tempo-replay.example.toml](tempo-replay.example.toml), then start:
+
+```sh
+tempo-replay run --config tempo-replay.toml --from-block 123456
+```
+
+`123456` is the **first block to mirror, inclusive**. The configured shadow snapshot must contain source state through block `123455`. The command captures and mirrors the backlog, catches up, and keeps following newly finalized blocks at 1× pacing until you stop it. There is no end height by default. It also works when the first requested block does not exist yet: it waits for that block to finalize.
+
+No separate capture or workload-profile command is required. Live startup verifies the configured chain/checkpoint/validator identities, pool budgets and execution RPC adapter. It validates actual history as it captures it, without scanning the entire configured retention horizon before starting. Workload and throughput qualification remain available separately through `verify`.
+
+Restart with the same command, or omit `--from-block`:
+
+```sh
+tempo-replay run --config tempo-replay.toml
+```
+
+The durable journal resumes unfinished work and follows new traffic. Repeating the original start height does not reset progress. Starting at a different fork boundary requires the matching snapshot and a new journal. Live traffic here means transactions from newly **finalized blocks**, with the configured lag; it does not capture pending mainnet mempool arrivals.
+
+## Build and test
+
+Run these commands from the Tempo workspace root. The executable is `target/release/tempo-replay`.
+
+Requires Rust 1.96+, a C/C++ compiler, CMake and libclang for RocksDB and cryptographic dependencies. On macOS, install the Xcode command-line tools; on Debian/Ubuntu, the usual build prerequisites are `build-essential clang libclang-dev cmake pkg-config`.
+
+```sh
+cargo build --locked --release -p tempo-replay
+cargo test --locked -p tempo-replay
+cargo clippy --locked -p tempo-replay --all-targets -- -D warnings
+cargo +nightly fmt --all --check
+```
+
+Tests start local loopback RPC servers. They never contact a live chain or submit to mainnet. The crate uses local `tempo-primitives` and the shared workspace lockfile. The protocol compatibility checks currently target Tempo revision `731535b9808eda12e81ab6459703602554eaee5a`. Run the same Tempo revision on the source and shadow nodes.
+
+## Optional capture before bootstrap
+
+For a pre-bootstrap recording or workload profile, copy [examples/capture.toml](examples/capture.toml), configure an owned reader, and choose a start height below the intended fork boundary. Keep this reader running while taking a separate donor's snapshot.
+
+```sh
+tempo-replay capture --config capture.toml --from-block "$START_HEIGHT"
+tempo-replay profile --journal ./data --output workload-profile.json
+tempo-replay status --journal ./data
+```
+
+`--from-block` fixes the initial capture boundary. Omit it when resuming. Optional `--to-block` ends capture after that finalized height. Empty blocks are retained. Capture requires only run/source/journal settings and does not open a shadow connection.
+
+Capture subscribes to native consensus events and polls finality for gap repair. Missing certificates trigger full execution-block recovery. Complete ranges are staged, checked for parent continuity, transaction roots and hashes, and connected to a trusted finalized hash before publication. `debug_getRawBlock` is cross-checked when available. Unknown encodings or conflicting history stop canonical advancement.
+
+## Prepare and verify a shadow fork
+
+Use Tempo's native `generate-shadowfork` and `bootstrap-shadowfork` on an immutable copy of the stopped donor's actual tip. Preserve chain ID 4217, configure independent validators and private P2P, and record the **patched shadow boundary hash**, which differs from the source hash. Tempo Replay does not bootstrap or modify nodes.
+
+Fill in [tempo-replay.example.toml](tempo-replay.example.toml) and [examples/shadow-deployment.json](examples/shadow-deployment.json). Keep the same run ID, source endpoint and journal used for capture. The deployment manifest lists **every participating validator**, its measured pool limits, future-nonce support and validation/fee configuration evidence. The provided manifest deliberately fails qualification until its placeholders, measurements and attestations are filled in.
+
+`checkpoint.bootstrap_artifact_digest` is `sha256:` followed by the SHA-256 of the **exact native generated manifest file bytes**. Use the same value in the deployment manifest. For example:
+
+```sh
+shasum -a 256 /etc/tempo-replay/shadowfork-manifest.json
+```
+
+Record the actual node binary and chainspec SHA-256 digests separately. Expected validator public keys must match the native generated manifest. HTTPS certificate validation, the configured private CA, bearer credentials from the named environment variables, and the patched checkpoint identify each ingress. URLs cannot embed credentials; redirects are disabled.
+
+`run` does its own live startup checks. For exhaustive workload and retained-history qualification, first generate a profile, set the optional `run.workload_profile` path, and run:
+
+```sh
+tempo-replay verify --config tempo-replay.toml
+```
+
+`verify` sends only read RPCs. It checks the checkpoint/state root, profile history, validator-set evidence, target identities and capacity bounds, and **forces execution-layer recovery** across the configured history horizon and cache boundary. This comprehensive history scan may take substantial time; it is separate from live startup. Capture continues while `run` performs its startup checks. Standard RPC does not expose all effective node configuration, so binary/configuration/fee/capacity values remain explicit operator attestations; the program does not pretend to independently discover them.
+
+A source workload profile is generated from actual captured blocks. For qualification, measure target sustained throughput, RPC p99 and source capture p99 on the intended deployment. Live startup reports unqualified throughput/latency as warnings and exposes runtime progress through status and metrics. Effective pool limits, memory accounting, validator identity and validation parity remain required deployment configuration. The example numbers are not measured capacity guarantees. If you explicitly configure a profile path, a missing or invalid file is an error.
+
+## Replay and recovery
+
+One ingress per sender is selected by rendezvous hashing. Budgets apply across all validators because gossip replicates transactions. Sequential nonce lanes pipeline only up to the configured window and verified per-family support. Unqualified families use one outstanding transaction per lane. AA key-zero and legacy transactions share a lane; 2D lanes and expiring nonces share sender credits.
+
+Attempt intents are written in a synchronous RocksDB batch **before** requests start. Accepted and ambiguous hashes retain reservations. A lost response triggers exact-hash reconciliation and at most one identical-byte resend while still admissible. A crash between the durable intent and socket write leaves an uncertain attempt, so `attempts` and `offered` count durable attempt intents, not independently proven packet delivery. Inclusion coverage requires verified finalized-block and receipt evidence.
+
+Expiry gets an initial attempt even when rejection is expected. Confirmed expiry or exhausted state-dependency budgets become explicit gaps; descendants in that sequential lane become `BlockedDependency`. Other lanes continue. Status-0 receipts count as included and are compared with source status/gas just like successful receipts.
+
+This version uses **conservative retained pool reservations**. A null transaction lookup is not treated as proof of eviction. Unresolved accepted/ambiguous transactions eventually pause dispatch until authoritative finality resolves them. There is no automatic eviction-based credit reuse or blind rerouting of an ambiguous attempt. Capacity qualification must demonstrate progress with this policy. Source capture continues during recoverable target stalls.
+
+`run --to-block N` exits when all occurrences through N have finalized or explicit terminal dispositions. It may finish with degraded coverage; inspect `gaps` and `included_through`. A compatibility/history/identity incident exits with an error. Investigate its durable evidence, then either restore a clean checkpoint into a new run/journal or explicitly use `--acknowledge-incident` after fixing the cause. That flag does not bypass verification. A checkpoint change requires a new journal.
+
+SIGINT/SIGTERM stop new dispatch, drain bounded submissions, stop subscriptions and metrics, and flush the journal. One writer owns a journal; distributed fencing across multiple machines is an operator deployment responsibility.
+
+## Inspect and monitor
+
+```sh
+tempo-replay status --journal ./data
+tempo-replay inspect --journal ./data --tx 0xTRANSACTION_HASH
+curl http://127.0.0.1:9090/metrics
+curl http://127.0.0.1:9090/healthz
+```
+
+Status and inspect use a RocksDB secondary reader and work while the daemon runs. The journal contains raw source evidence, exact envelopes, attempt history, endpoint IDs, gaps and source/target receipts. Protect the directory as operational data.
+
+The five cursors have different meanings:
+
+| Cursor | Meaning |
+| --- | --- |
+| `captured_through` | Contiguous validated source history is durable. |
+| `dispatch_accounted_through` | Every occurrence has an attempt intent or explicit disposition. |
+| `accounted_through` | Every occurrence is finalized or terminally accounted for. |
+| `included_through` | Every user occurrence is finalized; a gap stops this cursor. |
+| `shadow_observed_through` | Contiguous verified target finality has been observed. |
+
+Prometheus exposes coverage, attempts, gaps, reservations, phase, lag, slip and cursors without transaction/sender labels. `/healthz` reports recovery incidents and source unavailability. Inspect full-workload coverage separately from health. `reserved_raw_bytes` is encoded payload size; the scheduler uses the larger deployment-qualified memory estimate for its budget.
+
+Decoded dispatch lookahead, RPC concurrency and database buffers are bounded. `max_buffered_bytes` bounds serialized work/individual responses, not total process RSS. Disk limits stop progress without deleting unresolved history. **No automatic journal pruning is implemented**; provision retention space and rotate runs explicitly. Evidence and JSON/hex storage can be several times larger than raw transaction bytes.
+
+## Implementation and qualification
+
+See [IMPLEMENTATION.md](IMPLEMENTATION.md) for the code map, implementation choices and remaining deployment tests.
+
+Local tests cover signed envelope families, P256/WebAuthn and sponsored AA batches, root/ancestry rejection, durable attempts, lost responses, restart, lane gaps, pacing and capacity invariants. Real Tempo admission/eviction, TLS deployment configuration, bootstrap behavior and sustained mainnet-rate throughput still require a private-node qualification run. No live chain was used during implementation.

--- a/bin/tempo-replay/examples/capture.toml
+++ b/bin/tempo-replay/examples/capture.toml
@@ -1,0 +1,26 @@
+[run]
+schema_version = 2
+id = "tempo-shadow-example"
+mode = "finalized_bursts"
+chain_id = 4217
+tempo_revision = "731535b9808eda12e81ab6459703602554eaee5a"
+reth_revision = "8e55cc5"
+
+[source]
+consensus_ws = "wss://source-reader.example.invalid"
+rpc_http = "https://source-reader.example.invalid"
+finality = "finalized"
+fallback = "verified_execution_layer"
+raw_blocks = "prefer_if_verified"
+recovery_horizon_blocks = 200000
+history_probe_blocks = 16385
+
+[journal]
+path = "./data"
+sync_writes = true
+group_commit_max_ms = 5
+max_bytes = 100000000000
+min_free_bytes = 1000000000
+
+[metrics]
+listen = "127.0.0.1:9090"

--- a/bin/tempo-replay/examples/shadow-deployment.json
+++ b/bin/tempo-replay/examples/shadow-deployment.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "run_id": "tempo-shadow-example",
+  "chain_id": 4217,
+  "tempo_revision": "731535b9808eda12e81ab6459703602554eaee5a",
+  "reth_revision": "8e55cc5",
+  "bootstrap_artifact_digest": "sha256:REPLACE_WITH_NATIVE_MANIFEST_FILE_SHA256",
+  "binary_sha256": "sha256:REPLACE_WITH_DEPLOYED_NODE_BINARY_SHA256",
+  "chainspec_sha256": "sha256:REPLACE_WITH_DEPLOYED_CHAINSPEC_SHA256",
+  "isolated_network": false,
+  "exclusive_workload": false,
+  "fork_rules_match_source": false,
+  "fee_token_and_amm_parity": false,
+  "validity_buffer_seconds": 3,
+  "source_capture_p99_ms": 0,
+  "measured_rpc_p99_ms": 0,
+  "measured_sustained_tps": 0.0,
+  "validators": [
+    {
+      "id": "shadow-a",
+      "public_key": "REPLACE_WITH_VALIDATOR_A_PUBLIC_KEY",
+      "rpc_http": "https://shadow-a.example.invalid",
+      "max_sender_slots": 16,
+      "pending_count": 10000,
+      "queued_count": 10000,
+      "pending_bytes": 20971520,
+      "queued_bytes": 20971520,
+      "pool_fixed_overhead_bytes": 0,
+      "pool_raw_size_multiplier": 0,
+      "future_nonce_types": [],
+      "pool_observation": "conservative_retained_reservations"
+    },
+    {
+      "id": "shadow-b",
+      "public_key": "REPLACE_WITH_VALIDATOR_B_PUBLIC_KEY",
+      "rpc_http": "https://shadow-b.example.invalid",
+      "max_sender_slots": 16,
+      "pending_count": 10000,
+      "queued_count": 10000,
+      "pending_bytes": 20971520,
+      "queued_bytes": 20971520,
+      "pool_fixed_overhead_bytes": 0,
+      "pool_raw_size_multiplier": 0,
+      "future_nonce_types": [],
+      "pool_observation": "conservative_retained_reservations"
+    }
+  ]
+}

--- a/bin/tempo-replay/src/capture.rs
+++ b/bin/tempo-replay/src/capture.rs
@@ -1,0 +1,193 @@
+use crate::{
+    config::Config,
+    journal::{SharedJournal, lock},
+    model::*,
+    rpc::{EvidenceError, Rpc, RpcError, source_subscription},
+};
+use alloy_primitives::B256;
+use anyhow::{Context, Result, ensure};
+use serde_json::{Value, json};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+pub async fn capture_once(
+    c: &Config,
+    rpc: &Rpc,
+    journal: &SharedJournal,
+    event: Option<Value>,
+    to: Option<u64>,
+    stop: &CancellationToken,
+) -> Result<u64> {
+    let value = match event {
+        Some(v) => v,
+        None => rpc
+            .call("consensus_getLatest", json!([]))
+            .await?
+            .get("finalized")
+            .filter(|v| !v.is_null())
+            .context("no finalized source block")?
+            .clone(),
+    };
+    let anchor = match CapturedBlock::from_certified(value.clone(), c.run.chain_id) {
+        Ok(b) => b,
+        Err(e) => {
+            lock(journal)?.put(format!("evidence/incompatible/{}", now_ms()), &value)?;
+            return Err(e);
+        }
+    };
+    let (first, previous) = {
+        let j = lock(journal)?;
+        (
+            j.state.first_height,
+            j.state.cursors.captured_through.clone(),
+        )
+    };
+    if let Some(prev) = &previous {
+        if anchor.point.height == prev.height {
+            ensure!(&anchor.point == prev, "finalized source hash changed");
+            return Ok(prev.height);
+        }
+        if anchor.point.height < prev.height {
+            if let Some(known) = lock(journal)?.block(anchor.point.height)? {
+                ensure!(
+                    known.point == anchor.point,
+                    "delayed finalized event conflicts with canonical history"
+                );
+            }
+            return Ok(prev.height);
+        } // delayed socket event
+    }
+    let start = previous
+        .as_ref()
+        .map_or(first, |p| p.height.saturating_add(1));
+    let end = to.map_or(anchor.point.height, |n| n.min(anchor.point.height));
+    if end < start {
+        return Ok(previous.map_or(start.saturating_sub(1), |p| p.height));
+    }
+    let anchor = if end == anchor.point.height {
+        anchor
+    } else {
+        match rpc.certified(end, c.run.chain_id).await {
+            Ok(block) => block,
+            Err(e) if e.downcast_ref::<RpcError>().is_some() => anchor,
+            Err(e) => return Err(e),
+        }
+    };
+    ensure!(
+        anchor.point.height.saturating_sub(start) < c.source.recovery_horizon_blocks,
+        "backlog exceeds configured recovery horizon; extend the horizon without changing the cursor"
+    );
+    let mut parent = if let Some(p) = previous {
+        p.hash
+    } else if start == 0 {
+        B256::ZERO
+    } else {
+        rpc.header_point(start - 1).await?.hash
+    };
+    let mut last_time = if start > 0 {
+        lock(journal)?.block(start - 1)?.map(|b| b.timestamp_ms)
+    } else {
+        None
+    };
+    for height in start..=anchor.point.height {
+        ensure!(!stop.is_cancelled(), "capture cancelled");
+        let block = if height == anchor.point.height {
+            anchor.clone()
+        } else {
+            match rpc
+                .call("consensus_getFinalization", json!([{"height":height}]))
+                .await
+            {
+                Ok(value) => match CapturedBlock::from_certified(value.clone(), c.run.chain_id) {
+                    Ok(b) => b,
+                    Err(e) => {
+                        lock(journal)?
+                            .put(format!("evidence/incompatible/{height:020}"), &value)?;
+                        return Err(e);
+                    }
+                },
+                Err(e) if e.downcast_ref::<RpcError>().is_some() => {
+                    match rpc.execution(height, c.run.chain_id, true).await {
+                        Ok(block) => block,
+                        Err(e) => {
+                            if let Some(evidence) = e.downcast_ref::<EvidenceError>() {
+                                lock(journal)?.put(
+                                    format!("evidence/incompatible/{height:020}"),
+                                    &evidence.value,
+                                )?;
+                            }
+                            return Err(e);
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        };
+        ensure!(
+            block.point.height == height && block.parent == parent,
+            "source ancestry mismatch at {height}"
+        );
+        ensure!(
+            last_time.is_none_or(|t| block.timestamp_ms >= t),
+            "source timestamp regressed"
+        );
+        ensure!(
+            serde_json::to_vec(&block)?.len() as u64 <= c.limits.max_buffered_bytes,
+            "decoded block exceeds byte bound"
+        );
+        parent = block.point.hash;
+        last_time = Some(block.timestamp_ms);
+        lock(journal)?.stage(&block)?;
+    }
+    ensure!(
+        parent == anchor.point.hash,
+        "recovered range does not reach finality anchor"
+    );
+    let end_point = lock(journal)?
+        .block(end)?
+        .context("verified end block missing")?
+        .point;
+    lock(journal)?.put("meta/finality_anchor", &anchor.point)?;
+    lock(journal)?.publish(&end_point, start)?;
+    Ok(end)
+}
+pub async fn capture_loop(
+    c: Config,
+    rpc: Rpc,
+    journal: SharedJournal,
+    to: Option<u64>,
+    stop: CancellationToken,
+) -> Result<()> {
+    let (mut events, subscription) = source_subscription(
+        c.source.consensus_ws.clone(),
+        c.limits.max_buffered_bytes as usize,
+        stop.child_token(),
+    );
+    let result: Result<()> = async {
+    loop {
+        if stop.is_cancelled() { break; }
+        let event = if events.has_changed().unwrap_or(false) { events.borrow_and_update().clone() } else { None };
+        let r = capture_once(&c, &rpc, &journal, event, to, &stop).await;
+        if r.is_ok() {
+            let mut j = lock(&journal)?;
+            if j.state.capture_error.take().is_some() { j.save_state()?; }
+        }
+        match r {
+            Ok(h) if to.is_some_and(|n| h >= n) => break,
+            Ok(_) => {},
+            Err(_) if stop.is_cancelled() => break,
+            Err(e) if e.downcast_ref::<RpcError>().is_some() => {
+                let mut j = lock(&journal)?; j.state.capture_error = Some(e.to_string()); j.save_state()?;
+                tracing::warn!("source RPC unavailable; retaining capture cursor");
+            }
+            Err(e) => { lock(&journal)?.incident(&format!("capture: {e:#}"))?; return Err(e); }
+        }
+        tokio::select! { _ = stop.cancelled() => break, _ = tokio::time::sleep(Duration::from_millis(250)) => {}, r = events.changed() => { if r.is_err() { break; } } }
+    }
+    Ok(())
+    }.await;
+    // Abort is only used for the read-only socket task. No submission future is detached.
+    subscription.abort();
+    let _ = subscription.await;
+    result
+}

--- a/bin/tempo-replay/src/config.rs
+++ b/bin/tempo-replay/src/config.rs
@@ -1,0 +1,366 @@
+use anyhow::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
+use url::Url;
+
+pub const TEMPO_REVISION: &str = "731535b9808eda12e81ab6459703602554eaee5a";
+pub const RETH_REVISION: &str = "8e55cc5";
+
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Config {
+    pub run: Run,
+    pub source: Source,
+    pub journal: JournalConfig,
+    pub checkpoint: Option<Checkpoint>,
+    pub shadow: Option<Shadow>,
+    #[serde(default)]
+    pub timing: Timing,
+    #[serde(default)]
+    pub delivery: Delivery,
+    #[serde(default)]
+    pub limits: Limits,
+    #[serde(default)]
+    pub metrics: Metrics,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Run {
+    pub schema_version: u32,
+    pub id: String,
+    pub mode: String,
+    pub chain_id: u64,
+    pub tempo_revision: String,
+    pub reth_revision: String,
+    pub workload_profile: Option<PathBuf>,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Source {
+    pub consensus_ws: String,
+    pub rpc_http: String,
+    pub finality: String,
+    pub fallback: String,
+    pub raw_blocks: String,
+    pub recovery_horizon_blocks: u64,
+    pub history_probe_blocks: u64,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Checkpoint {
+    pub manifest: PathBuf,
+    pub source_height: u64,
+    pub source_hash: String,
+    pub shadow_hash: String,
+    pub bootstrap_artifact_digest: String,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Shadow {
+    pub deployment_manifest: PathBuf,
+    pub ingress_policy: String,
+    pub ca_file: PathBuf,
+    pub identity_check_interval_ms: u64,
+    pub validators: Vec<Validator>,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Validator {
+    pub id: String,
+    pub rpc_http: String,
+    pub consensus_ws: String,
+    pub credential_env: String,
+    pub expected_validator_public_key: String,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Timing {
+    pub live_speed: f64,
+    pub max_catch_up_speed: f64,
+    pub target_lag_ms: u64,
+    pub guard_ms: u64,
+    pub slip_warn_ms: u64,
+    pub slip_window_blocks: u64,
+    pub on_sustained_slip: String,
+    pub target_progress_timeout_ms: u64,
+    pub expected_inclusion_latency_ms: u64,
+    pub expiry_safety_margin_ms: u64,
+}
+impl Default for Timing {
+    fn default() -> Self {
+        Self {
+            live_speed: 1.,
+            max_catch_up_speed: 4.,
+            target_lag_ms: 2000,
+            guard_ms: 100,
+            slip_warn_ms: 1000,
+            slip_window_blocks: 20,
+            on_sustained_slip: "enter_catch_up".into(),
+            target_progress_timeout_ms: 30000,
+            expected_inclusion_latency_ms: 1000,
+            expiry_safety_margin_ms: 1000,
+        }
+    }
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Delivery {
+    pub on_permanent_gap: String,
+    pub first_attempt: String,
+    pub nonce_dependency_gap: String,
+    pub unknown_transaction: String,
+    pub subblock_transaction: String,
+    pub system_transaction: String,
+    pub ambiguous_resend_limit: u32,
+    pub dependency_wait_timeout_ms: u64,
+}
+impl Default for Delivery {
+    fn default() -> Self {
+        Self {
+            on_permanent_gap: "record_gap_and_continue".into(),
+            first_attempt: "all_routable_unblocked".into(),
+            nonce_dependency_gap: "block_lane".into(),
+            unknown_transaction: "pause_dispatch".into(),
+            subblock_transaction: "pause_dispatch".into(),
+            system_transaction: "record_generated_by_shadow".into(),
+            ambiguous_resend_limit: 1,
+            dependency_wait_timeout_ms: 30000,
+        }
+    }
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Limits {
+    pub max_inflight_rpc: usize,
+    pub max_inflight_per_lane: usize,
+    pub pool_budget_fraction: f64,
+    pub max_buffered_bytes: u64,
+    pub max_blocks_ahead: u64,
+    pub rpc_timeout_ms: u64,
+    pub max_retry_attempts: u32,
+}
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_inflight_rpc: 128,
+            max_inflight_per_lane: 8,
+            pool_budget_fraction: 0.8,
+            max_buffered_bytes: 268435456,
+            max_blocks_ahead: 64,
+            rpc_timeout_ms: 2000,
+            max_retry_attempts: 5,
+        }
+    }
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct JournalConfig {
+    pub path: PathBuf,
+    pub sync_writes: bool,
+    pub group_commit_max_ms: u64,
+    pub max_bytes: u64,
+    pub min_free_bytes: u64,
+}
+#[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Metrics {
+    pub listen: String,
+    pub coverage_denominator: String,
+    pub gap_warn_fraction: f64,
+    pub gap_window_blocks: usize,
+}
+impl Default for Metrics {
+    fn default() -> Self {
+        Self {
+            listen: "127.0.0.1:9090".into(),
+            coverage_denominator: "all_user_occurrences".into(),
+            gap_warn_fraction: 0.01,
+            gap_window_blocks: 100,
+        }
+    }
+}
+impl Config {
+    pub fn load(path: &Path) -> Result<Self> {
+        let config: Self =
+            toml::from_str(&std::fs::read_to_string(path)?).context("parse configuration")?;
+        config.validate()?;
+        Ok(config)
+    }
+    pub fn validate(&self) -> Result<()> {
+        ensure!(
+            self.run.schema_version == 2 && self.run.mode == "finalized_bursts",
+            "unsupported schema or run mode"
+        );
+        ensure!(
+            !self.run.id.is_empty() && self.run.chain_id > 0,
+            "run id and chain id are required"
+        );
+        ensure!(
+            self.run.tempo_revision == TEMPO_REVISION && self.run.reth_revision == RETH_REVISION,
+            "configuration differs from compiled Tempo/Reth revisions"
+        );
+        ensure!(
+            self.source.finality == "finalized"
+                && self.source.fallback == "verified_execution_layer"
+                && self.source.raw_blocks == "prefer_if_verified",
+            "unsupported source policy"
+        );
+        endpoint(&self.source.rpc_http, false)?;
+        endpoint(&self.source.consensus_ws, true)?;
+        ensure!(
+            self.source.recovery_horizon_blocks > 0 && self.source.history_probe_blocks > 16384,
+            "history probe must cross the 16384-block recent cache"
+        );
+        let t = &self.timing;
+        let l = &self.limits;
+        ensure!(
+            t.live_speed == 1. && t.max_catch_up_speed.is_finite() && t.max_catch_up_speed > 1.,
+            "live speed must be 1; catch-up speed must be finite and > 1"
+        );
+        ensure!(
+            t.guard_ms > 0
+                && t.slip_window_blocks > 0
+                && t.target_progress_timeout_ms > 0
+                && t.on_sustained_slip == "enter_catch_up",
+            "invalid timing policy"
+        );
+        ensure!(
+            l.pool_budget_fraction.is_finite()
+                && l.pool_budget_fraction > 0.
+                && l.pool_budget_fraction < 1.,
+            "pool fraction must be in (0,1)"
+        );
+        ensure!(
+            l.max_inflight_rpc > 0
+                && l.max_inflight_per_lane > 0
+                && l.max_buffered_bytes > 0
+                && l.max_blocks_ahead > 0
+                && l.rpc_timeout_ms > 0
+                && l.max_retry_attempts > 0,
+            "limits must be positive"
+        );
+        ensure!(
+            self.journal.sync_writes
+                && self.journal.max_bytes > 0
+                && self.journal.group_commit_max_ms > 0,
+            "durable sync writes and positive disk/group bounds required"
+        );
+        let d = &self.delivery;
+        ensure!(
+            d.on_permanent_gap == "record_gap_and_continue"
+                && d.first_attempt == "all_routable_unblocked"
+                && d.nonce_dependency_gap == "block_lane"
+                && d.unknown_transaction == "pause_dispatch"
+                && d.subblock_transaction == "pause_dispatch"
+                && d.system_transaction == "record_generated_by_shadow"
+                && d.ambiguous_resend_limit <= 1
+                && d.dependency_wait_timeout_ms > 0,
+            "unsupported delivery policy"
+        );
+        ensure!(
+            self.metrics.coverage_denominator == "all_user_occurrences"
+                && self.metrics.gap_warn_fraction.is_finite()
+                && (0. ..=1.).contains(&self.metrics.gap_warn_fraction)
+                && self.metrics.gap_window_blocks > 0,
+            "invalid metrics policy"
+        );
+        self.metrics
+            .listen
+            .parse::<std::net::SocketAddr>()
+            .context("metrics listen address")?;
+        if let Some(s) = &self.shadow {
+            ensure!(
+                s.ingress_policy == "sticky_sender"
+                    && !s.validators.is_empty()
+                    && s.identity_check_interval_ms > 0,
+                "invalid shadow configuration"
+            );
+            let mut ids = BTreeSet::new();
+            let mut urls = BTreeSet::new();
+            for v in &s.validators {
+                ensure!(
+                    ids.insert(&v.id) && urls.insert(&v.rpc_http) && !v.id.is_empty(),
+                    "duplicate/empty validator identity or endpoint"
+                );
+                endpoint(&v.rpc_http, false)?;
+                endpoint(&v.consensus_ws, true)?;
+                ensure!(
+                    v.rpc_http != self.source.rpc_http,
+                    "source cannot be a shadow ingress"
+                );
+                ensure!(
+                    !v.credential_env.is_empty(),
+                    "validator credential environment name required"
+                );
+            }
+        }
+        Ok(())
+    }
+    pub fn replay(&self) -> Result<(&Checkpoint, &Shadow)> {
+        Ok((
+            self.checkpoint
+                .as_ref()
+                .context("replay requires checkpoint")?,
+            self.shadow
+                .as_ref()
+                .context("replay requires shadow configuration")?,
+        ))
+    }
+}
+fn endpoint(value: &str, websocket: bool) -> Result<()> {
+    let u = Url::parse(value).context("invalid endpoint URL")?;
+    ensure!(
+        u.scheme() == if websocket { "wss" } else { "https" },
+        "endpoints must use authenticated TLS (https/wss)"
+    );
+    ensure!(
+        u.host_str().is_some()
+            && u.username().is_empty()
+            && u.password().is_none()
+            && u.query().is_none()
+            && u.fragment().is_none(),
+        "endpoints cannot embed credentials, queries, or fragments"
+    );
+    Ok(())
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Deployment {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub chain_id: u64,
+    pub tempo_revision: String,
+    pub reth_revision: String,
+    pub bootstrap_artifact_digest: String,
+    pub binary_sha256: String,
+    pub chainspec_sha256: String,
+    pub isolated_network: bool,
+    pub exclusive_workload: bool,
+    pub fork_rules_match_source: bool,
+    pub fee_token_and_amm_parity: bool,
+    pub validity_buffer_seconds: u64,
+    pub source_capture_p99_ms: u64,
+    pub measured_rpc_p99_ms: u64,
+    pub measured_sustained_tps: f64,
+    pub validators: Vec<ValidatorEvidence>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValidatorEvidence {
+    pub id: String,
+    pub public_key: String,
+    pub rpc_http: String,
+    pub max_sender_slots: usize,
+    pub pending_count: usize,
+    pub queued_count: usize,
+    pub pending_bytes: u64,
+    pub queued_bytes: u64,
+    pub pool_fixed_overhead_bytes: u64,
+    pub pool_raw_size_multiplier: u64,
+    pub future_nonce_types: Vec<u8>,
+    pub pool_observation: String,
+}

--- a/bin/tempo-replay/src/engine.rs
+++ b/bin/tempo-replay/src/engine.rs
@@ -1,0 +1,870 @@
+use crate::{
+    config::Config,
+    journal::{SharedJournal, lock},
+    model::*,
+    rpc::{Rpc, RpcError, quantity},
+    timing::Pacer,
+    verify::{Qualified, check_target, route},
+};
+use alloy_primitives::{Address, B256};
+use anyhow::{Context, Result, bail, ensure};
+use futures_util::{FutureExt, StreamExt, future::BoxFuture, stream::FuturesUnordered};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    time::Duration,
+};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+type Pending = FuturesUnordered<BoxFuture<'static, (String, Result<Value>)>>;
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    Accepted,
+    Ambiguous,
+    Capacity,
+    Transport,
+    Expired,
+    NonceLow,
+    Dependency,
+    Incident,
+}
+pub fn classify(e: &RpcError) -> Outcome {
+    let m = e.message.to_ascii_lowercase();
+    if e.ambiguous {
+        return Outcome::Ambiguous;
+    }
+    if e.code == 429 || e.code == 503 || e.code == 502 || e.code == -1 {
+        return Outcome::Transport;
+    }
+    if e.code == 401 || e.code == 403 || e.code == -32601 {
+        return Outcome::Incident;
+    }
+    if m.contains("already known") || m.contains("already imported") {
+        return Outcome::Accepted;
+    }
+    if m.contains("chain id")
+        || m.contains("chainid")
+        || m.contains("signature")
+        || m.contains("unsupported")
+        || m.contains("unknown transaction type")
+    {
+        return Outcome::Incident;
+    }
+    if m.contains("capacity")
+        || m.contains("pool full")
+        || m.contains("spammer")
+        || m.contains("exceeds maximum number")
+    {
+        return Outcome::Capacity;
+    }
+    if m.contains("expired") || m.contains("valid_before") || m.contains("valid before") {
+        return Outcome::Expired;
+    }
+    if m.contains("nonce too low")
+        || m.contains("nonce is too low")
+        || m.contains("already mined")
+        || m.contains("nonce has already")
+    {
+        return Outcome::NonceLow;
+    }
+    // Only recognized state/admission failures become bounded dependency gaps.
+    // An unfamiliar RPC rejection is a compatibility incident, never guessed permanent.
+    if [
+        "insufficient",
+        "nonce too high",
+        "nonce gap",
+        "future nonce",
+        "underpriced",
+        "fee token",
+        "feepayer",
+        "fee payer",
+        "sponsor",
+        "liquidity",
+        "not yet valid",
+        "valid_after",
+        "policy",
+        "authorization",
+        "execution reverted",
+    ]
+    .iter()
+    .any(|s| m.contains(s))
+    {
+        return Outcome::Dependency;
+    }
+    Outcome::Incident
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct LaneBlock {
+    source_height: u64,
+    source_index: usize,
+    hash: B256,
+    reason: String,
+}
+#[derive(Default)]
+pub struct Budget {
+    hashes: BTreeSet<B256>,
+    senders: BTreeMap<Address, usize>,
+    pub bytes: u64,
+}
+impl Budget {
+    pub fn from_active(active: &BTreeMap<String, Occurrence>, q: &Qualified) -> Self {
+        let mut b = Self::default();
+        for o in active.values().filter(|o| o.state.holds_credit()) {
+            b.reserve(o, q);
+        }
+        b
+    }
+    pub fn can_reserve(&self, o: &Occurrence, q: &Qualified) -> bool {
+        self.hashes.contains(&o.tx.hash)
+            || (self.hashes.len() < q.count_budget
+                && self.senders.get(&o.tx.sender).copied().unwrap_or(0) < q.sender_budget
+                && self.bytes.saturating_add(cost(o, q)) <= q.byte_budget)
+    }
+    fn reserve(&mut self, o: &Occurrence, q: &Qualified) {
+        if self.hashes.insert(o.tx.hash) {
+            *self.senders.entry(o.tx.sender).or_default() += 1;
+            self.bytes = self.bytes.saturating_add(cost(o, q));
+        }
+    }
+}
+fn cost(o: &Occurrence, q: &Qualified) -> u64 {
+    o.tx.raw_len()
+        .saturating_mul(q.multiplier)
+        .saturating_add(q.overhead)
+}
+fn after(o: &Occurrence, blocked: &LaneBlock) -> bool {
+    (o.source.height, o.index) > (blocked.source_height, blocked.source_index)
+}
+fn gap(journal: &SharedJournal, o: &mut Occurrence, reason: &str) -> Result<()> {
+    let mut j = lock(journal)?;
+    let mut lane_update = None;
+    if let Some(lane) = o.tx.lane() {
+        let old: Option<LaneBlock> = j.get(format!("lane/{lane}"))?;
+        if old.as_ref().is_none_or(|b| !after(o, b)) {
+            lane_update = Some((
+                format!("lane/{lane}"),
+                LaneBlock {
+                    source_height: o.source.height,
+                    source_index: o.index,
+                    hash: o.tx.hash,
+                    reason: reason.into(),
+                },
+            ));
+        }
+    }
+    o.transition(
+        State::Gap {
+            reason: reason.into(),
+        },
+        reason,
+    );
+    if let Some((key, block)) = lane_update {
+        j.update_and_put(o, &key, &block)?;
+    } else {
+        j.update(o)?;
+    }
+    tracing::warn!(reason, "coverage degraded: user occurrence has a gap");
+    Ok(())
+}
+
+pub async fn observe_target(
+    c: &Config,
+    rpc: &Rpc,
+    journal: &SharedJournal,
+    stop: &CancellationToken,
+) -> Result<bool> {
+    let anchor = rpc.latest_finalized(c.run.chain_id).await?;
+    let checkpoint = c.checkpoint.as_ref().context("missing checkpoint")?;
+    let previous = lock(journal)?
+        .state
+        .cursors
+        .shadow_observed_through
+        .clone()
+        .unwrap_or(Point {
+            height: checkpoint.source_height,
+            hash: checkpoint.shadow_hash.parse()?,
+        });
+    if anchor.point.height < previous.height {
+        return Ok(false);
+    }
+    if anchor.point.height == previous.height {
+        ensure!(anchor.point == previous, "shadow finalized hash conflict");
+        return Ok(false);
+    }
+    ensure!(
+        anchor.point.height.saturating_sub(previous.height) <= c.source.recovery_horizon_blocks,
+        "shadow observation backlog exceeds recovery horizon"
+    );
+    let mut parent = previous.hash;
+    for h in previous.height + 1..=anchor.point.height {
+        ensure!(!stop.is_cancelled(), "target observation cancelled");
+        let b = if h == anchor.point.height {
+            anchor.clone()
+        } else {
+            rpc.execution(h, c.run.chain_id, false).await?
+        };
+        ensure!(
+            b.parent == parent,
+            "shadow finalized ancestry conflict at {h}"
+        );
+        parent = b.point.hash;
+        lock(journal)?.check_disk()?;
+        lock(journal)?.put(format!("target/staged/{h:020}"), &b)?;
+    }
+    ensure!(
+        parent == anchor.point.hash,
+        "shadow finality anchor mismatch"
+    );
+    // Publish target evidence only after the range reaches the finality anchor.
+    for h in previous.height + 1..=anchor.point.height {
+        let b: CapturedBlock = lock(journal)?
+            .get(format!("target/staged/{h:020}"))?
+            .context("target staging missing")?;
+        lock(journal)?.publish_target(&b)?;
+    }
+    Ok(true)
+}
+async fn finalized_receipt(
+    rpc: &Rpc,
+    journal: &SharedJournal,
+    hash: B256,
+) -> Result<Option<Value>> {
+    let inclusion: Option<Inclusion> = lock(journal)?.get(format!("inclusion/{hash}"))?;
+    let Some(i) = inclusion else {
+        return Ok(None);
+    };
+    let r = rpc.call("eth_getTransactionReceipt", json!([hash])).await?;
+    ensure!(
+        !r.is_null(),
+        "receipt missing for finalized target transaction"
+    );
+    ensure!(
+        serde_json::from_value::<B256>(r["transactionHash"].clone())? == hash
+            && serde_json::from_value::<B256>(r["blockHash"].clone())? == i.point.hash
+            && quantity(&r["blockNumber"])? == i.point.height
+            && quantity(&r["transactionIndex"])? == i.index as u64,
+        "target receipt disagrees with finalized block"
+    );
+    quantity(&r["status"])?;
+    quantity(&r["gasUsed"])?;
+    Ok(Some(r))
+}
+async fn reconcile_one(
+    c: &Config,
+    source: &Rpc,
+    target: &Rpc,
+    journal: &SharedJournal,
+    o: &mut Occurrence,
+) -> Result<()> {
+    if let Some(r) = finalized_receipt(target, journal, o.tx.hash).await? {
+        let sr = source
+            .call("eth_getTransactionReceipt", json!([o.tx.hash]))
+            .await?;
+        ensure!(
+            !sr.is_null()
+                && serde_json::from_value::<B256>(sr["transactionHash"].clone())? == o.tx.hash
+                && serde_json::from_value::<B256>(sr["blockHash"].clone())? == o.source.hash
+                && quantity(&sr["transactionIndex"])? == o.index as u64,
+            "source receipt disagrees with captured occurrence"
+        );
+        o.receipt_mismatch = Some(
+            quantity(&r["status"])? != quantity(&sr["status"])?
+                || quantity(&r["gasUsed"])? != quantity(&sr["gasUsed"])?,
+        );
+        o.receipt = Some(r);
+        o.source_receipt = Some(sr);
+        o.transition(
+            State::Finalized,
+            "observed in verified finalized target history",
+        );
+        lock(journal)?.update(o)?;
+        return Ok(());
+    }
+    if let Some(lane) = o.tx.lane() {
+        let consumed: Option<B256> =
+            lock(journal)?.get(format!("consumed/{lane}/{}", o.tx.nonce))?;
+        ensure!(
+            consumed.is_none_or(|h| h == o.tx.hash),
+            "a different finalized transaction consumed the required nonce"
+        );
+    }
+    let nonce_low = lock(journal)?
+        .get::<bool>(format!("nonce_low/{}", o.tx.hash))?
+        .unwrap_or(false);
+    if nonce_low && !o.tx.expiring {
+        let observed_point = lock(journal)?.state.cursors.shadow_observed_through.clone();
+        if let Some(point) = observed_point {
+            let block = json!({"blockHash": point.hash, "requireCanonical": true});
+            let current = if o.tx.nonce_key.is_zero() {
+                quantity(
+                    &target
+                        .call("eth_getTransactionCount", json!([o.tx.sender, block]))
+                        .await?,
+                )?
+            } else {
+                let selector = alloy_primitives::keccak256(b"getNonce(address,uint256)");
+                let mut data = selector[..4].to_vec();
+                data.extend_from_slice(&[0; 12]);
+                data.extend_from_slice(o.tx.sender.as_slice());
+                data.extend_from_slice(&o.tx.nonce_key.to_be_bytes::<32>());
+                let v = target.call("eth_call", json!([{"to":"0x4E4F4E4345000000000000000000000000000000", "data":format!("0x{}", hex::encode(data))}, block])).await?;
+                let word: alloy_primitives::U256 = serde_json::from_value(v)?;
+                u64::try_from(word).context("nonce state overflow")?
+            };
+            ensure!(
+                current <= o.tx.nonce,
+                "required nonce consumed in finalized shadow state without this transaction hash"
+            );
+        }
+    }
+    if matches!(
+        o.state,
+        State::Unknown | State::Attempting | State::Accepted
+    ) {
+        let found = target
+            .call("eth_getTransactionByHash", json!([o.tx.hash]))
+            .await?;
+        if !found.is_null() {
+            ensure!(
+                serde_json::from_value::<B256>(found["hash"].clone())? == o.tx.hash,
+                "transaction lookup hash mismatch"
+            );
+            if o.state != State::Accepted {
+                o.transition(
+                    State::Accepted,
+                    "exact hash observed on shadow; finality pending",
+                );
+                lock(journal)?.update(o)?;
+            }
+        } else if o.retry_at_ms == 0
+            && !nonce_low
+            && o.state != State::Accepted
+            && o.ambiguous_resends < c.delivery.ambiguous_resend_limit
+            && !o.tx.expired_at(lock(journal)?.state.target_tip_seconds)
+        {
+            o.retry_at_ms = now_ms().saturating_add(1000);
+            lock(journal)?.update(o)?;
+        }
+        // A null lookup is not proof of pool removal, especially across validators.
+        // Keep the reservation and expose a recovery incident if it cannot be resolved.
+        if o.last_attempt_ms
+            .is_some_and(|t| now_ms().saturating_sub(t) > c.timing.target_progress_timeout_ms)
+            && o.state != State::Finalized
+        {
+            lock(journal)?.incident("recoverable: unresolved pool reservation; awaiting exact-hash finality/removal evidence")?;
+        }
+    }
+    Ok(())
+}
+async fn reconcile_active(
+    c: &Config,
+    q: &Qualified,
+    source: &Rpc,
+    target_index: usize,
+    journal: &SharedJournal,
+    active: &mut BTreeMap<String, Occurrence>,
+) -> Result<()> {
+    // Receipt lookups are bounded by the same worker limit as submissions. Each worker
+    // updates a distinct occurrence through the single journal writer.
+    let target = &q.targets[target_index].rpc;
+    let mut jobs = futures_util::stream::iter(active.values().cloned().map(|mut o| async move {
+        if !matches!(
+            o.state,
+            State::GeneratedByShadowConsensus | State::Gap { .. } | State::Finalized
+        ) {
+            reconcile_one(c, source, target, journal, &mut o).await?;
+        }
+        Ok::<_, anyhow::Error>((o.key(), o))
+    }))
+    .buffer_unordered(c.limits.max_inflight_rpc);
+    let mut refreshed = BTreeMap::new();
+    while let Some(r) = jobs.next().await {
+        let (key, o) = r?;
+        refreshed.insert(key, o);
+    }
+    drop(jobs);
+    *active = refreshed;
+    Ok(())
+}
+fn load_released(c: &Config, journal: &SharedJournal) -> Result<BTreeMap<String, Occurrence>> {
+    let j = lock(journal)?;
+    let boundary = j.state.replay_boundary.context("journal not bound")?;
+    let start = j
+        .state
+        .cursors
+        .accounted_through
+        .unwrap_or(boundary)
+        .saturating_add(1);
+    let end = j.state.last_release_height.unwrap_or(boundary);
+    ensure!(
+        end.saturating_sub(start) < c.limits.max_blocks_ahead,
+        "persisted backlog exceeds configured lookahead"
+    );
+    let mut out = BTreeMap::new();
+    let mut bytes = 0u64;
+    for h in start..=end {
+        for o in j.occurrences(h)? {
+            if !o.state.terminal() {
+                bytes += serde_json::to_vec(&o)?.len() as u64;
+                ensure!(
+                    bytes <= c.limits.max_buffered_bytes,
+                    "persisted outstanding work exceeds memory bound"
+                );
+                out.insert(o.key(), o);
+            }
+        }
+    }
+    Ok(out)
+}
+fn record_segment(journal: &SharedJournal, pacer: &Pacer) -> Result<()> {
+    let mut j = lock(journal)?;
+    j.put(
+        format!("phase/{:020}/{:020}", now_ms(), pacer.segment.first_height),
+        &pacer.segment,
+    )?;
+    j.state.phase = pacer.segment.phase.clone();
+    j.save_state()?;
+    tracing::info!(phase = ?pacer.segment.phase, from_block = pacer.segment.first_height, speed = pacer.segment.speed, "mirror pacing phase changed");
+    Ok(())
+}
+
+pub async fn replay(
+    c: Config,
+    q: Qualified,
+    source: Rpc,
+    journal: SharedJournal,
+    to: Option<u64>,
+    acknowledge: bool,
+    stop: CancellationToken,
+) -> Result<()> {
+    {
+        let mut j = lock(&journal)?;
+        if let Some(incident) = &j.state.incident {
+            ensure!(
+                acknowledge || incident.starts_with("recoverable:"),
+                "journal is paused: {incident}; investigate then use --acknowledge-incident or a new checkpoint"
+            );
+        }
+        if let Some(b) = j.block(
+            c.checkpoint
+                .as_ref()
+                .context("checkpoint missing")?
+                .source_height
+                .saturating_add(1),
+        )? {
+            ensure!(
+                b.parent == c.checkpoint.as_ref().unwrap().source_hash.parse::<B256>()?,
+                "captured backlog does not descend from configured source boundary"
+            );
+        }
+        j.bind(
+            c.checkpoint
+                .as_ref()
+                .context("checkpoint missing")?
+                .source_height,
+            &q.binding,
+        )?;
+        j.state.phase = Phase::Reconcile;
+        j.state.incident = None;
+        j.save_state()?;
+    }
+    let mut active = load_released(&c, &journal)?;
+    for o in active.values_mut().filter(|o| o.state == State::Attempting) {
+        o.transition(
+            State::Unknown,
+            "restart after durable attempt intent; response unknown",
+        );
+        o.retry_at_ms = 0;
+        lock(&journal)?.update(o)?;
+    }
+    let mut pending = Pending::new();
+    let mut inflight = BTreeSet::new();
+    let mut available = vec![true; q.targets.len()];
+    let mut observer = 0usize;
+    let mut pacer: Option<Pacer> = None;
+    let mut last_identity = Instant::now();
+    let mut last_observe = Instant::now() - Duration::from_secs(1);
+    let mut last_progress = Instant::now();
+    let mut started = false;
+    let work: Result<()> = async {
+        loop {
+            if stop.is_cancelled() { break; }
+            lock(&journal)?.check_disk()?;
+            if last_identity.elapsed().as_millis() >= u128::from(c.shadow.as_ref().unwrap().identity_check_interval_ms) {
+                for (index, target) in q.targets.iter().enumerate() {
+                    match check_target(&target.rpc, &c).await {
+                        Ok(()) => available[index] = true,
+                        Err(e) if e.downcast_ref::<RpcError>().is_some() => available[index] = false,
+                        Err(e) => return Err(e.context("periodic target identity verification")),
+                    }
+                }
+                last_identity = Instant::now();
+            }
+            // Drain submission responses before reconciliation; durable Attempting entries
+            // remain reserved while their requests are on the wire.
+            if last_observe.elapsed() >= Duration::from_millis(250) && pending.is_empty() {
+                let mut observed = false;
+                for (i, available_now) in available.iter_mut().enumerate() {
+                    if !*available_now { continue; }
+                    match observe_target(&c, &q.targets[i].rpc, &journal, &stop).await {
+                        Ok(progress) => { observer = i; observed = true; if progress { last_progress = Instant::now(); } break; },
+                        Err(_) if stop.is_cancelled() => break,
+                        Err(e) if e.downcast_ref::<RpcError>().is_some() => { *available_now = false; },
+                        Err(e) => return Err(e),
+                    }
+                }
+                if observed {
+                    match reconcile_active(&c, &q, &source, observer, &journal, &mut active).await {
+                        Ok(()) => { started = true; },
+                        Err(e) if e.downcast_ref::<RpcError>().is_some() => { started = false; },
+                        Err(e) => return Err(e),
+                    }
+                    let mut j = lock(&journal)?;
+                    let reservations_recent = active.values().filter(|o| o.state.holds_credit()).all(|o| o.last_attempt_ms.is_none_or(|ms| now_ms().saturating_sub(ms) <= c.timing.target_progress_timeout_ms));
+                    if j.state.incident.as_ref().is_some_and(|i| i.starts_with("recoverable:")) && reservations_recent && last_progress.elapsed().as_millis() < u128::from(c.timing.target_progress_timeout_ms) {
+                        j.state.incident = None; j.state.phase = Phase::Reconcile; pacer = None; j.save_state()?;
+                    }
+                } else { started = false; }
+                last_observe = Instant::now();
+            }
+            if last_progress.elapsed().as_millis() >= u128::from(c.timing.target_progress_timeout_ms) { lock(&journal)?.incident("recoverable: target finality stalled or unavailable")?; }
+            lock(&journal)?.refresh_cursors()?;
+            active.retain(|_, o| !o.state.terminal());
+            let state = lock(&journal)?.state.clone();
+            if to.is_some_and(|h| state.cursors.accounted_through.is_some_and(|n| n >= h)) && pending.is_empty() { break; }
+            if let Some(incident) = &state.incident && !incident.starts_with("recoverable:") { bail!("dispatch paused: {incident}"); }
+            if started && state.incident.is_none() {
+                // Load and release at most one source block per loop. The accounted frontier
+                // bounds unresolved lookahead; captured backlog remains on disk.
+                let boundary = state.replay_boundary.unwrap();
+                let next = state.last_release_height.unwrap_or(boundary).saturating_add(1);
+                if state.cursors.captured_through.as_ref().is_some_and(|p| next <= p.height) && to.is_none_or(|h| next <= h) && next <= state.cursors.accounted_through.unwrap_or(boundary).saturating_add(c.limits.max_blocks_ahead) {
+                    let block = lock(&journal)?.block(next)?.context("captured dispatch block missing")?;
+                    if pacer.is_none() {
+                        pacer = Some(Pacer::new(&c.timing, Phase::CatchUp, next, block.timestamp_ms, "startup or recovery")); record_segment(&journal, pacer.as_ref().unwrap())?;
+                    }
+                    let p = pacer.as_mut().unwrap();
+                    let dispatched = state.cursors.dispatch_accounted_through.unwrap_or(boundary);
+                    let can_live = dispatched >= next - 1 && now_ms().saturating_sub(block.timestamp_ms) <= c.timing.target_lag_ms;
+                    if p.segment.phase == Phase::CatchUp && can_live { *p = Pacer::new(&c.timing, Phase::Live, next, block.timestamp_ms, "contiguous dispatch frontier reached live lag"); record_segment(&journal, p)?; }
+                    if p.segment.phase == Phase::Live && p.consecutive_slips >= c.timing.slip_window_blocks { *p = Pacer::new(&c.timing, Phase::CatchUp, next, block.timestamp_ms, "sustained live schedule slip"); record_segment(&journal, p)?; }
+                    if Instant::now() >= p.release_at(block.timestamp_ms)? {
+                        let entries = lock(&journal)?.occurrences(next)?;
+                        let bytes: u64 = active.values().chain(entries.iter()).map(|o| serde_json::to_vec(o).map(|v| v.len() as u64)).collect::<std::result::Result<Vec<_>, _>>()?.into_iter().sum();
+                        ensure!(serde_json::to_vec(&entries)?.len() as u64 <= c.limits.max_buffered_bytes, "single block cannot fit scheduler memory bound");
+                        if bytes <= c.limits.max_buffered_bytes {
+                            let slip = p.released(block.timestamp_ms, &c.timing)?;
+                            for o in entries { if !o.state.terminal() { active.insert(o.key(), o); } }
+                            let mut j = lock(&journal)?; j.state.last_release_height = Some(next); j.state.lag_ms = now_ms().saturating_sub(block.timestamp_ms); j.state.slip_ms = slip; j.save_state()?;
+                        }
+                    }
+                }
+                if last_observe.elapsed() < Duration::from_millis(250) { issue(&c, &q, &journal, &mut active, &mut pending, &mut inflight, &available)?; }
+            }
+            tokio::select! {
+                _ = stop.cancelled() => break,
+                result = pending.next(), if !pending.is_empty() => {
+                    if let Some((key, result)) = result { inflight.remove(&key); handle_response(&c, &journal, &mut active, &key, result)?; }
+                },
+                _ = tokio::time::sleep(Duration::from_millis(10)) => {},
+            }
+        }
+        Ok(())
+    }.await;
+    // Stop issuing first, then drain every bounded HTTP request. This also handles errors.
+    while let Some((key, result)) = pending.next().await {
+        if let Err(e) = handle_response(&c, &journal, &mut active, &key, result) {
+            tracing::error!(error = %e, "submission drain requires recovery");
+        }
+    }
+    if let Err(e) = &work {
+        lock(&journal)?.incident(&format!("replay: {e:#}"))?;
+    }
+    lock(&journal)?.refresh_cursors()?;
+    lock(&journal)?.flush()?;
+    work
+}
+
+fn issue(
+    c: &Config,
+    q: &Qualified,
+    journal: &SharedJournal,
+    active: &mut BTreeMap<String, Occurrence>,
+    pending: &mut Pending,
+    inflight: &mut BTreeSet<String>,
+    available: &[bool],
+) -> Result<()> {
+    let mut budget = Budget::from_active(active, q);
+    let mut lane_counts = BTreeMap::<String, usize>::new();
+    let mut frozen = BTreeMap::<String, String>::new();
+    for (key, o) in active.iter() {
+        if let Some(lane) = o.tx.lane() {
+            if o.state.holds_credit() {
+                *lane_counts.entry(lane.clone()).or_default() += 1;
+            }
+            if matches!(o.state, State::Deferred | State::Unknown) {
+                frozen.entry(lane).or_insert_with(|| key.clone());
+            }
+        }
+    }
+    let mut prepared = Vec::new();
+    for (key, o) in active.iter_mut() {
+        if pending.len() + prepared.len() >= c.limits.max_inflight_rpc {
+            break;
+        }
+        if o.state.terminal()
+            || inflight.contains(key)
+            || matches!(o.state, State::Accepted | State::Attempting)
+        {
+            continue;
+        }
+        if o.tx.class == Class::Subblock {
+            lock(journal)?.incident(
+                "RequiresNativeIngress: source contains a reserved subblock transaction",
+            )?;
+            bail!("subblock route is unsupported; dispatch paused");
+        }
+        if let Some(lane) = o.tx.lane() {
+            let blocked: Option<LaneBlock> = lock(journal)?.get(format!("lane/{lane}"))?;
+            if blocked.as_ref().is_some_and(|b| after(o, b)) {
+                if !o.state.holds_credit() {
+                    gap(journal, o, "BlockedDependency")?;
+                }
+                continue;
+            }
+            if frozen.get(&lane).is_some_and(|first| first != key) {
+                continue;
+            }
+            let window = if q
+                .targets
+                .iter()
+                .all(|t| t.evidence.future_nonce_types.contains(&o.tx.tx_type))
+            {
+                c.limits.max_inflight_per_lane
+            } else {
+                1
+            };
+            if !o.state.holds_credit() && lane_counts.get(&lane).copied().unwrap_or(0) >= window {
+                continue;
+            }
+        }
+        if o.retry_at_ms > now_ms() {
+            continue;
+        }
+        let ambiguous_resend = o.state == State::Unknown;
+        if ambiguous_resend
+            && (o.retry_at_ms == 0
+                || o.ambiguous_resends >= c.delivery.ambiguous_resend_limit
+                || o.tx.expired_at(lock(journal)?.state.target_tip_seconds))
+        {
+            continue;
+        }
+        if !budget.can_reserve(o, q) {
+            continue;
+        }
+        let Some(index) = route(o.tx.sender, &q.targets, available) else {
+            continue;
+        };
+        // Failover only follows the observation/reconciliation pass. Unknown outcomes
+        // stay reserved, and an existing attempt is never rewritten or re-signed.
+        if o.endpoint
+            .as_ref()
+            .is_some_and(|id| id != &q.targets[index].id)
+            && ambiguous_resend
+        {
+            continue;
+        }
+        if let Some(since) = o.dependency_since_ms
+            && !o.state.holds_credit()
+            && now_ms().saturating_sub(since) >= c.delivery.dependency_wait_timeout_ms
+        {
+            gap(journal, o, "DependencyTimeout")?;
+            continue;
+        }
+        let had_credit = o.state.holds_credit();
+        budget.reserve(o, q);
+        if let Some(lane) = o.tx.lane()
+            && !had_credit
+        {
+            *lane_counts.entry(lane).or_default() += 1;
+        }
+        if ambiguous_resend {
+            o.ambiguous_resends += 1;
+        }
+        o.attempts += 1;
+        let now = now_ms();
+        o.first_attempt_ms.get_or_insert(now);
+        o.last_attempt_ms = Some(now);
+        o.endpoint = Some(q.targets[index].id.clone());
+        o.retry_at_ms = 0;
+        let tip = lock(journal)?.state.target_tip_seconds;
+        let projected_ms = tip
+            .saturating_mul(1000)
+            .max(now)
+            .saturating_add(3000)
+            .saturating_add(c.timing.expected_inclusion_latency_ms)
+            .saturating_add(c.timing.expiry_safety_margin_ms)
+            .saturating_add(999);
+        let detail = if o.tx.expired_at(tip) {
+            "initial/authorized retry attempt; exact valid_before admission risk"
+        } else if o
+            .tx
+            .valid_before
+            .is_some_and(|v| v.saturating_mul(1000) <= projected_ms)
+        {
+            "attempt; projected inclusion deadline risk"
+        } else {
+            "attempt intent persisted before network write"
+        };
+        o.transition(State::Attempting, detail);
+        prepared.push((o.clone(), index));
+    }
+    if !prepared.is_empty() {
+        {
+            let mut j = lock(journal)?;
+            ensure!(
+                j.state.incident.is_none(),
+                "dispatch paused before attempt batch commit"
+            );
+            j.update_many(&prepared.iter().map(|(o, _)| o.clone()).collect::<Vec<_>>())?;
+        }
+        for (o, index) in prepared {
+            let rpc = q.targets[index].rpc.clone();
+            let raw = o.tx.raw.clone();
+            let key = o.key();
+            inflight.insert(key.clone());
+            pending.push(
+                async move { (key, rpc.call("eth_sendRawTransaction", json!([raw])).await) }
+                    .boxed(),
+            );
+        }
+    }
+    Ok(())
+}
+fn handle_response(
+    c: &Config,
+    journal: &SharedJournal,
+    active: &mut BTreeMap<String, Occurrence>,
+    key: &str,
+    response: Result<Value>,
+) -> Result<()> {
+    let mut o: Occurrence = lock(journal)?
+        .get(key)?
+        .context("response occurrence missing")?;
+    if o.state.terminal() {
+        active.insert(key.into(), o);
+        return Ok(());
+    }
+    let result = match response {
+        Ok(value) => match serde_json::from_value::<B256>(value) {
+            Ok(hash) if hash == o.tx.hash => {
+                o.transition(
+                    State::Accepted,
+                    "RPC accepted exact signed transaction hash",
+                );
+                Ok(())
+            }
+            _ => {
+                o.transition(
+                    State::Unknown,
+                    "unexpected response hash; outcome requires reconciliation",
+                );
+                Err(anyhow::anyhow!("submission response hash mismatch"))
+            }
+        },
+        Err(e) => {
+            let Some(rpc_error) = e.downcast_ref::<RpcError>() else {
+                o.transition(
+                    State::Unknown,
+                    "malformed or oversized response after write",
+                );
+                lock(journal)?.update(&o)?;
+                active.insert(key.into(), o);
+                return Err(e);
+            };
+            let outcome = classify(rpc_error);
+            // Server strings can contain addresses or payloads. Persist the bounded category
+            // and numeric code; never echo arbitrary RPC messages into operational logs.
+            let detail = format!("RPC code {}; category {outcome:?}", rpc_error.code);
+            let had_uncertain_attempt = o.ambiguous_resends > 0
+                || o.history
+                    .iter()
+                    .any(|h| matches!(h.state, State::Accepted | State::Unknown));
+            let backoff = retry_delay(o.attempts, o.tx.hash, rpc_error.retry_ms);
+            match outcome {
+                Outcome::Accepted => {
+                    o.transition(State::Accepted, detail);
+                    Ok(())
+                }
+                Outcome::Ambiguous => {
+                    o.transition(State::Unknown, detail);
+                    o.retry_at_ms = 0;
+                    Ok(())
+                }
+                Outcome::Capacity | Outcome::Transport => {
+                    o.transition(
+                        if had_uncertain_attempt {
+                            State::Unknown
+                        } else {
+                            State::Deferred
+                        },
+                        detail,
+                    );
+                    o.retry_at_ms = now_ms().saturating_add(backoff);
+                    if outcome == Outcome::Transport && o.attempts >= c.limits.max_retry_attempts {
+                        lock(journal)?
+                            .incident("recoverable: submission transport retry budget exhausted")?;
+                    }
+                    Ok(())
+                }
+                Outcome::Expired if !had_uncertain_attempt => {
+                    gap(journal, &mut o, "ExpiredAtSubmission")?;
+                    Ok(())
+                }
+                Outcome::Expired => {
+                    o.transition(State::Unknown, "expiry rejection after earlier uncertain/accepted attempt; keep reservation");
+                    o.retry_at_ms = 0;
+                    Ok(())
+                }
+                Outcome::NonceLow => {
+                    o.transition(
+                        State::Unknown,
+                        "nonce already consumed; reconcile exact hash and finalized state",
+                    );
+                    o.retry_at_ms = 0;
+                    lock(journal)?.put(format!("nonce_low/{}", o.tx.hash), &true)?;
+                    Ok(())
+                }
+                Outcome::Dependency => {
+                    o.dependency_since_ms.get_or_insert(now_ms());
+                    o.transition(
+                        if had_uncertain_attempt {
+                            State::Unknown
+                        } else {
+                            State::Deferred
+                        },
+                        detail,
+                    );
+                    o.retry_at_ms = now_ms().saturating_add(backoff);
+                    Ok(())
+                }
+                Outcome::Incident => {
+                    o.transition(State::Unknown, detail);
+                    Err(anyhow::anyhow!(
+                        "unexpected transaction rejection; compatibility or target identity incident"
+                    ))
+                }
+            }
+        }
+    };
+    lock(journal)?.update(&o)?;
+    active.insert(key.into(), o);
+    result
+}
+pub fn retry_delay(attempts: u32, hash: B256, server: Option<u64>) -> u64 {
+    let base = 100u64.saturating_mul(1u64 << attempts.saturating_sub(1).min(8));
+    let jitter = u64::from(hash[(attempts as usize) % 32]) * base / 1024;
+    base.saturating_add(jitter).max(server.unwrap_or(0))
+}

--- a/bin/tempo-replay/src/journal.rs
+++ b/bin/tempo-replay/src/journal.rs
@@ -1,0 +1,477 @@
+use crate::{config::Config, model::*};
+use anyhow::{Context, Result, ensure};
+use rocksdb::{DB, Direction, IteratorMode, Options, WriteBatch, WriteOptions};
+use serde::{Serialize, de::DeserializeOwned};
+use std::{
+    fs::{File, OpenOptions},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex, MutexGuard,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+pub type SharedJournal = Arc<Mutex<Journal>>;
+pub fn lock(j: &SharedJournal) -> Result<MutexGuard<'_, Journal>> {
+    j.lock()
+        .map_err(|_| anyhow::anyhow!("journal writer panicked"))
+}
+pub struct Journal {
+    db: DB,
+    pub state: RunState,
+    path: PathBuf,
+    max_bytes: u64,
+    min_free: u64,
+    _lock: Option<File>,
+    secondary: Option<PathBuf>,
+}
+fn opts() -> Options {
+    let mut o = Options::default();
+    o.create_if_missing(true);
+    o.set_max_open_files(128);
+    o.set_write_buffer_size(32 * 1024 * 1024);
+    o.set_max_write_buffer_number(2);
+    o.set_compression_type(rocksdb::DBCompressionType::Lz4);
+    o
+}
+impl Journal {
+    /// A replay start names the first post-snapshot block, independently of an
+    /// earlier capture-only journal boundary. Repeated starts never reset cursors.
+    pub fn open_replay(c: &Config, from: Option<u64>, to: Option<u64>) -> Result<Self> {
+        let (checkpoint, _) = c.replay()?;
+        let first = checkpoint
+            .source_height
+            .checked_add(1)
+            .context("fork height overflow")?;
+        ensure!(
+            from.is_none_or(|height| height == first),
+            "--from-block must be {first}: the configured shadow snapshot contains source state through {}; starting elsewhere would skip or duplicate state transitions",
+            checkpoint.source_height
+        );
+        ensure!(
+            to.is_none_or(|height| height >= first),
+            "--to-block must be at or after the first mirrored block {first}"
+        );
+        let journal = Self::open(c, None)?;
+        ensure!(
+            journal.state.first_height <= first,
+            "journal starts after the required replay height {first}"
+        );
+        ensure!(
+            journal
+                .state
+                .replay_boundary
+                .is_none_or(|height| height == checkpoint.source_height),
+            "journal belongs to a different shadow checkpoint"
+        );
+        Ok(journal)
+    }
+    pub fn open(c: &Config, from: Option<u64>) -> Result<Self> {
+        std::fs::create_dir_all(&c.journal.path)?;
+        let file = OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(c.journal.path.join("RUN_LOCK"))?;
+        file.try_lock()
+            .context("another tempo-replay owns this journal")?;
+        let db = DB::open(&opts(), c.journal.path.join("db"))?;
+        let state = match db.get(b"meta/state")? {
+            Some(bytes) => {
+                let s: RunState = serde_json::from_slice(&bytes)?;
+                ensure!(
+                    s.schema_version == 2
+                        && s.run_id == c.run.id
+                        && s.chain_id == c.run.chain_id
+                        && s.source_identity == c.source.rpc_http,
+                    "journal run/source identity mismatch"
+                );
+                ensure!(
+                    from.is_none_or(|h| h == s.first_height),
+                    "cannot change journal start height"
+                );
+                s
+            }
+            None => RunState {
+                schema_version: 2,
+                run_id: c.run.id.clone(),
+                chain_id: c.run.chain_id,
+                source_identity: c.source.rpc_http.clone(),
+                first_height: from.unwrap_or_else(|| {
+                    c.checkpoint
+                        .as_ref()
+                        .map_or(0, |p| p.source_height.saturating_add(1))
+                }),
+                replay_boundary: None,
+                binding: None,
+                phase: Phase::CaptureOnly,
+                incident: None,
+                cursors: Cursors::default(),
+                counts: Counts::default(),
+                last_release_height: None,
+                lag_ms: 0,
+                slip_ms: 0,
+                target_tip_seconds: 0,
+                capture_error: None,
+            },
+        };
+        let mut j = Self {
+            db,
+            state,
+            path: c.journal.path.clone(),
+            max_bytes: c.journal.max_bytes,
+            min_free: c.journal.min_free_bytes,
+            _lock: Some(file),
+            secondary: None,
+        };
+        j.check_disk()?;
+        j.save_state()?;
+        Ok(j)
+    }
+    pub fn read(path: &Path) -> Result<Self> {
+        static N: AtomicU64 = AtomicU64::new(0);
+        let secondary = std::env::temp_dir().join(format!(
+            "tempo-replay-read-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(&secondary)?;
+        let mut o = opts();
+        o.create_if_missing(false);
+        o.set_max_open_files(-1);
+        let db = match DB::open_as_secondary(&o, path.join("db"), secondary.clone()) {
+            Ok(db) => db,
+            Err(e) => {
+                let _ = std::fs::remove_dir_all(&secondary);
+                return Err(e.into());
+            }
+        };
+        db.try_catch_up_with_primary()?;
+        let state =
+            serde_json::from_slice(&db.get(b"meta/state")?.context("journal metadata missing")?)?;
+        Ok(Self {
+            db,
+            state,
+            path: path.into(),
+            max_bytes: u64::MAX,
+            min_free: 0,
+            _lock: None,
+            secondary: Some(secondary),
+        })
+    }
+    fn write(&self, batch: WriteBatch) -> Result<()> {
+        ensure!(self.secondary.is_none(), "read-only journal");
+        let mut o = WriteOptions::default();
+        o.set_sync(true);
+        self.db.write_opt(batch, &o)?;
+        Ok(())
+    }
+    pub fn get<T: DeserializeOwned>(&self, key: impl AsRef<[u8]>) -> Result<Option<T>> {
+        self.db
+            .get(key)?
+            .map(|b| serde_json::from_slice(&b).map_err(Into::into))
+            .transpose()
+    }
+    pub fn put<T: Serialize>(&self, key: impl AsRef<[u8]>, value: &T) -> Result<()> {
+        let mut b = WriteBatch::default();
+        b.put(key, serde_json::to_vec(value)?);
+        self.write(b)
+    }
+    pub fn save_state(&mut self) -> Result<()> {
+        self.put(b"meta/state", &self.state)
+    }
+    pub fn check_disk(&self) -> Result<()> {
+        ensure!(
+            fs4::available_space(&self.path)? >= self.min_free,
+            "journal disk low-watermark reached"
+        );
+        let mut size = 0u64;
+        for e in std::fs::read_dir(self.path.join("db"))? {
+            size = size.saturating_add(e?.metadata()?.len());
+        }
+        ensure!(size < self.max_bytes, "journal maximum disk size reached");
+        Ok(())
+    }
+    pub fn stage(&self, b: &CapturedBlock) -> Result<()> {
+        self.check_disk()?;
+        ensure!(
+            self.state
+                .cursors
+                .captured_through
+                .as_ref()
+                .is_none_or(|p| b.point.height > p.height),
+            "cannot overwrite canonical block"
+        );
+        self.put(format!("b/{:020}", b.point.height), b)
+    }
+    pub fn block(&self, height: u64) -> Result<Option<CapturedBlock>> {
+        self.get(format!("b/{height:020}"))
+    }
+    pub fn publish(&mut self, through: &Point, start: u64) -> Result<()> {
+        // A durable verified-range marker permits bounded per-block publication after
+        // the entire range has linked to both canonical history and a finality anchor.
+        self.put("meta/verified_range", &(start, through))?;
+        for h in start..=through.height {
+            let mut block = self.block(h)?.context("verified staged block missing")?;
+            block.committed_ms = now_ms();
+            let mut batch = WriteBatch::default();
+            batch.put(format!("b/{h:020}"), serde_json::to_vec(&block)?);
+            for i in 0..block.transactions.len() {
+                let o = Occurrence::new(&block, i);
+                batch.put(o.key(), serde_json::to_vec(&o)?);
+                batch.put(
+                    format!("h/{}/{h:020}/{i:010}", o.tx.hash),
+                    o.key().as_bytes(),
+                );
+                if self
+                    .state
+                    .replay_boundary
+                    .is_none_or(|boundary| h > boundary)
+                {
+                    add_counts(&mut self.state.counts, &o, true);
+                }
+            }
+            self.state.cursors.captured_through = Some(block.point);
+            self.state.capture_error = None;
+            batch.put(b"meta/state", serde_json::to_vec(&self.state)?);
+            self.write(batch)?;
+        }
+        Ok(())
+    }
+    pub fn publish_target(&mut self, block: &CapturedBlock) -> Result<()> {
+        let mut batch = WriteBatch::default();
+        for (index, tx) in block
+            .transactions
+            .iter()
+            .enumerate()
+            .filter(|(_, tx)| tx.class != Class::System)
+        {
+            batch.put(
+                format!("inclusion/{}", tx.hash),
+                serde_json::to_vec(&Inclusion {
+                    point: block.point.clone(),
+                    index,
+                })?,
+            );
+            if let Some(lane) = tx.lane() {
+                batch.put(
+                    format!("consumed/{lane}/{}", tx.nonce),
+                    serde_json::to_vec(&tx.hash)?,
+                );
+            }
+        }
+        batch.put(
+            format!("target/canonical/{:020}", block.point.height),
+            serde_json::to_vec(&block.point)?,
+        );
+        self.state.cursors.shadow_observed_through = Some(block.point.clone());
+        self.state.target_tip_seconds = block.timestamp_ms / 1000;
+        batch.put(b"meta/state", serde_json::to_vec(&self.state)?);
+        self.write(batch)
+    }
+    pub fn occurrences(&self, height: u64) -> Result<Vec<Occurrence>> {
+        self.scan(&format!("o/{height:020}/"))
+    }
+    pub fn scan<T: DeserializeOwned>(&self, prefix: &str) -> Result<Vec<T>> {
+        let mut out = vec![];
+        for entry in self
+            .db
+            .iterator(IteratorMode::From(prefix.as_bytes(), Direction::Forward))
+        {
+            let (key, value) = entry?;
+            if !key.starts_with(prefix.as_bytes()) {
+                break;
+            }
+            out.push(serde_json::from_slice(&value)?);
+        }
+        Ok(out)
+    }
+    pub fn inspect(&self, hash: &str) -> Result<Vec<Occurrence>> {
+        let hash: alloy_primitives::B256 = hash.parse().context("invalid transaction hash")?;
+        let prefix = format!("h/{hash}/");
+        let mut out = vec![];
+        for entry in self
+            .db
+            .iterator(IteratorMode::From(prefix.as_bytes(), Direction::Forward))
+        {
+            let (k, v) = entry?;
+            if !k.starts_with(prefix.as_bytes()) {
+                break;
+            }
+            if let Some(o) = self.get(v)? {
+                out.push(o);
+            }
+        }
+        Ok(out)
+    }
+    pub fn update(&mut self, o: &Occurrence) -> Result<()> {
+        self.update_many(std::slice::from_ref(o))
+    }
+    pub fn update_many(&mut self, occurrences: &[Occurrence]) -> Result<()> {
+        let batch = self.update_batch(occurrences)?;
+        self.write(batch)
+    }
+    pub fn update_and_put<T: Serialize>(
+        &mut self,
+        occurrence: &Occurrence,
+        key: &str,
+        value: &T,
+    ) -> Result<()> {
+        let mut batch = self.update_batch(std::slice::from_ref(occurrence))?;
+        batch.put(key, serde_json::to_vec(value)?);
+        self.write(batch)
+    }
+    fn update_batch(&mut self, occurrences: &[Occurrence]) -> Result<WriteBatch> {
+        let mut batch = WriteBatch::default();
+        for o in occurrences {
+            let old: Occurrence = self.get(o.key())?.context("occurrence missing")?;
+            ensure!(
+                old.source == o.source && old.tx.hash == o.tx.hash && old.tx.raw == o.tx.raw,
+                "immutable occurrence changed"
+            );
+            add_counts(&mut self.state.counts, &old, false);
+            add_counts(&mut self.state.counts, o, true);
+            batch.put(o.key(), serde_json::to_vec(o)?);
+        }
+        batch.put(b"meta/state", serde_json::to_vec(&self.state)?);
+        Ok(batch)
+    }
+    pub fn bind(&mut self, boundary: u64, binding: &str) -> Result<()> {
+        if let Some(b) = &self.state.binding {
+            ensure!(
+                b == binding && self.state.replay_boundary == Some(boundary),
+                "run/deployment binding changed; use a new journal"
+            );
+            return Ok(());
+        }
+        ensure!(
+            self.state.first_height <= boundary.saturating_add(1),
+            "journal begins after fork backlog"
+        );
+        self.state.binding = Some(binding.into());
+        self.state.replay_boundary = Some(boundary);
+        self.state.counts = Counts::default();
+        if let Some(tip) = &self.state.cursors.captured_through {
+            for h in boundary.saturating_add(1).max(self.state.first_height)..=tip.height {
+                for o in self.occurrences(h)? {
+                    add_counts(&mut self.state.counts, &o, true);
+                }
+            }
+        }
+        self.state.cursors.dispatch_accounted_through = Some(boundary);
+        self.state.cursors.accounted_through = Some(boundary);
+        self.state.cursors.included_through = Some(boundary);
+        self.save_state()
+    }
+    pub fn refresh_cursors(&mut self) -> Result<()> {
+        let Some(end) = self
+            .state
+            .cursors
+            .captured_through
+            .as_ref()
+            .map(|p| p.height)
+        else {
+            return Ok(());
+        };
+        let Some(boundary) = self.state.replay_boundary else {
+            return Ok(());
+        };
+        let mut cursors = [
+            self.state
+                .cursors
+                .dispatch_accounted_through
+                .unwrap_or(boundary),
+            self.state.cursors.accounted_through.unwrap_or(boundary),
+            self.state.cursors.included_through.unwrap_or(boundary),
+        ];
+        for (kind, cursor) in cursors.iter_mut().enumerate() {
+            while *cursor < end {
+                let entries = self.occurrences(*cursor + 1)?;
+                if !entries.iter().all(|o| match kind {
+                    0 => o.dispatch_accounted(),
+                    1 => o.state.terminal(),
+                    _ => o.tx.class == Class::System || o.state == State::Finalized,
+                }) {
+                    break;
+                }
+                *cursor += 1;
+            }
+        }
+        if self.state.cursors.dispatch_accounted_through == Some(cursors[0])
+            && self.state.cursors.accounted_through == Some(cursors[1])
+            && self.state.cursors.included_through == Some(cursors[2])
+        {
+            return Ok(());
+        }
+        self.state.cursors.dispatch_accounted_through = Some(cursors[0]);
+        self.state.cursors.accounted_through = Some(cursors[1]);
+        self.state.cursors.included_through = Some(cursors[2]);
+        self.save_state()
+    }
+    pub fn incident(&mut self, detail: &str) -> Result<()> {
+        self.state.phase = Phase::PausedIncident;
+        self.state.incident = Some(detail.into());
+        self.save_state()
+    }
+    pub fn flush(&self) -> Result<()> {
+        self.db.flush_wal(true)?;
+        self.db.flush()?;
+        Ok(())
+    }
+}
+impl Drop for Journal {
+    fn drop(&mut self) {
+        if let Some(path) = &self.secondary {
+            let _ = std::fs::remove_dir_all(path);
+        }
+    }
+}
+fn add_counts(c: &mut Counts, o: &Occurrence, add: bool) {
+    fn change(n: &mut u64, by: u64, add: bool) {
+        *n = if add {
+            n.saturating_add(by)
+        } else {
+            n.saturating_sub(by)
+        };
+    }
+    let user = o.tx.class != Class::System;
+    change(&mut c.user_occurrences, u64::from(user), add);
+    change(&mut c.system_occurrences, u64::from(!user), add);
+    change(
+        &mut c.subblock_occurrences,
+        u64::from(o.tx.class == Class::Subblock),
+        add,
+    );
+    change(&mut c.offered, u64::from(user && o.attempts > 0), add);
+    change(
+        &mut c.finalized,
+        u64::from(user && o.state == State::Finalized),
+        add,
+    );
+    change(
+        &mut c.gaps,
+        u64::from(user && matches!(o.state, State::Gap { .. })),
+        add,
+    );
+    change(&mut c.attempts, u64::from(o.attempts), add);
+    change(
+        &mut c.receipt_mismatches,
+        u64::from(o.receipt_mismatch == Some(true)),
+        add,
+    );
+    change(
+        &mut c.reserved_count,
+        u64::from(o.state.holds_credit()),
+        add,
+    );
+    change(
+        &mut c.reserved_bytes,
+        if o.state.holds_credit() {
+            o.tx.raw_len()
+        } else {
+            0
+        },
+        add,
+    );
+}

--- a/bin/tempo-replay/src/lib.rs
+++ b/bin/tempo-replay/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod capture;
+pub mod config;
+pub mod engine;
+pub mod journal;
+pub mod model;
+pub mod profile;
+pub mod rpc;
+pub mod timing;
+pub mod verify;
+
+pub mod metrics;

--- a/bin/tempo-replay/src/main.rs
+++ b/bin/tempo-replay/src/main.rs
@@ -1,0 +1,278 @@
+use anyhow::{Context, Result, ensure};
+use clap::{Parser, Subcommand};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use tempo_replay::{
+    capture,
+    config::Config,
+    engine,
+    journal::{Journal, SharedJournal, lock},
+    metrics, profile, verify,
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Parser)]
+#[command(
+    version,
+    about = "Mirror finalized Tempo transaction traffic to verified independent shadow validators"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+#[derive(Subcommand)]
+enum Command {
+    /// Capture only; never submits a transaction. Use --from-block for a new journal.
+    Capture {
+        #[arg(long)]
+        config: PathBuf,
+        #[arg(long)]
+        from_block: Option<u64>,
+        #[arg(long)]
+        to_block: Option<u64>,
+    },
+    /// Summarize a captured interval for capacity and compatibility qualification.
+    Profile {
+        #[arg(long)]
+        journal: PathBuf,
+        #[arg(long)]
+        output: PathBuf,
+        #[arg(long)]
+        from_block: Option<u64>,
+        #[arg(long)]
+        to_block: Option<u64>,
+    },
+    /// Read-only deployment, identity, finality recovery and workload checks.
+    Verify {
+        #[arg(long)]
+        config: PathBuf,
+    },
+    /// Mirror from a source height, catch up, then follow finalized traffic until stopped.
+    Run {
+        #[arg(long)]
+        config: PathBuf,
+        /// First source block to mirror (inclusive); defaults to fork checkpoint + 1.
+        #[arg(long)]
+        from_block: Option<u64>,
+        /// Optional end height for a bounded replay; omitted for continuous live mirroring.
+        #[arg(long)]
+        to_block: Option<u64>,
+        #[arg(long)]
+        acknowledge_incident: bool,
+    },
+    /// Read durable counters and independent progress cursors, including while running.
+    Status {
+        #[arg(long)]
+        journal: PathBuf,
+    },
+    /// Inspect every captured occurrence of a transaction hash.
+    Inspect {
+        #[arg(long)]
+        journal: PathBuf,
+        #[arg(long)]
+        tx: String,
+    },
+}
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "tempo_replay=info".into()),
+        )
+        .json()
+        .with_writer(std::io::stderr)
+        .init();
+    let cli = Cli::parse();
+    match cli.command {
+        Command::Profile {
+            journal,
+            output,
+            from_block,
+            to_block,
+        } => {
+            let j = Journal::read(&journal)?;
+            let p = profile::profile(&j, from_block, to_block)?;
+            write_json(&output, &p)?;
+            println!("{}", serde_json::to_string_pretty(&p)?);
+        }
+        Command::Status { journal } => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&Journal::read(&journal)?.state)?
+            );
+        }
+        Command::Inspect { journal, tx } => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&Journal::read(&journal)?.inspect(&tx)?)?
+            );
+        }
+        Command::Verify { config } => {
+            let c = Config::load(&config)?;
+            let source = verify::source_rpc(&c)?;
+            tokio::select! { r = verify::verify(&c, &source) => { let (_, report) = r?; println!("{}", serde_json::to_string_pretty(&report)?); }, _ = shutdown_signal() => {} }
+        }
+        Command::Capture {
+            config,
+            from_block,
+            to_block,
+        } => {
+            let c = Config::load(&config)?;
+            ensure!(
+                from_block.is_some()
+                    || c.checkpoint.is_some()
+                    || c.journal.path.join("db").exists(),
+                "new capture requires --from-block or a checkpoint"
+            );
+            let j = Arc::new(Mutex::new(Journal::open(&c, from_block)?));
+            let source = verify::source_rpc(&c)?;
+            ensure!(
+                source.chain_id().await? == c.run.chain_id,
+                "source chain id mismatch"
+            );
+            supervise(c.clone(), j.clone(), async move |stop| {
+                capture::capture_loop(c, source, j, to_block, stop).await
+            })
+            .await?;
+        }
+        Command::Run {
+            config,
+            from_block,
+            to_block,
+            acknowledge_incident,
+        } => {
+            let c = Config::load(&config)?;
+            c.replay()?;
+            let j = Arc::new(Mutex::new(Journal::open_replay(&c, from_block, to_block)?));
+            let first = c.checkpoint.as_ref().unwrap().source_height + 1;
+            tracing::info!(
+                from_block = first,
+                to_block,
+                continuous = to_block.is_none(),
+                "starting traffic mirror; existing journal progress resumes automatically"
+            );
+            let source = verify::source_rpc(&c)?;
+            supervise(c.clone(), j.clone(), async move |stop| {
+                let capture_stop = stop.child_token();
+                let capture_journal = j.clone(); let capture_config = c.clone(); let capture_source = source.clone();
+                let mut capture_task = tokio::spawn(capture::capture_loop(capture_config, capture_source, capture_journal, None, capture_stop.clone()));
+                let mut capture_joined = false;
+                let replay_result = async {
+                    let qualified = tokio::select! {
+                        r = verify::verify_live(&c, &source) => {
+                            let (q, report) = r?;
+                            for warning in &report.warnings { tracing::warn!(message = %warning, "startup verification note"); }
+                            lock(&j)?.put("meta/verification", &report)?;
+                            q
+                        },
+                        r = &mut capture_task => { capture_joined = true; r??; anyhow::bail!("capture stopped during verification"); },
+                        _ = stop.cancelled() => return Ok(()),
+                    };
+                    let mut replay_future = Box::pin(engine::replay(c, qualified, source, j.clone(), to_block, acknowledge_incident, stop.clone()));
+                    tokio::select! {
+                        r = &mut replay_future => r,
+                        r = &mut capture_task => { capture_joined = true; stop.cancel(); let _ = replay_future.await; r??; Ok(()) },
+                    }
+                }.await;
+                capture_stop.cancel();
+                if !capture_joined { let capture_result = capture_task.await.context("capture task panicked")?; if replay_result.is_ok() { capture_result?; } }
+                replay_result
+            }).await?;
+        }
+    }
+    Ok(())
+}
+async fn supervise<F, Fut>(c: Config, journal: SharedJournal, work: F) -> Result<()>
+where
+    F: FnOnce(CancellationToken) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let stop = CancellationToken::new();
+    let listener = tokio::net::TcpListener::bind(&c.metrics.listen)
+        .await
+        .context("bind metrics listener")?;
+    let mut metrics_task = tokio::spawn(metrics::serve(
+        listener,
+        journal.clone(),
+        c.metrics,
+        stop.clone(),
+    ));
+    let mut future = Box::pin(work(stop.clone()));
+    let mut metrics_joined = false;
+    let result = tokio::select! {
+        r = &mut future => r,
+        _ = shutdown_signal() => { stop.cancel(); future.await },
+        r = &mut metrics_task => { metrics_joined = true; stop.cancel(); let _ = future.await; match r { Ok(Ok(())) => Err(anyhow::anyhow!("metrics listener stopped")), Ok(Err(e)) => Err(e), Err(e) => Err(e.into()) } },
+    };
+    stop.cancel();
+    if !metrics_joined {
+        metrics_task.await.context("metrics task panicked")??;
+    }
+    lock(&journal)?.flush()?;
+    result
+}
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        if let Ok(mut term) =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+        {
+            tokio::select! { _ = tokio::signal::ctrl_c() => {}, _ = term.recv() => {} };
+        } else {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+fn write_json(path: &std::path::Path, value: &impl serde::Serialize) -> Result<()> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    let tmp = path.with_extension(format!("tmp-{}", std::process::id()));
+    std::fs::write(&tmp, bytes)?;
+    std::fs::File::open(&tmp)?.sync_all()?;
+    std::fs::rename(tmp, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn run_from_height_is_continuous_by_default() {
+        let cli = Cli::try_parse_from([
+            "tempo-replay",
+            "run",
+            "--config",
+            "mirror.toml",
+            "--from-block",
+            "101",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Run {
+                from_block: Some(101),
+                to_block: None,
+                ..
+            }
+        ));
+    }
+    #[test]
+    fn run_can_resume_without_repeating_the_height() {
+        let cli = Cli::try_parse_from(["tempo-replay", "run", "--config", "mirror.toml"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Run {
+                from_block: None,
+                to_block: None,
+                ..
+            }
+        ));
+    }
+}

--- a/bin/tempo-replay/src/metrics.rs
+++ b/bin/tempo-replay/src/metrics.rs
@@ -1,0 +1,157 @@
+use crate::{
+    config::Metrics,
+    journal::{SharedJournal, lock},
+    model::{Class, Phase, State},
+};
+use anyhow::Result;
+use std::time::Duration;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+use tokio_util::sync::CancellationToken;
+
+pub fn render(journal: &SharedJournal, config: &Metrics) -> Result<String> {
+    let j = lock(journal)?;
+    let s = &j.state;
+    let c = &s.counts;
+    let mut text = String::new();
+    macro_rules! metric {
+        ($name:literal, $kind:literal, $value:expr) => {
+            text.push_str(&format!(
+                "# TYPE tempo_replay_{} {}\ntempo_replay_{} {}\n",
+                $name, $kind, $name, $value
+            ));
+        };
+    }
+    metric!("user_occurrences", "gauge", c.user_occurrences);
+    metric!("system_occurrences", "gauge", c.system_occurrences);
+    metric!("offered_occurrences", "gauge", c.offered);
+    metric!("finalized_occurrences", "gauge", c.finalized);
+    metric!("gap_occurrences", "gauge", c.gaps);
+    metric!("rpc_attempts_total", "counter", c.attempts);
+    metric!("receipt_mismatches", "gauge", c.receipt_mismatches);
+    metric!("reserved_occurrences", "gauge", c.reserved_count);
+    metric!("reserved_raw_bytes", "gauge", c.reserved_bytes);
+    metric!(
+        "coverage_degraded",
+        "gauge",
+        u8::from(c.gaps > 0 || c.subblock_occurrences > 0)
+    );
+    metric!("observed_lag_ms", "gauge", s.lag_ms);
+    metric!("schedule_slip_ms", "gauge", s.slip_ms);
+    metric!(
+        "capture_unavailable",
+        "gauge",
+        u8::from(s.capture_error.is_some())
+    );
+    metric!("paused_incident", "gauge", u8::from(s.incident.is_some()));
+    metric!(
+        "submission_coverage",
+        "gauge",
+        ratio(c.offered, c.user_occurrences)
+    );
+    metric!(
+        "inclusion_coverage",
+        "gauge",
+        ratio(c.finalized, c.user_occurrences)
+    );
+    let cursors = [
+        (
+            "captured",
+            s.cursors.captured_through.as_ref().map(|p| p.height),
+        ),
+        ("dispatch_accounted", s.cursors.dispatch_accounted_through),
+        ("accounted", s.cursors.accounted_through),
+        ("included", s.cursors.included_through),
+        (
+            "shadow_observed",
+            s.cursors.shadow_observed_through.as_ref().map(|p| p.height),
+        ),
+    ];
+    for (name, cursor) in cursors {
+        if let Some(h) = cursor {
+            text.push_str(&format!(
+                "tempo_replay_cursor_height{{cursor=\"{name}\"}} {h}\n"
+            ));
+        }
+    }
+    for phase in [
+        Phase::CaptureOnly,
+        Phase::Verify,
+        Phase::Reconcile,
+        Phase::CatchUp,
+        Phase::Live,
+        Phase::PausedIncident,
+    ] {
+        text.push_str(&format!(
+            "tempo_replay_phase{{phase=\"{phase:?}\"}} {}\n",
+            u8::from(s.phase == phase)
+        ));
+    }
+    let mut recent_users = 0;
+    let mut recent_gaps = 0;
+    if let Some(end) = s.last_release_height {
+        let start = end
+            .saturating_add(1)
+            .saturating_sub(config.gap_window_blocks as u64)
+            .max(
+                s.replay_boundary
+                    .map_or(s.first_height, |b| b.saturating_add(1)),
+            );
+        for h in start..=end {
+            for o in j.occurrences(h)? {
+                if o.tx.class != Class::System {
+                    recent_users += 1;
+                    recent_gaps += u64::from(matches!(o.state, State::Gap { .. }));
+                }
+            }
+        }
+    }
+    let recent_ratio = ratio(recent_gaps, recent_users);
+    metric!("recent_gap_fraction", "gauge", recent_ratio);
+    metric!(
+        "recent_gap_alarm",
+        "gauge",
+        u8::from(recent_users > 0 && recent_ratio > config.gap_warn_fraction)
+    );
+    Ok(text)
+}
+fn ratio(n: u64, d: u64) -> f64 {
+    if d == 0 { 0. } else { n as f64 / d as f64 }
+}
+pub async fn serve(
+    listener: TcpListener,
+    journal: SharedJournal,
+    config: Metrics,
+    stop: CancellationToken,
+) -> Result<()> {
+    loop {
+        let accepted = tokio::select! { _ = stop.cancelled() => break, accepted = listener.accept() => accepted? };
+        let mut socket = accepted.0;
+        let request = async {
+            let mut buf = [0u8; 2048];
+            let n = socket.read(&mut buf).await?;
+            let request = std::str::from_utf8(&buf[..n]).unwrap_or("");
+            let (status, body) = if request.starts_with("GET /metrics ") {
+                ("200 OK", render(&journal, &config)?)
+            } else if request.starts_with("GET /healthz ") {
+                let j = lock(&journal)?;
+                if j.state.incident.is_none() && j.state.capture_error.is_none() {
+                    ("200 OK", "ok\n".into())
+                } else {
+                    (
+                        "503 Service Unavailable",
+                        "paused or source unavailable\n".into(),
+                    )
+                }
+            } else {
+                ("404 Not Found", "not found\n".into())
+            };
+            socket.write_all(format!("HTTP/1.1 {status}\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}", body.len()).as_bytes()).await?;
+            Ok::<_, anyhow::Error>(())
+        };
+        tokio::select! { _ = stop.cancelled() => break, _ = tokio::time::timeout(Duration::from_secs(2), request) => {} }
+    }
+    Ok(())
+}

--- a/bin/tempo-replay/src/model.rs
+++ b/bin/tempo-replay/src/model.rs
@@ -1,0 +1,355 @@
+use alloy_consensus::{
+    Transaction, proofs::calculate_transaction_root, transaction::SignerRecoverable,
+};
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_primitives::{Address, B256, Sealable, U256, keccak256};
+use anyhow::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tempo_primitives::{Block, TempoTxEnvelope};
+
+pub fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(u128::from(u64::MAX)) as u64
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Point {
+    pub height: u64,
+    pub hash: B256,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Class {
+    User,
+    System,
+    Subblock,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Tx {
+    pub hash: B256,
+    pub raw: String,
+    pub sender: Address,
+    pub nonce_key: U256,
+    pub nonce: u64,
+    pub expiring: bool,
+    pub tx_type: u8,
+    pub gas_limit: u64,
+    pub valid_before: Option<u64>,
+    pub valid_after: Option<u64>,
+    pub class: Class,
+}
+impl Tx {
+    pub fn from_envelope(e: &TempoTxEnvelope, chain_id: u64) -> Result<Self> {
+        let raw = e.encoded_2718();
+        let hash = keccak256(&raw);
+        let mut bytes = raw.as_slice();
+        let decoded =
+            TempoTxEnvelope::decode_2718(&mut bytes).context("unsupported signed envelope")?;
+        ensure!(
+            bytes.is_empty() && decoded.encoded_2718() == raw,
+            "noncanonical transaction encoding"
+        );
+        let system = e.is_system_tx();
+        if !system {
+            ensure!(
+                e.chain_id().is_none_or(|c| c == chain_id),
+                "source transaction chain id mismatch"
+            );
+        }
+        let sender = e.recover_signer().context("invalid source signature")?;
+        Ok(Self {
+            hash,
+            raw: format!("0x{}", hex::encode(raw)),
+            sender,
+            nonce_key: e.nonce_key().unwrap_or(U256::ZERO),
+            nonce: e.nonce(),
+            expiring: e.is_expiring_nonce(),
+            tx_type: e.tx_type() as u8,
+            gas_limit: e.gas_limit(),
+            valid_before: e.valid_before(),
+            valid_after: e.valid_after(),
+            class: if system {
+                Class::System
+            } else if e.has_sub_block_nonce_key_prefix() {
+                Class::Subblock
+            } else {
+                Class::User
+            },
+        })
+    }
+    pub fn lane(&self) -> Option<String> {
+        (!self.expiring).then(|| format!("{}:{}", self.sender, self.nonce_key))
+    }
+    pub fn raw_len(&self) -> u64 {
+        (self.raw.len().saturating_sub(2) / 2) as u64
+    }
+    pub fn expired_at(&self, tip_seconds: u64) -> bool {
+        self.valid_before
+            .is_some_and(|v| v <= tip_seconds.saturating_add(3))
+    }
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CapturedBlock {
+    pub point: Point,
+    pub parent: B256,
+    pub timestamp_ms: u64,
+    pub seen_ms: Option<u64>,
+    pub received_ms: u64,
+    pub committed_ms: u64,
+    pub provenance: String,
+    pub evidence: Value,
+    pub transactions: Vec<Tx>,
+}
+impl CapturedBlock {
+    pub fn verified(
+        block: Block,
+        expected: Option<B256>,
+        evidence: Value,
+        provenance: &str,
+        chain: u64,
+    ) -> Result<Self> {
+        let hash = block.header.hash_slow();
+        ensure!(
+            expected.is_none_or(|h| h == hash),
+            "source header hash mismatch"
+        );
+        ensure!(
+            block.header.timestamp_millis_part < 1000,
+            "invalid header millisecond part"
+        );
+        ensure!(
+            block.header.inner.transactions_root
+                == calculate_transaction_root(&block.body.transactions),
+            "transaction root mismatch"
+        );
+        let timestamp_ms = block
+            .header
+            .inner
+            .timestamp
+            .checked_mul(1000)
+            .and_then(|t| t.checked_add(block.header.timestamp_millis_part))
+            .context("timestamp overflow")?;
+        let transactions = block
+            .body
+            .transactions
+            .iter()
+            .map(|e| Tx::from_envelope(e, chain))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            point: Point {
+                height: block.header.inner.number,
+                hash,
+            },
+            parent: block.header.inner.parent_hash,
+            timestamp_ms,
+            seen_ms: evidence.get("seen").and_then(Value::as_u64),
+            received_ms: now_ms(),
+            committed_ms: 0,
+            provenance: provenance.into(),
+            evidence,
+            transactions,
+        })
+    }
+    pub fn from_certified(value: Value, chain: u64) -> Result<Self> {
+        let block = serde_json::from_value(
+            value
+                .get("block")
+                .context("certified block body missing")?
+                .clone(),
+        )
+        .context("decode native Tempo block")?;
+        // The owned consensus RPC is the finality trust boundary. The consensus proposal
+        // digest is kept as evidence; it is not substituted for the execution header hash.
+        ensure!(
+            value
+                .get("certificate")
+                .and_then(Value::as_str)
+                .is_some_and(|s| s.starts_with("0x") && s.len() > 2),
+            "missing finality certificate"
+        );
+        Self::verified(block, None, value, "certified_event", chain)
+    }
+    pub fn from_execution(value: Value, chain: u64) -> Result<Self> {
+        ensure!(!value.is_null(), "execution history missing");
+        let header =
+            serde_json::from_value(value.clone()).context("decode Tempo execution header")?;
+        let values = value
+            .get("transactions")
+            .and_then(Value::as_array)
+            .context("full transactions required")?;
+        let mut transactions = Vec::with_capacity(values.len());
+        for v in values {
+            let tx: TempoTxEnvelope =
+                serde_json::from_value(v.clone()).context("decode complete Tempo RPC envelope")?;
+            if let Some(hash) = v.get("hash") {
+                ensure!(
+                    serde_json::from_value::<B256>(hash.clone())? == keccak256(tx.encoded_2718()),
+                    "RPC transaction hash mismatch"
+                );
+            }
+            transactions.push(tx);
+        }
+        let hash =
+            serde_json::from_value(value.get("hash").context("RPC block hash missing")?.clone())?;
+        Self::verified(
+            Block {
+                header,
+                body: alloy_consensus::BlockBody {
+                    transactions,
+                    ommers: vec![],
+                    withdrawals: None,
+                },
+            },
+            Some(hash),
+            value,
+            "anchored_execution_range",
+            chain,
+        )
+    }
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum State {
+    Ready,
+    Attempting,
+    Accepted,
+    Unknown,
+    Deferred,
+    Finalized,
+    Gap { reason: String },
+    GeneratedByShadowConsensus,
+}
+impl State {
+    pub fn terminal(&self) -> bool {
+        matches!(
+            self,
+            Self::Finalized | Self::Gap { .. } | Self::GeneratedByShadowConsensus
+        )
+    }
+    pub fn holds_credit(&self) -> bool {
+        matches!(self, Self::Attempting | Self::Accepted | Self::Unknown)
+    }
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Occurrence {
+    pub source: Point,
+    pub index: usize,
+    pub tx: Tx,
+    pub source_timestamp_ms: u64,
+    pub state: State,
+    pub attempts: u32,
+    pub ambiguous_resends: u32,
+    pub first_attempt_ms: Option<u64>,
+    pub last_attempt_ms: Option<u64>,
+    pub retry_at_ms: u64,
+    pub dependency_since_ms: Option<u64>,
+    pub endpoint: Option<String>,
+    pub receipt: Option<Value>,
+    pub source_receipt: Option<Value>,
+    pub receipt_mismatch: Option<bool>,
+    pub history: Vec<Event>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Event {
+    pub at_ms: u64,
+    pub state: State,
+    pub detail: String,
+}
+impl Occurrence {
+    pub fn new(b: &CapturedBlock, index: usize) -> Self {
+        let tx = b.transactions[index].clone();
+        let state = if tx.class == Class::System {
+            State::GeneratedByShadowConsensus
+        } else {
+            State::Ready
+        };
+        Self {
+            source: b.point.clone(),
+            index,
+            tx,
+            source_timestamp_ms: b.timestamp_ms,
+            state,
+            attempts: 0,
+            ambiguous_resends: 0,
+            first_attempt_ms: None,
+            last_attempt_ms: None,
+            retry_at_ms: 0,
+            dependency_since_ms: None,
+            endpoint: None,
+            receipt: None,
+            source_receipt: None,
+            receipt_mismatch: None,
+            history: vec![],
+        }
+    }
+    pub fn key(&self) -> String {
+        format!("o/{:020}/{:010}", self.source.height, self.index)
+    }
+    pub fn transition(&mut self, state: State, detail: impl Into<String>) {
+        self.history.push(Event {
+            at_ms: now_ms(),
+            state: state.clone(),
+            detail: detail.into(),
+        });
+        self.state = state;
+    }
+    pub fn dispatch_accounted(&self) -> bool {
+        self.attempts > 0 || self.state.terminal()
+    }
+}
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Cursors {
+    pub captured_through: Option<Point>,
+    pub dispatch_accounted_through: Option<u64>,
+    pub accounted_through: Option<u64>,
+    pub included_through: Option<u64>,
+    pub shadow_observed_through: Option<Point>,
+}
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub enum Phase {
+    CaptureOnly,
+    Verify,
+    Reconcile,
+    CatchUp,
+    Live,
+    PausedIncident,
+}
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Counts {
+    pub user_occurrences: u64,
+    pub system_occurrences: u64,
+    pub subblock_occurrences: u64,
+    pub offered: u64,
+    pub finalized: u64,
+    pub gaps: u64,
+    pub attempts: u64,
+    pub receipt_mismatches: u64,
+    pub reserved_count: u64,
+    pub reserved_bytes: u64,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RunState {
+    pub schema_version: u32,
+    pub run_id: String,
+    pub chain_id: u64,
+    pub source_identity: String,
+    pub first_height: u64,
+    pub replay_boundary: Option<u64>,
+    pub binding: Option<String>,
+    pub phase: Phase,
+    pub incident: Option<String>,
+    pub cursors: Cursors,
+    pub counts: Counts,
+    pub last_release_height: Option<u64>,
+    pub lag_ms: u64,
+    pub slip_ms: u64,
+    pub target_tip_seconds: u64,
+    pub capture_error: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Inclusion {
+    pub point: Point,
+    pub index: usize,
+}

--- a/bin/tempo-replay/src/profile.rs
+++ b/bin/tempo-replay/src/profile.rs
@@ -1,0 +1,103 @@
+use crate::{journal::Journal, model::Class};
+use anyhow::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Profile {
+    pub schema_version: u32,
+    pub chain_id: u64,
+    pub first_height: u64,
+    pub last_height: u64,
+    pub first_hash: String,
+    pub last_hash: String,
+    pub blocks: u64,
+    pub duration_ms: u64,
+    pub users: u64,
+    pub systems: u64,
+    pub subblocks: u64,
+    pub raw_bytes: u64,
+    pub gas_limit: u64,
+    pub transaction_types: BTreeMap<u8, u64>,
+    pub expiring_nonces: u64,
+    pub nonzero_nonce_keys: u64,
+    pub deadlines: u64,
+    pub earliest_valid_before: Option<u64>,
+    pub latest_valid_before: Option<u64>,
+    pub mean_tps: f64,
+    pub peak_block_users: u64,
+    pub peak_block_raw_bytes: u64,
+    pub peak_sender_block_users: u64,
+    pub capture_p99_ms: u64,
+    pub deadline_note: String,
+}
+pub fn profile(j: &Journal, from: Option<u64>, to: Option<u64>) -> Result<Profile> {
+    let end = j
+        .state
+        .cursors
+        .captured_through
+        .as_ref()
+        .context("no captured blocks")?
+        .height;
+    let start = from.unwrap_or(j.state.first_height);
+    let end = to.unwrap_or(end).min(end);
+    ensure!(
+        start >= j.state.first_height && start <= end,
+        "invalid captured profile interval"
+    );
+    let first = j.block(start)?.context("first profile block missing")?;
+    let last = j.block(end)?.context("last profile block missing")?;
+    let mut p = Profile { schema_version: 1, chain_id: j.state.chain_id, first_height: start, last_height: end,
+        first_hash: first.point.hash.to_string(), last_hash: last.point.hash.to_string(), blocks: end - start + 1,
+        duration_ms: last.timestamp_ms.saturating_sub(first.timestamp_ms), users: 0, systems: 0, subblocks: 0,
+        raw_bytes: 0, gas_limit: 0, transaction_types: BTreeMap::new(), expiring_nonces: 0, nonzero_nonce_keys: 0,
+        deadlines: 0, earliest_valid_before: None, latest_valid_before: None, mean_tps: 0., peak_block_users: 0,
+        peak_block_raw_bytes: 0, peak_sender_block_users: 0, capture_p99_ms: 0,
+        deadline_note: "valid_before only; access-key and state-dependent deadlines require deployment measurements".into() };
+    let mut capture_histogram = BTreeMap::<u64, u64>::new();
+    for h in start..=end {
+        let b = j.block(h)?.context("profile block missing")?;
+        let mut senders = BTreeMap::new();
+        let mut count = 0;
+        let mut bytes = 0;
+        *capture_histogram
+            .entry(b.committed_ms.saturating_sub(b.timestamp_ms) / 100 * 100)
+            .or_default() += 1;
+        for tx in b.transactions {
+            if tx.class == Class::System {
+                p.systems += 1;
+                continue;
+            }
+            count += 1;
+            p.users += 1;
+            p.subblocks += u64::from(tx.class == Class::Subblock);
+            bytes += tx.raw_len();
+            p.raw_bytes += tx.raw_len();
+            p.gas_limit = p.gas_limit.saturating_add(tx.gas_limit);
+            *p.transaction_types.entry(tx.tx_type).or_default() += 1;
+            p.expiring_nonces += u64::from(tx.expiring);
+            p.nonzero_nonce_keys += u64::from(!tx.nonce_key.is_zero());
+            let sender_count = senders.entry(tx.sender).or_insert(0);
+            *sender_count += 1;
+            p.peak_sender_block_users = p.peak_sender_block_users.max(*sender_count);
+            if let Some(v) = tx.valid_before {
+                p.deadlines += 1;
+                p.earliest_valid_before = Some(p.earliest_valid_before.map_or(v, |old| old.min(v)));
+                p.latest_valid_before = Some(p.latest_valid_before.map_or(v, |old| old.max(v)));
+            }
+        }
+        p.peak_block_users = p.peak_block_users.max(count);
+        p.peak_block_raw_bytes = p.peak_block_raw_bytes.max(bytes);
+    }
+    p.mean_tps = p.users as f64 * 1000. / p.duration_ms.max(1) as f64;
+    let mut seen = 0;
+    for (latency, n) in capture_histogram {
+        seen += n;
+        if seen * 100 >= p.blocks * 99 {
+            p.capture_p99_ms = latency + 99;
+            break;
+        }
+    }
+    Ok(p)
+}

--- a/bin/tempo-replay/src/rpc.rs
+++ b/bin/tempo-replay/src/rpc.rs
@@ -1,0 +1,312 @@
+use crate::model::{CapturedBlock, Point};
+use alloy_primitives::{B256, Sealable};
+use anyhow::{Context, Result, ensure};
+use futures_util::{SinkExt, StreamExt};
+use reqwest::{
+    Client,
+    header::{AUTHORIZATION, HeaderMap, HeaderValue},
+};
+use serde_json::{Value, json};
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
+use tokio::{sync::watch, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct Rpc {
+    client: Client,
+    url: String,
+    seq: Arc<AtomicU64>,
+    max_bytes: u64,
+}
+#[derive(Debug)]
+pub struct EvidenceError {
+    pub value: Value,
+    detail: String,
+}
+impl fmt::Display for EvidenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "incompatible execution block: {}", self.detail)
+    }
+}
+impl std::error::Error for EvidenceError {}
+#[derive(Debug, Clone)]
+pub struct RpcError {
+    pub code: i64,
+    pub message: String,
+    pub retry_ms: Option<u64>,
+    pub ambiguous: bool,
+}
+impl fmt::Display for RpcError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "RPC failure code {}", self.code)
+    }
+}
+impl std::error::Error for RpcError {}
+impl Rpc {
+    pub fn new(
+        url: &str,
+        timeout_ms: u64,
+        max_bytes: u64,
+        ca: Option<&[u8]>,
+        credential: Option<&str>,
+    ) -> Result<Self> {
+        // Select the workspace TLS provider before HTTP or WebSocket clients are built.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let mut headers = HeaderMap::new();
+        if let Some(secret) = credential {
+            ensure!(!secret.is_empty(), "empty RPC credential");
+            let mut h = HeaderValue::from_str(&format!("Bearer {secret}"))
+                .context("invalid credential header")?;
+            h.set_sensitive(true);
+            headers.insert(AUTHORIZATION, h);
+        }
+        let mut builder = Client::builder()
+            .timeout(Duration::from_millis(timeout_ms))
+            .redirect(reqwest::redirect::Policy::none())
+            .default_headers(headers);
+        if let Some(pem) = ca {
+            builder = builder.tls_certs_merge([
+                reqwest::Certificate::from_pem(pem).context("invalid shadow CA")?
+            ]);
+        }
+        Ok(Self {
+            client: builder.build()?,
+            url: url.into(),
+            seq: Arc::new(AtomicU64::new(1)),
+            max_bytes,
+        })
+    }
+    pub async fn call(&self, method: &str, params: Value) -> Result<Value> {
+        let id = self.seq.fetch_add(1, Ordering::Relaxed);
+        let mut response = self
+            .client
+            .post(&self.url)
+            .json(&json!({"jsonrpc":"2.0","id":id,"method":method,"params":params}))
+            .send()
+            .await
+            .map_err(|_| RpcError {
+                code: -1,
+                message: "transport failure".into(),
+                retry_ms: None,
+                ambiguous: true,
+            })?;
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let retry_ms = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| {
+                    s.parse::<u64>()
+                        .ok()
+                        .map(|seconds| seconds.saturating_mul(1000))
+                        .or_else(|| {
+                            httpdate::parse_http_date(s).ok().map(|date| {
+                                date.duration_since(std::time::SystemTime::now())
+                                    .unwrap_or_default()
+                                    .as_millis()
+                                    .min(u128::from(u64::MAX))
+                                    as u64
+                            })
+                        })
+                });
+            return Err(RpcError {
+                code: i64::from(status),
+                message: "HTTP failure".into(),
+                retry_ms,
+                ambiguous: status >= 500,
+            }
+            .into());
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(|_| RpcError {
+            code: -1,
+            message: "response interrupted".into(),
+            retry_ms: None,
+            ambiguous: true,
+        })? {
+            ensure!(
+                (bytes.len() as u64).saturating_add(chunk.len() as u64) <= self.max_bytes,
+                "RPC response exceeds configured byte bound"
+            );
+            bytes.extend_from_slice(&chunk);
+        }
+        let v: Value = serde_json::from_slice(&bytes).context("invalid JSON-RPC response")?;
+        ensure!(
+            v.get("id").and_then(Value::as_u64) == Some(id)
+                && v.get("jsonrpc").and_then(Value::as_str) == Some("2.0"),
+            "JSON-RPC response identity mismatch"
+        );
+        if let Some(e) = v.get("error") {
+            return Err(RpcError {
+                code: e["code"].as_i64().unwrap_or(-1),
+                message: e["message"].as_str().unwrap_or("unknown RPC error").into(),
+                retry_ms: None,
+                ambiguous: false,
+            }
+            .into());
+        }
+        v.get("result").cloned().context("missing RPC result")
+    }
+    pub async fn chain_id(&self) -> Result<u64> {
+        quantity(&self.call("eth_chainId", json!([])).await?)
+    }
+    pub async fn latest_finalized(&self, chain: u64) -> Result<CapturedBlock> {
+        let value = self.call("consensus_getLatest", json!([])).await?;
+        CapturedBlock::from_certified(
+            value
+                .get("finalized")
+                .filter(|v| !v.is_null())
+                .context("source has no finalized block")?
+                .clone(),
+            chain,
+        )
+    }
+    pub async fn certified(&self, height: u64, chain: u64) -> Result<CapturedBlock> {
+        let b = CapturedBlock::from_certified(
+            self.call("consensus_getFinalization", json!([{"height":height}]))
+                .await?,
+            chain,
+        )?;
+        ensure!(b.point.height == height, "certified height mismatch");
+        Ok(b)
+    }
+    pub async fn execution(
+        &self,
+        height: u64,
+        chain: u64,
+        prefer_raw: bool,
+    ) -> Result<CapturedBlock> {
+        let value = self
+            .call(
+                "eth_getBlockByNumber",
+                json!([format!("0x{height:x}"), true]),
+            )
+            .await?;
+        let typed =
+            CapturedBlock::from_execution(value.clone(), chain).map_err(|e| EvidenceError {
+                value,
+                detail: format!("{e:#}"),
+            })?;
+        ensure!(typed.point.height == height, "execution height mismatch");
+        if prefer_raw {
+            match self
+                .call("debug_getRawBlock", json!([format!("0x{height:x}")]))
+                .await
+            {
+                Ok(v) => {
+                    let raw = v.as_str().context("invalid raw block result")?;
+                    let bytes =
+                        hex::decode(raw.strip_prefix("0x").context("raw block must be hex")?)?;
+                    let mut input = bytes.as_slice();
+                    let block: tempo_primitives::Block = alloy_rlp::Decodable::decode(&mut input)
+                        .context("decode raw Tempo block")?;
+                    ensure!(input.is_empty(), "trailing raw block bytes");
+                    let decoded = CapturedBlock::verified(
+                        block,
+                        Some(typed.point.hash),
+                        json!({"rawBlock":raw}),
+                        "anchored_execution_range",
+                        chain,
+                    )?;
+                    ensure!(
+                        decoded
+                            .transactions
+                            .iter()
+                            .map(|t| &t.raw)
+                            .eq(typed.transactions.iter().map(|t| &t.raw)),
+                        "raw/typed block transaction mismatch"
+                    );
+                }
+                Err(e) if e.downcast_ref::<RpcError>().is_some() => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(typed)
+    }
+    pub async fn header_point(&self, height: u64) -> Result<Point> {
+        let v = self
+            .call(
+                "eth_getBlockByNumber",
+                json!([format!("0x{height:x}"), false]),
+            )
+            .await?;
+        ensure!(!v.is_null(), "checkpoint unavailable");
+        let h: tempo_primitives::TempoHeader = serde_json::from_value(v.clone())?;
+        let hash: B256 = serde_json::from_value(v["hash"].clone())?;
+        ensure!(
+            h.inner.number == height && h.hash_slow() == hash,
+            "checkpoint header hash mismatch"
+        );
+        Ok(Point { height, hash })
+    }
+}
+pub fn quantity(v: &Value) -> Result<u64> {
+    if let Some(n) = v.as_u64() {
+        return Ok(n);
+    }
+    u64::from_str_radix(
+        v.as_str()
+            .and_then(|s| s.strip_prefix("0x"))
+            .context("expected hex quantity")?,
+        16,
+    )
+    .context("quantity overflow")
+}
+// A bounded latest-event notification is intentional: HTTP gap repair is authoritative,
+// so socket loss, coalescing, and dropped events cannot skip a finalized height.
+pub fn source_subscription(
+    url: String,
+    max_bytes: usize,
+    stop: CancellationToken,
+) -> (watch::Receiver<Option<Value>>, JoinHandle<()>) {
+    let (tx, rx) = watch::channel(None);
+    let task = tokio::spawn(async move {
+        loop {
+            let connected = tokio::select! { _ = stop.cancelled() => break, result = tokio_tungstenite::connect_async_with_config(&url, Some(tokio_tungstenite::tungstenite::protocol::WebSocketConfig::default().max_message_size(Some(max_bytes)).max_frame_size(Some(max_bytes))), false) => result };
+            if let Ok((mut ws, _)) = connected {
+                let request =
+                    json!({"jsonrpc":"2.0","id":1,"method":"consensus_subscribe","params":[]})
+                        .to_string();
+                if ws
+                    .send(tokio_tungstenite::tungstenite::Message::Text(
+                        request.into(),
+                    ))
+                    .await
+                    .is_ok()
+                {
+                    loop {
+                        let msg = tokio::select! { _ = stop.cancelled() => break, msg = ws.next() => msg };
+                        match msg {
+                            Some(Ok(tokio_tungstenite::tungstenite::Message::Text(text))) => {
+                                if let Ok(v) = serde_json::from_str::<Value>(&text)
+                                    && v["method"] == "consensus_event"
+                                    && v["params"]["result"]["type"] == "finalized"
+                                {
+                                    tx.send_replace(Some(v["params"]["result"].clone()));
+                                }
+                            }
+                            Some(Ok(tokio_tungstenite::tungstenite::Message::Ping(data))) => {
+                                let _ = ws
+                                    .send(tokio_tungstenite::tungstenite::Message::Pong(data))
+                                    .await;
+                            }
+                            Some(Ok(_)) => {}
+                            _ => break,
+                        }
+                    }
+                }
+                // Dropping the socket closes it without waiting for a peer's close handshake.
+            }
+            tokio::select! { _ = stop.cancelled() => break, _ = tokio::time::sleep(Duration::from_secs(2)) => {} }
+        }
+    });
+    (rx, task)
+}

--- a/bin/tempo-replay/src/timing.rs
+++ b/bin/tempo-replay/src/timing.rs
@@ -1,0 +1,98 @@
+use crate::{
+    config::Timing,
+    model::{Phase, now_ms},
+};
+use anyhow::{Result, ensure};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio::time::Instant;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Segment {
+    pub phase: Phase,
+    pub first_height: u64,
+    pub source_ms: u64,
+    pub anchor_wall_ms: u64,
+    pub speed: f64,
+    pub reason: String,
+}
+pub struct Pacer {
+    pub segment: Segment,
+    anchor: Instant,
+    previous: Option<(u64, Instant)>,
+    pub consecutive_slips: u64,
+}
+impl Pacer {
+    pub fn new(c: &Timing, phase: Phase, height: u64, source_ms: u64, reason: &str) -> Self {
+        let now = now_ms();
+        let delay = if phase == Phase::Live {
+            c.guard_ms.max(
+                source_ms
+                    .saturating_add(c.target_lag_ms)
+                    .saturating_sub(now),
+            )
+        } else {
+            c.guard_ms
+        };
+        Self {
+            segment: Segment {
+                speed: if phase == Phase::Live {
+                    1.
+                } else {
+                    c.max_catch_up_speed
+                },
+                phase,
+                first_height: height,
+                source_ms,
+                anchor_wall_ms: now.saturating_add(delay),
+                reason: reason.into(),
+            },
+            anchor: Instant::now() + Duration::from_millis(delay),
+            previous: None,
+            consecutive_slips: 0,
+        }
+    }
+    pub fn due(&self, source_ms: u64) -> Result<Instant> {
+        ensure!(
+            source_ms >= self.segment.source_ms,
+            "pacing timestamp regression"
+        );
+        self.anchor
+            .checked_add(scaled(
+                source_ms - self.segment.source_ms,
+                self.segment.speed,
+            )?)
+            .ok_or_else(|| anyhow::anyhow!("pacing deadline overflow"))
+    }
+    pub fn release_at(&self, source_ms: u64) -> Result<Instant> {
+        let due = self.due(source_ms)?;
+        if let Some((previous_ms, previous_release)) = self.previous {
+            ensure!(source_ms >= previous_ms, "release timestamp regression");
+            Ok(due.max(
+                previous_release
+                    .checked_add(scaled(source_ms - previous_ms, self.segment.speed)?)
+                    .ok_or_else(|| anyhow::anyhow!("release deadline overflow"))?,
+            ))
+        } else {
+            Ok(due)
+        }
+    }
+    pub fn released(&mut self, source_ms: u64, c: &Timing) -> Result<u64> {
+        let now = Instant::now();
+        let slip = now
+            .saturating_duration_since(self.due(source_ms)?)
+            .as_millis()
+            .min(u128::from(u64::MAX)) as u64;
+        self.consecutive_slips = if slip > c.slip_warn_ms {
+            self.consecutive_slips + 1
+        } else {
+            0
+        };
+        self.previous = Some((source_ms, now));
+        Ok(slip)
+    }
+}
+fn scaled(ms: u64, speed: f64) -> Result<Duration> {
+    ensure!(speed.is_finite() && speed >= 1., "invalid pacing speed");
+    Ok(Duration::from_millis((ms as f64 / speed).ceil() as u64))
+}

--- a/bin/tempo-replay/src/verify.rs
+++ b/bin/tempo-replay/src/verify.rs
@@ -1,0 +1,474 @@
+use crate::{
+    config::*,
+    model::{CapturedBlock, Point},
+    profile::Profile,
+    rpc::Rpc,
+};
+use alloy_primitives::{B256, keccak256};
+use anyhow::{Context, Result, ensure};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeSet;
+
+#[derive(Clone)]
+pub struct Target {
+    pub id: String,
+    pub rpc: Rpc,
+    pub evidence: ValidatorEvidence,
+}
+#[derive(Clone)]
+pub struct Qualified {
+    pub targets: Vec<Target>,
+    pub deployment: Deployment,
+    pub binding: String,
+    pub sender_budget: usize,
+    pub count_budget: usize,
+    pub byte_budget: u64,
+    pub overhead: u64,
+    pub multiplier: u64,
+}
+#[derive(Debug, Serialize)]
+pub struct VerificationReport {
+    pub run_id: String,
+    pub boundary: u64,
+    pub binding: String,
+    pub targets: usize,
+    pub source_finalized: Point,
+    pub sender_budget: usize,
+    pub count_budget: usize,
+    pub byte_budget: u64,
+    pub measured_sustained_tps: f64,
+    pub profile_mean_tps: Option<f64>,
+    pub mode: VerificationMode,
+    pub warnings: Vec<String>,
+}
+#[derive(Deserialize)]
+struct NativeManifest {
+    source_chain_id: u64,
+    shadow_chain_id: u64,
+    fork_block_number: u64,
+    fork_block_hash: B256,
+    fork_state_root: B256,
+    validators: Vec<NativeValidator>,
+}
+#[derive(Deserialize)]
+struct NativeValidator {
+    validator_public_key: B256,
+}
+pub fn source_rpc(c: &Config) -> Result<Rpc> {
+    Rpc::new(
+        &c.source.rpc_http,
+        c.limits.rpc_timeout_ms,
+        c.limits.max_buffered_bytes,
+        None,
+        None,
+    )
+}
+pub fn sha256(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(bytes)))
+}
+fn valid_digest(s: &str) -> bool {
+    s.strip_prefix("sha256:")
+        .is_some_and(|v| v.len() == 64 && hex::decode(v).is_ok())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationMode {
+    Live,
+    Qualification,
+}
+
+pub async fn verify(c: &Config, source: &Rpc) -> Result<(Qualified, VerificationReport)> {
+    verify_with_mode(c, source, VerificationMode::Qualification).await
+}
+
+/// Identity and pool bounds remain mandatory. No pre-captured workload is needed:
+/// live capture validates every range as it arrives, including an initial backlog.
+pub async fn verify_live(c: &Config, source: &Rpc) -> Result<(Qualified, VerificationReport)> {
+    verify_with_mode(c, source, VerificationMode::Live).await
+}
+
+fn load_profile(c: &Config, mode: VerificationMode) -> Result<Option<Profile>> {
+    match &c.run.workload_profile {
+        Some(path) => Ok(Some(serde_json::from_slice(
+            &std::fs::read(path).context("read configured workload profile")?,
+        )?)),
+        None if mode == VerificationMode::Live => Ok(None),
+        None => anyhow::bail!(
+            "workload profile required for qualification; use run for continuous live mirroring without a prior profile"
+        ),
+    }
+}
+
+async fn verify_with_mode(
+    c: &Config,
+    source: &Rpc,
+    mode: VerificationMode,
+) -> Result<(Qualified, VerificationReport)> {
+    let (checkpoint, shadow) = c.replay()?;
+    let source_hash: B256 = checkpoint
+        .source_hash
+        .parse()
+        .context("set actual source checkpoint hash")?;
+    let shadow_hash: B256 = checkpoint
+        .shadow_hash
+        .parse()
+        .context("set actual patched shadow checkpoint hash")?;
+    ensure!(
+        source_hash != shadow_hash,
+        "native shadow checkpoint must differ from source"
+    );
+    let native_bytes =
+        std::fs::read(&checkpoint.manifest).context("read native bootstrap manifest")?;
+    ensure!(
+        sha256(&native_bytes) == checkpoint.bootstrap_artifact_digest,
+        "bootstrap manifest digest mismatch"
+    );
+    let native: NativeManifest = serde_json::from_slice(&native_bytes)?;
+    ensure!(
+        native.source_chain_id == c.run.chain_id
+            && native.shadow_chain_id == c.run.chain_id
+            && native.fork_block_number == checkpoint.source_height
+            && native.fork_block_hash == source_hash,
+        "native bootstrap manifest disagrees with checkpoint"
+    );
+    let deployment_bytes =
+        std::fs::read(&shadow.deployment_manifest).context("read deployment evidence")?;
+    let deployment: Deployment = serde_json::from_slice(&deployment_bytes)?;
+    ensure!(
+        deployment.schema_version == 1
+            && deployment.run_id == c.run.id
+            && deployment.chain_id == c.run.chain_id
+            && deployment.tempo_revision == TEMPO_REVISION
+            && deployment.reth_revision == RETH_REVISION
+            && deployment.bootstrap_artifact_digest == checkpoint.bootstrap_artifact_digest,
+        "deployment revision/identity mismatch"
+    );
+    ensure!(
+        valid_digest(&deployment.binary_sha256) && valid_digest(&deployment.chainspec_sha256),
+        "binary/chainspec SHA256 evidence required"
+    );
+    ensure!(
+        deployment.isolated_network
+            && deployment.exclusive_workload
+            && deployment.fork_rules_match_source
+            && deployment.fee_token_and_amm_parity
+            && deployment.validity_buffer_seconds == 3,
+        "deployment isolation, validation, fee, or validity-buffer qualification failed"
+    );
+    let p = load_profile(c, mode)?;
+    let mut warnings = vec!["Validator configuration, keys, binary digests and measured capacity are operator attestations; standard RPC cannot independently verify them.".into(), "Accepted or ambiguous transactions retain pool reservations until finalized or definitively rejected. Unobservable eviction pauses progress instead of inventing free capacity.".into()];
+    if let Some(p) = &p {
+        ensure!(
+            p.schema_version == 1
+                && p.chain_id == c.run.chain_id
+                && p.blocks >= 2
+                && p.duration_ms > 0
+                && p.users > 0
+                && p.mean_tps.is_finite()
+                && p.mean_tps > 0.,
+            "profile must contain a nonempty representative interval"
+        );
+        ensure!(
+            p.subblocks == 0
+                && p.transaction_types
+                    .keys()
+                    .all(|t| [0, 1, 2, 4, 0x76].contains(t)),
+            "profile contains unsupported routes or transaction types"
+        );
+        ensure!(
+            p.peak_block_raw_bytes <= c.limits.max_buffered_bytes,
+            "profile peak block exceeds byte bound"
+        );
+    }
+    ensure!(
+        deployment.measured_sustained_tps.is_finite() && deployment.measured_sustained_tps >= 0.,
+        "invalid measured throughput"
+    );
+    let throughput_qualified = p
+        .as_ref()
+        .is_some_and(|p| deployment.measured_sustained_tps > p.mean_tps);
+    let latency_qualified = deployment.measured_rpc_p99_ms > 0
+        && deployment.source_capture_p99_ms > 0
+        && deployment.source_capture_p99_ms < c.timing.target_lag_ms;
+    if mode == VerificationMode::Qualification {
+        ensure!(
+            throughput_qualified,
+            "measured target throughput cannot catch up with source"
+        );
+        ensure!(
+            latency_qualified,
+            "measured latency does not qualify configured live lag"
+        );
+    } else {
+        if !throughput_qualified {
+            warnings.push("Starting continuous mirroring without a qualified throughput profile; catch-up and live lag are measured at runtime.".into());
+        }
+        if !latency_qualified {
+            warnings.push("Configured live lag is a pacing target; measured source/target latency has not qualified it.".into());
+        }
+    }
+    ensure!(
+        source.chain_id().await? == c.run.chain_id,
+        "source chain id mismatch"
+    );
+    ensure!(
+        source.header_point(checkpoint.source_height).await?.hash == source_hash,
+        "source checkpoint mismatch"
+    );
+    let source_boundary = source
+        .call(
+            "eth_getBlockByNumber",
+            json!([format!("0x{:x}", checkpoint.source_height), false]),
+        )
+        .await?;
+    ensure!(
+        serde_json::from_value::<B256>(source_boundary["stateRoot"].clone())?
+            == native.fork_state_root,
+        "native source state root mismatch"
+    );
+    if let Some(p) = &p {
+        ensure!(
+            source.header_point(p.first_height).await?.hash.to_string() == p.first_hash
+                && source.header_point(p.last_height).await?.hash.to_string() == p.last_hash,
+            "workload profile is not from this source history"
+        );
+    }
+    let anchor = source.latest_finalized(c.run.chain_id).await?;
+    ensure!(
+        anchor.point.height >= checkpoint.source_height,
+        "source finality has not reached the configured fork checkpoint"
+    );
+    // A live start probes the complete execution adapter at the trusted tip. Capture
+    // verifies the actual backlog, then each new range, while dispatch runs concurrently.
+    // The separate qualification command performs the exhaustive retention-horizon scan.
+    let history_start = match mode {
+        VerificationMode::Live => anchor.point.height,
+        VerificationMode::Qualification => anchor
+            .point
+            .height
+            .saturating_sub(
+                c.source
+                    .recovery_horizon_blocks
+                    .max(c.source.history_probe_blocks),
+            )
+            .min(checkpoint.source_height),
+    };
+    verify_execution_range(source, c.run.chain_id, history_start, &anchor).await?;
+    let ca = std::fs::read(&shadow.ca_file).context("read shadow CA certificate")?;
+    let native_keys: BTreeSet<_> = native
+        .validators
+        .iter()
+        .map(|v| v.validator_public_key)
+        .collect();
+    let deployed_keys = deployment
+        .validators
+        .iter()
+        .map(|v| {
+            v.public_key
+                .parse::<B256>()
+                .context("invalid deployment validator public key")
+        })
+        .collect::<Result<BTreeSet<_>>>()?;
+    ensure!(
+        native_keys == deployed_keys && native_keys.len() == shadow.validators.len(),
+        "deployment validator set disagrees with native bootstrap artifact"
+    );
+    let mut targets = vec![];
+    let mut ids = BTreeSet::new();
+    let mut sender = usize::MAX;
+    let mut count = usize::MAX;
+    let mut bytes = u64::MAX;
+    let mut overhead = 0;
+    let mut multiplier = 0;
+    ensure!(
+        deployment.validators.len() == shadow.validators.len(),
+        "configure every participating validator"
+    );
+    for v in &shadow.validators {
+        let e = deployment
+            .validators
+            .iter()
+            .find(|e| e.id == v.id)
+            .context("validator missing from deployment evidence")?;
+        ensure!(
+            ids.insert(e.id.clone())
+                && e.public_key == v.expected_validator_public_key
+                && e.rpc_http == v.rpc_http,
+            "validator identity/endpoint evidence mismatch"
+        );
+        ensure!(
+            !e.public_key.contains("REPLACE") && !e.public_key.is_empty(),
+            "validator public key is a placeholder"
+        );
+        ensure!(
+            e.max_sender_slots > 0
+                && e.pending_count > 0
+                && e.queued_count > 0
+                && e.pending_bytes > 0
+                && e.queued_bytes > 0
+                && e.pool_fixed_overhead_bytes > 0
+                && e.pool_raw_size_multiplier >= 1,
+            "missing pool capacity measurements"
+        );
+        ensure!(
+            e.pool_observation == "conservative_retained_reservations",
+            "unsupported pool observation adapter"
+        );
+        let credential = std::env::var(&v.credential_env).with_context(|| {
+            format!(
+                "missing credential environment variable for validator {}",
+                v.id
+            )
+        })?;
+        let rpc = Rpc::new(
+            &v.rpc_http,
+            c.limits.rpc_timeout_ms,
+            c.limits.max_buffered_bytes,
+            Some(&ca),
+            Some(&credential),
+        )?;
+        check_target(&rpc, c).await?;
+        sender = sender.min(e.max_sender_slots);
+        count = count.min(e.pending_count.min(e.queued_count));
+        bytes = bytes.min(e.pending_bytes.min(e.queued_bytes));
+        overhead = overhead.max(e.pool_fixed_overhead_bytes);
+        multiplier = multiplier.max(e.pool_raw_size_multiplier);
+        targets.push(Target {
+            id: v.id.clone(),
+            rpc,
+            evidence: e.clone(),
+        });
+    }
+    let sender_budget = (sender as f64 * c.limits.pool_budget_fraction).floor() as usize;
+    let count_budget = (count as f64 * c.limits.pool_budget_fraction).floor() as usize;
+    let byte_budget = (bytes as f64 * c.limits.pool_budget_fraction).floor() as u64;
+    ensure!(
+        sender_budget > 0 && count_budget > 0 && byte_budget > overhead,
+        "budget fraction leaves no capacity"
+    );
+    for ty in [0, 1, 2, 4, 0x76] {
+        if !targets
+            .iter()
+            .all(|t| t.evidence.future_nonce_types.contains(&ty))
+        {
+            warnings.push(format!("Transaction family 0x{ty:x} uses a one-outstanding-transaction lane window until future-nonce queuing is qualified."));
+        }
+    }
+    let binding = sha256(
+        &[
+            native_bytes,
+            deployment_bytes,
+            checkpoint.shadow_hash.as_bytes().to_vec(),
+            c.run.id.as_bytes().to_vec(),
+        ]
+        .concat(),
+    );
+    let q = Qualified {
+        targets,
+        deployment,
+        binding: binding.clone(),
+        sender_budget,
+        count_budget,
+        byte_budget,
+        overhead,
+        multiplier,
+    };
+    let report = VerificationReport {
+        run_id: c.run.id.clone(),
+        boundary: checkpoint.source_height,
+        binding,
+        targets: q.targets.len(),
+        source_finalized: anchor.point,
+        sender_budget,
+        count_budget,
+        byte_budget,
+        measured_sustained_tps: q.deployment.measured_sustained_tps,
+        profile_mean_tps: p.as_ref().map(|p| p.mean_tps),
+        mode,
+        warnings,
+    };
+    Ok((q, report))
+}
+pub async fn check_target(rpc: &Rpc, c: &Config) -> Result<()> {
+    let (checkpoint, _) = c.replay()?;
+    ensure!(
+        rpc.chain_id().await? == c.run.chain_id,
+        "shadow chain id mismatch"
+    );
+    ensure!(
+        rpc.header_point(checkpoint.source_height).await?.hash
+            == checkpoint.shadow_hash.parse::<B256>()?,
+        "shadow boundary hash mismatch"
+    );
+    let tip = rpc.latest_finalized(c.run.chain_id).await?;
+    ensure!(
+        tip.point.height >= checkpoint.source_height,
+        "shadow finalized head precedes boundary"
+    );
+    Ok(())
+}
+pub async fn verify_execution_range(
+    rpc: &Rpc,
+    chain: u64,
+    start: u64,
+    anchor: &CapturedBlock,
+) -> Result<()> {
+    ensure!(
+        start <= anchor.point.height,
+        "invalid verification interval"
+    );
+    let mut expected = anchor.point.hash;
+    for h in (start..=anchor.point.height).rev() {
+        let block = rpc
+            .execution(h, chain, h == start || h == anchor.point.height)
+            .await?;
+        ensure!(
+            block.point.hash == expected,
+            "execution fallback does not link to trusted finalized anchor at {h}"
+        );
+        expected = block.parent;
+    }
+    if start > 0 {
+        ensure!(
+            rpc.header_point(start - 1).await?.hash == expected,
+            "execution recovery lower anchor mismatch"
+        );
+    }
+    Ok(())
+}
+pub fn route(
+    sender: alloy_primitives::Address,
+    targets: &[Target],
+    available: &[bool],
+) -> Option<usize> {
+    targets
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| available[*i])
+        .max_by_key(|(_, t)| {
+            let mut input = sender.as_slice().to_vec();
+            input.extend_from_slice(t.id.as_bytes());
+            keccak256(input)
+        })
+        .map(|(i, _)| i)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn live_start_does_not_need_a_prior_capture_profile_but_qualification_does() {
+        let mut c: Config = toml::from_str(include_str!("../tempo-replay.example.toml")).unwrap();
+        c.run.workload_profile = None;
+        assert!(load_profile(&c, VerificationMode::Live).unwrap().is_none());
+        assert!(load_profile(&c, VerificationMode::Qualification).is_err());
+        c.run.workload_profile = Some(std::path::PathBuf::from("missing-explicit-profile.json"));
+        assert!(
+            load_profile(&c, VerificationMode::Live).is_err(),
+            "an explicitly configured missing profile must not be silently ignored"
+        );
+    }
+}

--- a/bin/tempo-replay/tempo-replay.example.toml
+++ b/bin/tempo-replay/tempo-replay.example.toml
@@ -1,0 +1,96 @@
+# Implemented schema, revision 2. See README.md for deployment qualification.
+# Paths/identities are placeholders. Start with: tempo-replay run --config tempo-replay.toml --from-block N
+# N is inclusive and must equal checkpoint.source_height + 1. No end height is needed.
+
+[run]
+schema_version = 2
+id = "tempo-shadow-example"
+mode = "finalized_bursts"
+chain_id = 4217
+tempo_revision = "731535b9808eda12e81ab6459703602554eaee5a"
+reth_revision = "8e55cc5" # verified dependency of the inspected Tempo revision
+# Optional for live run; required for the separate exhaustive verify command.
+# workload_profile = "/etc/tempo-replay/workload-profile.json"
+
+[source]
+consensus_ws = "wss://source-reader.example.invalid"
+rpc_http = "https://source-reader.example.invalid"
+finality = "finalized"
+fallback = "verified_execution_layer" # live startup probes the adapter; capture verifies each range
+raw_blocks = "prefer_if_verified"
+recovery_horizon_blocks = 200000 # illustrative; source must retain the chosen horizon
+history_probe_blocks = 16385 # used by exhaustive verify, not the live-start history probe
+
+[checkpoint]
+manifest = "/etc/tempo-replay/shadowfork-manifest.json"
+# Read the actual boundary from the generated manifest; these pin expected values.
+source_height = 0 # REPLACE with actual finalized donor tip H
+source_hash = "REPLACE_WITH_SOURCE_BLOCK_HASH"
+shadow_hash = "REPLACE_WITH_PATCHED_SHADOW_BOUNDARY_HASH"
+bootstrap_artifact_digest = "sha256:REPLACE_WITH_NATIVE_MANIFEST_FILE_SHA256"
+
+[shadow]
+deployment_manifest = "/etc/tempo-replay/shadow-deployment.json"
+ingress_policy = "sticky_sender"
+ca_file = "/etc/tempo-replay/shadow-ca.pem"
+identity_check_interval_ms = 30000
+# Manifest records all participating validators, effective limits and fee settings.
+# These entries are direct ingress endpoints; no custom gateway is required.
+
+[[shadow.validators]]
+id = "shadow-a"
+rpc_http = "https://shadow-a.example.invalid"
+consensus_ws = "wss://shadow-a.example.invalid"
+credential_env = "TEMPO_REPLAY_SHADOW_A_CREDENTIAL"
+expected_validator_public_key = "REPLACE_WITH_VALIDATOR_A_PUBLIC_KEY"
+
+[[shadow.validators]]
+id = "shadow-b"
+rpc_http = "https://shadow-b.example.invalid"
+consensus_ws = "wss://shadow-b.example.invalid"
+credential_env = "TEMPO_REPLAY_SHADOW_B_CREDENTIAL"
+expected_validator_public_key = "REPLACE_WITH_VALIDATOR_B_PUBLIC_KEY"
+
+[timing]
+live_speed = 1.0
+max_catch_up_speed = 4.0
+target_lag_ms = 2000 # qualify against measured source latency and target capacity
+guard_ms = 100
+slip_warn_ms = 1000
+slip_window_blocks = 20
+on_sustained_slip = "enter_catch_up"
+target_progress_timeout_ms = 30000
+expected_inclusion_latency_ms = 1000 # replace with measured estimate
+expiry_safety_margin_ms = 1000
+
+[delivery]
+on_permanent_gap = "record_gap_and_continue"
+first_attempt = "all_routable_unblocked" # includes expected expiry; no repeated futile retries
+nonce_dependency_gap = "block_lane"
+unknown_transaction = "pause_dispatch"
+subblock_transaction = "pause_dispatch"
+system_transaction = "record_generated_by_shadow"
+ambiguous_resend_limit = 1 # same bytes; keep reconciliation and existing reservation
+dependency_wait_timeout_ms = 30000
+
+[limits]
+max_inflight_rpc = 128
+max_inflight_per_lane = 8 # clamped by verified queuing support and available credits
+pool_budget_fraction = 0.8 # network-wide minimum effective sender/count/byte limits
+max_buffered_bytes = 268435456
+max_blocks_ahead = 64
+rpc_timeout_ms = 2000
+max_retry_attempts = 5 # transport exhaustion -> recovery; capacity failures stay deferred
+
+[journal]
+path = "/var/lib/tempo-replay"
+sync_writes = true
+group_commit_max_ms = 5 # no deliberate batching wait; submission intents share a sync batch
+max_bytes = 1000000000000
+min_free_bytes = 100000000000
+
+[metrics]
+listen = "127.0.0.1:9090"
+coverage_denominator = "all_user_occurrences"
+gap_warn_fraction = 0.01 # first gap also raises coverage_degraded immediately
+gap_window_blocks = 100

--- a/bin/tempo-replay/tests/common/mod.rs
+++ b/bin/tempo-replay/tests/common/mod.rs
@@ -1,0 +1,397 @@
+#![allow(dead_code)]
+use alloy_consensus::{SignableTransaction, TxLegacy, proofs::calculate_transaction_root};
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_primitives::{B256, Bytes, Sealable, Signature, TxKind, U256, keccak256};
+use axum::{Json, Router, extract::State as AxumState, routing::post};
+use serde_json::{Value, json};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::Path,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tempo_primitives::{Block, TempoHeader, TempoTransaction, TempoTxEnvelope};
+use tempo_replay::{
+    config::*,
+    model::{CapturedBlock, now_ms},
+    rpc::Rpc,
+    verify::{Qualified, Target},
+};
+use tokio_util::sync::CancellationToken;
+
+pub(crate) fn sign(hash: B256, key: u8) -> Signature {
+    let sk = k256::ecdsa::SigningKey::from_slice(&[key; 32]).unwrap();
+    let (sig, recovery) = sk.sign_prehash_recoverable(hash.as_slice()).unwrap();
+    Signature::from_signature_and_parity(sig, recovery.is_y_odd())
+}
+pub(crate) fn legacy(nonce: u64, key: u8) -> TempoTxEnvelope {
+    let tx = TxLegacy {
+        chain_id: Some(4217),
+        nonce,
+        gas_price: 1_000_000_000,
+        gas_limit: 21000,
+        to: TxKind::Call(alloy_primitives::Address::repeat_byte(0x42)),
+        value: U256::ZERO,
+        input: Bytes::new(),
+    };
+    let signature = sign(tx.signature_hash(), key);
+    TempoTxEnvelope::Legacy(tx.into_signed(signature))
+}
+pub(crate) fn aa(
+    nonce: u64,
+    nonce_key: U256,
+    valid_before: Option<u64>,
+    key: u8,
+) -> TempoTxEnvelope {
+    let tx = TempoTransaction {
+        chain_id: 4217,
+        nonce,
+        nonce_key,
+        gas_limit: 100000,
+        max_fee_per_gas: 1000000000,
+        valid_before: valid_before.and_then(std::num::NonZeroU64::new),
+        calls: vec![tempo_primitives::transaction::Call {
+            to: TxKind::Call(alloy_primitives::Address::repeat_byte(0x33)),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        }],
+        ..Default::default()
+    };
+    let signature = sign(tx.signature_hash(), key);
+    TempoTxEnvelope::AA(tx.into_signed(signature.into()))
+}
+pub(crate) fn block(
+    height: u64,
+    parent: B256,
+    timestamp: u64,
+    txs: Vec<TempoTxEnvelope>,
+    shadow: bool,
+) -> Block {
+    let mut header = TempoHeader::default();
+    header.inner.number = height;
+    header.inner.parent_hash = parent;
+    header.inner.timestamp = timestamp / 1000;
+    header.timestamp_millis_part = timestamp % 1000;
+    header.inner.extra_data = Bytes::from(vec![u8::from(shadow)]);
+    header.inner.transactions_root = calculate_transaction_root(&txs);
+    Block {
+        header,
+        body: alloy_consensus::BlockBody {
+            transactions: txs,
+            ommers: vec![],
+            withdrawals: None,
+        },
+    }
+}
+pub(crate) fn certified(b: &Block) -> Value {
+    json!({"epoch":1,"view":b.header.inner.number,"digest":b.header.hash_slow(),"certificate":"0x1234","block":b,"seen":now_ms()})
+}
+pub(crate) fn captured(b: &Block) -> CapturedBlock {
+    CapturedBlock::from_certified(certified(b), 4217).unwrap()
+}
+pub(crate) fn execution(b: &Block, full: bool) -> Value {
+    let mut v = serde_json::to_value(&b.header).unwrap();
+    v["hash"] = json!(b.header.hash_slow());
+    v["transactions"] = Value::Array(
+        b.body
+            .transactions
+            .iter()
+            .map(|t| {
+                let hash = keccak256(t.encoded_2718());
+                if full {
+                    let mut value = serde_json::to_value(t).unwrap();
+                    value["hash"] = json!(hash);
+                    value
+                } else {
+                    json!(hash)
+                }
+            })
+            .collect(),
+    );
+    v
+}
+pub(crate) fn config(path: &Path) -> Config {
+    Config {
+        run: Run {
+            schema_version: 2,
+            id: "test".into(),
+            mode: "finalized_bursts".into(),
+            chain_id: 4217,
+            tempo_revision: TEMPO_REVISION.into(),
+            reth_revision: RETH_REVISION.into(),
+            workload_profile: None,
+        },
+        source: Source {
+            rpc_http: "https://source.example".into(),
+            consensus_ws: "wss://source.example".into(),
+            finality: "finalized".into(),
+            fallback: "verified_execution_layer".into(),
+            raw_blocks: "prefer_if_verified".into(),
+            recovery_horizon_blocks: 1000,
+            history_probe_blocks: 16385,
+        },
+        journal: JournalConfig {
+            path: path.into(),
+            sync_writes: true,
+            group_commit_max_ms: 5,
+            max_bytes: 1000000000,
+            min_free_bytes: 0,
+        },
+        checkpoint: None,
+        shadow: None,
+        timing: Timing {
+            guard_ms: 1,
+            target_progress_timeout_ms: 10000,
+            ..Default::default()
+        },
+        delivery: Delivery::default(),
+        limits: Limits {
+            rpc_timeout_ms: 100,
+            ..Default::default()
+        },
+        metrics: Metrics::default(),
+    }
+}
+pub(crate) struct MockState {
+    pub(crate) blocks: BTreeMap<u64, Block>,
+    pub(crate) missing_certificates: BTreeSet<u64>,
+    pub(crate) is_shadow: bool,
+    pub(crate) sent: Vec<String>,
+    pub(crate) queued: Vec<TempoTxEnvelope>,
+    pub(crate) reject: BTreeMap<B256, String>,
+    pub(crate) lose_response: BTreeSet<B256>,
+    pub(crate) corrupt_height: Option<u64>,
+    pub(crate) auto_mine: bool,
+}
+pub(crate) struct Mock {
+    pub(crate) state: Arc<Mutex<MockState>>,
+    pub(crate) url: String,
+    stop: CancellationToken,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+impl Mock {
+    pub(crate) async fn start(blocks: Vec<Block>, shadow: bool) -> Self {
+        let state = Arc::new(Mutex::new(MockState {
+            blocks: blocks
+                .into_iter()
+                .map(|b| (b.header.inner.number, b))
+                .collect(),
+            missing_certificates: BTreeSet::new(),
+            is_shadow: shadow,
+            sent: vec![],
+            queued: vec![],
+            reject: BTreeMap::new(),
+            lose_response: BTreeSet::new(),
+            corrupt_height: None,
+            auto_mine: true,
+        }));
+        let app = Router::new()
+            .route("/", post(handler))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}", listener.local_addr().unwrap());
+        let stop = CancellationToken::new();
+        let stopped = stop.clone();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(stopped.cancelled_owned())
+                .await
+                .unwrap();
+        });
+        Self {
+            state,
+            url,
+            stop,
+            task: Some(task),
+        }
+    }
+    pub(crate) fn rpc(&self, timeout: u64) -> Rpc {
+        Rpc::new(&self.url, timeout, 16 * 1024 * 1024, None, None).unwrap()
+    }
+    pub(crate) async fn close(mut self) {
+        self.stop.cancel();
+        if let Some(task) = self.task.take() {
+            task.await.unwrap();
+        }
+    }
+}
+impl Drop for Mock {
+    fn drop(&mut self) {
+        self.stop.cancel();
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+async fn handler(
+    AxumState(state): AxumState<Arc<Mutex<MockState>>>,
+    Json(request): Json<Value>,
+) -> Json<Value> {
+    let (response, delay) = {
+        let mut s = state.lock().unwrap();
+        let method = request["method"].as_str().unwrap();
+        let p = &request["params"];
+        let mut delay = false;
+        let result: std::result::Result<Value, String> = match method {
+            "eth_chainId" => Ok(json!("0x1079")),
+            "consensus_getLatest" => {
+                if s.is_shadow && s.auto_mine {
+                    let latest = s.blocks.last_key_value().unwrap().1;
+                    let h = latest.header.inner.number + 1;
+                    let parent = latest.header.hash_slow();
+                    let ts = now_ms().max(latest.header.timestamp_millis() + 1);
+                    let txs = std::mem::take(&mut s.queued);
+                    s.blocks.insert(h, block(h, parent, ts, txs, true));
+                }
+                Ok(
+                    json!({"finalized":certified(s.blocks.last_key_value().unwrap().1),"notarized":null}),
+                )
+            }
+            "consensus_getFinalization" => {
+                let h = p[0]["height"].as_u64().unwrap();
+                if s.missing_certificates.contains(&h) {
+                    Err("missing historical certificate".into())
+                } else {
+                    s.blocks
+                        .get(&h)
+                        .map(certified)
+                        .ok_or("missing block".into())
+                }
+            }
+            "eth_getBlockByNumber" | "debug_getRawBlock" => {
+                let h = u64::from_str_radix(p[0].as_str().unwrap().trim_start_matches("0x"), 16)
+                    .unwrap();
+                match s.blocks.get(&h) {
+                    Some(b) if method == "debug_getRawBlock" => {
+                        Ok(json!(format!("0x{}", hex::encode(alloy_rlp::encode(b)))))
+                    }
+                    Some(b) => {
+                        let mut v = execution(b, p[1].as_bool().unwrap_or(false));
+                        if s.corrupt_height == Some(h) {
+                            v["parentHash"] = json!(B256::repeat_byte(0x66));
+                        }
+                        Ok(v)
+                    }
+                    None => Ok(Value::Null),
+                }
+            }
+            "eth_sendRawTransaction" => {
+                let raw = p[0].as_str().unwrap().to_string();
+                let bytes = hex::decode(raw.trim_start_matches("0x")).unwrap();
+                let hash = keccak256(&bytes);
+                s.sent.push(raw);
+                delay = s.lose_response.remove(&hash);
+                if let Some(error) = s.reject.get(&hash) {
+                    Err(error.clone())
+                } else {
+                    if !s.queued.iter().any(|t| keccak256(t.encoded_2718()) == hash) {
+                        let tx = TempoTxEnvelope::decode_2718(&mut bytes.as_slice()).unwrap();
+                        s.queued.push(tx);
+                    }
+                    Ok(json!(hash))
+                }
+            }
+            "eth_getTransactionReceipt" => {
+                let hash: B256 = serde_json::from_value(p[0].clone()).unwrap();
+                let mut receipt = Value::Null;
+                for b in s.blocks.values() {
+                    for (index, t) in b.body.transactions.iter().enumerate() {
+                        if keccak256(t.encoded_2718()) == hash {
+                            receipt = json!({"transactionHash":hash,"blockHash":b.header.hash_slow(),"blockNumber":format!("0x{:x}",b.header.inner.number),"transactionIndex":format!("0x{index:x}"),"status":"0x1","gasUsed":"0x5208","logs":[]});
+                        }
+                    }
+                }
+                Ok(receipt)
+            }
+            "eth_getTransactionByHash" => {
+                let hash: B256 = serde_json::from_value(p[0].clone()).unwrap();
+                if s.queued
+                    .iter()
+                    .chain(s.blocks.values().flat_map(|b| b.body.transactions.iter()))
+                    .any(|t| keccak256(t.encoded_2718()) == hash)
+                {
+                    Ok(json!({"hash":hash}))
+                } else {
+                    Ok(Value::Null)
+                }
+            }
+            "eth_getTransactionCount" => Ok(json!("0x0")),
+            _ => Err("method not found".into()),
+        };
+        let response = match result {
+            Ok(value) => json!({"jsonrpc":"2.0","id":request["id"],"result":value}),
+            Err(message) => {
+                json!({"jsonrpc":"2.0","id":request["id"],"error":{"code":-32000,"message":message}})
+            }
+        };
+        (response, delay)
+    };
+    if delay {
+        tokio::time::sleep(Duration::from_millis(350)).await;
+    }
+    Json(response)
+}
+pub(crate) fn qualified(mock: &Mock) -> Qualified {
+    let evidence = ValidatorEvidence {
+        id: "shadow-a".into(),
+        public_key: "test".into(),
+        rpc_http: mock.url.clone(),
+        max_sender_slots: 16,
+        pending_count: 10000,
+        queued_count: 10000,
+        pending_bytes: 20000000,
+        queued_bytes: 20000000,
+        pool_fixed_overhead_bytes: 1024,
+        pool_raw_size_multiplier: 2,
+        future_nonce_types: vec![0, 1, 2, 4, 0x76],
+        pool_observation: "conservative_retained_reservations".into(),
+    };
+    Qualified {
+        targets: vec![Target {
+            id: "shadow-a".into(),
+            rpc: mock.rpc(100),
+            evidence: evidence.clone(),
+        }],
+        binding: "test-binding".into(),
+        sender_budget: 12,
+        count_budget: 8000,
+        byte_budget: 16000000,
+        overhead: 1024,
+        multiplier: 2,
+        deployment: Deployment {
+            schema_version: 1,
+            run_id: "test".into(),
+            chain_id: 4217,
+            tempo_revision: TEMPO_REVISION.into(),
+            reth_revision: RETH_REVISION.into(),
+            bootstrap_artifact_digest: String::new(),
+            binary_sha256: String::new(),
+            chainspec_sha256: String::new(),
+            isolated_network: true,
+            exclusive_workload: true,
+            fork_rules_match_source: true,
+            fee_token_and_amm_parity: true,
+            validity_buffer_seconds: 3,
+            source_capture_p99_ms: 100,
+            measured_rpc_p99_ms: 10,
+            measured_sustained_tps: 10000.,
+            validators: vec![evidence],
+        },
+    }
+}
+pub(crate) fn attach_shadow(c: &mut Config, source: &Block, target: &Block) {
+    c.checkpoint = Some(Checkpoint {
+        manifest: Path::new("unused").into(),
+        source_height: source.header.inner.number,
+        source_hash: source.header.hash_slow().to_string(),
+        shadow_hash: target.header.hash_slow().to_string(),
+        bootstrap_artifact_digest: String::new(),
+    });
+    c.shadow = Some(Shadow {
+        deployment_manifest: Path::new("unused").into(),
+        ingress_policy: "sticky_sender".into(),
+        ca_file: Path::new("unused").into(),
+        identity_check_interval_ms: 100000,
+        validators: vec![],
+    });
+}

--- a/bin/tempo-replay/tests/invariants.rs
+++ b/bin/tempo-replay/tests/invariants.rs
@@ -1,0 +1,252 @@
+mod common;
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_primitives::{B256, Sealable, Signature, U256};
+use common::*;
+use std::{collections::BTreeMap, time::Duration};
+use tempo_primitives::TempoTxEnvelope;
+use tempo_replay::{
+    config::Config,
+    engine::{Budget, Outcome, classify, retry_delay},
+    journal::Journal,
+    model::*,
+    rpc::RpcError,
+    timing::Pacer,
+    verify::route,
+};
+
+#[test]
+fn signed_envelope_families_roundtrip_and_share_protocol_lane() {
+    let d = tempfile::tempdir().unwrap();
+    let c = config(d.path());
+    c.validate().unwrap();
+    let mut txs = vec![
+        legacy(0, 1),
+        aa(1, U256::ZERO, None, 1),
+        aa(0, U256::from(2), None, 1),
+        aa(0, U256::MAX, Some(100000), 1),
+    ];
+    let t = TxEip2930 {
+        chain_id: 4217,
+        ..Default::default()
+    };
+    let sig = sign(t.signature_hash(), 1);
+    txs.push(TempoTxEnvelope::Eip2930(t.into_signed(sig)));
+    let t = TxEip1559 {
+        chain_id: 4217,
+        ..Default::default()
+    };
+    let sig = sign(t.signature_hash(), 1);
+    txs.push(TempoTxEnvelope::Eip1559(t.into_signed(sig)));
+    let auth = alloy_eips::eip7702::Authorization {
+        chain_id: U256::from(4217),
+        address: alloy_primitives::Address::repeat_byte(4),
+        nonce: 9,
+    };
+    let signature = sign(auth.signature_hash(), 2);
+    let t = TxEip7702 {
+        chain_id: 4217,
+        authorization_list: vec![auth.into_signed(signature)],
+        ..Default::default()
+    };
+    let sig = sign(t.signature_hash(), 1);
+    txs.push(TempoTxEnvelope::Eip7702(t.into_signed(sig)));
+    for tx in &txs {
+        let raw = tx.encoded_2718();
+        let decoded = TempoTxEnvelope::decode_2718(&mut raw.as_slice()).unwrap();
+        assert_eq!(decoded.encoded_2718(), raw);
+        let v = serde_json::to_value(tx).unwrap();
+        let again: TempoTxEnvelope = serde_json::from_value(v).unwrap();
+        assert_eq!(again.encoded_2718(), raw);
+        Tx::from_envelope(tx, 4217).unwrap();
+    }
+    assert_eq!(
+        Tx::from_envelope(&txs[0], 4217).unwrap().lane(),
+        Tx::from_envelope(&txs[1], 4217).unwrap().lane()
+    );
+    assert!(Tx::from_envelope(&txs[3], 4217).unwrap().lane().is_none());
+    assert!(Tx::from_envelope(&txs[0], 42431).is_err());
+    assert!(TempoTxEnvelope::decode_2718(&mut [0x77, 0xc0].as_slice()).is_err());
+}
+#[test]
+fn system_hash_occurrences_and_root_validation() {
+    let dir = tempfile::tempdir().unwrap();
+    let c = config(dir.path());
+    let mut j = Journal::open(&c, Some(1)).unwrap();
+    let t = TxLegacy {
+        chain_id: Some(4217),
+        ..Default::default()
+    };
+    let tx = TempoTxEnvelope::Legacy(t.into_signed(Signature::new(U256::ZERO, U256::ZERO, false)));
+    let b1 = block(1, B256::ZERO, 1000, vec![tx.clone()], false);
+    let b2 = block(2, b1.header.hash_slow(), 1100, vec![tx], false);
+    let c1 = captured(&b1);
+    let c2 = captured(&b2);
+    assert_eq!(c1.transactions[0].class, Class::System);
+    j.stage(&c1).unwrap();
+    j.stage(&c2).unwrap();
+    j.publish(&c2.point, 1).unwrap();
+    assert_eq!(
+        j.inspect(&c1.transactions[0].hash.to_string())
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(j.state.counts.system_occurrences, 2);
+    let mut invalid = b1;
+    invalid.header.inner.transactions_root = B256::ZERO;
+    assert!(CapturedBlock::from_certified(certified(&invalid), 4217).is_err());
+}
+#[test]
+fn journal_attempt_intent_survives_reopen_and_observers_do_not_own_writer_lock() {
+    let dir = tempfile::tempdir().unwrap();
+    let c = config(dir.path());
+    let b = captured(&block(1, B256::ZERO, 1000, vec![legacy(0, 1)], false));
+    let mut j = Journal::open(&c, Some(1)).unwrap();
+    j.stage(&b).unwrap();
+    j.publish(&b.point, 1).unwrap();
+    j.bind(0, "binding").unwrap();
+    let mut o = j.occurrences(1).unwrap().remove(0);
+    o.attempts = 1;
+    o.first_attempt_ms = Some(now_ms());
+    o.last_attempt_ms = o.first_attempt_ms;
+    o.transition(State::Attempting, "before-write crash");
+    j.update(&o).unwrap();
+    j.refresh_cursors().unwrap();
+    assert!(Journal::open(&c, None).is_err());
+    {
+        let reader = Journal::read(dir.path()).unwrap();
+        assert_eq!(reader.state.counts.attempts, 1);
+    }
+    assert_eq!(j.state.cursors.dispatch_accounted_through, Some(1));
+    assert_eq!(j.state.cursors.accounted_through, Some(0));
+    drop(j);
+    let j = Journal::open(&c, None).unwrap();
+    assert_eq!(j.occurrences(1).unwrap()[0].state, State::Attempting);
+    assert_eq!(j.state.counts.reserved_count, 1);
+}
+#[tokio::test(start_paused = true)]
+async fn anchored_pacing_preserves_slip_and_never_dumps_overdue_blocks() {
+    let d = tempfile::tempdir().unwrap();
+    let c = config(d.path());
+    let mut p = Pacer::new(&c.timing, Phase::CatchUp, 1, 1000, "test");
+    assert!(
+        p.release_at(1000).unwrap() > tokio::time::Instant::now(),
+        "old source timestamps start at a new catch-up anchor"
+    );
+    tokio::time::advance(Duration::from_secs(10)).await;
+    let slip = p.released(1000, &c.timing).unwrap();
+    assert!(slip >= 9990);
+    let next = p.release_at(1400).unwrap();
+    assert_eq!(
+        next.duration_since(tokio::time::Instant::now()),
+        Duration::from_millis(100)
+    );
+    tokio::time::advance(Duration::from_millis(100)).await;
+    let next_slip = p.released(1400, &c.timing).unwrap();
+    assert!(
+        next_slip >= slip,
+        "rate limiting must not reset ideal schedule slip"
+    );
+    assert!(p.release_at(1399).is_err());
+    let live = Pacer::new(&c.timing, Phase::Live, 1, now_ms(), "test");
+    assert_eq!(
+        live.due(live.segment.source_ms + 250).unwrap() - live.due(live.segment.source_ms).unwrap(),
+        Duration::from_millis(250)
+    );
+}
+#[test]
+fn configuration_rejects_unknown_policy_and_unsafe_bounds() {
+    let mut c: Config = toml::from_str(include_str!("../tempo-replay.example.toml")).unwrap();
+    c.validate().unwrap();
+    c.timing.live_speed = 2.;
+    assert!(c.validate().is_err());
+    c.timing.live_speed = 1.;
+    c.limits.pool_budget_fraction = 1.;
+    assert!(c.validate().is_err());
+    c.limits.pool_budget_fraction = 0.8;
+    c.source.rpc_http = "http://localhost".into();
+    assert!(c.validate().is_err());
+    let bad = include_str!("../tempo-replay.example.toml")
+        .replace("schema_version = 2", "schema_version = 2\nunknown = true");
+    assert!(toml::from_str::<Config>(&bad).is_err());
+}
+#[test]
+fn submission_errors_are_not_false_success_or_permanent_capacity_gaps() {
+    let error = |message: &str| RpcError {
+        code: -32000,
+        message: message.into(),
+        retry_ms: None,
+        ambiguous: false,
+    };
+    assert_eq!(classify(&error("already known")), Outcome::Accepted);
+    assert_eq!(
+        classify(&error("SpammerExceededCapacity")),
+        Outcome::Capacity
+    );
+    assert_eq!(
+        classify(&error("Access key expired: expiry 5 <= min allowed 6")),
+        Outcome::Expired
+    );
+    assert_eq!(classify(&error("nonce too low")), Outcome::NonceLow);
+    assert_eq!(classify(&error("invalid signature")), Outcome::Incident);
+    assert_eq!(
+        classify(&error("brand new node failure")),
+        Outcome::Incident
+    );
+    assert!(retry_delay(1, B256::ZERO, Some(5000)) >= 5000);
+}
+#[test]
+fn reserved_subblock_prefix_and_expiry_second_boundary() {
+    let key = U256::from_be_bytes::<32>({
+        let mut k = [0; 32];
+        k[0] = 0x5b;
+        k
+    });
+    assert_eq!(
+        Tx::from_envelope(&aa(0, key, None, 1), 4217).unwrap().class,
+        Class::Subblock
+    );
+    let t = Tx::from_envelope(&aa(0, U256::MAX, Some(104), 1), 4217).unwrap();
+    assert!(!t.expired_at(100));
+    assert!(t.expired_at(101));
+}
+#[tokio::test]
+async fn network_budget_deduplicates_retries_and_counts_across_lanes() {
+    let mock = Mock::start(vec![block(0, B256::ZERO, 0, vec![], true)], true).await;
+    let mut q = qualified(&mock);
+    q.sender_budget = 1;
+    let b = captured(&block(
+        1,
+        B256::ZERO,
+        1000,
+        vec![legacy(0, 1), aa(0, U256::from(5), None, 1), legacy(0, 2)],
+        false,
+    ));
+    let mut first = Occurrence::new(&b, 0);
+    first.state = State::Unknown;
+    let mut active = BTreeMap::new();
+    active.insert(first.key(), first.clone());
+    let budget = Budget::from_active(&active, &q);
+    assert!(budget.can_reserve(&first, &q));
+    assert!(!budget.can_reserve(&Occurrence::new(&b, 1), &q));
+    assert!(budget.can_reserve(&Occurrence::new(&b, 2), &q));
+    assert_eq!(route(first.tx.sender, &q.targets, &[true]), Some(0));
+    assert_eq!(route(first.tx.sender, &q.targets, &[false]), None);
+    mock.close().await;
+}
+
+#[test]
+fn disk_low_watermark_fails_before_capture_and_examples_parse() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    c.journal.min_free_bytes = u64::MAX;
+    assert!(Journal::open(&c, Some(1)).is_err());
+    let capture: Config = toml::from_str(include_str!("../examples/capture.toml")).unwrap();
+    capture.validate().unwrap();
+    assert!(capture.replay().is_err());
+    serde_json::from_str::<tempo_replay::config::Deployment>(include_str!(
+        "../examples/shadow-deployment.json"
+    ))
+    .unwrap();
+}

--- a/bin/tempo-replay/tests/live.rs
+++ b/bin/tempo-replay/tests/live.rs
@@ -1,0 +1,221 @@
+mod common;
+
+use alloy_primitives::{B256, Sealable};
+use common::*;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tempo_replay::{
+    capture::capture_loop,
+    config::Config,
+    engine::replay,
+    journal::{Journal, SharedJournal, lock},
+    model::{Phase, now_ms},
+};
+use tokio::{task::JoinSet, time::timeout};
+use tokio_util::sync::CancellationToken;
+
+fn start(
+    c: &Config,
+    source: &Mock,
+    shadow: &Mock,
+    journal: &SharedJournal,
+    stop: &CancellationToken,
+) -> JoinSet<anyhow::Result<()>> {
+    let mut tasks = JoinSet::new();
+    tasks.spawn(capture_loop(
+        c.clone(),
+        source.rpc(1000),
+        journal.clone(),
+        None,
+        stop.clone(),
+    ));
+    tasks.spawn(replay(
+        c.clone(),
+        qualified(shadow),
+        source.rpc(1000),
+        journal.clone(),
+        None,
+        false,
+        stop.clone(),
+    ));
+    tasks
+}
+async fn included(journal: &SharedJournal, height: u64) {
+    timeout(Duration::from_secs(8), async {
+        loop {
+            let s = lock(journal).unwrap().state.clone();
+            assert!(
+                s.incident.is_none(),
+                "unexpected incident: {:?}",
+                s.incident
+            );
+            if s.cursors.included_through == Some(height) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("mirror did not follow newly finalized traffic");
+}
+async fn shutdown(tasks: &mut JoinSet<anyhow::Result<()>>, stop: &CancellationToken) {
+    stop.cancel();
+    timeout(Duration::from_secs(3), async {
+        while let Some(result) = tasks.join_next().await {
+            result.unwrap().unwrap();
+        }
+    })
+    .await
+    .expect("mirror tasks did not stop");
+}
+
+#[tokio::test]
+async fn catches_up_follows_new_blocks_and_resumes_the_same_start_height() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut c = config(directory.path());
+    c.timing.target_lag_ms = 1000;
+    let old = now_ms() - 30000;
+    let g = block(100, B256::ZERO, old, vec![], false);
+    let sg = block(100, B256::ZERO, old, vec![], true);
+    let b1 = block(
+        101,
+        g.header.hash_slow(),
+        old + 100,
+        vec![legacy(0, 1)],
+        false,
+    );
+    let b2 = block(
+        102,
+        b1.header.hash_slow(),
+        old + 200,
+        vec![legacy(1, 1)],
+        false,
+    );
+    let source = Mock::start(vec![g.clone(), b1, b2.clone()], false).await;
+    let shadow = Mock::start(vec![sg.clone()], true).await;
+    attach_shadow(&mut c, &g, &sg);
+    // No websocket feed is served here: polling must continue to discover new finality.
+    c.source.consensus_ws = source.url.replacen("http://", "ws://", 1);
+    let journal = Arc::new(Mutex::new(
+        Journal::open_replay(&c, Some(101), None).unwrap(),
+    ));
+    let stop = CancellationToken::new();
+    let mut tasks = start(&c, &source, &shadow, &journal, &stop);
+    included(&journal, 102).await;
+    assert_eq!(lock(&journal).unwrap().state.phase, Phase::CatchUp);
+    assert_eq!(
+        tasks.len(),
+        2,
+        "reaching the startup tip must not end either task"
+    );
+
+    // These blocks did not exist when the process started. Preserve the empty block too.
+    let b3 = block(103, b2.header.hash_slow(), now_ms(), vec![], false);
+    let b4 = block(
+        104,
+        b3.header.hash_slow(),
+        b3.header.timestamp_millis() + 100,
+        vec![legacy(2, 1)],
+        false,
+    );
+    {
+        let mut state = source.state.lock().unwrap();
+        state.blocks.insert(103, b3);
+        state.blocks.insert(104, b4.clone());
+    }
+    included(&journal, 104).await;
+    assert_eq!(lock(&journal).unwrap().state.phase, Phase::Live);
+    assert_eq!(shadow.state.lock().unwrap().sent.len(), 3);
+    shutdown(&mut tasks, &stop).await;
+    drop(journal);
+
+    // A block arrives during downtime. Repeating --from-block is an assertion, not a reset.
+    let b5 = block(
+        105,
+        b4.header.hash_slow(),
+        now_ms().max(b4.header.timestamp_millis() + 100),
+        vec![legacy(3, 1)],
+        false,
+    );
+    source.state.lock().unwrap().blocks.insert(105, b5);
+    let journal = Arc::new(Mutex::new(
+        Journal::open_replay(&c, Some(101), None).unwrap(),
+    ));
+    let stop = CancellationToken::new();
+    let mut tasks = start(&c, &source, &shadow, &journal, &stop);
+    included(&journal, 105).await;
+    assert_eq!(
+        shadow.state.lock().unwrap().sent.len(),
+        4,
+        "only new traffic should be sent after restart"
+    );
+    assert_eq!(lock(&journal).unwrap().state.counts.finalized, 4);
+    shutdown(&mut tasks, &stop).await;
+    source.close().await;
+    shadow.close().await;
+}
+
+#[tokio::test]
+async fn can_start_at_the_tip_before_the_first_mirrored_block_exists() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut c = config(directory.path());
+    c.timing.target_lag_ms = 1000;
+    let g = block(50, B256::ZERO, now_ms(), vec![], false);
+    let sg = block(50, B256::ZERO, g.header.timestamp_millis(), vec![], true);
+    let source = Mock::start(vec![g.clone()], false).await;
+    let shadow = Mock::start(vec![sg.clone()], true).await;
+    attach_shadow(&mut c, &g, &sg);
+    c.source.consensus_ws = source.url.replacen("http://", "ws://", 1);
+    let journal = Arc::new(Mutex::new(
+        Journal::open_replay(&c, Some(51), None).unwrap(),
+    ));
+    let stop = CancellationToken::new();
+    let mut tasks = start(&c, &source, &shadow, &journal, &stop);
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    assert!(!tasks.is_empty());
+    assert!(shadow.state.lock().unwrap().sent.is_empty());
+    assert!(
+        lock(&journal)
+            .unwrap()
+            .state
+            .cursors
+            .captured_through
+            .is_none()
+    );
+    let next = block(
+        51,
+        g.header.hash_slow(),
+        now_ms(),
+        vec![legacy(0, 1)],
+        false,
+    );
+    source.state.lock().unwrap().blocks.insert(51, next);
+    included(&journal, 51).await;
+    assert_eq!(shadow.state.lock().unwrap().sent.len(), 1);
+    shutdown(&mut tasks, &stop).await;
+    source.close().await;
+    shadow.close().await;
+}
+
+#[test]
+fn replay_height_matches_snapshot_and_can_reuse_an_earlier_capture_journal() {
+    let directory = tempfile::tempdir().unwrap();
+    let mut c = config(directory.path());
+    let g = block(100, B256::ZERO, 1000, vec![], false);
+    attach_shadow(&mut c, &g, &block(100, B256::ZERO, 1000, vec![], true));
+    assert!(Journal::open_replay(&c, Some(100), None).is_err());
+    assert!(Journal::open_replay(&c, Some(102), None).is_err());
+    assert!(Journal::open_replay(&c, Some(101), Some(100)).is_err());
+    assert!(
+        !directory.path().join("db").exists(),
+        "invalid start must fail before creating a journal"
+    );
+    drop(Journal::open(&c, Some(90)).unwrap());
+    let journal = Journal::open_replay(&c, Some(101), None).unwrap();
+    assert_eq!(journal.state.first_height, 90);
+    drop(journal);
+    c.checkpoint.as_mut().unwrap().source_height = u64::MAX;
+    assert!(Journal::open_replay(&c, None, None).is_err());
+}

--- a/bin/tempo-replay/tests/replay.rs
+++ b/bin/tempo-replay/tests/replay.rs
@@ -1,0 +1,438 @@
+mod common;
+use alloy_primitives::{B256, Sealable, U256};
+use common::*;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tempo_replay::{
+    capture::capture_once,
+    engine::replay,
+    journal::{Journal, lock},
+    model::*,
+    profile::profile,
+};
+use tokio_util::sync::CancellationToken;
+
+#[tokio::test]
+async fn capture_fallback_replay_lost_response_and_restart() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    let ts = now_ms() - 2000;
+    let genesis = block(0, B256::ZERO, ts, vec![], false);
+    let target_genesis = block(0, B256::ZERO, ts, vec![], true);
+    let b1 = block(
+        1,
+        genesis.header.hash_slow(),
+        ts + 100,
+        vec![legacy(0, 1), aa(0, U256::from(42), None, 2)],
+        false,
+    );
+    let b2 = block(
+        2,
+        b1.header.hash_slow(),
+        ts + 200,
+        vec![legacy(1, 1)],
+        false,
+    );
+    let source = Mock::start(vec![genesis.clone(), b1, b2], false).await;
+    source.state.lock().unwrap().missing_certificates.insert(1);
+    let target = Mock::start(vec![target_genesis.clone()], true).await;
+    attach_shadow(&mut c, &genesis, &target_genesis);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    let stop = CancellationToken::new();
+    assert_eq!(
+        capture_once(&c, &source.rpc(1000), &j, None, Some(2), &stop)
+            .await
+            .unwrap(),
+        2
+    );
+    assert_eq!(
+        lock(&j).unwrap().block(1).unwrap().unwrap().provenance,
+        "anchored_execution_range"
+    );
+    let first = lock(&j).unwrap().occurrences(1).unwrap()[0].clone();
+    target
+        .state
+        .lock()
+        .unwrap()
+        .lose_response
+        .insert(first.tx.hash);
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        replay(
+            c.clone(),
+            qualified(&target),
+            source.rpc(1000),
+            j.clone(),
+            Some(2),
+            false,
+            stop.clone(),
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let state = lock(&j).unwrap().state.clone();
+    assert_eq!(state.counts.offered, 3);
+    assert_eq!(state.counts.finalized, 3);
+    assert_eq!(state.counts.gaps, 0);
+    assert_eq!(state.cursors.included_through, Some(2));
+    assert_eq!(
+        state.counts.attempts, 3,
+        "lost response must reconcile without another submission"
+    );
+    assert_eq!(target.state.lock().unwrap().sent.len(), 3);
+    let p = profile(&lock(&j).unwrap(), None, None).unwrap();
+    assert_eq!(p.users, 3);
+    assert_eq!(p.nonzero_nonce_keys, 1);
+    lock(&j).unwrap().flush().unwrap();
+    drop(j);
+    let j = Arc::new(Mutex::new(Journal::open(&c, None).unwrap()));
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        replay(
+            c,
+            qualified(&target),
+            source.rpc(1000),
+            j.clone(),
+            Some(2),
+            false,
+            stop,
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    assert_eq!(
+        target.state.lock().unwrap().sent.len(),
+        3,
+        "restart must not resend finalized hashes"
+    );
+    source.close().await;
+    target.close().await;
+}
+#[tokio::test]
+async fn expiry_gap_blocks_successor_but_other_sender_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    let ts = now_ms() - 10000;
+    let g = block(0, B256::ZERO, ts, vec![], false);
+    let sg = block(0, B256::ZERO, ts, vec![], true);
+    let bad = aa(0, U256::from(7), Some(ts / 1000 + 1), 1);
+    let b1 = block(1, g.header.hash_slow(), ts + 100, vec![bad.clone()], false);
+    let b2 = block(
+        2,
+        b1.header.hash_slow(),
+        ts + 200,
+        vec![aa(1, U256::from(7), None, 1), legacy(0, 2)],
+        false,
+    );
+    let source = Mock::start(vec![g.clone(), b1, b2], false).await;
+    let target = Mock::start(vec![sg.clone()], true).await;
+    target.state.lock().unwrap().reject.insert(
+        Tx::from_envelope(&bad, 4217).unwrap().hash,
+        "transaction expired".into(),
+    );
+    attach_shadow(&mut c, &g, &sg);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    let stop = CancellationToken::new();
+    capture_once(&c, &source.rpc(1000), &j, None, Some(2), &stop)
+        .await
+        .unwrap();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        replay(
+            c,
+            qualified(&target),
+            source.rpc(1000),
+            j.clone(),
+            Some(2),
+            false,
+            stop,
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let s = lock(&j).unwrap().state.clone();
+    assert_eq!(s.counts.user_occurrences, 3);
+    assert_eq!(s.counts.offered, 2);
+    assert_eq!(s.counts.finalized, 1);
+    assert_eq!(s.counts.gaps, 2);
+    assert_eq!(s.cursors.included_through, Some(0));
+    assert_eq!(s.cursors.accounted_through, Some(2));
+    assert_eq!(target.state.lock().unwrap().sent.len(), 2);
+    source.close().await;
+    target.close().await;
+}
+#[tokio::test]
+async fn corrupt_fallback_never_advances_canonical_cursor() {
+    let dir = tempfile::tempdir().unwrap();
+    let c = config(dir.path());
+    let g = block(0, B256::ZERO, 1000, vec![], false);
+    let b1 = block(1, g.header.hash_slow(), 1100, vec![legacy(0, 1)], false);
+    let b2 = block(2, b1.header.hash_slow(), 1200, vec![], false);
+    let source = Mock::start(vec![g, b1, b2], false).await;
+    {
+        let mut s = source.state.lock().unwrap();
+        s.missing_certificates.insert(1);
+        s.corrupt_height = Some(1);
+    }
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    assert!(
+        capture_once(
+            &c,
+            &source.rpc(1000),
+            &j,
+            None,
+            None,
+            &CancellationToken::new()
+        )
+        .await
+        .is_err()
+    );
+    assert!(lock(&j).unwrap().state.cursors.captured_through.is_none());
+    source.close().await;
+}
+
+#[tokio::test]
+async fn durable_attempt_before_write_is_reconciled_and_resent_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    let ts = now_ms() - 1000;
+    let g = block(0, B256::ZERO, ts, vec![], false);
+    let sg = block(0, B256::ZERO, ts, vec![], true);
+    let b = block(1, g.header.hash_slow(), ts + 100, vec![legacy(0, 1)], false);
+    let source = Mock::start(vec![g.clone(), b], false).await;
+    let target = Mock::start(vec![sg.clone()], true).await;
+    attach_shadow(&mut c, &g, &sg);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    let stop = CancellationToken::new();
+    capture_once(&c, &source.rpc(1000), &j, None, Some(1), &stop)
+        .await
+        .unwrap();
+    {
+        let mut db = lock(&j).unwrap();
+        db.bind(0, "test-binding").unwrap();
+        let mut o = db.occurrences(1).unwrap().remove(0);
+        o.attempts = 1;
+        o.first_attempt_ms = Some(now_ms());
+        o.last_attempt_ms = o.first_attempt_ms;
+        o.endpoint = Some("shadow-a".into());
+        o.transition(State::Attempting, "crash before socket write");
+        db.update(&o).unwrap();
+        db.state.last_release_height = Some(1);
+        db.save_state().unwrap();
+    }
+    drop(j);
+    let j = Arc::new(Mutex::new(Journal::open(&c, None).unwrap()));
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        replay(
+            c,
+            qualified(&target),
+            source.rpc(1000),
+            j.clone(),
+            Some(1),
+            false,
+            stop,
+        ),
+    )
+    .await
+    .unwrap()
+    .unwrap();
+    let o = lock(&j).unwrap().occurrences(1).unwrap().remove(0);
+    assert_eq!(o.state, State::Finalized);
+    assert_eq!(o.ambiguous_resends, 1);
+    assert_eq!(target.state.lock().unwrap().sent.len(), 1);
+    source.close().await;
+    target.close().await;
+}
+#[tokio::test]
+async fn target_finality_conflict_stops_before_sending() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    let ts = now_ms() - 1000;
+    let g = block(0, B256::ZERO, ts, vec![], false);
+    let sg = block(0, B256::ZERO, ts, vec![], true);
+    let b = block(1, g.header.hash_slow(), ts + 100, vec![legacy(0, 1)], false);
+    let source = Mock::start(vec![g.clone(), b], false).await;
+    let bad = block(1, B256::repeat_byte(99), ts + 200, vec![], true);
+    let target = Mock::start(vec![sg.clone(), bad], true).await;
+    attach_shadow(&mut c, &g, &sg);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    let stop = CancellationToken::new();
+    capture_once(&c, &source.rpc(1000), &j, None, Some(1), &stop)
+        .await
+        .unwrap();
+    assert!(
+        replay(
+            c,
+            qualified(&target),
+            source.rpc(1000),
+            j.clone(),
+            Some(1),
+            false,
+            stop
+        )
+        .await
+        .is_err()
+    );
+    assert!(target.state.lock().unwrap().sent.is_empty());
+    assert!(lock(&j).unwrap().state.incident.is_some());
+    source.close().await;
+    target.close().await;
+}
+
+#[tokio::test]
+async fn bounded_capture_uses_later_finality_anchor_when_end_certificate_is_missing() {
+    let dir = tempfile::tempdir().unwrap();
+    let c = config(dir.path());
+    let g = block(0, B256::ZERO, 1000, vec![], false);
+    let b1 = block(1, g.header.hash_slow(), 1100, vec![legacy(0, 1)], false);
+    let b2 = block(2, b1.header.hash_slow(), 1200, vec![legacy(1, 1)], false);
+    let source = Mock::start(vec![g, b1, b2], false).await;
+    source.state.lock().unwrap().missing_certificates.insert(1);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    capture_once(
+        &c,
+        &source.rpc(1000),
+        &j,
+        None,
+        Some(1),
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        lock(&j)
+            .unwrap()
+            .state
+            .cursors
+            .captured_through
+            .as_ref()
+            .unwrap()
+            .height,
+        1
+    );
+    assert_eq!(lock(&j).unwrap().state.counts.user_occurrences, 1);
+    capture_once(
+        &c,
+        &source.rpc(1000),
+        &j,
+        None,
+        Some(2),
+        &CancellationToken::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(lock(&j).unwrap().state.counts.user_occurrences, 2);
+    source.close().await;
+}
+#[tokio::test]
+async fn capacity_rejection_is_deferred_then_retried_without_a_gap() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    let ts = now_ms() - 1000;
+    let g = block(0, B256::ZERO, ts, vec![], false);
+    let sg = block(0, B256::ZERO, ts, vec![], true);
+    let tx = legacy(0, 1);
+    let hash = Tx::from_envelope(&tx, 4217).unwrap().hash;
+    let b = block(1, g.header.hash_slow(), ts + 100, vec![tx], false);
+    let source = Mock::start(vec![g.clone(), b], false).await;
+    let target = Mock::start(vec![sg.clone()], true).await;
+    attach_shadow(&mut c, &g, &sg);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    let stop = CancellationToken::new();
+    target
+        .state
+        .lock()
+        .unwrap()
+        .reject
+        .insert(hash, "SpammerExceededCapacity".into());
+    capture_once(&c, &source.rpc(1000), &j, None, Some(1), &stop)
+        .await
+        .unwrap();
+    let task = tokio::spawn(replay(
+        c,
+        qualified(&target),
+        source.rpc(1000),
+        j.clone(),
+        Some(1),
+        false,
+        stop.clone(),
+    ));
+    wait_for_state(&j, State::Deferred).await;
+    target.state.lock().unwrap().reject.clear();
+    tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    let s = lock(&j).unwrap().state.clone();
+    assert_eq!(s.counts.gaps, 0);
+    assert_eq!(s.counts.finalized, 1);
+    assert!(s.counts.attempts >= 2);
+    source.close().await;
+    target.close().await;
+}
+#[tokio::test]
+async fn cancellation_drains_writes_and_retains_unfinalized_reservations() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut c = config(dir.path());
+    let ts = now_ms() - 1000;
+    let g = block(0, B256::ZERO, ts, vec![], false);
+    let sg = block(0, B256::ZERO, ts, vec![], true);
+    let b = block(1, g.header.hash_slow(), ts + 100, vec![legacy(0, 1)], false);
+    let source = Mock::start(vec![g.clone(), b], false).await;
+    let target = Mock::start(vec![sg.clone()], true).await;
+    target.state.lock().unwrap().auto_mine = false;
+    attach_shadow(&mut c, &g, &sg);
+    let j = Arc::new(Mutex::new(Journal::open(&c, Some(1)).unwrap()));
+    let stop = CancellationToken::new();
+    capture_once(&c, &source.rpc(1000), &j, None, Some(1), &stop)
+        .await
+        .unwrap();
+    let task = tokio::spawn(replay(
+        c,
+        qualified(&target),
+        source.rpc(1000),
+        j.clone(),
+        None,
+        false,
+        stop.clone(),
+    ));
+    wait_for_state(&j, State::Accepted).await;
+    stop.cancel();
+    tokio::time::timeout(Duration::from_secs(2), task)
+        .await
+        .unwrap()
+        .unwrap()
+        .unwrap();
+    assert_eq!(target.state.lock().unwrap().sent.len(), 1);
+    let o = lock(&j).unwrap().occurrences(1).unwrap().remove(0);
+    assert_eq!(o.state, State::Accepted);
+    assert_eq!(lock(&j).unwrap().state.counts.reserved_count, 1);
+    source.close().await;
+    target.close().await;
+}
+
+async fn wait_for_state(j: &tempo_replay::journal::SharedJournal, state: State) {
+    tokio::time::timeout(Duration::from_secs(4), async {
+        loop {
+            if lock(j)
+                .unwrap()
+                .occurrences(1)
+                .unwrap()
+                .iter()
+                .any(|o| o.state == state)
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("expected journal transition did not occur");
+}

--- a/bin/tempo-replay/tests/signatures.rs
+++ b/bin/tempo-replay/tests/signatures.rs
@@ -1,0 +1,171 @@
+mod common;
+use alloy_eips::eip2718::{Decodable2718, Encodable2718};
+use alloy_primitives::{B256, Bytes, TxKind, U256};
+use base64::Engine;
+use common::*;
+use p256::ecdsa::signature::hazmat::PrehashSigner;
+use sha2::{Digest, Sha256};
+use tempo_primitives::{
+    TempoSignature, TempoTransaction, TempoTxEnvelope,
+    transaction::{
+        Call, PrimitiveSignature,
+        tt_signature::{P256SignatureWithPreHash, WebAuthnSignature},
+    },
+};
+use tempo_replay::model::Tx;
+
+fn aa_template() -> TempoTransaction {
+    TempoTransaction {
+        chain_id: 4217,
+        nonce: 3,
+        nonce_key: U256::from(17),
+        gas_limit: 200000,
+        max_fee_per_gas: 1000000000,
+        calls: vec![
+            Call {
+                to: TxKind::Create,
+                value: U256::ZERO,
+                input: Bytes::from_static(&[0x60, 0x00]),
+            },
+            Call {
+                to: TxKind::Call(alloy_primitives::Address::repeat_byte(7)),
+                value: U256::ZERO,
+                input: Bytes::from_static(&[1, 2, 3, 4]),
+            },
+        ],
+        ..Default::default()
+    }
+}
+fn assert_roundtrip(tx: TempoTxEnvelope) {
+    let raw = tx.encoded_2718();
+    let decoded = TempoTxEnvelope::decode_2718(&mut raw.as_slice()).unwrap();
+    assert_eq!(decoded.encoded_2718(), raw);
+    let json = serde_json::to_value(&tx).unwrap();
+    let decoded: TempoTxEnvelope = serde_json::from_value(json).unwrap();
+    assert_eq!(decoded.encoded_2718(), raw);
+    assert_eq!(
+        Tx::from_envelope(&tx, 4217).unwrap().sender,
+        Tx::from_envelope(&decoded, 4217).unwrap().sender
+    );
+}
+#[test]
+fn p256_and_webauthn_batched_envelopes_preserve_signed_bytes() {
+    let key = p256::ecdsa::SigningKey::from_slice(&[3; 32]).unwrap();
+    let point = key.verifying_key().to_encoded_point(false);
+    let x = B256::from_slice(point.x().unwrap());
+    let y = B256::from_slice(point.y().unwrap());
+    for webauthn in [false, true] {
+        let tx = aa_template();
+        let hash = tx.signature_hash();
+        let mut data = vec![0u8; 37];
+        data[32] = 1;
+        let digest = if webauthn {
+            let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash);
+            let client = format!("{{\"type\":\"webauthn.get\",\"challenge\":\"{challenge}\"}}");
+            let mut signed = data.clone();
+            signed.extend_from_slice(&Sha256::digest(client.as_bytes()));
+            data.extend_from_slice(client.as_bytes());
+            B256::from_slice(&Sha256::digest(signed))
+        } else {
+            hash
+        };
+        let sig: p256::ecdsa::Signature = key.sign_prehash(digest.as_slice()).unwrap();
+        let sig = sig.normalize_s().unwrap_or(sig);
+        let bytes = sig.to_bytes();
+        let r = B256::from_slice(&bytes[..32]);
+        let s = B256::from_slice(&bytes[32..]);
+        let signature = if webauthn {
+            PrimitiveSignature::WebAuthn(WebAuthnSignature {
+                r,
+                s,
+                pub_key_x: x,
+                pub_key_y: y,
+                webauthn_data: data.into(),
+            })
+        } else {
+            PrimitiveSignature::P256(P256SignatureWithPreHash {
+                r,
+                s,
+                pub_key_x: x,
+                pub_key_y: y,
+                pre_hash: false,
+            })
+        };
+        let envelope = TempoTxEnvelope::AA(tx.into_signed(TempoSignature::Primitive(signature)));
+        assert_eq!(
+            Tx::from_envelope(&envelope, 4217).unwrap().sender,
+            tempo_primitives::derive_p256_address(&x, &y)
+        );
+        assert_roundtrip(envelope);
+    }
+}
+#[test]
+fn sponsored_aa_retains_fee_payer_signature_and_batch() {
+    let mut tx = aa_template();
+    let sender = Tx::from_envelope(&legacy(0, 1), 4217).unwrap().sender;
+    tx.fee_payer_signature = Some(sign(tx.fee_payer_signature_hash(sender), 2));
+    let sig = sign(tx.signature_hash(), 1);
+    let envelope = TempoTxEnvelope::AA(tx.into_signed(sig.into()));
+    assert_eq!(Tx::from_envelope(&envelope, 4217).unwrap().sender, sender);
+    assert_roundtrip(envelope);
+}
+#[test]
+fn altered_p256_signature_is_not_accepted_as_compatible_source_traffic() {
+    let tx = aa_template();
+    let signature = PrimitiveSignature::P256(P256SignatureWithPreHash {
+        r: B256::ZERO,
+        s: B256::ZERO,
+        pub_key_x: B256::ZERO,
+        pub_key_y: B256::ZERO,
+        pre_hash: false,
+    });
+    assert!(
+        Tx::from_envelope(
+            &TempoTxEnvelope::AA(tx.into_signed(TempoSignature::Primitive(signature))),
+            4217
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn keychain_v2_preserves_root_sender_and_expiring_key_authorization() {
+    use tempo_primitives::transaction::{KeyAuthorization, KeychainSignature, SignatureType};
+    let root = Tx::from_envelope(&legacy(0, 1), 4217).unwrap().sender;
+    let access_key = Tx::from_envelope(&legacy(0, 2), 4217).unwrap().sender;
+    let authorization = KeyAuthorization::unrestricted(4217, SignatureType::Secp256k1, access_key)
+        .with_expiry(123456);
+    let auth_sig = sign(authorization.signature_hash(), 1);
+    let mut tx = aa_template();
+    tx.key_authorization = Some(authorization.into_signed(PrimitiveSignature::Secp256k1(auth_sig)));
+    let sig_hash = KeychainSignature::signing_hash(tx.signature_hash(), root);
+    let sig = KeychainSignature::new(root, PrimitiveSignature::Secp256k1(sign(sig_hash, 2)));
+    let envelope = TempoTxEnvelope::AA(tx.into_signed(TempoSignature::Keychain(sig)));
+    assert_eq!(Tx::from_envelope(&envelope, 4217).unwrap().sender, root);
+    assert_roundtrip(envelope);
+}
+#[test]
+fn tempo_authorization_list_retains_authority_nonce() {
+    use tempo_primitives::transaction::TempoSignedAuthorization;
+    let authorization = alloy_eips::eip7702::Authorization {
+        chain_id: U256::from(4217),
+        address: alloy_primitives::Address::repeat_byte(9),
+        nonce: 27,
+    };
+    let signature = sign(authorization.signature_hash(), 2);
+    let mut tx = aa_template();
+    tx.calls.remove(0); // Tempo forbids CREATE in a transaction with an AA authorization list.
+    tx.tempo_authorization_list = vec![TempoSignedAuthorization::new_unchecked(
+        authorization,
+        signature.into(),
+    )];
+    let signature = sign(tx.signature_hash(), 1);
+    let envelope = TempoTxEnvelope::AA(tx.into_signed(signature.into()));
+    assert_eq!(
+        envelope.as_aa().unwrap().tx().tempo_authorization_list[0]
+            .inner()
+            .nonce,
+        27
+    );
+    assert_roundtrip(envelope);
+}


### PR DESCRIPTION
Adds `tempo-replay run --from-block N` to submit original signed transactions from finalized source blocks to independent shadow validators, catch up, and continuously follow live traffic. The workspace binary uses local Tempo primitives and a durable RocksDB journal to resume after restarts, with bounded scheduling and receipt accounting for delivery gaps.

Validated with all 28 replay tests, Clippy with warnings denied, workspace nightly formatting, typo checks, and CLI help/version checks. Live-node compatibility and mainnet-rate throughput still require deployment qualification.