### PR TITLE
fix(dkg): decouple artifacts from consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13678,7 +13678,6 @@ version = "1.14.0"
 dependencies = [
  "bytes",
  "commonware-codec",
- "commonware-consensus",
  "commonware-cryptography",
  "commonware-math",
  "commonware-utils",
@@ -13754,7 +13753,6 @@ dependencies = [
  "alloy-sol-types",
  "codspeed-criterion-compat",
  "commonware-codec",
- "commonware-consensus",
  "commonware-cryptography",
  "commonware-math",
  "commonware-utils",

--- a/crates/chainspec/src/network_identity.rs
+++ b/crates/chainspec/src/network_identity.rs
@@ -57,7 +57,7 @@ impl NetworkIdentity {
             OnchainDkgOutcome::read(&mut extra_data).wrap_err("unable to parse dkg outcome")?;
 
         Ok(Self {
-            from_epoch: outcome.epoch.get(),
+            from_epoch: outcome.epoch,
             identity: *outcome.network_identity(),
         })
     }

--- a/crates/consensus/src/alias.rs
+++ b/crates/consensus/src/alias.rs
@@ -376,7 +376,7 @@ pub(crate) mod marshal {
         let onchain_outcome = OnchainDkgOutcome::read(&mut header.extra_data().as_ref())
             .wrap_err("failed to read DKG outcome from boundary header")?;
         ensure!(
-            onchain_outcome.epoch == epoch,
+            Epoch::new(onchain_outcome.epoch) == epoch,
             "boundary outcome is for epoch `{}`, expected finalization epoch `{epoch}`",
             onchain_outcome.epoch,
         );

--- a/crates/consensus/src/consensus/application/actor.rs
+++ b/crates/consensus/src/consensus/application/actor.rs
@@ -23,7 +23,7 @@ use commonware_consensus::{
     Heightable as _,
     marshal::core::DigestFallback,
     simplex::{Plan, types::Context},
-    types::{Epocher as _, FixedEpocher, HeightDelta, Round, View},
+    types::{Epoch, Epocher as _, FixedEpocher, HeightDelta, Round, View},
 };
 use commonware_cryptography::ed25519::PublicKey;
 use commonware_macros::select;
@@ -512,7 +512,7 @@ impl Inner<Init> {
                 .await
                 .wrap_err("failed getting public dkg ceremony outcome")?;
             ensure!(
-                round.epoch().next() == outcome.epoch,
+                round.epoch().next() == Epoch::new(outcome.epoch),
                 "outcome is for epoch `{}`, but we are trying to include the \
                 outcome for epoch `{}`",
                 outcome.epoch,

--- a/crates/consensus/src/dkg/manager/actor/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/mod.rs
@@ -873,7 +873,7 @@ where
         }
 
         Ok(Some(State {
-            epoch: onchain_outcome.epoch,
+            epoch: Epoch::new(onchain_outcome.epoch),
             seed: Summary::random(self.context.as_present_mut()),
             output: onchain_outcome.output.clone(),
             share,
@@ -1208,7 +1208,7 @@ where
         request
             .response
             .send(OnchainDkgOutcome {
-                epoch: next_epoch,
+                epoch: next_epoch.get(),
                 output,
                 next_players,
                 is_next_full_dkg: will_be_re_dkg,
@@ -1302,7 +1302,7 @@ where
         }
 
         let mut state = State {
-            epoch: onchain_outcome.epoch,
+            epoch: Epoch::new(onchain_outcome.epoch),
             seed: Summary::random(&mut self.context),
             output: onchain_outcome.output.clone(),
             share: state::ShareState::Plaintext(share),
@@ -1352,7 +1352,7 @@ where
         .wrap_err("failed reading outcome for ceremony boundary")?;
 
         ensure!(
-            ceremony_outcome.epoch == ceremony_epoch,
+            Epoch::new(ceremony_outcome.epoch) == ceremony_epoch,
             "boundary outcome is for epoch `{}`, expected ceremony epoch `{ceremony_epoch}`",
             ceremony_outcome.epoch,
         );
@@ -1365,7 +1365,7 @@ where
         }
 
         let ceremony_state = State {
-            epoch: ceremony_outcome.epoch,
+            epoch: Epoch::new(ceremony_outcome.epoch),
             seed: state.seed,
             output: ceremony_outcome.output,
             share: state::ShareState::Plaintext(None),

--- a/crates/consensus/src/dkg/manager/actor/tests/harness.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/harness.rs
@@ -676,7 +676,7 @@ pub(super) fn block(header: TempoHeader) -> Block {
 
 pub(super) fn outcome_header(height: Height, state: &State) -> TempoHeader {
     let outcome = OnchainDkgOutcome {
-        epoch: state.epoch,
+        epoch: state.epoch.get(),
         output: state.output.clone(),
         next_players: state.players().clone(),
         is_next_full_dkg: state.is_full_dkg,

--- a/crates/consensus/src/dkg/manager/actor/tests/mod.rs
+++ b/crates/consensus/src/dkg/manager/actor/tests/mod.rs
@@ -510,14 +510,18 @@ fn failed_dkg_outcomes_carry_share_forward() {
             .get_dkg_outcome(first_digest, Height::new(10))
             .await
             .unwrap();
-        assert_eq!(first_outcome.epoch, state.epoch.next());
+        assert_eq!(Epoch::new(first_outcome.epoch), state.epoch.next());
         assert_eq!(first_outcome.output, state.output);
 
         let mut first_boundary = header(Height::new(19));
         first_boundary.inner.parent_hash = first_digest.0;
         first_boundary.inner.extra_data = first_outcome.encode().into();
         harness.report_finalized_header(first_boundary).await;
-        assert!(!harness.has_dealer_log(first_outcome.epoch).await);
+        assert!(
+            !harness
+                .has_dealer_log(Epoch::new(first_outcome.epoch))
+                .await
+        );
 
         harness
             .report_finalized_header(header(Height::new(20)))
@@ -532,14 +536,21 @@ fn failed_dkg_outcomes_carry_share_forward() {
             .get_dkg_outcome(second_digest, Height::new(20))
             .await
             .unwrap();
-        assert_eq!(second_outcome.epoch, first_outcome.epoch.next());
+        assert_eq!(
+            Epoch::new(second_outcome.epoch),
+            Epoch::new(first_outcome.epoch).next()
+        );
         assert_eq!(second_outcome.output, state.output);
 
         let mut second_boundary = header(Height::new(29));
         second_boundary.inner.parent_hash = second_digest.0;
         second_boundary.inner.extra_data = second_outcome.encode().into();
         harness.report_finalized_header(second_boundary).await;
-        assert!(!harness.has_dealer_log(second_outcome.epoch).await);
+        assert!(
+            !harness
+                .has_dealer_log(Epoch::new(second_outcome.epoch))
+                .await
+        );
 
         assert_eq!(
             harness.epoch_manager.events(),
@@ -552,14 +563,14 @@ fn failed_dkg_outcomes_carry_share_forward() {
                 },
                 EpochEvent::Exit(state.epoch),
                 EpochEvent::Enter {
-                    epoch: first_outcome.epoch,
+                    epoch: Epoch::new(first_outcome.epoch),
                     public: state.output.public().clone(),
                     share: Some(share.clone()),
                     participants: state.dealers().clone(),
                 },
-                EpochEvent::Exit(first_outcome.epoch),
+                EpochEvent::Exit(Epoch::new(first_outcome.epoch)),
                 EpochEvent::Enter {
-                    epoch: second_outcome.epoch,
+                    epoch: Epoch::new(second_outcome.epoch),
                     public: state.output.public().clone(),
                     share: Some(share),
                     participants: state.dealers().clone(),
@@ -859,7 +870,7 @@ fn finalized_blocks_preserve_legacy_revealed_share_calculation() {
             }
             let output = observe::<_, _, N3f1, Batch>(&mut context, logs, &Sequential).unwrap();
             let outcome = OnchainDkgOutcome {
-                epoch: state.epoch.next(),
+                epoch: state.epoch.next().get(),
                 output,
                 next_players: state.players().clone(),
                 is_next_full_dkg: false,
@@ -1140,8 +1151,16 @@ fn reshare_produces_new_shares() {
             .await;
 
         second_harness.report_finalized_header(boundary).await;
-        assert!(!first_harness.has_dealer_log(first_outcome.epoch).await);
-        assert!(!second_harness.has_dealer_log(first_outcome.epoch).await);
+        assert!(
+            !first_harness
+                .has_dealer_log(Epoch::new(first_outcome.epoch))
+                .await
+        );
+        assert!(
+            !second_harness
+                .has_dealer_log(Epoch::new(first_outcome.epoch))
+                .await
+        );
 
         let first_events = first_harness.epoch_manager.events();
         let EpochEvent::Enter {
@@ -1340,7 +1359,7 @@ fn outcome_requests_use_reshare_fallback_and_require_next_players() {
             .await
             .unwrap();
 
-        assert_eq!(outcome.epoch, state.epoch.next());
+        assert_eq!(Epoch::new(outcome.epoch), state.epoch.next());
 
         // The incomplete ceremony fails forward by carrying the prior output
         // into the next epoch.

--- a/crates/consensus/src/epoch/manager/actor.rs
+++ b/crates/consensus/src/epoch/manager/actor.rs
@@ -500,7 +500,7 @@ where
             )
             .expect("boundary blocks must contain DKG outcomes");
             self.config.scheme_provider.register(
-                onchain_outcome.epoch,
+                Epoch::new(onchain_outcome.epoch),
                 Scheme::verifier(
                     crate::config::NAMESPACE,
                     onchain_outcome.players().clone(),
@@ -508,7 +508,7 @@ where
                 ),
             );
             self.confirmed_latest_network_epoch
-                .replace(onchain_outcome.epoch);
+                .replace(Epoch::new(onchain_outcome.epoch));
             debug!(
                 next_epoch = %onchain_outcome.epoch,
                 "read DKG outcome from boundary and registered scheme",

--- a/crates/consensus/src/finalization_verifier/mod.rs
+++ b/crates/consensus/src/finalization_verifier/mod.rs
@@ -7,7 +7,7 @@ use commonware_codec::{DecodeExt as _, ReadExt as _};
 use commonware_consensus::{
     Epochable as _,
     simplex::{scheme::bls12381_threshold::vrf::Scheme, types::Finalization},
-    types::{Epocher as _, FixedEpocher, Height},
+    types::{Epoch, Epocher as _, FixedEpocher, Height},
 };
 use commonware_cryptography::{
     bls12381::primitives::variant::MinSig, certificate::Provider as _, ed25519::PublicKey,
@@ -75,7 +75,7 @@ impl FinalizationVerifier {
     ) -> Result<OnchainDkgOutcome, commonware_codec::Error> {
         let outcome = OnchainDkgOutcome::read(&mut extra_data)?;
         self.scheme_provider.register(
-            outcome.epoch,
+            Epoch::new(outcome.epoch),
             Scheme::certificate_verifier(NAMESPACE, *outcome.network_identity()),
         );
         Ok(outcome)

--- a/crates/consensus/src/finalized_header_stream/mod.rs
+++ b/crates/consensus/src/finalized_header_stream/mod.rs
@@ -272,7 +272,7 @@ where
                 })?;
 
             let network_identity = self.verifier.network_identity();
-            if onchain_outcome.epoch.get() >= network_identity.from_epoch
+            if onchain_outcome.epoch >= network_identity.from_epoch
                 && network_identity.identity != *onchain_outcome.network_identity()
             {
                 warn!(
@@ -401,7 +401,7 @@ where
 
     Ok(FinalizationVerifier::new(
         NetworkIdentity {
-            from_epoch: outcome.epoch.get(),
+            from_epoch: outcome.epoch,
             identity: *outcome.network_identity(),
         },
         strategy.clone(),

--- a/crates/consensus/src/finalized_header_stream/test.rs
+++ b/crates/consensus/src/finalized_header_stream/test.rs
@@ -150,8 +150,11 @@ async fn uses_authoritative_identity_for_initial_backfill() {
     }
 
     let tip = blocks.last().expect("tip was inserted");
-    let tip_finalization =
-        make_finalization(tip, authoritative.outcome.epoch, &authoritative.schemes);
+    let tip_finalization = make_finalization(
+        tip,
+        Epoch::new(authoritative.outcome.epoch),
+        &authoritative.schemes,
+    );
     let certified = make_certified_block(tip.clone(), &tip_finalization);
     let asserter = Asserter::new();
     push_header(&asserter, &blocks[0]);
@@ -161,7 +164,7 @@ async fn uses_authoritative_identity_for_initial_backfill() {
 
     let genesis = &blocks[0];
     let network_identity = NetworkIdentity {
-        from_epoch: authoritative.outcome.epoch.get(),
+        from_epoch: authoritative.outcome.epoch,
         identity: *authoritative.outcome.network_identity(),
     };
     let mut config = Config::new(genesis.digest().0, Some(network_identity), EPOCH_LENGTH);
@@ -214,7 +217,7 @@ async fn falls_back_to_identity_anchored_by_start() {
     push_header(&asserter, &tip);
 
     let stale_identity = NetworkIdentity {
-        from_epoch: old.outcome.epoch.get(),
+        from_epoch: old.outcome.epoch,
         identity: *old.outcome.network_identity(),
     };
     let mut stream = FinalizedHeaderStream::init(
@@ -251,7 +254,7 @@ async fn applies_transition_from_start_boundary() {
     push_header(&asserter, &tip);
 
     let network_identity = NetworkIdentity {
-        from_epoch: current.outcome.epoch.get(),
+        from_epoch: current.outcome.epoch,
         identity: *current.outcome.network_identity(),
     };
     let mut stream = FinalizedHeaderStream::init(
@@ -283,7 +286,7 @@ async fn does_not_resolve_start_identity_when_caught_up() {
     asserter.push_success(&certified);
 
     let network_identity = NetworkIdentity {
-        from_epoch: fixture.outcome.epoch.get(),
+        from_epoch: fixture.outcome.epoch,
         identity: *fixture.outcome.network_identity(),
     };
     FinalizedHeaderStream::init(
@@ -307,7 +310,7 @@ async fn rejects_mismatched_start_header() {
     push_header(&asserter, &start);
 
     let network_identity = NetworkIdentity {
-        from_epoch: fixture.outcome.epoch.get(),
+        from_epoch: fixture.outcome.epoch,
         identity: *fixture.outcome.network_identity(),
     };
     let error = FinalizedHeaderStream::init(

--- a/crates/consensus/src/follow/driver/actor.rs
+++ b/crates/consensus/src/follow/driver/actor.rs
@@ -80,7 +80,7 @@ where
             )
         })?;
 
-    let current_epoch = onchain_outcome.epoch;
+    let current_epoch = Epoch::new(onchain_outcome.epoch);
 
     let actor = Driver {
         context: ContextCell::new(context),
@@ -201,7 +201,7 @@ where
                     )
                 })?;
 
-            self.current_epoch = self.current_epoch.max(onchain_outcome.epoch);
+            self.current_epoch = self.current_epoch.max(Epoch::new(onchain_outcome.epoch));
         } else {
             debug!("no gap detected");
         }
@@ -377,7 +377,7 @@ where
                 .expect("boundary blocks must contain DKG outcomes");
 
             let network_identity = self.verifier.network_identity();
-            if onchain_outcome.epoch.get() >= network_identity.from_epoch
+            if onchain_outcome.epoch >= network_identity.from_epoch
                 && network_identity.identity != *onchain_outcome.network_identity()
             {
                 warn!(
@@ -389,7 +389,7 @@ where
                 );
             }
 
-            self.current_epoch = self.current_epoch.max(onchain_outcome.epoch);
+            self.current_epoch = self.current_epoch.max(Epoch::new(onchain_outcome.epoch));
 
             if self
                 .epoch_sync_target

--- a/crates/consensus/src/follow/driver/test/mod.rs
+++ b/crates/consensus/src/follow/driver/test/mod.rs
@@ -197,7 +197,7 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
                 execution_provider: provider,
                 scheme_provider: schemes.clone(),
                 network_identity: NetworkIdentity {
-                    from_epoch: network_fixture.outcome.epoch.get(),
+                    from_epoch: network_fixture.outcome.epoch,
                     identity: *network_fixture.outcome.network_identity(),
                 },
                 last_finalized_height: Height::zero(),
@@ -208,7 +208,9 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
         .expect("driver should initialize");
 
         assert!(
-            schemes.scoped(network_fixture.outcome.epoch).is_none(),
+            schemes
+                .scoped(Epoch::new(network_fixture.outcome.epoch))
+                .is_none(),
             "network identity fallback requires the epoch scheme to be missing",
         );
         actor.start();
@@ -216,7 +218,7 @@ fn network_identity_verifies_finalization_when_epoch_scheme_is_missing() {
         let block = make_block(EPOCH_LENGTH.get() * 2 + 1, None);
         let finalization = make_finalization(
             &block,
-            network_fixture.outcome.epoch,
+            Epoch::new(network_fixture.outcome.epoch),
             &network_fixture.schemes,
         );
         let certified = make_certified_block(block, &finalization);
@@ -253,7 +255,7 @@ fn gossiped_certificate_is_admitted_and_reported_only_to_marshal() {
                 execution_provider: provider,
                 scheme_provider: schemes.clone(),
                 network_identity: NetworkIdentity {
-                    from_epoch: network_fixture.outcome.epoch.get(),
+                    from_epoch: network_fixture.outcome.epoch,
                     identity: *network_fixture.outcome.network_identity(),
                 },
                 last_finalized_height: Height::zero(),
@@ -268,11 +270,13 @@ fn gossiped_certificate_is_admitted_and_reported_only_to_marshal() {
         let block = make_block(EPOCH_LENGTH.get() * 2 + 1, None);
         let finalization = make_finalization(
             &block,
-            network_fixture.outcome.epoch,
+            Epoch::new(network_fixture.outcome.epoch),
             &network_fixture.schemes,
         );
         assert!(
-            schemes.scoped(network_fixture.outcome.epoch).is_none(),
+            schemes
+                .scoped(Epoch::new(network_fixture.outcome.epoch))
+                .is_none(),
             "the certificate must require the network identity fallback",
         );
 
@@ -282,7 +286,9 @@ fn gossiped_certificate_is_admitted_and_reported_only_to_marshal() {
             .expect("driver should answer");
         assert_eq!(result, Ok(()));
         assert!(
-            schemes.scoped(network_fixture.outcome.epoch).is_some(),
+            schemes
+                .scoped(Epoch::new(network_fixture.outcome.epoch))
+                .is_some(),
             "marshal needs the successful fallback to re-verify the resolved block",
         );
         // The driver reports only the certificate to marshal.
@@ -292,7 +298,7 @@ fn gossiped_certificate_is_admitted_and_reported_only_to_marshal() {
         // The first offer became the latest verified round, so a repeat is stale.
         let repeat = make_finalization(
             &make_block(EPOCH_LENGTH.get() * 2 + 1, None),
-            network_fixture.outcome.epoch,
+            Epoch::new(network_fixture.outcome.epoch),
             &network_fixture.schemes,
         );
         let result = mailbox
@@ -826,7 +832,7 @@ fn scheme_before_network_identity_epoch_is_required() {
                 execution_provider: provider,
                 scheme_provider: schemes.clone(),
                 network_identity: NetworkIdentity {
-                    from_epoch: missing_fixture.outcome.epoch.get() + 1,
+                    from_epoch: missing_fixture.outcome.epoch + 1,
                     identity: *missing_fixture.outcome.network_identity(),
                 },
                 last_finalized_height: Height::zero(),
@@ -836,13 +842,17 @@ fn scheme_before_network_identity_epoch_is_required() {
         )
         .expect("driver should initialize");
 
-        assert!(schemes.scoped(missing_fixture.outcome.epoch).is_none());
+        assert!(
+            schemes
+                .scoped(Epoch::new(missing_fixture.outcome.epoch))
+                .is_none()
+        );
         actor.start();
 
         let block = make_block(EPOCH_LENGTH.get() + 1, None);
         let finalization = make_finalization(
             &block,
-            missing_fixture.outcome.epoch,
+            Epoch::new(missing_fixture.outcome.epoch),
             &missing_fixture.schemes,
         );
 
@@ -878,7 +888,7 @@ fn gossiped_certificate_without_a_usable_identity_needs_scheme() {
                 execution_provider: provider,
                 scheme_provider: SchemeProvider::new(),
                 network_identity: NetworkIdentity {
-                    from_epoch: missing_fixture.outcome.epoch.get() + 1,
+                    from_epoch: missing_fixture.outcome.epoch + 1,
                     identity: *missing_fixture.outcome.network_identity(),
                 },
                 last_finalized_height: Height::zero(),
@@ -893,7 +903,7 @@ fn gossiped_certificate_without_a_usable_identity_needs_scheme() {
         let block = make_block(EPOCH_LENGTH.get() + 1, None);
         let certificate = make_finalization(
             &block,
-            missing_fixture.outcome.epoch,
+            Epoch::new(missing_fixture.outcome.epoch),
             &missing_fixture.schemes,
         );
         let result = mailbox
@@ -904,7 +914,7 @@ fn gossiped_certificate_without_a_usable_identity_needs_scheme() {
         assert_eq!(
             result,
             Err(CertificateError::NeedsScheme {
-                epoch: missing_fixture.outcome.epoch,
+                epoch: Epoch::new(missing_fixture.outcome.epoch),
             })
         );
         assert_eq!(marshal.report_count(), 0);
@@ -1046,7 +1056,9 @@ fn startup_installs_missing_consensus_epoch_scheme_from_marshal() {
 
         actor.start();
         wait_until(&context, || {
-            schemes.scoped(recovered_fixture.outcome.epoch).is_some()
+            schemes
+                .scoped(Epoch::new(recovered_fixture.outcome.epoch))
+                .is_some()
         })
         .await;
 

--- a/crates/consensus/src/peer_manager/actor.rs
+++ b/crates/consensus/src/peer_manager/actor.rs
@@ -495,7 +495,6 @@ mod tests {
     use alloy_consensus::Header;
     use alloy_primitives::{Address as AlloyAddress, B256, Keccak256, U256};
     use commonware_codec::Encode as _;
-    use commonware_consensus::types::Epoch;
     use commonware_cryptography::{
         Signer as _,
         bls12381::{
@@ -669,7 +668,7 @@ mod tests {
         )?;
 
         Ok(OnchainDkgOutcome {
-            epoch: Epoch::new(0),
+            epoch: 0,
             output,
             next_players: ordered::Set::try_from_iter(next_players)?,
             is_next_full_dkg: false,

--- a/crates/consensus/src/test_utils.rs
+++ b/crates/consensus/src/test_utils.rs
@@ -63,7 +63,7 @@ pub(crate) fn dkg_fixture(rng: &mut impl CryptoRng, epoch: Epoch) -> DkgFixture 
         .collect();
 
     let outcome = OnchainDkgOutcome {
-        epoch,
+        epoch: epoch.get(),
         next_players: output.players().clone(),
         output,
         is_next_full_dkg: false,

--- a/crates/dkg-onchain-artifacts/Cargo.toml
+++ b/crates/dkg-onchain-artifacts/Cargo.toml
@@ -14,8 +14,7 @@ publish.workspace = true
 [dependencies]
 bytes.workspace = true
 commonware-codec.workspace = true
-commonware-consensus.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["bls12381", "std"] }
 commonware-utils.workspace = true
 modular-bitfield = { version = "0.13.1", optional = true }
 

--- a/crates/dkg-onchain-artifacts/src/lib.rs
+++ b/crates/dkg-onchain-artifacts/src/lib.rs
@@ -3,8 +3,7 @@
 use std::num::NonZeroU32;
 
 use bytes::{Buf, BufMut};
-use commonware_codec::{EncodeSize, RangeCfg, Read, ReadExt, Write};
-use commonware_consensus::types::Epoch;
+use commonware_codec::{EncodeSize, RangeCfg, Read, ReadExt, Write, varint::UInt};
 use commonware_cryptography::{
     bls12381::{
         dkg::feldman_desmedt::Output,
@@ -26,8 +25,8 @@ const MAX_VALIDATORS: NonZeroU32 = NZU32!(u16::MAX as u32);
 /// is likely out of reach.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OnchainDkgOutcome {
-    /// The epoch for which this outcome is used.
-    pub epoch: Epoch,
+    /// The epoch for which this outcome is used, encoded as an unsigned varint.
+    pub epoch: u64,
 
     /// The output of the DKG ceremony. Contains the shared public polynomial,
     /// and the players in the ceremony (which will be the dealers for the
@@ -67,7 +66,7 @@ impl OnchainDkgOutcome {
 
 impl Write for OnchainDkgOutcome {
     fn write(&self, buf: &mut impl BufMut) {
-        self.epoch.write(buf);
+        UInt(self.epoch).write(buf);
         self.output.write(buf);
         self.next_players.write(buf);
         self.is_next_full_dkg.write(buf);
@@ -78,7 +77,7 @@ impl Read for OnchainDkgOutcome {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
-        let epoch = ReadExt::read(buf)?;
+        let epoch = UInt::<u64>::read(buf)?.into();
         let output = Read::read_cfg(buf, &(MAX_VALIDATORS, ModeVersion::v0()))?;
         let next_players = Read::read_cfg(
             buf,
@@ -96,7 +95,7 @@ impl Read for OnchainDkgOutcome {
 
 impl EncodeSize for OnchainDkgOutcome {
     fn encode_size(&self) -> usize {
-        self.epoch.encode_size()
+        UInt(self.epoch).encode_size()
             + self.output.encode_size()
             + self.next_players.encode_size()
             + self.is_next_full_dkg.encode_size()
@@ -107,8 +106,7 @@ impl EncodeSize for OnchainDkgOutcome {
 mod tests {
     use std::iter::repeat_with;
 
-    use commonware_codec::{Encode as _, ReadExt as _};
-    use commonware_consensus::types::Epoch;
+    use commonware_codec::{Encode as _, EncodeSize as _, ReadExt as _};
     use commonware_cryptography::{
         Signer as _,
         bls12381::{dkg::feldman_desmedt as dkg, primitives::sharing::Mode},
@@ -135,8 +133,8 @@ mod tests {
         )
         .unwrap();
 
-        let on_chain = OnchainDkgOutcome {
-            epoch: Epoch::new(42),
+        let mut on_chain = OnchainDkgOutcome {
+            epoch: 42,
             output,
             next_players: ordered::Set::try_from_iter(
                 player_keys.iter().map(|key| key.public_key()),
@@ -144,10 +142,28 @@ mod tests {
             .unwrap(),
             is_next_full_dkg: false,
         };
-        let bytes = on_chain.encode();
-        assert_eq!(
-            OnchainDkgOutcome::read(&mut bytes.as_ref()).unwrap(),
-            on_chain,
-        );
+        // Preserve Commonware Epoch's wire encoding, including varint boundaries.
+        let payload = on_chain.encode()[1..].to_vec();
+        for (epoch, prefix) in [
+            (0, &[0][..]),
+            (127, &[127][..]),
+            (128, &[128, 1][..]),
+            (16383, &[255, 127][..]),
+            (16384, &[128, 128, 1][..]),
+            (
+                u64::MAX,
+                &[255, 255, 255, 255, 255, 255, 255, 255, 255, 1][..],
+            ),
+        ] {
+            on_chain.epoch = epoch;
+            let bytes = on_chain.encode();
+            assert_eq!(&bytes[..prefix.len()], prefix);
+            assert_eq!(&bytes[prefix.len()..], payload);
+            assert_eq!(bytes.len(), on_chain.encode_size());
+            assert_eq!(
+                OnchainDkgOutcome::read(&mut bytes.as_ref()).unwrap(),
+                on_chain
+            );
+        }
     }
 }

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -26,7 +26,6 @@ alloy-genesis = { workspace = true, features = ["std"] }
 alloy-primitives.workspace = true
 
 commonware-codec.workspace = true
-commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
 commonware-math.workspace = true
 commonware-p2p.workspace = true

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -13,7 +13,6 @@
 use std::{iter::repeat_with, net::SocketAddr, time::Duration};
 
 use alloy_primitives::Address;
-use commonware_consensus::types::Epoch;
 use commonware_cryptography::{
     Signer as _,
     bls12381::{
@@ -75,7 +74,7 @@ fn generate_consensus_node_config(
     .unwrap();
 
     let onchain_dkg_outcome = OnchainDkgOutcome {
-        epoch: Epoch::zero(),
+        epoch: 0,
         output: initial_dkg_outcome,
         next_players: shares.keys().clone(),
         is_next_full_dkg: false,

--- a/crates/e2e/src/tests/dkg/current_committee.rs
+++ b/crates/e2e/src/tests/dkg/current_committee.rs
@@ -32,7 +32,7 @@ fn current_committee_matches_boundary_dkg_outcome() {
         join_all(validators.iter_mut().map(|v| v.start(&context))).await;
 
         let outcome = wait_for_outcome(&context, &validators, 0, epoch_length).await;
-        wait_for_validators_to_reach_epoch(&context, outcome.epoch.get(), how_many_signers).await;
+        wait_for_validators_to_reach_epoch(&context, outcome.epoch, how_many_signers).await;
         context.to_metrics().assert_no_dkg_failures();
 
         let provider = validators[0].execution_provider();
@@ -68,7 +68,7 @@ fn current_committee_matches_boundary_dkg_outcome() {
             .map(|key| B256::from_slice(key.as_ref()))
             .collect::<Vec<_>>();
 
-        assert_eq!(epoch, outcome.epoch.get());
+        assert_eq!(epoch, outcome.epoch);
         assert_eq!(public_keys, expected_public_keys);
     });
 }

--- a/crates/evm/Cargo.toml
+++ b/crates/evm/Cargo.toml
@@ -56,7 +56,6 @@ alloy-primitives = { workspace = true, features = ["asm-keccak", "keccak-cache-g
 alloy-signer-local = { workspace = true, features = ["mnemonic"] }
 alloy-signer.workspace = true
 alloy-sol-types.workspace = true
-commonware-consensus.workspace = true
 commonware-cryptography.workspace = true
 commonware-math.workspace = true
 commonware-utils.workspace = true

--- a/crates/evm/src/block.rs
+++ b/crates/evm/src/block.rs
@@ -309,7 +309,7 @@ where
                         "failed decoding boundary block extra data as DKG outcome: {err}"
                     ))
                 })?;
-        let epoch = outcome.epoch.get();
+        let epoch = outcome.epoch;
         let public_keys = outcome
             .players()
             .iter()
@@ -677,7 +677,6 @@ mod tests {
     use alloy_primitives::{Bytes, Log, Signature, TxKind, address, bytes::BytesMut};
     use alloy_rlp::Encodable;
     use commonware_codec::Encode as _;
-    use commonware_consensus::types::Epoch;
     use commonware_cryptography::{
         Signer,
         bls12381::{dkg::feldman_desmedt as dkg, primitives::sharing::Mode},
@@ -753,7 +752,7 @@ mod tests {
             dkg::deal::<_, _, N3f1>(&mut rng, Mode::NonZeroCounter, player_set).unwrap();
 
         OnchainDkgOutcome {
-            epoch: Epoch::new(epoch),
+            epoch,
             output,
             next_players: shares.keys().clone(),
             is_next_full_dkg: false,
@@ -1150,7 +1149,7 @@ mod tests {
         executor.apply_current_committee_system_call().unwrap();
 
         let committee = read_current_committee(&mut executor);
-        assert_eq!(committee.epoch, outcome.epoch.get());
+        assert_eq!(committee.epoch, outcome.epoch);
         assert_eq!(committee.publicKeys, expected_public_keys);
     }
 

--- a/xtask/src/bootstrap_shadowfork.rs
+++ b/xtask/src/bootstrap_shadowfork.rs
@@ -152,7 +152,7 @@ impl BootstrapShadowfork {
         };
 
         ensure!(
-            outcome.epoch == Epoch::new(SHADOW_EPOCH),
+            outcome.epoch == SHADOW_EPOCH,
             "shadow DKG outcome is for epoch `{}`, expected `{SHADOW_EPOCH}`",
             outcome.epoch,
         );
@@ -635,7 +635,7 @@ fn read_private_genesis_outcome(manifest_dir: &Path) -> eyre::Result<OnchainDkgO
         .and_then(serde_json::Value::as_str)
         .ok_or_eyre("shadow genesis JSON does not contain string field `extraData`")?;
     let mut outcome = decode_outcome(extra_data)?;
-    outcome.epoch = Epoch::new(SHADOW_EPOCH);
+    outcome.epoch = SHADOW_EPOCH;
     Ok(outcome)
 }
 
@@ -1131,7 +1131,7 @@ fn seed_consensus_state(
 
                 let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
                 let state = BootstrapDkgState {
-                    epoch: outcome.epoch,
+                    epoch: Epoch::new(outcome.epoch),
                     seed: Summary::random(&mut rng),
                     output: outcome.output,
                     share: BootstrapShareState::Plaintext(Some(signing_share)),

--- a/xtask/src/generate_shadowfork.rs
+++ b/xtask/src/generate_shadowfork.rs
@@ -9,7 +9,6 @@ use std::{
 use alloy::primitives::{Address, B256};
 use alloy_consensus::Sealable as _;
 use commonware_codec::Encode as _;
-use commonware_consensus::types::Epoch;
 use commonware_cryptography::Signer as _;
 use eyre::{Context as _, OptionExt as _, ensure, eyre};
 use rand_08::SeedableRng as _;
@@ -192,7 +191,7 @@ impl GenerateShadowfork {
         let shadow_chainspec_path =
             write_shadow_chainspec(&output, &source_chain, source_chain_id, shadow_epoch_length)?;
         let mut shadow_dkg_outcome = consensus_config.to_genesis_dkg_outcome();
-        shadow_dkg_outcome.epoch = Epoch::new(SHADOW_EPOCH);
+        shadow_dkg_outcome.epoch = SHADOW_EPOCH;
         let shadow_dkg_outcome = const_hex::encode_prefixed(shadow_dkg_outcome.encode());
 
         for (validator, node) in consensus_config.validators.iter().zip(node_outputs.iter()) {

--- a/xtask/src/genesis_args.rs
+++ b/xtask/src/genesis_args.rs
@@ -6,7 +6,6 @@ use alloy::{
 use alloy_eips::eip2935::{HISTORY_STORAGE_ADDRESS, HISTORY_STORAGE_CODE};
 use alloy_primitives::{B256, Bytes};
 use commonware_codec::Encode as _;
-use commonware_consensus::types::Epoch;
 use commonware_cryptography::{
     Signer as _,
     bls12381::{
@@ -232,7 +231,7 @@ pub(crate) struct ConsensusConfig {
 impl ConsensusConfig {
     pub(crate) fn to_genesis_dkg_outcome(&self) -> OnchainDkgOutcome {
         OnchainDkgOutcome {
-            epoch: Epoch::zero(),
+            epoch: 0,
             output: self.output.clone(),
             next_players: ordered::Set::try_from_iter(
                 self.validators.iter().map(Validator::public_key),

--- a/xtask/src/get_dkg_outcome.rs
+++ b/xtask/src/get_dkg_outcome.rs
@@ -113,7 +113,7 @@ impl GetDkgOutcome {
         let sharing = outcome.sharing();
 
         let info = DkgOutcomeInfo {
-            epoch: outcome.epoch.get(),
+            epoch: outcome.epoch,
             block_number,
             block_hash,
             dealers: outcome.dealers().iter().map(pubkey_to_hex).collect(),


### PR DESCRIPTION
Related to #7484.

Removes the Commonware consensus/runtime dependency from Tempo’s reusable EVM dependency graph, addressing Foundry’s Windows compilation failure https://github.com/foundry-rs/foundry/actions/runs/34677048615/job/103508837690. Stores `OnchainDkgOutcome.epoch` as `u64` while preserving its existing varint encoding, and exposes `epoch() -> Epoch` through an optional `commonware-consensus` feature used by `tempo-consensus`. The full execution-only feature split remains separate work.

Prepared with AI assistance.
