### PR TITLE
fix(evm): clear pool validation state after rejected transactions

### DIFF
--- a/crates/evm/src/evm.rs
+++ b/crates/evm/src/evm.rs
@@ -215,6 +215,7 @@ where
         // key authorisation) while keeping loaded accounts and storage warm for the
         // rest of the batch.
         self.ctx_mut().journal_mut().discard_tx();
+        self.inner.clear();
         (result, tx)
     }
 }

--- a/crates/evm/tests/pool_key_expiry_leak.rs
+++ b/crates/evm/tests/pool_key_expiry_leak.rs
@@ -1,0 +1,88 @@
+use alloy_evm::EvmEnv;
+use alloy_primitives::{Address, B256, Bytes, TxKind, U256};
+use alloy_signer::SignerSync;
+use alloy_signer_local::PrivateKeySigner;
+use revm::{
+    context::{CfgEnv, TxEnv},
+    database::EmptyDB,
+};
+use tempo_chainspec::hardfork::TempoHardfork;
+use tempo_evm::{TempoBlockEnv, TempoPoolValidationEvm, evm::TempoEvm};
+use tempo_precompiles::PATH_USD_ADDRESS;
+use tempo_primitives::{
+    SignatureType, TempoSignature,
+    transaction::{Call, KeyAuthorization, PrimitiveSignature},
+};
+use tempo_revm::{TempoBatchCallEnv, TempoTxEnv, gas_params::tempo_gas_params_with_amsterdam};
+
+#[test]
+fn rejected_pool_transaction_does_not_leak_key_expiry() {
+    const BLOCK_TIMESTAMP: u64 = 10;
+
+    let root = PrivateKeySigner::from_bytes(&B256::with_last_byte(1)).unwrap();
+    let key = PrivateKeySigner::from_bytes(&B256::with_last_byte(2)).unwrap();
+    let authorization = KeyAuthorization::unrestricted(1, SignatureType::Secp256k1, key.address())
+        .with_expiry(BLOCK_TIMESTAMP);
+    let authorization_signature = root
+        .sign_hash_sync(&authorization.signature_hash())
+        .unwrap();
+
+    let mut env = EvmEnv::new(
+        CfgEnv::new_with_spec_and_gas_params(
+            TempoHardfork::T10,
+            tempo_gas_params_with_amsterdam(TempoHardfork::T10, false),
+        ),
+        TempoBlockEnv::default(),
+    );
+    env.cfg_env.chain_id = 1;
+    env.block_env.inner.timestamp = U256::from(BLOCK_TIMESTAMP);
+    env.block_env.inner.basefee = 0;
+    let mut evm = TempoEvm::new(EmptyDB::default(), env);
+    evm.configure_for_pool();
+
+    let rejected = TempoTxEnv {
+        inner: TxEnv {
+            caller: root.address(),
+            gas_limit: 1_000_000,
+            gas_price: 0,
+            kind: TxKind::Call(Address::repeat_byte(0x44)),
+            ..Default::default()
+        },
+        fee_token: Some(PATH_USD_ADDRESS),
+        tempo_tx_env: Some(Box::new(TempoBatchCallEnv {
+            signature: TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                root.sign_hash_sync(&B256::ZERO).unwrap(),
+            )),
+            aa_calls: vec![Call {
+                to: TxKind::Call(Address::repeat_byte(0x44)),
+                value: U256::ZERO,
+                input: Bytes::new(),
+            }],
+            key_authorization: Some(
+                authorization.into_signed(PrimitiveSignature::Secp256k1(authorization_signature)),
+            ),
+            signature_hash: B256::ZERO,
+            ..Default::default()
+        })),
+        ..Default::default()
+    };
+
+    let (result, _) = evm.validate_pool_transaction(rejected);
+    assert!(result.is_err(), "the first transaction must be rejected");
+
+    let valid_non_aa_transaction = TempoTxEnv {
+        inner: TxEnv {
+            caller: root.address(),
+            gas_limit: 1_000_000,
+            gas_price: 0,
+            kind: TxKind::Call(Address::repeat_byte(0x55)),
+            ..Default::default()
+        },
+        fee_token: Some(PATH_USD_ADDRESS),
+        ..Default::default()
+    };
+
+    let (result, _) = evm.validate_pool_transaction(valid_non_aa_transaction);
+    let context = result.expect("the second non-AA transaction must be valid");
+    assert_eq!(context.key_expiry, None);
+}

--- a/crates/transaction-pool/src/validator.rs
+++ b/crates/transaction-pool/src/validator.rs
@@ -3224,4 +3224,97 @@ mod tests {
             ),
         }
     }
+
+    #[tokio::test]
+    async fn rejected_inline_key_authorization_does_not_poison_next_root_aa_transaction() {
+        use alloy_signer::SignerSync;
+        use alloy_signer_local::PrivateKeySigner;
+        use tempo_primitives::transaction::{KeyAuthorization, SignatureType};
+
+        const TIP_TIMESTAMP: u64 = 1_788_393_600;
+
+        let root = PrivateKeySigner::from_bytes(&B256::with_last_byte(1)).unwrap();
+        let access_key = PrivateKeySigner::from_bytes(&B256::with_last_byte(2)).unwrap();
+        let chain_id = MODERATO.chain_id();
+
+        let authorization = KeyAuthorization::unrestricted(
+            chain_id,
+            SignatureType::Secp256k1,
+            access_key.address(),
+        )
+        .with_expiry(TIP_TIMESTAMP);
+        let authorization_signature = root
+            .sign_hash_sync(&authorization.signature_hash())
+            .unwrap();
+        let signed_authorization =
+            authorization.into_signed(PrimitiveSignature::Secp256k1(authorization_signature));
+
+        let build_root_aa = |target: Address, key_authorization| {
+            let tx = TempoTransaction {
+                chain_id,
+                max_priority_fee_per_gas: 1_000_000_000,
+                max_fee_per_gas: 20_000_000_000,
+                gas_limit: 1_000_000,
+                calls: vec![Call {
+                    to: TxKind::Call(target),
+                    value: U256::ZERO,
+                    input: Bytes::new(),
+                }],
+                nonce_key: U256::ZERO,
+                nonce: 0,
+                fee_token: Some(PATH_USD_ADDRESS),
+                key_authorization,
+                ..Default::default()
+            };
+            let unsigned = AASigned::new_unhashed(
+                tx.clone(),
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(
+                    Signature::test_signature(),
+                )),
+            );
+            let signature = root.sign_hash_sync(&unsigned.signature_hash()).unwrap();
+            let signed = AASigned::new_unhashed(
+                tx,
+                TempoSignature::Primitive(PrimitiveSignature::Secp256k1(signature)),
+            );
+            TempoPooledTransaction::new(TempoTxEnvelope::from(signed).try_into_recovered().unwrap())
+        };
+
+        let rejected = build_root_aa(Address::repeat_byte(0x44), Some(signed_authorization));
+        let valid = build_root_aa(Address::repeat_byte(0x55), None);
+        assert!(rejected.is_aa());
+        assert!(valid.is_aa());
+        assert_eq!(rejected.sender(), root.address());
+        assert_eq!(valid.sender(), root.address());
+
+        let validator = setup_validator(&rejected, TIP_TIMESTAMP);
+        let outcomes = validator
+            .validate_transactions([
+                (TransactionOrigin::External, rejected),
+                (TransactionOrigin::External, valid),
+            ])
+            .await;
+
+        let TransactionValidationOutcome::Invalid(_, error) = &outcomes[0] else {
+            panic!(
+                "the expired inline authorization must be rejected: {:?}",
+                outcomes[0]
+            );
+        };
+        let Some(TempoPoolTransactionError::Evm(
+            TempoInvalidTransaction::KeychainPrecompileError { reason },
+        )) = error.downcast_other_ref::<TempoPoolTransactionError>()
+        else {
+            panic!("unexpected rejection for the expired inline authorization: {error:?}");
+        };
+        assert!(
+            reason.contains("ExpiryInPast"),
+            "unexpected keychain error: {reason}"
+        );
+        assert!(
+            matches!(&outcomes[1], TransactionValidationOutcome::Valid { .. }),
+            "the valid root-signed AA transaction was rejected after the invalid transaction: {:?}",
+            outcomes[1]
+        );
+    }
 }


### PR DESCRIPTION
Closes #7530

Clears transaction-local EVM state after pool validation errors so an expired inline key authorization cannot cause the next valid transaction in a batch to be rejected. Adds EVM and transaction-pool regression coverage.

Carries the changes from #7549 for Cyclops review.
