### PR TITLE
feat(multiversion): add experimental per-hardfork bundle tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13727,6 +13727,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempo-multiversion"
+version = "1.13.2"
+dependencies = [
+ "sha2 0.10.9",
+ "tempo-hardfork",
+]
+
+[[package]]
+name = "tempo-multiversion-cli"
+version = "1.13.2"
+dependencies = [
+ "clap",
+ "rustix",
+ "tempfile",
+ "tempo-hardfork",
+ "tempo-multiversion",
+]
+
+[[package]]
 name = "tempo-node"
 version = "1.13.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 members = [
   "bin/tempo",
   "bin/tempo-sidecar",
+  "bin/tempo-multiversion",
   "crates/alloy",
   "crates/chainspec",
   "crates/consensus",
@@ -24,6 +25,7 @@ members = [
   "crates/ext",
   "crates/evm",
   "crates/hardfork",
+  "crates/multiversion",
   "crates/e2e",
   "crates/faucet",
   "crates/node",

--- a/bin/tempo-multiversion/Cargo.toml
+++ b/bin/tempo-multiversion/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tempo-multiversion-cli"
+description = "Experimental packer and launcher for Tempo hardfork executables"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[[bin]]
+name = "tempo-multiversion"
+path = "src/main.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+clap.workspace = true
+tempo-hardfork.workspace = true
+tempo-multiversion = { path = "../../crates/multiversion" }
+tempfile.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rustix = { version = "1.1.4", features = ["fs"] }

--- a/bin/tempo-multiversion/src/main.rs
+++ b/bin/tempo-multiversion/src/main.rs
@@ -1,0 +1,223 @@
+//! Explicit launcher for experimental per-hardfork bundles.
+//! This does not replace `tempo` or automatically route node execution.
+
+use clap::{Parser, Subcommand};
+use std::{
+    ffi::OsString,
+    fs::File,
+    io::{self, Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+};
+use tempo_hardfork::TempoHardfork;
+use tempo_multiversion::{Bundle, pack};
+
+#[derive(Debug, Parser)]
+#[command(version, about)]
+struct Args {
+    #[command(subcommand)]
+    action: Action,
+}
+
+#[derive(Debug, Subcommand)]
+enum Action {
+    /// Print the canonical executable names expected by the packer.
+    Forks,
+    /// Append one native executable per hardfork to this launcher.
+    Pack {
+        /// Directory containing tempo-genesis, tempo-t0, tempo-t1, etc.
+        #[arg(long)]
+        input_dir: PathBuf,
+        /// Destination must not already exist.
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// List the hardforks in a bundle after verifying every checksum.
+    Inspect {
+        /// Defaults to this executable.
+        #[arg(long)]
+        bundle: Option<PathBuf>,
+    },
+    /// Extract a verified executable without overwriting an existing file.
+    Extract {
+        hardfork: TempoHardfork,
+        #[arg(long)]
+        bundle: Option<PathBuf>,
+        #[arg(long)]
+        output: PathBuf,
+    },
+    /// Execute an explicitly selected hardfork (Linux only).
+    ///
+    /// No database inspection or automatic protocol selection is performed.
+    Run {
+        hardfork: TempoHardfork,
+        #[arg(long)]
+        bundle: Option<PathBuf>,
+        #[arg(last = true)]
+        args: Vec<OsString>,
+    },
+}
+
+fn main() -> io::Result<()> {
+    match Args::parse().action {
+        Action::Forks => {
+            for fork in TempoHardfork::VARIANTS {
+                println!("{}", executable_name(*fork));
+            }
+            Ok(())
+        }
+        Action::Pack { input_dir, output } => pack_command(&input_dir, &output),
+        Action::Inspect { bundle } => {
+            let mut bundle = open_bundle(bundle)?;
+            bundle.verify()?;
+            for entry in bundle.entries() {
+                let checksum: String = entry
+                    .sha256
+                    .iter()
+                    .map(|byte| format!("{byte:02x}"))
+                    .collect();
+                println!("{}\t{}\t{checksum}", entry.hardfork, entry.length);
+            }
+            Ok(())
+        }
+        Action::Extract {
+            hardfork,
+            bundle,
+            output,
+        } => {
+            let mut bundle = open_bundle(bundle)?;
+            publish(&output, |file| bundle.copy_executable(hardfork, file))
+        }
+        Action::Run {
+            hardfork,
+            bundle,
+            args,
+        } => run(open_bundle(bundle)?, hardfork, args),
+    }
+}
+
+fn executable_name(fork: TempoHardfork) -> String {
+    format!("tempo-{}", fork.to_string().to_ascii_lowercase())
+}
+
+fn open_bundle(path: Option<PathBuf>) -> io::Result<Bundle<File>> {
+    Bundle::open(File::open(path.map_or_else(std::env::current_exe, Ok)?)?)
+}
+
+fn pack_command(input_dir: &Path, output: &Path) -> io::Result<()> {
+    let mut launcher = File::open(std::env::current_exe()?)?;
+    // A bundle cannot be used as a launcher: that would recursively embed previous packs.
+    // Check only the fixed footer magic; a corrupt bundle must not be repacked either.
+    if has_bundle_footer(&mut launcher)? {
+        return Err(io::Error::other(
+            "pack with the unbundled tempo-multiversion launcher",
+        ));
+    }
+    launcher.rewind()?;
+    let target = native_target(&mut launcher)?;
+    let mut executables = Vec::new();
+    for fork in TempoHardfork::VARIANTS {
+        let path = input_dir.join(executable_name(*fork));
+        let mut file = File::open(&path)
+            .map_err(|err| io::Error::new(err.kind(), format!("{}: {err}", path.display())))?;
+        if has_bundle_footer(&mut file)? {
+            return Err(io::Error::other(format!(
+                "{}: extract individual executables before packing; nested bundles are not allowed",
+                path.display()
+            )));
+        }
+        if native_target(&mut file)? != target {
+            return Err(io::Error::other(format!(
+                "{}: executable target differs from launcher",
+                path.display()
+            )));
+        }
+        executables.push((*fork, file));
+    }
+    publish(output, |file| {
+        pack(&mut launcher, &mut executables, &mut *file)?;
+        file.rewind()?;
+        Bundle::open(file)?.verify()
+    })
+}
+
+fn has_bundle_footer(file: &mut File) -> io::Result<bool> {
+    if file.metadata()?.len() < 56 {
+        return Ok(false);
+    }
+    file.seek(SeekFrom::End(-56))?;
+    let mut magic = [0; 8];
+    file.read_exact(&mut magic)?;
+    file.rewind()?;
+    Ok(&magic == b"TEMPMV01")
+}
+
+/// Use the ELF machine or Mach-O CPU fields to reject scripts and mixed architectures.
+/// The release builder still owns ABI, linkage, fork semantics, and provenance validation.
+fn native_target(file: &mut File) -> io::Result<[u8; 8]> {
+    let mut header = [0; 20];
+    file.rewind()?;
+    file.read_exact(&mut header)?;
+    file.rewind()?;
+    if &header[..4] == b"\x7fELF" && header[4] == 2 && header[5] == 1 {
+        Ok([
+            b'E', b'L', b'F', header[4], header[5], header[7], header[18], header[19],
+        ])
+    } else if header[..4] == [0xcf, 0xfa, 0xed, 0xfe] {
+        Ok(header[..8].try_into().unwrap())
+    } else {
+        Err(io::Error::other(
+            "expected a little-endian 64-bit ELF or Mach-O executable",
+        ))
+    }
+}
+
+fn publish(output: &Path, write: impl FnOnce(&mut File) -> io::Result<()>) -> io::Result<()> {
+    let parent = output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let mut staged = tempfile::NamedTempFile::new_in(parent)?;
+    write(staged.as_file_mut())?;
+    staged.flush()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        staged
+            .as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o755))?;
+    }
+    staged.as_file().sync_all()?;
+    staged.persist_noclobber(output).map_err(|err| err.error)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn run(mut bundle: Bundle<File>, fork: TempoHardfork, args: Vec<OsString>) -> io::Result<()> {
+    use rustix::fs::{MemfdFlags, SealFlags, fcntl_add_seals, memfd_create};
+    use std::os::{fd::AsRawFd as _, unix::process::CommandExt as _};
+
+    let mut executable = File::from(memfd_create(
+        "tempo-hardfork",
+        MemfdFlags::CLOEXEC | MemfdFlags::ALLOW_SEALING,
+    )?);
+    bundle.copy_executable(fork, &mut executable)?;
+    // Seal the exact bytes that were verified, then replace this process. This preserves
+    // PID, signals, standard IO, exit status, and argument bytes without a supervising shell.
+    fcntl_add_seals(
+        &executable,
+        SealFlags::WRITE | SealFlags::GROW | SealFlags::SHRINK | SealFlags::SEAL,
+    )?;
+    Err(
+        std::process::Command::new(format!("/proc/self/fd/{}", executable.as_raw_fd()))
+            .args(args)
+            .exec(),
+    )
+}
+
+#[cfg(not(target_os = "linux"))]
+fn run(_bundle: Bundle<File>, _fork: TempoHardfork, _args: Vec<OsString>) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "in-memory launch is Linux-only; extract the selected executable explicitly",
+    ))
+}

--- a/bin/tempo-multiversion/tests/cli.rs
+++ b/bin/tempo-multiversion/tests/cli.rs
@@ -1,0 +1,227 @@
+//! Exercise the actual native launcher, including process replacement. The input binaries
+//! are native fixtures, not fork-specialized Tempo nodes.
+#![cfg(target_os = "linux")]
+
+use std::{
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom, Write},
+    os::unix::{ffi::OsStrExt as _, process::ExitStatusExt as _},
+    path::PathBuf,
+    process::Command,
+};
+use tempo_hardfork::TempoHardfork;
+use tempo_multiversion::Bundle;
+
+const CLI: &str = env!("CARGO_BIN_EXE_tempo-multiversion");
+
+struct Fixture {
+    _dir: tempfile::TempDir,
+    inputs: PathBuf,
+    bundle: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let inputs = dir.path().join("inputs");
+        fs::create_dir(&inputs).unwrap();
+        // Native system executables keep these tests independent of a Rust compiler at runtime.
+        // Distinct behavior for T12 lets the test detect accidental latest-version fallback.
+        for fork in TempoHardfork::VARIANTS {
+            let source = if *fork == TempoHardfork::T12 {
+                "/bin/false"
+            } else {
+                "/bin/echo"
+            };
+            fs::copy(
+                source,
+                inputs.join(format!("tempo-{}", fork.to_string().to_ascii_lowercase())),
+            )
+            .unwrap();
+        }
+        let bundle = dir.path().join("tempo-bundle");
+        Self {
+            _dir: dir,
+            inputs,
+            bundle,
+        }
+    }
+
+    fn pack(&self) -> std::process::Output {
+        Command::new(CLI)
+            .args(["pack", "--input-dir"])
+            .arg(&self.inputs)
+            .arg("--output")
+            .arg(&self.bundle)
+            .output()
+            .unwrap()
+    }
+}
+
+#[test]
+fn packs_inspects_extracts_and_runs_real_executables() {
+    let fixture = Fixture::new();
+    let output = fixture.pack();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let inspect = Command::new(&fixture.bundle)
+        .arg("inspect")
+        .output()
+        .unwrap();
+    assert!(inspect.status.success());
+    let listing = String::from_utf8(inspect.stdout).unwrap();
+    assert_eq!(listing.lines().count(), TempoHardfork::VARIANTS.len());
+    for fork in TempoHardfork::VARIANTS {
+        let result = Command::new(&fixture.bundle)
+            .args([
+                "run",
+                &fork.to_string(),
+                "--",
+                "one argument with spaces",
+                "--literal-flag",
+            ])
+            .output()
+            .unwrap();
+        if *fork == TempoHardfork::T12 {
+            assert_eq!(result.status.code(), Some(1));
+        } else {
+            assert!(result.status.success());
+            assert_eq!(result.stdout, b"one argument with spaces --literal-flag\n");
+        }
+    }
+    let extracted = fixture._dir.path().join("extracted");
+    let output = Command::new(&fixture.bundle)
+        .args(["extract", "T1B", "--output"])
+        .arg(&extracted)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert_eq!(fs::read(extracted).unwrap(), fs::read("/bin/echo").unwrap());
+    // A bundle cannot be recursively wrapped in another bundle.
+    let output = Command::new(&fixture.bundle)
+        .args(["pack", "--input-dir"])
+        .arg(&fixture.inputs)
+        .arg("--output")
+        .arg(fixture._dir.path().join("nested"))
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let nested_fixture = Fixture::new();
+    fs::copy(&fixture.bundle, nested_fixture.inputs.join("tempo-t12")).unwrap();
+    assert!(!nested_fixture.pack().status.success());
+    assert!(!nested_fixture.bundle.exists());
+}
+
+#[test]
+fn preserves_non_utf8_arguments_and_signal_exit() {
+    let fixture = Fixture::new();
+    // /bin/sh is itself a native ELF fixture; the launcher never interprets a shell command.
+    fs::copy("/bin/sh", fixture.inputs.join("tempo-t1a")).unwrap();
+    assert!(fixture.pack().status.success());
+    let arg = std::ffi::OsStr::from_bytes(b"argument-\xff");
+    let result = Command::new(&fixture.bundle)
+        .args(["run", "T1", "--"])
+        .arg(arg)
+        .output()
+        .unwrap();
+    assert!(result.status.success());
+    assert_eq!(result.stdout, b"argument-\xff\n");
+    let result = Command::new(&fixture.bundle)
+        .args(["run", "T1A", "--", "-c", "kill -TERM $$"])
+        .output()
+        .unwrap();
+    assert_eq!(result.status.signal(), Some(15));
+}
+
+#[test]
+fn corrupt_payload_is_never_executed_or_published() {
+    let fixture = Fixture::new();
+    assert!(fixture.pack().status.success());
+    let bundle = Bundle::open(File::open(&fixture.bundle).unwrap()).unwrap();
+    let offset = bundle
+        .entries()
+        .iter()
+        .find(|entry| entry.hardfork == TempoHardfork::T1)
+        .unwrap()
+        .offset;
+    drop(bundle);
+    let mut file = File::options()
+        .read(true)
+        .write(true)
+        .open(&fixture.bundle)
+        .unwrap();
+    file.seek(SeekFrom::Start(offset)).unwrap();
+    let mut byte = [0];
+    file.read_exact(&mut byte).unwrap();
+    byte[0] ^= 1;
+    file.seek(SeekFrom::Start(offset)).unwrap();
+    file.write_all(&byte).unwrap();
+    drop(file);
+    let output = Command::new(&fixture.bundle)
+        .args(["run", "T1", "--", "MUST-NOT-RUN"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("checksum mismatch"));
+    let extracted = fixture._dir.path().join("corrupt");
+    assert!(
+        !Command::new(&fixture.bundle)
+            .args(["extract", "T1", "--output"])
+            .arg(&extracted)
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    assert!(!extracted.exists());
+}
+
+#[test]
+fn rejects_missing_inputs_scripts_mixed_targets_and_existing_output() {
+    let fixture = Fixture::new();
+    let input = fixture.inputs.join("tempo-t1c");
+    let original = fs::read(&input).unwrap();
+    fs::remove_file(&input).unwrap();
+    assert!(!fixture.pack().status.success());
+    assert!(!fixture.bundle.exists());
+    fs::write(&input, b"#!/bin/sh\necho not-a-native-executable\n").unwrap();
+    assert!(!fixture.pack().status.success());
+    assert!(!fixture.bundle.exists());
+    let mut wrong_target = original.clone();
+    wrong_target[18] ^= 1;
+    fs::write(&input, wrong_target).unwrap();
+    assert!(!fixture.pack().status.success());
+    assert!(!fixture.bundle.exists());
+    fs::write(input, original).unwrap();
+    fs::write(&fixture.bundle, b"do not replace").unwrap();
+    assert!(!fixture.pack().status.success());
+    assert_eq!(fs::read(&fixture.bundle).unwrap(), b"do not replace");
+}
+
+#[test]
+fn launcher_requires_an_explicit_known_fork() {
+    let fixture = Fixture::new();
+    assert!(fixture.pack().status.success());
+    for args in [vec!["run"], vec!["run", "T13"], vec!["node"]] {
+        assert!(
+            !Command::new(&fixture.bundle)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success()
+        );
+    }
+    assert!(
+        !Command::new(CLI)
+            .args(["run", "T12"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+}

--- a/crates/multiversion/Cargo.toml
+++ b/crates/multiversion/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tempo-multiversion"
+description = "Format and verification for bundles of Tempo hardfork executables"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+sha2.workspace = true
+tempo-hardfork.workspace = true

--- a/crates/multiversion/src/lib.rs
+++ b/crates/multiversion/src/lib.rs
@@ -1,0 +1,242 @@
+//! A flat, checksummed archive appended to a native launcher.
+//!
+//! Fork identifiers come from `tempo-hardfork`, including Genesis and T1A/T1B/T1C.
+//! The archive does not select execution rules or change the node's database: those are
+//! responsibilities of the execution dispatcher. A checksum detects corruption, not an
+//! untrusted publisher; release provenance must cover the complete bundled artifact.
+
+use sha2::{Digest, Sha256};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use tempo_hardfork::TempoHardfork;
+
+const MAGIC: &[u8; 8] = b"TEMPMV01";
+const FOOTER_LEN: u64 = 56;
+const INDEX_HEADER_LEN: usize = 12;
+const ENTRY_LEN: usize = 49;
+
+/// A binary range in the containing file. Offsets are absolute.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Entry {
+    /// The only hardfork this entry is intended to execute.
+    pub hardfork: TempoHardfork,
+    /// Start of the embedded executable.
+    pub offset: u64,
+    /// Length of the embedded executable.
+    pub length: u64,
+    /// SHA-256 of the executable, excluding the launcher and index.
+    pub sha256: [u8; 32],
+}
+
+/// An opened bundle. The same reader is retained for verification and extraction.
+#[derive(Debug)]
+pub struct Bundle<R> {
+    reader: R,
+    launcher_len: u64,
+    entries: Vec<Entry>,
+}
+
+fn invalid(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn u64_at(bytes: &[u8], offset: usize) -> u64 {
+    u64::from_le_bytes(
+        bytes[offset..offset + 8]
+            .try_into()
+            .expect("validated index size"),
+    )
+}
+
+impl<R: Read + Seek> Bundle<R> {
+    /// Checks the index checksum and every range before accepting a bundle.
+    /// Payload checksums are verified by [`Self::verify`] or [`Self::copy_executable`].
+    pub fn open(mut reader: R) -> io::Result<Self> {
+        let len = reader.seek(SeekFrom::End(0))?;
+        if len < FOOTER_LEN {
+            return Err(invalid("missing multiversion footer"));
+        }
+        reader.seek(SeekFrom::End(-(FOOTER_LEN as i64)))?;
+        let mut footer = [0; FOOTER_LEN as usize];
+        reader.read_exact(&mut footer)?;
+        if &footer[..8] != MAGIC {
+            return Err(invalid("unknown or missing multiversion format"));
+        }
+        let index_offset = u64_at(&footer, 8);
+        let index_len = u64_at(&footer, 16);
+        let max_index_len = INDEX_HEADER_LEN + ENTRY_LEN * TempoHardfork::VARIANTS.len();
+        if index_len < INDEX_HEADER_LEN as u64
+            || index_len > max_index_len as u64
+            || index_offset.checked_add(index_len) != Some(len - FOOTER_LEN)
+        {
+            return Err(invalid("invalid index bounds"));
+        }
+        reader.seek(SeekFrom::Start(index_offset))?;
+        let mut index = vec![0; index_len as usize];
+        reader.read_exact(&mut index)?;
+        let digest: [u8; 32] = Sha256::digest(&index).into();
+        if digest != footer[24..] {
+            return Err(invalid("index checksum mismatch"));
+        }
+        let launcher_len = u64_at(&index, 0);
+        let count = u32::from_le_bytes(index[8..12].try_into().unwrap()) as usize;
+        if count == 0
+            || count > TempoHardfork::VARIANTS.len()
+            || index.len() != INDEX_HEADER_LEN + count * ENTRY_LEN
+            || launcher_len == 0
+            || launcher_len >= index_offset
+        {
+            return Err(invalid("invalid executable count or launcher length"));
+        }
+        let mut entries = Vec::with_capacity(count);
+        let mut next_offset = launcher_len;
+        for (i, record) in index[INDEX_HEADER_LEN..]
+            .as_chunks::<ENTRY_LEN>()
+            .0
+            .iter()
+            .enumerate()
+        {
+            let hardfork = TempoHardfork::VARIANTS[i];
+            if record[0] != hardfork.variant_index() {
+                return Err(invalid(
+                    "hardforks must appear exactly once in canonical order",
+                ));
+            }
+            let offset = u64_at(record, 1);
+            let length = u64_at(record, 9);
+            let end = offset
+                .checked_add(length)
+                .ok_or_else(|| invalid("range overflow"))?;
+            if offset != next_offset || length == 0 || end > index_offset {
+                return Err(invalid("invalid executable bounds"));
+            }
+            entries.push(Entry {
+                hardfork,
+                offset,
+                length,
+                sha256: record[17..].try_into().unwrap(),
+            });
+            next_offset = end;
+        }
+        if next_offset != index_offset {
+            return Err(invalid("unexpected bytes before index"));
+        }
+        Ok(Self {
+            reader,
+            launcher_len,
+            entries,
+        })
+    }
+
+    /// The flat list of embedded executables, in protocol order.
+    pub fn entries(&self) -> &[Entry] {
+        &self.entries
+    }
+
+    /// The length of the launcher, excluding embedded executables and metadata.
+    pub const fn launcher_len(&self) -> u64 {
+        self.launcher_len
+    }
+
+    /// Copies one executable, verifying its hash before returning success.
+    /// The caller must discard the output on error and must not execute it before success.
+    /// No fallback to the latest hardfork is allowed.
+    pub fn copy_executable(
+        &mut self,
+        hardfork: TempoHardfork,
+        mut output: impl Write,
+    ) -> io::Result<()> {
+        let entry = self
+            .entries
+            .iter()
+            .find(|entry| entry.hardfork == hardfork)
+            .ok_or_else(|| invalid("requested hardfork is absent from bundle"))?;
+        self.reader.seek(SeekFrom::Start(entry.offset))?;
+        let mut payload = (&mut self.reader).take(entry.length);
+        let (length, sha256) = copy_hash(&mut payload, &mut output)?;
+        if length != entry.length || sha256 != entry.sha256 {
+            return Err(invalid("executable checksum mismatch"));
+        }
+        Ok(())
+    }
+
+    /// Verifies all executable checksums without loading the bundle into memory.
+    pub fn verify(&mut self) -> io::Result<()> {
+        let forks: Vec<_> = self.entries.iter().map(|entry| entry.hardfork).collect();
+        for hardfork in forks {
+            self.copy_executable(hardfork, io::sink())?;
+        }
+        Ok(())
+    }
+}
+
+/// Writes one executable for every known hardfork after an unbundled launcher.
+///
+/// Inputs must be in [`TempoHardfork::VARIANTS`] order. This function does not establish
+/// that an input implements its declared rules; that requires fork-specific builds and
+/// execution tests. Output must be staged and discarded if any input or write fails.
+pub fn pack<R: Read>(
+    mut launcher: impl Read,
+    executables: &mut [(TempoHardfork, R)],
+    mut output: impl Write,
+) -> io::Result<()> {
+    if executables.len() != TempoHardfork::VARIANTS.len()
+        || executables
+            .iter()
+            .zip(TempoHardfork::VARIANTS)
+            .any(|((actual, _), expected)| actual != expected)
+    {
+        return Err(invalid(
+            "supply one executable per hardfork in canonical order",
+        ));
+    }
+    let launcher_len = io::copy(&mut launcher, &mut output)?;
+    if launcher_len == 0 {
+        return Err(invalid("empty launcher"));
+    }
+    let mut index = Vec::with_capacity(INDEX_HEADER_LEN + ENTRY_LEN * executables.len());
+    index.extend_from_slice(&launcher_len.to_le_bytes());
+    index.extend_from_slice(&(executables.len() as u32).to_le_bytes());
+    let mut offset = launcher_len;
+    for (hardfork, executable) in executables {
+        let (length, sha256) = copy_hash(executable, &mut output)?;
+        if length == 0 {
+            return Err(invalid("empty executable"));
+        }
+        index.push(hardfork.variant_index());
+        index.extend_from_slice(&offset.to_le_bytes());
+        index.extend_from_slice(&length.to_le_bytes());
+        index.extend_from_slice(&sha256);
+        offset = offset
+            .checked_add(length)
+            .ok_or_else(|| invalid("bundle size overflow"))?;
+    }
+    output.write_all(&index)?;
+    output.write_all(MAGIC)?;
+    output.write_all(&offset.to_le_bytes())?;
+    output.write_all(&(index.len() as u64).to_le_bytes())?;
+    output.write_all(&Sha256::digest(&index))?;
+    Ok(())
+}
+
+fn copy_hash(mut input: impl Read, mut output: impl Write) -> io::Result<(u64, [u8; 32])> {
+    let mut hash = Sha256::new();
+    let mut length = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let n = match input.read(&mut buffer) {
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            result => result?,
+        };
+        if n == 0 {
+            return Ok((length, hash.finalize().into()));
+        }
+        output.write_all(&buffer[..n])?;
+        hash.update(&buffer[..n]);
+        length = length
+            .checked_add(n as u64)
+            .ok_or_else(|| invalid("payload size overflow"))?;
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/multiversion/src/tests.rs
+++ b/crates/multiversion/src/tests.rs
@@ -1,0 +1,139 @@
+use super::*;
+use std::io::Cursor;
+
+fn fixture() -> Vec<u8> {
+    let mut binaries: Vec<_> = TempoHardfork::VARIANTS
+        .iter()
+        .map(|fork| (*fork, Cursor::new(format!("executable-{fork}"))))
+        .collect();
+    let mut output = Vec::new();
+    pack(&b"launcher"[..], &mut binaries, &mut output).unwrap();
+    output
+}
+
+// Recompute the index checksum to exercise structural checks independently of hashing.
+fn mutate_index(bytes: &mut [u8], mutate: impl FnOnce(&mut [u8])) {
+    let footer = bytes.len() - FOOTER_LEN as usize;
+    let offset = u64_at(&bytes[footer..], 8) as usize;
+    mutate(&mut bytes[offset..footer]);
+    let hash = Sha256::digest(&bytes[offset..footer]);
+    bytes[footer + 24..].copy_from_slice(&hash);
+}
+
+#[test]
+fn deterministic_round_trip_includes_every_hardfork() {
+    let bytes = fixture();
+    assert_eq!(bytes, fixture());
+    let mut bundle = Bundle::open(Cursor::new(bytes)).unwrap();
+    assert_eq!(bundle.launcher_len(), 8);
+    assert_eq!(bundle.entries().len(), TempoHardfork::VARIANTS.len());
+    for fork in TempoHardfork::VARIANTS {
+        let mut extracted = Vec::new();
+        bundle.copy_executable(*fork, &mut extracted).unwrap();
+        assert_eq!(extracted, format!("executable-{fork}").as_bytes());
+    }
+    bundle.verify().unwrap();
+}
+
+#[test]
+fn rejects_corruption_in_each_payload() {
+    let bytes = fixture();
+    let entries = Bundle::open(Cursor::new(&bytes))
+        .unwrap()
+        .entries()
+        .to_vec();
+    for entry in entries {
+        let mut corrupt = bytes.clone();
+        corrupt[entry.offset as usize] ^= 1;
+        let mut bundle = Bundle::open(Cursor::new(corrupt)).unwrap();
+        assert!(bundle.copy_executable(entry.hardfork, io::sink()).is_err());
+        assert!(bundle.verify().is_err());
+    }
+}
+
+#[test]
+fn rejects_truncation_and_trailing_bytes() {
+    let bytes = fixture();
+    for end in 0..bytes.len() {
+        assert!(Bundle::open(Cursor::new(&bytes[..end])).is_err());
+    }
+    let mut trailing = bytes;
+    trailing.push(0);
+    assert!(Bundle::open(Cursor::new(trailing)).is_err());
+}
+
+#[test]
+fn rejects_corrupt_index_and_footer() {
+    let bytes = fixture();
+    let footer = bytes.len() - FOOTER_LEN as usize;
+    let index = u64_at(&bytes[footer..], 8) as usize;
+    for at in index..bytes.len() {
+        let mut corrupt = bytes.clone();
+        corrupt[at] ^= 0x80;
+        assert!(
+            Bundle::open(Cursor::new(corrupt)).is_err(),
+            "accepted corruption at {at}"
+        );
+    }
+}
+
+#[test]
+fn rejects_duplicate_forks_gaps_overlap_overflow_and_empty_payloads() {
+    for (offset, value) in [
+        (INDEX_HEADER_LEN + ENTRY_LEN, vec![0]),
+        (INDEX_HEADER_LEN + 1, 0u64.to_le_bytes().to_vec()),
+        (INDEX_HEADER_LEN + 1, 9u64.to_le_bytes().to_vec()),
+        (INDEX_HEADER_LEN + 9, u64::MAX.to_le_bytes().to_vec()),
+        (INDEX_HEADER_LEN + 9, 0u64.to_le_bytes().to_vec()),
+        (8, u32::MAX.to_le_bytes().to_vec()),
+    ] {
+        let mut bytes = fixture();
+        mutate_index(&mut bytes, |index| {
+            index[offset..offset + value.len()].copy_from_slice(&value)
+        });
+        assert!(Bundle::open(Cursor::new(bytes)).is_err());
+    }
+}
+
+#[test]
+fn pack_rejects_missing_duplicate_and_misordered_inputs() {
+    let mut inputs: Vec<_> = TempoHardfork::VARIANTS
+        .iter()
+        .map(|fork| (*fork, &b"binary"[..]))
+        .collect();
+    inputs.pop();
+    assert!(pack(&b"launcher"[..], &mut inputs, io::sink()).is_err());
+    inputs.push((TempoHardfork::Genesis, &b"binary"[..]));
+    assert!(pack(&b"launcher"[..], &mut inputs, io::sink()).is_err());
+    inputs.last_mut().unwrap().0 = TempoHardfork::latest();
+    inputs.swap(1, 2);
+    assert!(pack(&b"launcher"[..], &mut inputs, io::sink()).is_err());
+}
+
+#[test]
+fn older_bundle_never_falls_forward_to_a_missing_fork() {
+    let mut bytes = fixture();
+    let footer = bytes.len() - FOOTER_LEN as usize;
+    let index_offset = u64_at(&bytes[footer..], 8) as usize;
+    let old_count = TempoHardfork::VARIANTS.len() - 1;
+    let old_end = u64_at(
+        &bytes[index_offset..],
+        INDEX_HEADER_LEN + old_count * ENTRY_LEN + 1,
+    ) as usize;
+    let mut index =
+        bytes[index_offset..index_offset + INDEX_HEADER_LEN + old_count * ENTRY_LEN].to_vec();
+    index[8..12].copy_from_slice(&(old_count as u32).to_le_bytes());
+    bytes.truncate(old_end);
+    bytes.extend_from_slice(&index);
+    bytes.extend_from_slice(MAGIC);
+    bytes.extend_from_slice(&(old_end as u64).to_le_bytes());
+    bytes.extend_from_slice(&(index.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(&Sha256::digest(&index));
+    let mut bundle = Bundle::open(Cursor::new(bytes)).unwrap();
+    bundle.verify().unwrap();
+    assert!(
+        bundle
+            .copy_executable(TempoHardfork::latest(), io::sink())
+            .is_err()
+    );
+}

--- a/docs/multiversion.md
+++ b/docs/multiversion.md
@@ -1,0 +1,124 @@
+# Per-hardfork executables
+
+Status: experimental bundle tooling. This is **not yet a replacement for the Tempo
+node or the release workflow**. It does not yet build fork-specialized nodes, route
+historical execution, or remove pre-T12 code from the current executable.
+
+The intended unit is one executable per protocol hardfork, not one per release
+tag. The canonical list is `TempoHardfork::VARIANTS`: Genesis, T0, T1, T1A, T1B,
+T1C, T2 through T12. Genesis is necessary for chains whose history starts before
+T0. Executable names are generated from that list, rather than maintained separately.
+
+The packaging follows the flat-bundle approach in
+[TigerBeetle's upgrade design](https://github.com/tigerbeetle/tigerbeetle/blob/47aeb2212a255273dda508288412e537d11e4b7c/docs/internals/upgrades.md).
+The launcher, each embedded executable, and the archive format are separate from
+the protocol's execution and activation policy.
+
+## Bundle tooling
+
+Build the development tool with:
+
+```sh
+cargo build --locked --bin tempo-multiversion
+target/debug/tempo-multiversion forks
+```
+
+Given a directory with one **independently validated** native executable for each
+of the printed names:
+
+```sh
+target/debug/tempo-multiversion pack --input-dir hardfork-binaries --output tempo-bundle
+./tempo-bundle inspect
+./tempo-bundle extract T12 --output tempo-t12
+./tempo-bundle run T12 -- --help
+```
+
+`run` requires an explicit fork and currently supports Linux only. It verifies the
+selected payload, seals it in an anonymous file, and replaces the launcher process.
+It needs Linux memfd support and `/proc/self/fd`. macOS can pack, inspect, and
+extract Mach-O bundles but still needs a native launch and code-signing implementation.
+Do not replace a production `tempo` with this tool.
+
+The packer requires all known forks, in canonical order, and rejects inputs with a
+different native architecture from its launcher. It **cannot prove** a file named
+`tempo-t12` implements only T12. It must not be used to relabel ordinary multi-fork
+nodes as specialized executables. Rebuilding the bundle uses the unbundled launcher
+and flat input files; it never embeds an earlier bundle recursively.
+
+All integers in the archive are little-endian. Its layout is:
+
+| Region | Fields |
+| --- | --- |
+| Launcher | Native executable bytes |
+| Payloads | One nonempty executable per fork, in canonical order |
+| Index header | Launcher length (`u64`), entry count (`u32`) |
+| Index entry | Fork index (`u8`), absolute offset (`u64`), length (`u64`), SHA-256 (32 bytes) |
+| Footer | `TEMPMV01` (8 bytes), index offset (`u64`), index length (`u64`), index SHA-256 (32 bytes) |
+
+The reader bounds the index before allocating, rejects duplicates, gaps, overlaps,
+unknown fork IDs, unsupported formats, overflows, and trailing bytes, and checks
+payload hashes before successful extraction or execution. It can read an older
+bundle ending before the latest fork, but never substitutes a different executable
+for a missing requested fork. Payloads are streamed with bounded memory.
+
+Checksums detect corruption; they do not authenticate the publisher. Release
+checksums, signatures, SBOMs, and attestations must cover the **finished bundle**,
+including its launcher. Packing happens before those release steps. The current
+release workflow remains unchanged until the execution requirements below pass.
+
+## Execution work required before T12-only cleanup
+
+Tempo selects EVM rules using the block timestamp in `TempoEvmConfig::evm_env`
+and `next_evm_env`. Historical calls and traces can request old rules while the
+node is following the current chain. Choosing a binary once at startup is not
+sufficient. T12 has no built-in mainnet or Moderato activation timestamp in this
+source snapshot; dispatch must use the configured chain schedule, not the date,
+the highest installed binary, or a guessed activation height.
+
+The intended execution boundary is:
+
+1. The node owns consensus, networking, RPC, and persistent database writes. A
+   dispatcher derives the fork from the requested block's chain schedule and
+   selects the matching bundled execution worker.
+2. A worker receives versioned execution input and accesses the exact parent-state
+   snapshot through a stable interface. It returns receipts, state changes, gas
+   accounting, and errors for the node to validate and commit. Historical reads
+   must not open the database with a second writer or a different schema version.
+3. Calls, estimates, traces, imports, replay, payload building, system transactions,
+   and pool validation must all use the same dispatch contract. Tracing currently
+   uses generic Rust inspectors; serializing transactions alone does not preserve
+   these callbacks or arbitrary Rust embedding APIs.
+4. Each worker rejects inputs for another fork. At T12 activation, the T12 worker
+   applies the T12 runtime migration against T11 parent state. Earlier initialization
+   remains available for genesis and custom chains that activate multiple forks at
+   timestamp zero. Fork metadata and old serialized data formats remain readable.
+5. Only after dispatch works, specialize the T12 worker and remove superseded
+   execution branches and inactive features. Keep protocol functionality inherited
+   from earlier forks that is still active in T12. Preserve the general SDK's
+   historical hardfork predicates; making them unconditionally true would silently
+   change callers' semantics.
+
+This requires a process protocol: the current EVM interface borrows mutable state,
+generic databases, and inspectors in-process. The bundle tool does not introduce a
+pretend IPC boundary or rewrite the hardfork predicates to bypass that constraint.
+
+## Acceptance gates for release integration
+
+- Replay from genesis across every fork boundary with identical block/state roots,
+  receipts, gas, and errors to the existing node; include T1A/T1B/T1C.
+- Historical calls, estimates, and supported traces during T12 execution agree with
+  the existing node, including concurrent requests for different forks.
+- Test custom genesis schedules, equal activation timestamps, boundary migrations,
+  invalid payloads, and speculative state without committing partial worker output.
+- Interrupt workers and restart the node before/after commit and at each boundary;
+  verify database recovery and consensus restart. Never switch database writers
+  while a previous process retains ownership.
+- Missing/corrupt/wrong-architecture workers fail before executing or writing state.
+- Build and exercise real specialized workers for every supported release target;
+  verify the T12 artifact no longer contains obsolete execution implementations.
+- Package and attest the final bundle, exercise installation through containers and
+  tempoup, and test the macOS signature and launch path.
+
+Until these gates pass, deleting historical execution code would break existing
+node behavior. The experimental tool is deliberately not wired into production
+releases and its tests are not evidence that those node-level gates have passed.


### PR DESCRIPTION
Adds experimental flat-bundle tooling with one entry per hardfork, including Genesis and T1A/T1B/T1C, plus checksummed extraction and an explicit Linux in-memory launcher. This is preparatory work, not the completed node migration: fork-specialized builds, historical execution/RPC routing, automatic upgrades, release integration, macOS launch, and T12-only code removal remain unimplemented. The design document explains the shared-state/tracing boundary and the replay checks required before deleting old execution paths.

Validation: 12 format and native-process tests pass; nightly formatting and targeted clippy pass. Native fixtures validate packaging and launching, not Tempo fork semantics.

Prompted by: @0xalpharush
