### PR TITLE
fix(consensus-config): enable Commonware BLS feature

### DIFF
--- a/crates/consensus-config/Cargo.toml
+++ b/crates/consensus-config/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 age.workspace = true
 commonware-codec.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["bls12381"] }
 commonware-math.workspace = true
 const-hex.workspace = true
 rand_core.workspace = true


### PR DESCRIPTION
Enable Commonware's `bls12381` feature explicitly in `tempo-consensus-config`, which imports BLS shares but disables Commonware's default features through the workspace dependency. This fixes the standalone crate check failing after the Commonware v2026.9.0 upgrade: [failed job](https://github.com/tempoxyz/tempo/actions/runs/34514844768/job/102997568009).

Validated with `cargo +stable check --locked --manifest-path crates/consensus-config/Cargo.toml` and `cargo +nightly fmt --all --check`. All 31 crate checks from the original failure onward also pass locally using `cargo +stable hack check --feature-powerset --depth 1 --keep-going --locked` on the corresponding packages; all PR build, test, and lint jobs pass.

Prompted by: @DaniPopes
