### PR TITLE
fix(ci): gate release artifacts on version validation

### DIFF
--- a/.github/scripts/check-release-version.sh
+++ b/.github/scripts/check-release-version.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ $# -ne 2 || -z ${1-} || -z ${2-} ]]; then
+  echo "Usage: check-release-version.sh <tag> <cargo-version> (both nonempty)" >&2
+  exit 1
+fi
+
 tag=${1#v}
 cargo_ver=$2
 
@@ -10,9 +15,10 @@ fi
 
 # Cargo can use the base version while release tags add a SemVer prerelease.
 # Numeric prerelease identifiers cannot have leading zeroes; build metadata can.
+# A Cargo version that already has a suffix must match exactly.
 identifier='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
 prerelease="^${identifier}(\.${identifier})*(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
-if [[ "$tag" == "$cargo_ver"-* && "${tag#"$cargo_ver"-}" =~ $prerelease ]]; then
+if [[ "$cargo_ver" != *[-+]* && "$tag" == "$cargo_ver"-* && "${tag#"$cargo_ver"-}" =~ $prerelease ]]; then
   exit 0
 fi
 

--- a/.github/scripts/check-release-version.sh
+++ b/.github/scripts/check-release-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag=${1#v}
+cargo_ver=$2
+
+if [[ "$tag" == "$cargo_ver" ]]; then
+  exit 0
+fi
+
+# Cargo can use the base version while release tags add a SemVer prerelease.
+# Numeric prerelease identifiers cannot have leading zeroes; build metadata can.
+identifier='(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)'
+prerelease="^${identifier}(\.${identifier})*(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
+if [[ "$tag" == "$cargo_ver"-* && "${tag#"$cargo_ver"-}" =~ $prerelease ]]; then
+  exit 0
+fi
+
+echo "Tag $tag doesn't match the Cargo version $cargo_ver" >&2
+exit 1

--- a/.github/scripts/test-release-version.sh
+++ b/.github/scripts/test-release-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+checks=0
+
+check() {
+  local expected=$1 tag=$2 cargo_ver=$3 status=0
+  bash "$script_dir/check-release-version.sh" "$tag" "$cargo_ver" >/dev/null 2>&1 || status=$?
+  if [[ "$status" != "$expected" ]]; then
+    echo "Tag '$tag' with Cargo '$cargo_ver': expected exit $expected, got $status" >&2
+    exit 1
+  fi
+  checks=$((checks + 1))
+}
+
+for tag in v1.14.0 1.14.0 v1.14.0-rc.1 v1.14.0-alpha v1.14.0-beta.2 \
+  v1.14.0-0 v1.14.0-0a v1.14.0-rc.1+build.001; do
+  check 0 "$tag" 1.14.0
+done
+
+for tag in v1.14.00 v1.14.01 v1.14.0junk v1.14.1 v1.140.0 v11.14.0 \
+  v1.14.0- v1.14.0-rc. v1.14.0-.rc v1.14.0-rc..1 v1.14.0-01 \
+  v1.14.0-rc.01 v1.14.0-rc_1 v1.14.0-rc.1+ v1.14.0-rc.1+build..1 \
+  v1.14.0+build.1 vv1.14.0 '' 'v1.14.0-rc.1 extra'; do
+  check 1 "$tag" 1.14.0
+done
+
+# Exact Cargo prereleases and build metadata remain valid.
+check 0 v1.14.0-rc.1 1.14.0-rc.1
+check 1 v1.14.0-rc.10 1.14.0-rc.1
+check 0 v1.14.0+build.1 1.14.0+build.1
+
+printf 'Passed %s release version checks\n' "$checks"

--- a/.github/scripts/test-release-version.sh
+++ b/.github/scripts/test-release-version.sh
@@ -30,5 +30,13 @@ done
 check 0 v1.14.0-rc.1 1.14.0-rc.1
 check 1 v1.14.0-rc.10 1.14.0-rc.1
 check 0 v1.14.0+build.1 1.14.0+build.1
+check 1 v1.14.0-rc.1-rc.2 1.14.0-rc.1
+check 1 v1.14.0+build.1-rc.1 1.14.0+build.1
+
+# Missing metadata must never turn into a successful comparison.
+check 1 '' ''
+check 1 v ''
+check 1 v1.14.0 ''
+check 1 '' 1.14.0
 
 printf 'Passed %s release version checks\n' "$checks"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
         env:
           TAG: ${{ needs.get-version.outputs.version }}
         run: |
-          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tempo").version')
+          cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -er '.packages[] | select(.name == "tempo").version')
           bash .github/scripts/check-release-version.sh "$TAG" "$cargo_ver"
 
   build-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,6 @@ jobs:
     name: check version
     runs-on: ubuntu-latest
     needs: get-version
-    if: ${{ !startsWith(github.ref, 'refs/heads/rc/') && github.event.inputs.dry_run != 'true' }}
     permissions:
       contents: read
     steps:
@@ -66,19 +65,17 @@ jobs:
           persist-credentials: false
       - uses: tempoxyz/gh-actions/vendor/dtolnay/rust-toolchain@3626124474a987bc74b41fc7ae65b2e23f8e4e4e
       - name: Verify crate version matches tag
-        # Check that the Cargo version starts with the tag,
-        # so that Cargo version 1.4.8 can be matched against both v1.4.8 and v1.4.8-rc.1
+        # Skip the step, not the job, so RC and dry-run builds still satisfy needs.
+        if: ${{ !startsWith(github.ref, 'refs/heads/rc/') && inputs.dry_run != true }}
         env:
           TAG: ${{ needs.get-version.outputs.version }}
         run: |
-          tag="$TAG"
-          tag=${tag#v}
           cargo_ver=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "tempo").version')
-          [[ "$tag" == "$cargo_ver"* ]] || { echo "Tag $tag doesn't match the Cargo version $cargo_ver"; exit 1; }
+          bash .github/scripts/check-release-version.sh "$TAG" "$cargo_ver"
 
   build-release:
     name: Build Release Binaries
-    needs: get-version
+    needs: [get-version, check-version]
     environment: release
     runs-on: ${{ matrix.platform.os }}
     permissions:

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -17,6 +17,7 @@ permissions: {}
 
 jobs:
   release-version-tests:
+    if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/scan-github-actions.yml
+++ b/.github/workflows/scan-github-actions.yml
@@ -16,6 +16,17 @@ on:
 permissions: {}
 
 jobs:
+  release-version-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: bash .github/scripts/test-release-version.sh
+
   scan:
     if: ${{ github.event_name != 'schedule' || github.repository == 'tempoxyz/tempo' }}
     uses: tempoxyz/gh-actions/.github/workflows/scan-github-actions.yml@5d3a903b51ce8d1f6d363d1c59d7243ecf80f026


### PR DESCRIPTION
Closes #7541

Requires successful version validation before release builds and artifact distribution, preserving RC branch and dry-run builds. Rejects version-prefix collisions and missing metadata while accepting exact Cargo versions and valid prerelease tags from a stable base; follows up on #6778 and #7542.

Validation: 36 shell regressions, six checks of the actual workflow shell step (including Cargo/metadata failures), Bash syntax, ShellCheck, actionlint, offline zizmor, and [GitHub scheduling tests with harmless artifact stubs](https://github.com/john-lawniczak/tempo-contributions/actions/workflows/release.yml).
