### PR TITLE
fix(txpool): allow max expiring nonce discriminator

### DIFF
--- a/crates/alloy/src/fillers/nonce.rs
+++ b/crates/alloy/src/fillers/nonce.rs
@@ -78,7 +78,9 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for R
 
 /// A [`TxFiller`] that populates transactions with expiring nonce fields ([TIP-1009]).
 ///
-/// Sets `nonce_key` to `U256::MAX`, `nonce` to `0`, and `valid_before` to current time + expiry window.
+/// Sets `nonce_key` to `U256::MAX`, defaults an unset `nonce` to `0`, and sets `valid_before` to
+/// current time + expiry window. An explicitly supplied nonce is preserved as an opaque
+/// discriminator for TIP-1106.
 /// This enables transactions to use the circular buffer replay protection instead of 2D nonce storage.
 ///
 /// [TIP-1009]: <https://docs.tempo.xyz/protocol/tips/tip-1009>
@@ -112,11 +114,11 @@ impl ExpiringNonceFiller {
 
     /// Returns `true` if all expiring nonce fields are properly set:
     /// - `nonce_key` is `TEMPO_EXPIRING_NONCE_KEY`
-    /// - `nonce` is `0`
+    /// - `nonce` is set
     /// - `valid_before` is set
     fn is_filled(tx: &TempoTransactionRequest) -> bool {
         tx.nonce_key == Some(TEMPO_EXPIRING_NONCE_KEY)
-            && tx.nonce() == Some(0)
+            && tx.nonce().is_some()
             && tx.valid_before.is_some()
     }
 
@@ -149,8 +151,10 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for E
         {
             // Set expiring nonce key (U256::MAX)
             builder.set_nonce_key(TEMPO_EXPIRING_NONCE_KEY);
-            // Nonce must be 0 for expiring nonce transactions
-            builder.set_nonce(0);
+            // Preserve an explicit TIP-1106 discriminator, defaulting to zero.
+            if builder.nonce().is_none() {
+                builder.set_nonce(0);
+            }
             // Set valid_before to current time + expiry window
             builder.set_valid_before(
                 NonZeroU64::new(Self::current_timestamp() + self.expiry_secs)
@@ -188,8 +192,8 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for E
 ///
 /// Nonce resolution depends on the key:
 /// - `U256::ZERO` (protocol nonce): uses `get_transaction_count`
-/// - `TEMPO_EXPIRING_NONCE_KEY` (U256::MAX): always 0, no caching (use [`ExpiringNonceFiller`]
-///   instead for full expiring nonce support including `valid_before`)
+/// - `TEMPO_EXPIRING_NONCE_KEY` (U256::MAX): defaults an unset nonce to 0, no caching (use
+///   [`ExpiringNonceFiller`] instead for full expiring nonce support including `valid_before`)
 /// - Any other key: queries the `NonceManager` precompile via `eth_call`
 #[derive(Clone, Debug)]
 pub struct NonceKeyFiller {
@@ -267,7 +271,7 @@ impl<N: Network<TransactionRequest = TempoTransactionRequest>> TxFiller<N> for N
             .nonce_key
             .ok_or_else(|| TransportErrorKind::custom_str("missing `nonce_key`"))?;
 
-        // Expiring nonces always use nonce 0
+        // Expiring nonces default to discriminator 0 when the caller did not supply one.
         if nonce_key == TEMPO_EXPIRING_NONCE_KEY {
             return Ok(0);
         }
@@ -320,6 +324,23 @@ mod tests {
     use alloy_primitives::{Bytes, ruint::aliases::U256};
     use alloy_provider::{ProviderBuilder, mock::Asserter};
     use eyre;
+
+    #[test]
+    fn expiring_nonce_filler_preserves_explicit_discriminator() {
+        let filler = ExpiringNonceFiller::default();
+        let mut request = TempoTransactionRequest::default().with_nonce(42);
+        let mut tx = SendableTx::Builder(request.clone());
+
+        TxFiller::<TempoNetwork>::fill_sync(&filler, &mut tx);
+        request = tx
+            .as_builder()
+            .expect("transaction remains a builder")
+            .clone();
+
+        assert_eq!(request.nonce_key, Some(TEMPO_EXPIRING_NONCE_KEY));
+        assert_eq!(request.nonce(), Some(42));
+        assert!(request.valid_before.is_some());
+    }
 
     #[tokio::test]
     async fn test_random_2d_nonce_filler() -> eyre::Result<()> {

--- a/crates/node/tests/it/tempo_transaction/local.rs
+++ b/crates/node/tests/it/tempo_transaction/local.rs
@@ -23,7 +23,7 @@ use reth_ethereum::network::{NetworkSyncUpdater, SyncState};
 use reth_node_api::BuiltPayload;
 use reth_primitives_traits::transaction::TxHashRef;
 use reth_transaction_pool::TransactionPool;
-use tempo_alloy::TempoNetwork;
+use tempo_alloy::{TempoNetwork, provider::TempoProviderBuilderExt};
 use tempo_chainspec::{hardfork::TempoHardfork, spec::TEMPO_T1_BASE_FEE};
 use tempo_contracts::precompiles::{
     DEFAULT_FEE_TOKEN,
@@ -32,6 +32,7 @@ use tempo_contracts::precompiles::{
         revokeKeyCall,
     },
 };
+use tempo_node::rpc::TempoTransactionRequest;
 use tempo_precompiles::{
     ACCOUNT_KEYCHAIN_ADDRESS,
     tip20::ITIP20::{self},
@@ -1939,11 +1940,71 @@ async fn test_aa_keychain_revocation_toctou_dos() -> eyre::Result<()> {
 // Expiring Nonce Tests
 // ============================================================================
 
+#[test_case::test_case(TempoHardfork::T11, [true, false, false] ; "t11")]
+#[test_case::test_case(TempoHardfork::T12, [true, true, true] ; "t12")]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_expiring_nonce_discriminators_across_t12(
+    hardfork: TempoHardfork,
+    expected_admission: [bool; 3],
+) -> eyre::Result<()> {
+    let mut localnet = Localnet::with_schedule(ForkSchedule::DevnetAt(hardfork)).await?;
+    let valid_before = super::types::TestEnv::current_block_timestamp(&mut localnet).await?
+        + localnet.setup.hardfork.expiring_nonce_max_expiry_secs();
+    let Localnet {
+        mut setup,
+        provider,
+        chain_id,
+        funder_signer,
+        funder_addr,
+    } = localnet;
+    let recipient = Address::random();
+    let protocol_nonce = provider.get_transaction_count(funder_addr).await?;
+    let tempo_provider = ProviderBuilder::new_with_network::<TempoNetwork>()
+        .with_expiring_nonces()
+        .wallet(funder_signer)
+        .connect_http(setup.node.rpc_url());
+    let mut accepted_hashes = Vec::new();
+
+    for (discriminator, should_accept) in [0, 1, u64::MAX].into_iter().zip(expected_admission) {
+        let mut tx = create_expiring_nonce_tx(chain_id, valid_before, recipient);
+        tx.nonce = discriminator;
+        let mut request = TempoTransactionRequest::from(tx);
+        request.inner.from = Some(funder_addr);
+        // Estimation skips nonce validity checks but still exercises request conversion.
+        estimate_gas(&provider, &request).await?;
+
+        let submission = tempo_provider.send_transaction(request).await;
+        if should_accept {
+            accepted_hashes.push(*submission?.tx_hash());
+        } else {
+            assert!(
+                submission.is_err(),
+                "{hardfork:?} admitted discriminator {discriminator}"
+            );
+        }
+    }
+
+    assert!(
+        accepted_hashes
+            .iter()
+            .all(|hash| setup.node.inner.pool.contains(hash)),
+        "{hardfork:?} accepted discriminators must coexist in the pool"
+    );
+    setup.node.advance_block().await?;
+    for hash in accepted_hashes {
+        assert_receipt_status(&provider, hash, true).await?;
+    }
+    assert_eq!(
+        provider.get_transaction_count(funder_addr).await?,
+        protocol_nonce,
+        "expiring nonce discriminators must not change the protocol nonce"
+    );
+    Ok(())
+}
+
 /// Test expiring nonce replay protection - same tx hash should be rejected
 #[tokio::test(flavor = "multi_thread")]
 async fn test_aa_expiring_nonce_replay_protection() -> eyre::Result<()> {
-    println!("\n=== Testing Expiring Nonce Replay Protection ===\n");
-
     let Localnet {
         mut setup,
         provider,
@@ -1952,51 +2013,32 @@ async fn test_aa_expiring_nonce_replay_protection() -> eyre::Result<()> {
         ..
     } = Localnet::new().await?;
 
-    let recipient = Address::random();
-
-    // Advance a few blocks to get a meaningful timestamp
     for _ in 0..3 {
         setup.node.advance_block().await?;
     }
-
-    // Get current block timestamp
     let block = provider
         .get_block_by_number(Default::default())
         .await?
         .unwrap();
     let current_timestamp = block.header.timestamp();
-
-    // Create expiring nonce transaction
     let valid_before = current_timestamp + setup.hardfork.expiring_nonce_max_expiry_secs();
 
-    let tx = create_expiring_nonce_tx(chain_id, valid_before, recipient);
+    for discriminator in [0, 1, u64::MAX] {
+        let mut tx = create_expiring_nonce_tx(chain_id, valid_before, Address::random());
+        tx.nonce = discriminator;
+        let signature = sign_aa_tx_secp256k1(&tx, &alice_signer)?;
+        let envelope: TempoTxEnvelope = tx.into_signed(signature).into();
+        let tx_hash = *envelope.tx_hash();
+        let encoded = envelope.encoded_2718();
 
-    let aa_signature = sign_aa_tx_secp256k1(&tx, &alice_signer)?;
-    let envelope: TempoTxEnvelope = tx.into_signed(aa_signature).into();
-    let tx_hash = *envelope.tx_hash();
-    let encoded = envelope.encoded_2718();
-
-    println!("First submission - tx hash: {tx_hash}");
-
-    // First submission should succeed
-    setup.node.rpc.inject_tx(encoded.clone().into()).await?;
-    setup.node.advance_block().await?;
-
-    assert_receipt_status(&provider, tx_hash, true).await?;
-    println!("✓ First submission succeeded");
-
-    // Second submission with SAME encoded tx (same hash) should fail
-    println!("\nSecond submission - attempting replay with same tx hash...");
-
-    // Try to inject the same transaction again - should be rejected at pool level
-    let replay_result = setup.node.rpc.inject_tx(encoded.clone().into()).await;
-
-    // The replay MUST be rejected at pool validation (we check seen[tx_hash] in validator)
-    assert!(
-        replay_result.is_err(),
-        "Replay should be rejected at transaction pool level"
-    );
-    println!("✓ Replay rejected at transaction pool level");
+        setup.node.rpc.inject_tx(encoded.clone().into()).await?;
+        setup.node.advance_block().await?;
+        assert_receipt_status(&provider, tx_hash, true).await?;
+        assert!(
+            setup.node.rpc.inject_tx(encoded.into()).await.is_err(),
+            "replayed discriminator {discriminator} was admitted"
+        );
+    }
 
     Ok(())
 }

--- a/crates/primitives/src/transaction/tt_signed.rs
+++ b/crates/primitives/src/transaction/tt_signed.rs
@@ -808,6 +808,37 @@ mod tests {
     }
 
     #[test]
+    fn test_expiring_nonce_discriminator_separates_hashes() {
+        let sender = Address::repeat_byte(0x01);
+        let tx = TempoTransaction {
+            chain_id: 1,
+            gas_limit: 1_000_000,
+            nonce_key: U256::MAX,
+            nonce: 0,
+            valid_before: Some(core::num::NonZeroU64::new(100).unwrap()),
+            calls: vec![Call {
+                to: TxKind::Call(Address::repeat_byte(0x42)),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }],
+            ..Default::default()
+        };
+        let mut discriminated_tx = tx.clone();
+        discriminated_tx.nonce = 1;
+        let sig =
+            TempoSignature::Primitive(PrimitiveSignature::Secp256k1(Signature::test_signature()));
+        let signed = AASigned::new_unhashed(tx, sig.clone());
+        let discriminated = AASigned::new_unhashed(discriminated_tx, sig);
+
+        assert_ne!(signed.signature_hash(), discriminated.signature_hash());
+        assert_ne!(signed.hash(), discriminated.hash());
+        assert_ne!(
+            signed.expiring_nonce_hash(sender),
+            discriminated.expiring_nonce_hash(sender)
+        );
+    }
+
+    #[test]
     fn test_expiring_nonce_hash_unique_per_sender() {
         let tx = TempoTransaction {
             chain_id: 1,

--- a/crates/revm/src/error.rs
+++ b/crates/revm/src/error.rs
@@ -86,8 +86,8 @@ pub enum TempoInvalidTransaction {
     #[error("expiring nonce transaction requires valid_before to be set")]
     ExpiringNonceMissingValidBefore,
 
-    /// Expiring nonce transaction must have nonce == 0.
-    #[error("expiring nonce transaction must have nonce == 0")]
+    /// Pre-T12 expiring nonce transaction must have nonce == 0.
+    #[error("expiring nonce transaction must have nonce == 0 before T12")]
     ExpiringNonceNonceNotZero,
 
     /// Subblock transaction must have zero fee.

--- a/crates/revm/src/evm.rs
+++ b/crates/revm/src/evm.rs
@@ -566,6 +566,31 @@ mod tests {
         evm
     }
 
+    /// Create an EVM at a specific Tempo hardfork and timestamp with a funded account.
+    fn create_funded_evm_at_spec_with_timestamp(
+        address: Address,
+        timestamp: u64,
+        spec: TempoHardfork,
+    ) -> TempoEvm<CacheDB<EmptyDB>, ()> {
+        let db = CacheDB::new(EmptyDB::new());
+        let mut cfg = CfgEnv::<TempoHardfork>::default();
+        cfg.spec = spec;
+        cfg.gas_params = tempo_gas_params_with_amsterdam(spec, false);
+
+        let mut block = TempoBlockEnv::default();
+        block.inner.timestamp = U256::from(timestamp);
+
+        let ctx = Context::mainnet()
+            .with_db(db)
+            .with_block(block)
+            .with_cfg(cfg)
+            .with_tx(Default::default());
+
+        let mut evm = TempoEvm::new(ctx, ());
+        fund_account(&mut evm, address);
+        evm
+    }
+
     /// Create an EVM with a specific timestamp and a funded account.
     fn create_funded_evm_with_timestamp(
         address: Address,
@@ -3787,6 +3812,58 @@ mod tests {
             0,
             "expiring nonce bookkeeping must not accrue storage credits"
         );
+
+        Ok(())
+    }
+
+    /// TIP-1106: expiring nonces become opaque discriminators at T12.
+    #[test]
+    fn test_expiring_nonce_discriminator_activation() -> eyre::Result<()> {
+        use tempo_primitives::transaction::TEMPO_EXPIRING_NONCE_KEY;
+
+        let key_pair = P256KeyPair::random();
+        let caller = key_pair.address;
+        let timestamp = 1_000u64;
+
+        let build_env = |nonce| -> eyre::Result<_> {
+            let tx = TxBuilder::new()
+                .call_identity(&[])
+                .nonce_key(TEMPO_EXPIRING_NONCE_KEY)
+                .nonce(nonce)
+                .valid_before(Some(timestamp + 30))
+                .gas_limit(500_000)
+                .build();
+            let signed_tx = key_pair.sign_tx(tx)?;
+            Ok(TempoTxEnv::from_recovered_tx(&signed_tx, caller))
+        };
+
+        let mut pre_activation =
+            create_funded_evm_at_spec_with_timestamp(caller, timestamp, TempoHardfork::T11);
+        assert!(
+            pre_activation.transact_commit(build_env(1)?).is_err(),
+            "T11 must reject a non-zero expiring nonce"
+        );
+
+        for nonce in [0, 1, u64::MAX] {
+            let mut evm =
+                create_funded_evm_at_spec_with_timestamp(caller, timestamp, TempoHardfork::T12);
+            let result = evm.transact_commit(build_env(nonce)?)?;
+            assert!(
+                result.is_success(),
+                "T12 must accept expiring nonce discriminator {nonce}"
+            );
+            assert_eq!(
+                evm.ctx
+                    .db()
+                    .basic_ref(caller)
+                    .ok()
+                    .flatten()
+                    .map(|account| account.nonce)
+                    .unwrap_or_default(),
+                0,
+                "expiring nonce discriminator must not mutate the protocol nonce"
+            );
+        }
 
         Ok(())
     }

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1086,8 +1086,10 @@ where
                 .as_ref()
                 .ok_or(TempoInvalidTransaction::ExpiringNonceMissingTxEnv)?;
 
-            // Expiring nonce txs must have nonce == 0
-            if tx.nonce() != 0 {
+            // Before TIP-1106 activates, expiring nonce txs must have nonce == 0.
+            // At T12+, the nonce is an opaque discriminator committed to by the
+            // signing and replay-protection hashes.
+            if !spec.is_t12() && tx.nonce() != 0 {
                 return Err(TempoInvalidTransaction::ExpiringNonceNonceNotZero.into());
             }
 
@@ -1784,9 +1786,27 @@ where
             return Err(TempoInvalidTransaction::ValueTransferNotAllowed.into());
         }
 
-        // First perform standard validation (header + transaction environment)
+        // First perform standard validation (header + transaction environment).
         // This validates: prevrandao, excess_blob_gas, chain_id, gas limits, tx type support, etc.
-        validation::validate_env::<_, Self::Error>(evm.ctx())?;
+        // REVM rejects u64::MAX because protocol nonces are incremented after execution. T12
+        // expiring nonces are opaque discriminators and never incremented, so validate the rest
+        // of the environment with a temporary in-range value.
+        let accepts_max_expiring_nonce = evm.ctx.cfg.spec.is_t12()
+            && evm.ctx.tx.nonce() == u64::MAX
+            && evm
+                .ctx
+                .tx
+                .tempo_tx_env
+                .as_ref()
+                .is_some_and(|aa| aa.nonce_key == TEMPO_EXPIRING_NONCE_KEY);
+        if accepts_max_expiring_nonce {
+            evm.ctx.tx.inner.nonce = 0;
+        }
+        let validation_result = validation::validate_env::<_, Self::Error>(evm.ctx());
+        if accepts_max_expiring_nonce {
+            evm.ctx.tx.inner.nonce = u64::MAX;
+        }
+        validation_result?;
 
         // AA-specific validations
         let cfg = &evm.inner.cfg;

--- a/crates/revm/src/handler.rs
+++ b/crates/revm/src/handler.rs
@@ -1791,6 +1791,8 @@ where
         // REVM rejects u64::MAX because protocol nonces are incremented after execution. T12
         // expiring nonces are opaque discriminators and never incremented, so validate the rest
         // of the environment with a temporary in-range value.
+        // TODO: Remove this workaround when migrating to EVM2. Its per-transaction-type handlers
+        // let Tempo omit the nonce-overflow check for T12+ expiring nonce transactions.
         let accepts_max_expiring_nonce = evm.ctx.cfg.spec.is_t12()
             && evm.ctx.tx.nonce() == u64::MAX
             && evm

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -34,7 +34,7 @@ use tempo_precompiles::{
     tip403_registry::tip403_registry_slots,
 };
 use tempo_primitives::{
-    TempoTxEnvelope,
+    AASigned, TempoTxEnvelope,
     transaction::{InvalidValidAfter, InvalidValidBefore, calc_gas_balance_spending},
 };
 use tempo_revm::{TempoInvalidTransaction, TempoTxEnv};
@@ -90,6 +90,27 @@ impl TempoPooledTransaction {
         });
         let encoded_length = transaction.encode_2718_len();
         Self::new_with(transaction, expiring_nonce_hash, encoded_length)
+    }
+
+    /// Returns a copy whose AA nonce is safe for Reth's EIP-2681 stateless validation.
+    ///
+    /// T12 expiring nonces treat `u64::MAX` as an opaque discriminator, while Reth rejects that
+    /// value for protocol nonces. The original encoded length is retained so all other stateless
+    /// checks run against the real transaction's size.
+    pub(crate) fn eip2681_validation_proxy(&self) -> Option<Self> {
+        let (envelope, signer) = self.inner.transaction.clone().into_parts();
+        let TempoTxEnvelope::AA(signed) = envelope else {
+            return None;
+        };
+        let (mut tx, signature, _) = signed.into_parts();
+        tx.nonce = 0;
+
+        let mut proxy = Self::new(Recovered::new_unchecked(
+            TempoTxEnvelope::AA(AASigned::new_unhashed(tx, signature)),
+            signer,
+        ));
+        proxy.inner.encoded_length = self.inner.encoded_length;
+        Some(proxy)
     }
 
     /// Create a new pooled transaction with optional precomputed transaction metadata.

--- a/crates/transaction-pool/src/transaction.rs
+++ b/crates/transaction-pool/src/transaction.rs
@@ -180,7 +180,7 @@ impl TempoPooledTransaction {
         self.inner().is_aa()
     }
 
-    /// Returns the nonce key of this transaction if it's an [`AASigned`](tempo_primitives::AASigned) transaction.
+    /// Returns the nonce key of this transaction if it's an [`AASigned`] transaction.
     pub fn nonce_key(&self) -> Option<U256> {
         self.inner.transaction.nonce_key()
     }

--- a/crates/transaction-pool/src/tt_2d_pool.rs
+++ b/crates/transaction-pool/src/tt_2d_pool.rs
@@ -2468,6 +2468,7 @@ mod tests {
     use crate::test_utils::{TxBuilder, wrap_valid_tx};
     use alloy_eips::eip2930::AccessList;
     use alloy_primitives::{Address, Bytes, Signature, TxKind, U256};
+    use proptest::prelude::*;
     use reth_primitives_traits::Recovered;
     use reth_transaction_pool::PoolTransaction;
     use std::collections::HashSet;
@@ -6888,6 +6889,75 @@ mod tests {
         assert_eq!(pool.expiring_nonce_txs.len(), 1);
         assert_expiring_eviction_index_len(&pool, 1);
         pool.assert_invariants();
+    }
+
+    fn expiring_nonce_discriminator() -> impl Strategy<Value = u64> {
+        prop_oneof![any::<u64>(), Just(0), Just(1), Just(u64::MAX)]
+    }
+
+    proptest! {
+        #[test]
+        fn expiring_nonce_discriminators_coexist_and_are_removed_independently(
+            (first_nonce, second_nonce) in (
+                expiring_nonce_discriminator(),
+                expiring_nonce_discriminator(),
+            ).prop_filter("discriminators must differ", |(first, second)| first != second)
+        ) {
+            use revm::database::{AccountStatus, BundleAccount, states::StorageSlot};
+
+            let mut pool = AA2dPool::default();
+            let sender = Address::random();
+            let base = TxBuilder::aa(sender)
+                .nonce_key(U256::MAX)
+                .valid_before(123)
+                .max_fee(30_000_000_000);
+            let first = base.clone().nonce(first_nonce).build();
+            let second = base.nonce(second_nonce).build();
+            let first_hash = *first.hash();
+            let second_hash = *second.hash();
+            let first_slot = first
+                .expiring_nonce_slot()
+                .expect("expiring nonce transaction has a replay slot");
+
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(first, TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T12,
+            )
+            .unwrap();
+            pool.add_transaction(
+                Arc::new(wrap_valid_tx(second, TransactionOrigin::Local)),
+                0,
+                TempoHardfork::T12,
+            )
+            .unwrap();
+
+            let best = pool
+                .best_transactions()
+                .map(|tx| *tx.hash())
+                .collect::<HashSet<_>>();
+            prop_assert_eq!(best, HashSet::from([first_hash, second_hash]));
+
+            let mut storage = HashMap::default();
+            storage.insert(
+                first_slot,
+                StorageSlot::new_changed(U256::ZERO, U256::from(123_u64)),
+            );
+            let mut state = AddressMap::default();
+            state.insert(
+                NONCE_PRECOMPILE_ADDRESS,
+                BundleAccount::new(None, None, storage, AccountStatus::Changed),
+            );
+
+            let (_, mined, _) = pool.on_state_updates(&state);
+            prop_assert_eq!(mined.len(), 1);
+            prop_assert_eq!(mined[0].hash(), &first_hash);
+            prop_assert!(!pool.contains(&first_hash));
+            prop_assert!(pool.contains(&second_hash));
+            let remaining_hash = *pool.best_transactions().next().unwrap().hash();
+            prop_assert_eq!(remaining_hash, second_hash);
+            pool.assert_invariants();
+        }
     }
 
     /// Verifies that removing an expiring nonce tx by hash correctly cleans up

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -5,7 +5,7 @@ use crate::{
     transaction::{TempoPoolTransactionError, TempoPooledTransaction},
 };
 
-use alloy_consensus::constants::KECCAK_EMPTY;
+use alloy_consensus::{Transaction, constants::KECCAK_EMPTY};
 use alloy_evm::{Database, EvmEnv};
 use alloy_primitives::{Address, B256};
 use parking_lot::RwLock;
@@ -557,8 +557,27 @@ where
         // the Valid outcome with state_nonce and balance for pool ordering.
         let inner_validation = {
             let cached_state_provider = CachedAccountInfoReader::new(evm.db());
-            self.inner
-                .validate_one_with_state_provider(origin, transaction, &cached_state_provider)
+            let accepts_max_expiring_nonce = spec.is_t12()
+                && transaction.nonce() == u64::MAX
+                && transaction.nonce_key() == Some(TEMPO_EXPIRING_NONCE_KEY);
+            if accepts_max_expiring_nonce {
+                let proxy = transaction
+                    .eip2681_validation_proxy()
+                    .expect("expiring nonce transaction must be AA");
+                match self.inner.validate_stateless(origin, &proxy) {
+                    Ok(()) => {
+                        self.inner
+                            .validate_stateful(origin, transaction, &cached_state_provider)
+                    }
+                    Err(err) => TransactionValidationOutcome::Invalid(transaction, err),
+                }
+            } else {
+                self.inner.validate_one_with_state_provider(
+                    origin,
+                    transaction,
+                    &cached_state_provider,
+                )
+            }
         };
 
         match inner_validation {

--- a/tips/tip-1106.md
+++ b/tips/tip-1106.md
@@ -1,0 +1,126 @@
+---
+id: TIP-1106
+title: Expiring Nonce Discriminators
+description: Allows the nonce field of an expiring nonce transaction to distinguish otherwise identical transactions.
+authors: Alexey Shekhirin (@shekhirin)
+status: Draft
+related: TIP-1009, TIP-1000, Transactions
+protocolVersion: TBD
+---
+
+# TIP-1106: Expiring Nonce Discriminators
+
+## Abstract
+
+This TIP allows the `nonce` field of an expiring nonce transaction to contain any `uint64` value,
+rather than requiring zero. In expiring nonce mode the field is an opaque discriminator, not a
+sequential nonce. Two otherwise identical transactions can therefore choose different values and
+produce different signing, transaction, and replay-protection hashes.
+
+## Motivation
+
+[TIP-1009](./tip-1009.md) requires every expiring nonce transaction to set `nonce = 0`. As a result,
+two transactions from the same sender with identical calls, validity bounds, fee parameters, and
+other signable fields have the same signing payload. This is useful for deduplication, but prevents
+an application from intentionally creating distinct instances of the same operation within one
+validity window.
+
+Applications can vary another signed field, such as `validBefore`, but doing so changes that
+field's actual semantics and may not be possible when transactions are produced concurrently.
+Using the existing `nonce` field as an opaque discriminator provides an explicit source of
+uniqueness without changing the transaction encoding or adding protocol state.
+
+The alternative is to add a new salt field to the Tempo transaction type. That would require a new
+encoding and duplicate functionality already provided by the encoded `nonce` field.
+
+## Assumptions
+
+- Tempo transaction signing and transaction encodings continue to commit to the `nonce` field.
+- Expiring nonce replay protection continues to use the transaction hash or a sender-scoped hash
+  derived from the signable transaction payload, depending on the active protocol version.
+- Applications that require distinct hashes choose distinct discriminator values or vary another
+  committed field. The protocol does not allocate discriminator values or guarantee their
+  uniqueness.
+- Existing expiring nonce transactions with `nonce = 0` remain valid after activation. A non-zero
+  expiring nonce transaction submitted before activation remains invalid.
+
+If an implementation omits `nonce` from a signing or replay-protection hash, the uniqueness
+property in this TIP does not hold and that implementation is non-conforming.
+
+## Threat Model
+
+- **Transaction sender:** May choose any discriminator, including reusing a value. Reuse is safe,
+  but identical signable payloads retain identical replay-protection identifiers and are treated as
+  the same transaction.
+- **Wallet or relayer:** Is responsible for choosing distinct discriminator values when distinct
+  transactions are required. A malicious or faulty generator can cause local hash collisions by
+  reusing the complete signable payload, but cannot bypass signature checks or replay protection.
+- **Block producer and node operator:** Must not interpret the discriminator as a sequential nonce,
+  read or update 2D nonce state for it, or accept the same replay-protection identifier twice.
+- **Fee payer:** Cannot create a distinct replayable transaction solely by changing sponsorship
+  data that is excluded from the sender's signable payload; the existing sender-scoped replay
+  protection remains unchanged.
+
+---
+
+# Specification
+
+At the activation protocol version, replace TIP-1009's `nonce == 0` validity requirement with the
+following rule:
+
+> When `nonceKey == TEMPO_EXPIRING_NONCE_KEY`, `nonce` MAY be any value in the transaction field's
+> existing `uint64` range. The value is an opaque transaction discriminator and has no ordering or
+> state-transition semantics.
+
+For an expiring nonce transaction:
+
+1. Validation MUST NOT compare `nonce` with the sender's protocol nonce or a 2D nonce.
+2. Execution MUST NOT increment, initialize, read, or write protocol or 2D nonce state as a result
+   of the discriminator value.
+3. `nonce` MUST remain included in the existing transaction signing payload and transaction
+   encoding.
+4. The replay-protection identifier MUST continue to commit to the complete signable payload,
+   including `nonce`, and to the sender where required by the active protocol version.
+5. All other TIP-1009 requirements, including `nonceKey`, validity-window checks, replay checks,
+   circular-buffer behavior, and gas charging, remain unchanged.
+
+Consequently, for two valid expiring nonce transactions that differ only in `nonce`, their signing
+hashes, signed transaction hashes, and replay-protection identifiers MUST differ. No new state or
+storage layout is introduced.
+
+The rule is fork-gated. Before activation, an expiring nonce transaction with `nonce != 0` MUST be
+rejected according to TIP-1009. At and after activation, both zero and non-zero values MUST be
+accepted.
+
+# Tooling
+
+Transaction builders, RPC helpers, and fillers MUST stop overriding an explicitly supplied
+expiring `nonce` with zero after activation. Helpers MAY continue to use zero by default. Helpers
+intended to create distinct otherwise identical transactions SHOULD assign distinct `uint64`
+values and document whether those values are random, monotonic, or caller-supplied.
+
+RPC estimation and transaction submission MUST apply the fork-gated validation rule. Existing
+wire formats and JSON-RPC field types do not change.
+
+# Observability
+
+N/A. The change adds no new state transition or event. Existing invalid-transaction metrics and
+logs are sufficient, but implementations SHOULD preserve a distinct pre-activation rejection
+reason for a non-zero expiring nonce so cross-fork submission failures remain diagnosable.
+
+# Invariants
+
+| ID | Invariant | Critical cases |
+|----|-----------|----------------|
+| **D1** | Full range accepted | At and after activation, expiring transactions with `nonce` equal to `0`, `1`, and `uint64.max` pass nonce validation. |
+| **D2** | Pre-activation compatibility | Before activation, `nonce = 0` passes and every non-zero value is rejected. |
+| **D3** | Hash separation | Two otherwise identical expiring transactions with different `nonce` values have different signing, transaction, and replay-protection hashes. |
+| **D4** | Replay protection | Repeating the same complete expiring transaction remains a replay and cannot execute twice within its replay-protection lifetime. |
+| **D5** | No ordering | Transactions with discriminator values `2`, `0`, and `1` may execute in any order or in the same block. |
+| **D6** | No nonce state mutation | Successful and reverted expiring transactions do not change the sender's protocol nonce or any 2D nonce solely because of the discriminator. |
+| **D7** | Sponsorship invariance | Changing only fee-payer data excluded from the sender's signable payload does not create a new replay-protection identifier. |
+| **D8** | Encoding compatibility | Existing `nonce = 0` expiring transactions retain their current encoding and hash. |
+
+Tests MUST cover the boundary values, both sides of the activation boundary, identical payloads
+with equal and unequal discriminators, multiple discriminators from one sender in a block, replay
+attempts, reverted execution, and sponsored transactions.


### PR DESCRIPTION
Stacked on #7474.

Aligns T12 pool admission with execution for the maximum expiring-nonce discriminator. Adds focused RPC-to-block coverage for fork boundaries, discriminator coexistence, replay, and independent pool removal.